### PR TITLE
gopkg.in/launchdarkly/ld-relay.v5 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ defaults:
               go_cover_args="-covermode=atomic -coverpkg=./... -coverprofile /tmp/circle-artifacts/coverage.txt"
             fi
             go test -race $go_cover_args -v . | tee >(richgo testfilter) > $CIRCLE_ARTIFACTS/report.txt
-            if [ -z "$DISABLE_COVERAGE" ]; then
+            if [[ -z "$DISABLE_COVERAGE" && -n "$CC_TEST_REPORTER_ID" ]]; then
               ./cc-test-reporter format-coverage $CIRCLE_ARTIFACTS/coverage.txt -t gocov --output $CIRCLE_ARTIFACTS/coverage.json
               ./cc-test-reporter upload-coverage --input $CIRCLE_ARTIFACTS/coverage.json
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ experimental:
 
 defaults:
   environment: &environment
-    GOLANGCI_LINT_VERSION: v1.6.1
     CIRCLE_TEST_REPORTS: /tmp/circle-reports
     CIRCLE_ARTIFACTS: /tmp/circle-artifacts
     COMMON_GO_PACKAGES: >
@@ -18,15 +17,13 @@ defaults:
       gopkg.in/alecthomas/gometalinter.v2
 
   build_steps: &build_steps
-    working_directory: /go/src/gopkg.in/launchdarkly/ld-relay
+    working_directory: /go/src/gopkg.in/launchdarkly/ld-relay.v5
     steps:
       - checkout
       - run: go get -u $COMMON_GO_PACKAGES
-      - run: gometalinter.v2 --install
-      - run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s $GOLANGCI_LINT_VERSION
-      - run: gometalinter.v2
-      - run: ./bin/golangci-lint run ./...
       - run: dep ensure -dry-run
+      - run: make init
+      - run: make lint
       - run:
           name: Set up Code Climate test-reporter
           command: |
@@ -90,22 +87,22 @@ jobs:
     docker:
       - <<: *release_docker_image
 
-    working_directory: /go/src/gopkg.in/launchdarkly/ld-relay
+    working_directory: /go/src/gopkg.in/launchdarkly/ld-relay.v5
     steps:
       - checkout
-      - setup_remote_docker  # start docker engine
-      - run: docker build -t "ld-relay:$CIRCLE_BUILD_NUM" .
 
+      # Generate and upload binaries
       - run: mkdir -p $CIRCLE_ARTIFACTS
-
       - run: go get -u github.com/laher/goxc
       - run:
           name: generate all binaries
           command: ./scripts/package.sh
-
       - store_artifacts:
           path: /tmp/circle-artifacts
 
+      # Upload docker changes
+      - setup_remote_docker  # start docker engine
+      - run: docker build -t "ld-relay:$CIRCLE_BUILD_NUM" .
       - deploy:
           name: Push docker image
           command: |

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/bin/
+/ld-relay

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ ld-relay.prod.conf
 
 pkg
 _out
