### PR TITLE
fix(deps): bump supported Go versions to 1.22 and 1.21

### DIFF
--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,2 +1,2 @@
-latest=1.21.6
-penultimate=1.20.13
+latest=1.22.0
+penultimate=1.21.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # This is a standalone Dockerfile that does not depend on goreleaser building the binary
 # It is NOT the version that is pushed to dockerhub
-FROM golang:1.21.6-alpine3.19 as builder
+FROM golang:1.22.0-alpine3.19 as builder
 # See "Runtime platform versions" in CONTRIBUTING.md
 
 RUN apk --no-cache add \


### PR DESCRIPTION
Closes https://github.com/launchdarkly/ld-relay/issues/303.