### PR TITLE
Adding ability to load configuration from string

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -28,12 +28,12 @@ import (
 	"gopkg.in/launchdarkly/go-client.v4/lddynamodb"
 	ldr "gopkg.in/launchdarkly/go-client.v4/redis"
 
-	"ld-relay/internal/events"
-	"ld-relay/internal/metrics"
-	"ld-relay/internal/store"
-	"ld-relay/internal/util"
-	"ld-relay/internal/version"
-	"ld-relay/logging"
+	"gopkg.in/launchdarkly/ld-relay.v5/internal/events"
+	"gopkg.in/launchdarkly/ld-relay.v5/internal/metrics"
+	"gopkg.in/launchdarkly/ld-relay.v5/internal/store"
+	"gopkg.in/launchdarkly/ld-relay.v5/internal/util"
+	"gopkg.in/launchdarkly/ld-relay.v5/internal/version"
+	"gopkg.in/launchdarkly/ld-relay.v5/logging"
 )
 
 const (

--- a/relay_test.go
+++ b/relay_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/launchdarkly/eventsource"
 	ld "gopkg.in/launchdarkly/go-client.v4"
 
-	"ld-relay/internal/events"
-	"ld-relay/logging"
+	"gopkg.in/launchdarkly/ld-relay.v5/internal/events"
+	"gopkg.in/launchdarkly/ld-relay.v5/logging"
 )
 
 type FakeLDClient struct{ initialized bool }


### PR DESCRIPTION
In the 12-Factor App the third factor is: Config. A config should be stored in the environment not the package. Only exposing a LoadConfigFile limits the ways that one would be able to store the config for individual environments. 

Let's say that a fictitious company -- Bob's Feature Rich App -- has a development team that has created a on-premise private cloud for their app hosting. They decided that LD is the feature toggling system that they wish to use. They spend time setting up a project for their Super Secret App and they match their on-premise hosting environments up to the environments that they create under the project in their LD admin. The have the following:

Project: Super Secret App
Env: Dev, QA, PreProd, Production

In order to get something into production, they take their master branch and run a CI/CD pipeline to create an individual package that will be moved through QA --> PreProd --> Prod. The developers do  not have the ability open the package and edit the *.conf file nor path in each environment because technically that is a change to the package and it no longer matches the originally built package.

The developers decide that to get around this they setup a way of retargeting the files. They write some code to change the path that is given to the LoadConfig method for each environment. This achieves the goal of not having to modify the package for each environment. But the relay config is still in the deployment package. In this scenario, what happens if at the last minute the product owner convinces everyone that they now need a new UAT environment?

If developers had a way to put the config for the relay into each of the environments, instead of files in the deployment package, there would be no need to modify the package contents nor write custom environment code. With the changes purposed in the pull request, developers now have a choice between a config loaded via file or string. 

The developers of our fictitious could load the relay into their deployment package like so:

```
router := mux.NewRouter()
envConfig := os.Getenv("RELAY_CONFIG")
cfg := relay.DefaultConfig
if err := relay.LoadConfigString(&cfg, envConfig); err != nil {
log.Fatalf("Error loading config: %s", err)
}
r, err := relay.NewRelay(cfg, relay.DefaultClientFactory)
if err != nil {
log.Fatalf("Error creating relay: %s", err)
}
router.PathPrefix("/relay").Handler(r)
```

In order to obscure the API Keys from the prying eyes of "peepers", the method introduced requiers that the string be base64 encoded.

p.s. two commits, had to change the imports to get my local copy to stop whining at me then forgot to revert before initial check-in. 