### PR TITLE
ci: improve job name for Go Install workflow

### DIFF
--- a/.github/workflows/daily-installation-test.yml
+++ b/.github/workflows/daily-installation-test.yml
@@ -8,7 +8,7 @@ jobs:
     uses: ./.github/workflows/go-versions.yml
 
   install-relay:
-    name: ${{ format('Go Install Test (Go {0})', matrix.go-version) }}
+    name: ${{ format('Installation Test (Go {0}, Relay {1})', matrix.go-version, matrix.relay-major) }}
     needs: go-versions
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
When looking at the workflow runs for the installation test, it's confusing to tell which Relay branch was tested. This adds the branch to the job name.