### PR TITLE
Release 6.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly Relay will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [6.6.5] - 2022-03-17
+### Fixed:
+- Updated Docker image to use Alpine 3.14.4. The previous Alpine version, 3.14.3, was reported to have security vulnerability [CVE-2022-0778](https://nvd.nist.gov/vuln/detail/CVE-2022-0778) in OpenSSL, although the Relay Proxy itself uses Go's implementation of TLS rather than OpenSSL.
+
 ## [6.6.4] - 2022-02-07
 ### Fixed:
 - In auto-configuration mode, if the auto-configuration key is invalid, the Relay Proxy should exit with an error code just as it would for other kinds of invalid configuration properties, since there is no way for it to perform any useful functions without having environment information. ([#165](https://github.com/launchdarkly/ld-relay/issues/165))

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV GOPATH=/go
 
 RUN go build -a -o ldr .
 
-FROM alpine:3.14.3
+FROM alpine:3.14.4
 
 RUN addgroup -g 1000 -S ldr-user && \
     adduser -u 1000 -S ldr-user -G ldr-user && \

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -2,7 +2,7 @@
 
 # See .ldrelease/config.yml for an explanation of the build/release process.
 
-FROM alpine:3.14.3
+FROM alpine:3.14.4
 # See "Runtime platform versions" in CONTRIBUTING.md
 
 RUN apk add --no-cache \

--- a/relay/version/version.go
+++ b/relay/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version is the package version
-const Version = "6.6.4"
+const Version = "6.6.5"


### PR DESCRIPTION
## [6.6.5] - 2022-03-17
### Fixed:
- Updated Docker image to use Alpine 3.14.4. The previous Alpine version, 3.14.3, was reported to have security vulnerability [CVE-2022-0778](https://nvd.nist.gov/vuln/detail/CVE-2022-0778) in OpenSSL, although the Relay Proxy itself uses Go's implementation of TLS rather than OpenSSL.