### PR TITLE
fix empty response body when allowedOrigins is set

### DIFF
--- a/internal/core/middleware/middleware.go
+++ b/internal/core/middleware/middleware.go
@@ -129,14 +129,14 @@ func CORS(next http.Handler) http.Handler {
 			headers = corsContext.AllowedHeaders()
 		}
 		if len(domains) > 0 {
+			domain := domains[0]
 			for _, d := range domains {
 				if r.Header.Get("Origin") == d {
-					browser.SetCORSHeaders(w, d, headers)
-					return
+					domain = d
+					break
 				}
 			}
-			// Not a valid origin, set allowed origin to any allowed origin
-			browser.SetCORSHeaders(w, domains[0], headers)
+			browser.SetCORSHeaders(w, domain, headers)
 		} else {
 			origin := browser.DefaultAllowedOrigin
 			if r.Header.Get("Origin") != "" {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

When setting the allowedOrigins to something other than `*`, as in a real domain, we do not see any response body for `GET` requests. This change stops the short-circuiting that was happening if an origin was matched.

**Describe alternatives you've considered**

I thought about always passing `*` in production as an absolute last resort.

**Additional context**

Add any other context about the pull request here.