+
+/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --no-cache add \
     libc-dev \
  && rm -rf /var/cache/apk/*
 
-ARG SRC_DIR=/go/src/github.com/launchdarkly/ld-relay
+ARG SRC_DIR=/go/src/gopkg.in/launchdarkly/ld-relay.v5
 
 RUN mkdir -p $SRC_DIR
 
@@ -16,7 +16,7 @@ ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOPATH=/go
 
-RUN go build -a -o ldr
+RUN go build -a -o ldr ./cmd/ld-relay
 
 FROM alpine:3.7
 
@@ -26,8 +26,7 @@ RUN apk add --no-cache \
  && update-ca-certificates \
  && rm -rf /var/cache/apk/*
 
-
-ARG SRC_DIR=/go/src/github.com/launchdarkly/ld-relay
+ARG SRC_DIR=/go/src/gopkg.in/launchdarkly/ld-relay.v5
 
 COPY --from=builder ${SRC_DIR}/ldr /usr/bin/ldr
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+GOLANGCI_VERSION=v1.7
+
+test: lint
+	go test ./...
+
+lint:
+	./bin/golangci-lint run ./...
+	gometalinter.v2 ./...
+
+init:
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s $(GOLANGCI_VERSION)
+	go get -u gopkg.in/alecthomas/gometalinter.v2
+	gometalinter.v2 --install
+
+.PHONY: docker init lint test

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Quick setup
 
 2. Build and install the binary in your $GOPATH:
 ```
-go get -u github.com/launchdarkly/ld-relay
+go get -u gopkg.in/launchdarkly/ld-relay.v5/...
 ```
 
 3. Create LD Relay configuration file. Create a new filed called `ld-relay.conf` containing the text:
@@ -322,3 +322,24 @@ To register ld-relay as a service, run a command prompt as Administrator
 $ sc create ld-relay DisplayName="LaunchDarkly Relay Proxy" start="auto" binPath="C:\path\to\ld-relay.exe -config C:\path\to\ld-relay.conf"
 ```
 
+
+Integrating LD Relay into your own application
+----------------------------------------------
+
+
+You can also use relay to handle endpoints in your own application if you don't want to use the default `ld-relay` application.  Below is an
+example using [Gorilla](https://github.com/gorilla/mux) of how you might instantiate a relay inside your web server beneath a path called "/relay":
+
+```go
+router := mux.NewRouter()
+configFileName := "path/to/my-config-file"
+cfg := relay.DefaultConfig
+if err := relay.LoadConfigFile(&cfg, configFileName); err != nil {
+  log.Fatalf("Error loading config file: %s", err)
+}
+r, err := relay.NewRelay(cfg, relay.DefaultClientFactory)
+if err != nil {
+  log.Fatalf("Error creating relay: %s", err)
+}
+router.PathPrefix("/relay").Handler(r)
+```

--- a/cmd/ld-relay/ld-relay.go
+++ b/cmd/ld-relay/ld-relay.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"strings"
+
+	_ "github.com/kardianos/minwinsvc"
+
+	"gopkg.in/launchdarkly/ld-relay.v5"
+	"gopkg.in/launchdarkly/ld-relay.v5/logging"
+	"gopkg.in/launchdarkly/ld-relay.v5/version"
+)
+
+func main() {
+	var configFile string
+	flag.StringVar(&configFile, "config", "/etc/ld-relay.conf", "configuration file location")
+	flag.Parse()
+
+	logging.Info.Printf("Starting LaunchDarkly relay version %s with configuration file %s\n", formatVersion(version.Version), configFile)
+
+	c := relay.DefaultConfig
+	if err := relay.LoadConfigFile(&c, configFile); err != nil {
+		log.Fatalf("Error loading config file: %s", err)
+	}
+
+	r, err := relay.NewRelay(c, relay.DefaultClientFactory)
+	if err != nil {
+		logging.Error.Printf("Unable to create relay: %s", err)
+		os.Exit(1)
+	}
+
+	logging.Info.Printf("Listening on port %d\n", c.Main.Port)
+
+	err = http.ListenAndServe(fmt.Sprintf(":%d", c.Main.Port), r)
+	if err != nil {
+		if c.Main.ExitOnError {
+			logging.Error.Fatalf("Error starting http listener on port: %d  %s", c.Main.Port, err)
+		}
+		logging.Error.Printf("Error starting http listener on port: %d  %s", c.Main.Port, err)
+	}
+}
+
+func formatVersion(version string) string {
+	split := strings.Split(version, "+")
+
+	if len(split) == 2 {
+		return fmt.Sprintf("%s (build %s)", split[0], split[1])
+	}
+	return version
+}

--- a/events/event-summarizing-relay.go
+++ b/events/event-summarizing-relay.go
@@ -1,4 +1,4 @@
-package main
+package events
 
 import (
 	"encoding/json"
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	ld "gopkg.in/launchdarkly/go-client.v4"
+
+	"gopkg.in/launchdarkly/ld-relay.v5/logging"
 )
 
 type eventSummarizingRelay struct {
@@ -16,10 +18,10 @@ type eventSummarizingRelay struct {
 
 func newEventSummarizingRelay(sdkKey string, config Config, featureStore ld.FeatureStore) *eventSummarizingRelay {
 	ldConfig := ld.DefaultConfig
-	ldConfig.EventsUri = config.Events.EventsUri
-	ldConfig.Capacity = config.Events.Capacity
-	ldConfig.InlineUsersInEvents = config.Events.InlineUsers
-	ldConfig.FlushInterval = time.Duration(config.Events.FlushIntervalSecs) * time.Second
+	ldConfig.EventsUri = config.EventsUri
+	ldConfig.Capacity = config.Capacity
+	ldConfig.InlineUsersInEvents = config.InlineUsers
+	ldConfig.FlushInterval = time.Duration(config.FlushIntervalSecs) * time.Second
 	ep := ld.NewDefaultEventProcessor(sdkKey, ldConfig, nil)
 	return &eventSummarizingRelay{
 		eventProcessor: ep,
@@ -34,7 +36,7 @@ func (er *eventSummarizingRelay) enqueue(rawEvents []json.RawMessage, schemaVers
 		if err == nil {
 			evt, err := er.translateEvent(rawEvent, fields, schemaVersion)
 			if err != nil {
-				Error.Printf("Error in event processing, event was discarded: %+v", err)
+				logging.Error.Printf("Error in event processing, event was discarded: %+v", err)
 			}
 			if evt != nil {
 				er.eventProcessor.SendEvent(evt)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,44 @@
+package logging
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+// Global package level loggers
+var (
+	Debug   *log.Logger
+	Info    *log.Logger
+	Warning *log.Logger
+	Error   *log.Logger
+)
+
+func init() {
+	InitLogging(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr)
+}
+
+// InitLogging overrides the default loggers that write to stdout
+func InitLogging(
+	debugHandle io.Writer,
+	infoHandle io.Writer,
+	warningHandle io.Writer,
+	errorHandle io.Writer) {
+
+	Debug = log.New(debugHandle,
+		"DEBUG: ",
+		log.Ldate|log.Ltime|log.Lshortfile)
+
+	Info = log.New(infoHandle,
+		"INFO: ",
+		log.Ldate|log.Ltime|log.Lshortfile)
+
+	Warning = log.New(warningHandle,
+		"WARNING: ",
+		log.Ldate|log.Ltime|log.Lshortfile)
+
+	Error = log.New(errorHandle,
+		"ERROR: ",
+		log.Ldate|log.Ltime|log.Lshortfile)
+}

--- a/relay.go
+++ b/relay.go
@@ -96,7 +96,7 @@ func init() {
 
 // LoadConfigFile reads a config file into a Config struct
 func LoadConfigFile(c *Config, path string) error {
-	if err := gcfg.ReadFileInto(&c, path); err != nil {
+	if err := gcfg.ReadFileInto(c, path); err != nil {
 		return fmt.Errorf(`failed to read configuration file "%s": %s`, path, err)
 	}
 	return nil
@@ -408,13 +408,21 @@ func (m clientMux) getStatus(w http.ResponseWriter, req *http.Request) {
 		envs[clientCtx.name] = status
 	}
 
-	resp := make(map[string]interface{})
+	resp := struct {
+		Environments  map[string]environmentStatus `json:"environments"`
+		Status        string                       `json:"status"`
+		Version       string                       `json:"version"`
+		ClientVersion string                       `json:"clientVersion"`
+	}{
+		Environments:  envs,
+		Version:       version.Version,
+		ClientVersion: ld.Version,
+	}
 
-	resp["environments"] = envs
 	if healthy {
-		resp["status"] = "healthy"
+		resp.Status = "healthy"
 	} else {
-		resp["status"] = "degraded"
+		resp.Status = "degraded"
 	}
 
 	data, _ := json.Marshal(resp)

--- a/scripts/upload_to_dockerhub.sh
+++ b/scripts/upload_to_dockerhub.sh
@@ -23,7 +23,7 @@ echo "build@example.com" | docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWO
 docker tag "ld-relay:$CIRCLE_BUILD_NUM" "$DOCKER_REPO:$TAG"
 docker push "$DOCKER_REPO:$TAG"
 
-if [ "$TAG" = "master" ]; then
+if [ "$TAG" = "v5" ]; then
   # tag the master branch as latest
   docker tag "$DOCKER_REPO:$TAG" "$DOCKER_REPO:latest" 
   docker push "$DOCKER_REPO:latest"

--- a/store/relay_feature_store_test.go
+++ b/store/relay_feature_store_test.go
@@ -1,4 +1,4 @@
-package main
+package store
 
 import (
 	"testing"

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type errorJson struct {
+	Message string `json:"message"`
+}
+
+// ErrorJsonMsg returns a json-encoded error message
+func ErrorJsonMsg(msg string) (j []byte) {
+	j, _ = json.Marshal(errorJson{Message: msg})
+	return
+}
+
+// ErrorJsonMsgf returns a json-encoded error message using the printf formatter
+func ErrorJsonMsgf(fmtStr string, args ...interface{}) []byte {
+	return ErrorJsonMsg(fmt.Sprintf(fmtStr, args...))
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the package version
+const Version = "5.0.0"


### PR DESCRIPTION
This package is now known as `gopkg.in/launchdarkly/ld-relay.v5`.

### Changes
* `relay` is available as an http handler for use in other servers.
* Add godoc comments for public methods.
* Enable multiple linters and fix lint issues.
* Switch to multi-stage docker build.