### PR TITLE
Update link to Relay usage doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can configure the Relay Proxy to proxy multiple environment streams, even ac
 
 ## When should I use the LaunchDarkly Relay Proxy?
 
-To learn more about appropriate use cases for the Relay Proxy, read [Should I use the Relay Proxy?](https://docs.launchdarkly.com/home/advanced/relay-proxy#should-i-use-the-relay-proxy).
+To learn more about appropriate use cases for the Relay Proxy, read [Determining whether to use the Relay Proxy](https://docs.launchdarkly.com/home/relay-proxy/determining).
 
 
 ## Getting started


### PR DESCRIPTION
Relay docs were updated recently and I noticed this link was no longer pointing to the correct place. It may be worth checking other links as well since there were some pretty significant changes to the doc structure.