### PR TITLE
chore(v7): only tag latest Docker images on default branch

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         echo $DOCKER_TOKEN | docker login --username $DOCKER_USERNAME --password-stdin
     - name: Check if default branch
-      uses: launchdarkly/gh-actions/actions/default-branch@b954c1539a76dff335127ec5210d47ddfaa8e5a6
+      uses: launchdarkly/gh-actions/actions/default-branch@e263727a30ba88045416f413b9ffa67c0478ae6f
       id: default-branch
       with:
         token: ${{ inputs.token }}

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         echo $DOCKER_TOKEN | docker login --username $DOCKER_USERNAME --password-stdin
     - name: Check if default branch
-      uses: launchdarkly/gh-actions/actions/default-branch@e263727a30ba88045416f413b9ffa67c0478ae6f
+      uses: launchdarkly/gh-actions/actions/default-branch@ead22860bb097df32a9a1a2d06066922b00b86ca
       id: default-branch
       with:
         token: ${{ inputs.token }}

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -28,11 +28,6 @@ runs:
       shell: bash
       run: |
         echo $DOCKER_TOKEN | docker login --username $DOCKER_USERNAME --password-stdin
-    - name: Check if default branch
-      uses: launchdarkly/gh-actions/actions/default-branch@ead22860bb097df32a9a1a2d06066922b00b86ca
-      id: default-branch
-      with:
-        token: ${{ inputs.token }}
     - name: Run Goreleaser
       uses: goreleaser/goreleaser-action@v5
       with:
@@ -40,7 +35,7 @@ runs:
         args: release --clean ${{ inputs.dry-run == 'true' && '--skip=publish' || '' }}
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
-        DEFAULT_BRANCH: ${{ steps.default-branch.outputs.value }}
+        NOT_DEFAULT_BRANCH: ${{ github.ref_name != github.event.repository.default_branch }}
 
     - name: Upload Release Artifacts
       shell: bash

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -28,6 +28,11 @@ runs:
       shell: bash
       run: |
         echo $DOCKER_TOKEN | docker login --username $DOCKER_USERNAME --password-stdin
+    - name: Check if default branch
+      uses: launchdarkly/gh-actions/actions/default-branch@b954c1539a76dff335127ec5210d47ddfaa8e5a6
+      id: default-branch
+      with:
+        token: ${{ inputs.token }}
     - name: Run Goreleaser
       uses: goreleaser/goreleaser-action@v5
       with:
@@ -35,6 +40,7 @@ runs:
         args: release --clean ${{ inputs.dry-run == 'true' && '--skip=publish' || '' }}
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
+        DEFAULT_BRANCH: ${{ steps.default-branch.outputs.value }}
 
     - name: Upload Release Artifacts
       shell: bash

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,7 +83,7 @@ dockers:
     goos: linux
     goarch: '386'
     dockerfile: Dockerfile.goreleaser
-    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
+    skip_push: "{{ .Env.NOT_DEFAULT_BRANCH }}"
     build_flag_templates:
     - "--pull"
     - "--platform=linux/386"
@@ -108,7 +108,7 @@ dockers:
     goos: linux
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
-    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
+    skip_push: "{{ .Env.NOT_DEFAULT_BRANCH }}"
     build_flag_templates:
     - "--pull"
     - "--platform=linux/amd64"
@@ -135,7 +135,7 @@ dockers:
     goarch: arm
     goarm: 7
     dockerfile: Dockerfile.goreleaser
-    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
+    skip_push: "{{ .Env.NOT_DEFAULT_BRANCH }}"
     build_flag_templates:
     - "--pull"
     - "--platform=linux/arm/v7"
@@ -160,7 +160,7 @@ dockers:
     goos: linux
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
-    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
+    skip_push: "{{ .Env.NOT_DEFAULT_BRANCH }}"
     build_flag_templates:
     - "--pull"
     - "--platform=linux/arm64/v8"
