### PR TITLE
ci: add v7 branch to matrix for installation tests + security scans

### DIFF
--- a/.github/workflows/daily-installation-test.yml
+++ b/.github/workflows/daily-installation-test.yml
@@ -1,20 +1,5 @@
 name: 'Install Relay Go Module'
 on:
-  workflow_dispatch:
-    inputs:
-      relay-version:
-        description: "Relay version to install, e.g. 'latest'"
-        type: string
-        required: false
-      relay-major:
-        description: "Relay major version to install, e.g. 'v8'."
-        type: string
-        required: false
-      branch:
-        description: "Branch to test."
-        type: string
-        required: false
-
   schedule:
     - cron: "0 8 * * *"
 
@@ -29,12 +14,12 @@ jobs:
     strategy:
         matrix:
             go-version: ${{ fromJson(needs.go-versions.outputs.matrix) }}
+            relay-major: ['v7', 'v8']
+        fail-fast: false
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
       - uses: ./.github/actions/install-relay
         with:
           go-version: ${{ matrix.go-version }}
-          relay-version: ${{ inputs.relay-version }}
-          relay-major: ${{ inputs.relay-major }}
+          relay-version: 'latest'
+          relay-major: ${{ matrix.relay-major }}

--- a/.github/workflows/daily-integration-tests.yml
+++ b/.github/workflows/daily-integration-tests.yml
@@ -17,7 +17,6 @@ jobs:
   integration-test:
     needs: go-versions
     strategy:
-      # Let each job fail independently.
       fail-fast: false
       matrix:
         environment: ['staging', 'production']

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -1,31 +1,21 @@
 name: Security Scan
 
 on:
-  workflow_dispatch:
-    inputs:
-      docker-image:
-        description: 'The image. Defaults to launchdarkly/ld-relay:latest.'
-        type: string
-        required: false
-
   schedule:
     - cron: "0 8 * * *"
 
 jobs:
   scan-relay:
+    strategy:
+      matrix:
+        tag: ['latest', 'v7', 'v8']
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Determine image
-        id: image
-        env:
-          IMAGE: ${{ inputs.docker-image }}
-        run: |
-          echo "value=${IMAGE:-launchdarkly/ld-relay:latest}" >> $GITHUB_OUTPUT
-
       - uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ steps.image.outputs.value }}
+          image-ref: launchdarkly/ld-relay:${{ matrix.tag }}
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true


### PR DESCRIPTION
Sister PR: https://github.com/launchdarkly/ld-relay/pull/318

This adds `v7` into the installation test + security scan scheduled workflows. 