### PR TITLE
replace `DYNAMODB_ENABLED` with `USE_DYNAMODB` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Note that the TLS and password options can also be specified as part of the URL:
 
 Property in file    | Environment var    | Type    | Default | Description
 ------------------- | ------------------ | :-----: | :------ | -----------
-`enabled`           | `DYNAMODB_ENABLED` | Boolean | `false` | Enables DynamoDB.
+`enabled`           | `USE_DYNAMODB`     | Boolean | `false` | Enables DynamoDB.
 `tableName`         | `DYNAMODB_TABLE`   | String  |         | The DynamoDB table name, if you are using the same table for all environments. Otherwise, omit this and specify it in each environment section. (Note, credentials and region are controlled by the usual AWS environment variables and/or local AWS configuration files.)
 `localTtl`          | `CACHE_TTL`        | Number  | `30000`     | Length of time (in milliseconds) that database items can be cached in memory.
 


### PR DESCRIPTION
The documentation states that one should set the environment variable `DYNAMODB_ENABLED` to enable persisting flags to a DynamoDB table. However, the variable is really `USE_DYNAMODB`:

https://github.com/launchdarkly/ld-relay/blob/f8ffe0d3c3c80f1d5cfbff82c70aa690a2cf81be/config.go#L402

This PR updates the `README.md` accordingly.