### PR TITLE
Add TLS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ variable name            | type    | default                           | descrip
 `ignoreConnectionErrors` | Boolean | `false`                           | Ignore any initial connectivity issues with LaunchDarkly. Best used when network connectivity is not reliable.
 `port`                   | Number  | `8030`                            | Port the LD Relay should listen on
 `heartbeatIntervalSecs`  | Number  | `0`                               | If > 0, sends heartbeats to connected clients at this interval
+`tlsEnabled`             | Boolean | `false`                           | Enable TLS on the relay
+`tlsCert`                | String  | ``                                | Required if `tlsEnabled` is true. Path to TLS Certificate
+`tlsKey`                 | String  | ``                                | Required if `tlsEnabled` is true. Path to TLS Private Key 
 
 ## [events]
 variable name       | type    | default                           | description

--- a/cmd/ld-relay/ld-relay.go
+++ b/cmd/ld-relay/ld-relay.go
@@ -38,7 +38,22 @@ func main() {
 		logging.Error.Printf("Error initializing metrics: %s", err)
 	}
 
-	err = http.ListenAndServe(fmt.Sprintf(":%d", c.Main.Port), r)
+	if c.Main.TLS {
+		if c.Main.TLSCert == "" {
+			logging.Error.Printf("TLS: tlscert required")
+			os.Exit(1)
+		}
+		if c.Main.TLSKey == "" {
+			logging.Error.Printf("TLS: tlskey required")
+			os.Exit(1)
+		}
+
+		err = http.ListenAndServeTLS(fmt.Sprintf(":%d", c.Main.Port), c.Main.TLSCert, c.Main.TLSKey, r)
+		logging.Info.Printf("Server started with TLS enabled")
+	} else {
+		err = http.ListenAndServe(fmt.Sprintf(":%d", c.Main.Port), r)
+	}
+
 	if err != nil {
 		if c.Main.ExitOnError {
 			logging.Error.Fatalf("Error starting http listener on port: %d  %s", c.Main.Port, err)

--- a/cmd/ld-relay/ld-relay.go
+++ b/cmd/ld-relay/ld-relay.go
@@ -41,11 +41,11 @@ func main() {
 
 	if c.Main.TLSEnabled {
 		if c.Main.TLSCert == "" {
-			logging.Error.Printf("TLS: tlscert required")
+			logging.Error.Printf("TLS: tlsCert required")
 			os.Exit(1)
 		}
 		if c.Main.TLSKey == "" {
-			logging.Error.Printf("TLS: tlskey required")
+			logging.Error.Printf("TLS: tlsKey required")
 			os.Exit(1)
 		}
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,6 +17,23 @@ port = 8030
 heartbeatIntervalSecs = ${HEARTBEAT_INTERVAL:-15}
 " > $CONF_FILE
 
+# TLS Configuration for listener
+if [ "${TLS_ENABLED:-false}" = "true" ]; then
+  echo "tlsEnabled = ${TLS_ENABLED}" >> $CONF_FILE
+  if [ -z "${TLS_CERT}" ]; then
+    echo "ERROR: TLS_ENABLED is true and needs to have TLS_CERT set"
+    exit 1
+  else
+    echo "tlsCert = ${TLS_CERT}" >> $CONF_FILE
+  fi
+  if [ -z "${TLS_KEY}" ]; then
+    echo "ERROR: TLS_ENABLED is true and needs to have TLS_KEY set"
+    exit 1
+  else
+    echo "tlsKey = ${TLS_KEY}" >> $CONF_FILE
+  fi
+fi
+
 CONFIGURED_DATABASE=""
 
 if [ "$USE_REDIS" = "1" ] || [ "$USE_REDIS" = "true" ]; then

--- a/relay.go
+++ b/relay.go
@@ -47,6 +47,7 @@ const (
 	defaultHeartbeatIntervalSecs = 180
 	defaultMetricsPrefix         = "launchdarkly_relay"
 	defaultFlushIntervalSecs     = 5
+	defaultTls                   = false
 
 	userAgentHeader   = "user-agent"
 	ldUserAgentHeader = "X-LaunchDarkly-User-Agent"
@@ -147,6 +148,9 @@ type MainConfig struct {
 	BaseUri                string
 	Port                   int
 	HeartbeatIntervalSecs  int
+	TLS                    bool
+	TLSCert                string
+	TLSKey                 string
 }
 
 type ConsulConfig struct {

--- a/relay.go
+++ b/relay.go
@@ -211,6 +211,7 @@ func init() {
 	DefaultConfig.Main.StreamUri = defaultStreamUri
 	DefaultConfig.Main.HeartbeatIntervalSecs = defaultHeartbeatIntervalSecs
 	DefaultConfig.Main.Port = defaultPort
+	DefaultConfig.Main.TLSEnabled = defaultTLSEnabled
 	DefaultConfig.Redis.LocalTtl = defaultRedisLocalTtlMs
 	DefaultConfig.Events.FlushIntervalSecs = defaultFlushIntervalSecs
 }

--- a/relay.go
+++ b/relay.go
@@ -47,7 +47,7 @@ const (
 	defaultHeartbeatIntervalSecs = 180
 	defaultMetricsPrefix         = "launchdarkly_relay"
 	defaultFlushIntervalSecs     = 5
-	defaultTls                   = false
+	defaultTLSEnabled            = false
 
 	userAgentHeader   = "user-agent"
 	ldUserAgentHeader = "X-LaunchDarkly-User-Agent"
@@ -148,7 +148,7 @@ type MainConfig struct {
 	BaseUri                string
 	Port                   int
 	HeartbeatIntervalSecs  int
-	TLS                    bool
+	TLSEnabled             bool
 	TLSCert                string
 	TLSKey                 string
 }


### PR DESCRIPTION
This adds TLS support to the relay exposed endpoint, closing #62.

It also moves the listener to a go func so the listening port properly logs.