### PR TITLE
prepare 6.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly Relay will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [6.0.3] - 2020-10-26
+### Fixed:
+- Fixed a dependency path that could cause a compiler error (`code in directory $GOPATH/src/github.com/go-gcfg/gcfg expects import "gopkg.in/gcfg.v1"`) when building the Relay Proxy from source code in some cases.
+
 ## [6.0.2] - 2020-10-20
 ### Fixed:
 - If a flag or segment was deleted in LaunchDarkly after the Relay Proxy started up, SDK clients that connected to Relay Proxy endpoints after that point could receive an unexpected null value for that flag or segment in the JSON data. This would cause an error in some SDKs causing their stream connections to stop working. This bug was introduced in version 6.0.0.

--- a/config/config_from_file.go
+++ b/config/config_from_file.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-gcfg/gcfg"
+	"gopkg.in/gcfg.v1"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldlog"
 )

--- a/docs/in-app.md
+++ b/docs/in-app.md
@@ -56,7 +56,7 @@ Alternatively, you can parse the configuration from a string that is in the same
 ```go
 import (
     "github.com/launchdarkly/ld-relay/v6/config"
-    "github.com/go-gcfg/gcfg"
+    "gopkg.in/gcfg.v1"
 )
 
 var configString = `

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20190726131236-c7b72e836616
 	github.com/antihax/optional v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.15.74
-	github.com/go-gcfg/gcfg v1.2.3
 	github.com/gomodule/redigo v1.8.2
 	github.com/googleapis/gax-go v2.0.0+incompatible // indirect
 	github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f // indirect
@@ -32,7 +31,7 @@ require (
 	go.opencensus.io v0.21.0
 	google.golang.org/api v0.0.0-20180717000714-0025a57598c0 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.16.1 // indirect
-	gopkg.in/gcfg.v1 v1.2.3 // indirect
+	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/launchdarkly/go-sdk-common.v2 v2.0.1
 	gopkg.in/launchdarkly/go-sdk-events.v1 v1.0.0
 	gopkg.in/launchdarkly/go-server-sdk-evaluation.v1 v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/go-gcfg/gcfg v1.2.3 h1:8X/LtK7rOSSGqvh4gHqR9wpWOIsq3tGCH2t0R2mgEUU=
-github.com/go-gcfg/gcfg v1.2.3/go.mod h1:D+YdKk714qkU4V0pntcxhDsrHgQDmI91IEbXXqwRZqA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/relay/version/version.go
+++ b/relay/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version is the package version
-const Version = "6.0.2"
+const Version = "6.0.3"


### PR DESCRIPTION
## [6.0.3] - 2020-10-26
### Fixed:
- Fixed a dependency path that could cause a compiler error (`code in directory $GOPATH/src/github.com/go-gcfg/gcfg expects import "gopkg.in/gcfg.v1"`) when building the Relay Proxy from source code in some cases.