### PR TITLE
Adds Dockerfile and a script for building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+
+RUN apk --update upgrade && \
+    apk add curl ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/cache/apk/*
+
+ADD ldr /
+
+CMD ["/ldr", "--config=config/ld-relay.conf"]

--- a/README.md
+++ b/README.md
@@ -74,4 +74,11 @@ To set up LDR in this mode, provide a redis host and port, and supply a Redis ke
 
 If you're not using a load balancer in front of LDR, you can configure your SDKs to connect to Redis directly by setting `use_ldd` mode to `true` in your SDK, and connecting to Redis with the same host and port in your SDK configuration.
 
+Docker
+-------
+
+You can build a Docker image by running `./scripts/build_docker_image.sh`. The container expects the config file to be mounted at `/config/ld-relay.conf`.
+
+To start a container, run `docker run -it -v /path/to/your/ld-relay.conf:/config/ld-relay.conf ld-relay`
+
 

--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -1,0 +1,3 @@
+CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -o ldr .
+docker build -t ld-relay -f Dockerfile .
+rm ldr


### PR DESCRIPTION
A somewhat speculative PR. I'm inexperienced with the go language/run-time, so I'm not 100% sure if this is good. But we're running the relay in Kubernetes, and this is how we're building the image. Even if there's nothing to merge here, would be interested in your feedback from the go context.

The image is here as well: https://hub.docker.com/r/andyhume/ld-relay/