@@ -183,7 +183,7 @@ docker_manifests:
     - "launchdarkly/ld-relay:v{{ .Major }}-i386"
 
   - name_template: "launchdarkly/ld-relay:latest"
-    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
+    skip_push: "{{ .Env.NOT_DEFAULT_BRANCH }}"
     image_templates:
     - "launchdarkly/ld-relay:latest-amd64"
     - "launchdarkly/ld-relay:latest-armv7"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,7 +67,6 @@ dockers:
   - image_templates:
     - "launchdarkly/ld-relay:{{ .Version }}-i386"
     - "launchdarkly/ld-relay:v{{ .Major }}-i386"
-    - "launchdarkly/ld-relay:latest-i386"
     use: buildx
     goos: linux
     goarch: '386'
@@ -77,11 +76,23 @@ dockers:
     - "--pull"
     - "--platform=linux/386"
 
+  # i386 - latest tag
+  - image_templates:
+      - "launchdarkly/ld-relay:latest-i386"
+    use: buildx
+    goos: linux
+    goarch: '386'
+    dockerfile: Dockerfile.goreleaser
+    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
+
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/386"
+
   # AMD64
   - image_templates:
     - "launchdarkly/ld-relay:{{ .Version }}-amd64"
     - "launchdarkly/ld-relay:v{{ .Major }}-amd64"
-    - "launchdarkly/ld-relay:latest-amd64"
     use: buildx
     goos: linux
     goarch: amd64
@@ -91,11 +102,22 @@ dockers:
     - "--pull"
     - "--platform=linux/amd64"
 
+  # AMD64 - latest tag
+  - image_templates:
+      - "launchdarkly/ld-relay:latest-amd64"
+    use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.goreleaser
+    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/amd64"
+
   # ARMv7
   - image_templates:
     - "launchdarkly/ld-relay:{{ .Version }}-armv7"
     - "launchdarkly/ld-relay:v{{ .Major }}-armv7"
-    - "launchdarkly/ld-relay:latest-armv7"
     use: buildx
     goos: linux
     goarch: arm
@@ -106,11 +128,23 @@ dockers:
     - "--pull"
     - "--platform=linux/arm/v7"
 
+  # ARMv7 - latest tag
+  - image_templates:
+      - "launchdarkly/ld-relay:latest-armv7"
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    dockerfile: Dockerfile.goreleaser
+    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/arm/v7"
+
   # ARM64v8
   - image_templates:
     - "launchdarkly/ld-relay:{{ .Version }}-arm64v8"
     - "launchdarkly/ld-relay:v{{ .Major }}-arm64v8"
-    - "launchdarkly/ld-relay:latest-arm64v8"
     use: buildx
     goos: linux
     goarch: arm64
@@ -119,6 +153,19 @@ dockers:
     build_flag_templates:
     - "--pull"
     - "--platform=linux/arm64/v8"
+
+  # ARM64v8 - latest tag
+  - image_templates:
+      - "launchdarkly/ld-relay:latest-arm64v8"
+    use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/arm64/v8"
+
 docker_manifests:
   - name_template: "launchdarkly/ld-relay:{{ .Version}}"
     skip_push: false
@@ -131,15 +178,15 @@ docker_manifests:
   - name_template: "launchdarkly/ld-relay:v{{ .Major }}"
     skip_push: false
     image_templates:
-      - "launchdarkly/ld-relay:v{{ .Major }}-amd64"
-      - "launchdarkly/ld-relay:v{{ .Major }}-armv7"
-      - "launchdarkly/ld-relay:v{{ .Major }}-arm64v8"
-      - "launchdarkly/ld-relay:v{{ .Major }}-i386"
+    - "launchdarkly/ld-relay:v{{ .Major }}-amd64"
+    - "launchdarkly/ld-relay:v{{ .Major }}-armv7"
+    - "launchdarkly/ld-relay:v{{ .Major }}-arm64v8"
+    - "launchdarkly/ld-relay:v{{ .Major }}-i386"
 
   - name_template: "launchdarkly/ld-relay:latest"
