### PR TITLE
docs: fix broken badges [v7]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # LaunchDarkly Relay Proxy
 
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml)
-[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml)
 
 ## About the LaunchDarkly Relay Proxy
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml)
-[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan.yml)
-[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml)
 
 ## About the LaunchDarkly Relay Proxy
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LaunchDarkly Relay Proxy
 
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml)
-[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml?branch=v7/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml)
+[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml)
 


### PR DESCRIPTION
The integration test, security scan, and installation test badges aren't relevant for the v7 branch as these are scheduled jobs run on the v8 branch. 