### PR TITLE
chore: enable check-go-version workflow

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -15,7 +15,6 @@ jobs:
 
   check-go-eol:
     needs: go-versions
-    if: github.repository == 'launchdarkly/ld-relay-private'
     permissions:
       issues: write
       contents: read


### PR DESCRIPTION
Runs the `check-go-versions` workflow in this repo.