-    skip_push: false
+    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
     image_templates:
-      - "launchdarkly/ld-relay:latest-amd64"
-      - "launchdarkly/ld-relay:latest-armv7"
-      - "launchdarkly/ld-relay:latest-arm64v8"
-      - "launchdarkly/ld-relay:latest-i386"
+    - "launchdarkly/ld-relay:latest-amd64"
+    - "launchdarkly/ld-relay:latest-armv7"
+    - "launchdarkly/ld-relay:latest-arm64v8"
+    - "launchdarkly/ld-relay:latest-i386"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,7 +83,7 @@ dockers:
     goos: linux
     goarch: '386'
     dockerfile: Dockerfile.goreleaser
-    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
+    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
     build_flag_templates:
     - "--pull"
     - "--platform=linux/386"
@@ -108,7 +108,7 @@ dockers:
     goos: linux
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
-    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
+    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
     build_flag_templates:
     - "--pull"
     - "--platform=linux/amd64"
@@ -135,7 +135,7 @@ dockers:
     goarch: arm
     goarm: 7
     dockerfile: Dockerfile.goreleaser
-    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
+    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
     build_flag_templates:
     - "--pull"
     - "--platform=linux/arm/v7"
@@ -160,7 +160,7 @@ dockers:
     goos: linux
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
-    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
+    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
     build_flag_templates:
     - "--pull"
     - "--platform=linux/arm64/v8"
@@ -183,7 +183,7 @@ docker_manifests:
     - "launchdarkly/ld-relay:v{{ .Major }}-i386"
 
   - name_template: "launchdarkly/ld-relay:latest"
-    skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
+    skip_push: "{{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}"
     image_templates:
     - "launchdarkly/ld-relay:latest-amd64"
     - "launchdarkly/ld-relay:latest-armv7"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,16 +78,15 @@ dockers:
 
   # i386 - latest tag
   - image_templates:
-      - "launchdarkly/ld-relay:latest-i386"
+    - "launchdarkly/ld-relay:latest-i386"
     use: buildx
     goos: linux
     goarch: '386'
     dockerfile: Dockerfile.goreleaser
     skip_push: {{ if .Env.DEFAULT_BRANCH eq .Major }}false{{ else }}true{{ end }}
-
     build_flag_templates:
-      - "--pull"
-      - "--platform=linux/386"
+    - "--pull"
+    - "--platform=linux/386"
 
   # AMD64
   - image_templates:
@@ -104,7 +103,7 @@ dockers:
 
   # AMD64 - latest tag
   - image_templates:
-      - "launchdarkly/ld-relay:latest-amd64"
+    - "launchdarkly/ld-relay:latest-amd64"
     use: buildx
     goos: linux
     goarch: amd64
@@ -130,7 +129,7 @@ dockers:
 
   # ARMv7 - latest tag
   - image_templates:
-      - "launchdarkly/ld-relay:latest-armv7"
+    - "launchdarkly/ld-relay:latest-armv7"
     use: buildx
     goos: linux
     goarch: arm
@@ -156,7 +155,7 @@ dockers:
 
   # ARM64v8 - latest tag
   - image_templates:
-      - "launchdarkly/ld-relay:latest-arm64v8"
+    - "launchdarkly/ld-relay:latest-arm64v8"
     use: buildx
     goos: linux
     goarch: arm64


### PR DESCRIPTION
When a v7 release happens, one of the docker images published will be `ld-relay:latest` (this is also true for the individual architecture images, after the ARM builds PR was just merged.) The same occurs for v8.

This is confusing, to say the least.  You might get a `v7` or `v8` revision just depending on the order of Relay releases. 

Although one shouldn't ever rely on `latest` tag in production, some may, and it's the default when you run `docker pull`.

This PR modifies the publishing step to only push `latest` and `latest-{architecture}` images from the default branch (which is currently `v8`).  