### PR TITLE
Add curl to relay Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM golang:1.20.7-alpine3.18 as builder
 
 RUN apk --no-cache add \
     libc-dev \
+    curl \
  && rm -rf /var/cache/apk/*
 
 ARG SRC_DIR=/go/ld-relay

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -7,6 +7,7 @@ FROM alpine:3.18.3
 
 RUN apk add --no-cache \
     ca-certificates \
+    curl \
  && apk add --upgrade libcrypto1.1 libssl1.1 \
  && update-ca-certificates \
  && rm -rf /var/cache/apk/*


### PR DESCRIPTION
**Requirements**

- [n/a] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/ld-relay-helm defines a simple readiness probe using the /status endpoint, which always returns 200 status (interpreted as healthy) when the relay is running.  Parsing the payload is necessary to detect a degraded status, which cannot be done using the simple httpGet probe handler.  Using an exec command for the probe combined with a grep, as follows, is viable, but requires that the relay image be rebuilt to include the curl command.

  readinessProbe:
    httpGet: null
    failureThreshold: 1
    exec:
      command:
        - sh
        - -c
        - >-
          curl -s -X GET "http://127.0.0.1:8030/status" |
          grep -q healthy

**Describe the solution you've provided**

By adding curl to the Dockerfile and Dockerfile.gorelease, the relay images will include curl by default.

**Describe alternatives you've considered**

An alternative would be to create a new endpoint that returns a different status code for degraded health status.  That would be more complex to implement but might be a useful future enhancement.  There is no conflict between adding curl and this alternative approach; if in the future such an endpoint is added, having curl in the image will still provide more flexibility.

**Additional context**

No additional context for this change, but just for awareness, the inclusion of httpGet: null in the example above (which would be used in the helm chart) is needed to disable the default httpGet handler in the helm chart, as each probe is only allowed to use one handler (httpGet vs. exec in this case).  Also, setting failureThreshold to 1 (down from default 3) is a more conservative approach as it will cause a degraded (not-healthy) relay to be taken out of service sooner, potentially allowing newly started clients to find a healthy relay faster if there are multiple relays running in the cluster.