### PR TITLE
Modify the archive manager so that atomic updates of the configuration archive work correctly.

### DIFF
--- a/internal/filedata/archive_manager.go
+++ b/internal/filedata/archive_manager.go
@@ -2,6 +2,7 @@ package filedata
 
 import (
 	"io"
+	"path/filepath"
 	"os"
 	"sync"
 	"time"
@@ -80,7 +81,7 @@ func NewArchiveManager(
 		// COVERAGE: can't cause this condition in unit tests - unexpected failure of fsnotify package
 		return nil, errCreateArchiveManagerFailed(filePath, err)
 	}
-	if err := watcher.Add(filePath); err != nil {
+	if err := watcher.Add(filepath.Dir(filePath)); err != nil {
 		return nil, errCreateArchiveManagerFailed(filePath, err) // COVERAGE: see above
 	}
 	am.watcher = watcher

--- a/internal/filedata/archive_manager_test.go
+++ b/internal/filedata/archive_manager_test.go
@@ -109,6 +109,28 @@ func TestFileUpdatedWithValidDataAddedEnvironment(t *testing.T) {
 	})
 }
 
+func TestFileAtomicUpdatedWithValidDataAddedEnvironment(t *testing.T) {
+	archiveManagerTest(t, func(filePath string) {
+		writeAtomicArchive(t, filePath, false, nil, testEnv1)
+	}, func(p archiveManagerTestParams) {
+		require.NoError(t, p.archiveManagerError)
+
+		p.expectEnvironmentsAdded(testEnv1)
+
+		writeAtomicArchive(t, p.filePath, false, nil, testEnv1, testEnv2)
+
+		p.expectEnvironmentsAdded(testEnv2)
+		p.expectReloaded()
+	})
+}
+
+func writeAtomicArchive(t *testing.T, filePath string, compressed bool, modifyFn func(dirPath string), envs ...testEnv) {
+	tmpFilePath := fmt.Sprintf("%s.%d", filePath, time.Now().UnixNano())
+	writeArchive(t, tmpFilePath, compressed, modifyFn, envs)
+	// do this as an atomic operation
+	os.Rename(tmpFilePath, filePath)
+}
+
 func TestFileUpdatedWithValidDataUpdatedEnvironmentMetadataOnly(t *testing.T) {
 	archiveManagerTest(t, func(filePath string) {
 		writeArchive(t, filePath, false, nil, testEnv1, testEnv2)

--- a/internal/filedata/archive_manager_test.go
+++ b/internal/filedata/archive_manager_test.go
@@ -126,7 +126,7 @@ func TestFileAtomicUpdatedWithValidDataAddedEnvironment(t *testing.T) {
 
 func writeAtomicArchive(t *testing.T, filePath string, compressed bool, modifyFn func(dirPath string), envs ...testEnv) {
 	tmpFilePath := fmt.Sprintf("%s.%d", filePath, time.Now().UnixNano())
-	writeArchive(t, tmpFilePath, compressed, modifyFn, envs)
+	writeArchive(t, tmpFilePath, compressed, modifyFn, envs...)
 	// do this as an atomic operation
 	os.Rename(tmpFilePath, filePath)
 }

--- a/internal/filedata/archive_manager_test.go
+++ b/internal/filedata/archive_manager_test.go
@@ -121,6 +121,11 @@ func TestFileAtomicUpdatedWithValidDataAddedEnvironment(t *testing.T) {
 
 		p.expectEnvironmentsAdded(testEnv2)
 		p.expectReloaded()
+
+		writeAtomicArchive(t, p.filePath, false, nil, testEnv1)
+
+		p.expectEnvironmentsDeleted(testEnv2)
+		p.expectReloaded()
 	})
 }
 

--- a/internal/filedata/archive_manager_test.go
+++ b/internal/filedata/archive_manager_test.go
@@ -124,16 +124,9 @@ func TestFileAtomicUpdatedWithValidDataAddedEnvironment(t *testing.T) {
 
 		writeAtomicArchive(t, p.filePath, false, nil, testEnv1)
 
-		p.expectEnvironmentsDeleted(testEnv2)
+		p.expectEnvironmentsDeleted(testEnv2.id())
 		p.expectReloaded()
 	})
-}
-
-func writeAtomicArchive(t *testing.T, filePath string, compressed bool, modifyFn func(dirPath string), envs ...testEnv) {
-	tmpFilePath := fmt.Sprintf("%s.%d", filePath, time.Now().UnixNano())
-	writeArchive(t, tmpFilePath, compressed, modifyFn, envs...)
-	// do this as an atomic operation
-	os.Rename(tmpFilePath, filePath)
 }
 
 func TestFileUpdatedWithValidDataUpdatedEnvironmentMetadataOnly(t *testing.T) {

--- a/internal/filedata/testdata_test.go
+++ b/internal/filedata/testdata_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"

--- a/internal/filedata/testdata_test.go
+++ b/internal/filedata/testdata_test.go
@@ -170,6 +170,13 @@ func withTestData(fn func(dirPath string), envs ...testEnv) {
 	})
 }
 
+func writeAtomicArchive(t *testing.T, filePath string, compressed bool, modifyFn func(dirPath string), envs ...testEnv) {
+	tmpFilePath := fmt.Sprintf("%s.%d", filePath, time.Now().UnixNano())
+	writeArchive(t, tmpFilePath, compressed, modifyFn, envs...)
+	// do this as an atomic operation
+	os.Rename(tmpFilePath, filePath)
+}
+
 func writeArchive(t *testing.T, filePath string, compressed bool, modifyFn func(dirPath string), envs ...testEnv) {
 	_ = os.Remove(filePath)
 


### PR DESCRIPTION
**Requirements**
- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**
https://github.com/launchdarkly/ld-relay/issues/280

**Describe the solution you've provided**
Rather than use `nsnotify` to watch the explicit configuration file, we monitor the parent directory which means both slow-copy and atomic update semantics both work as expected.

**Describe alternatives you've considered**
In our current use case we have deferred to slow-copy semantics rather than atomic updates.
