### PR TITLE
ci: run check-go-versions workflow on v7 and v8 branches

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -67,6 +67,7 @@ jobs:
           branch: "launchdarklyreleasebot/update-to-go${{ env.officialLatestVersion }}-${{ matrix.branch }}"
           author: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
           committer: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
+          labels: ${{ matrix.branch }}
           title: "fix(deps): bump supported Go versions to ${{ env.officialLatestVersion }} and ${{ env.officialPenultimateVersion }}"
           commit-message: "Bumps from Go ${{ steps.go-versions.outputs.latest }} -> ${{ env.officialLatestVersion }} and ${{ steps.go-versions.outputs.penultimate }} -> ${{ env.officialPenultimateVersion }}."
           body: |

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -5,15 +5,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  go-versions:
-    uses: ./.github/workflows/go-versions.yml
-
   check-go-eol:
-    needs: go-versions
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
+    outputs:
+        latest: ${{ steps.parse.outputs.latest }}
+        penultimate: ${{ steps.parse.outputs.penultimate }}
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
@@ -27,12 +23,36 @@ jobs:
           debug: true
         # Parse the response JSON and insert into environment variables for the next step.
       - name: Parse officially supported Go versions
+        id: parse
         run: |
-          echo "officialLatestVersion=${{ fromJSON(env.fetch-api-data)[0].latest }}" >> $GITHUB_ENV
-          echo "officialPenultimateVersion=${{ fromJSON(env.fetch-api-data)[1].latest }}" >> $GITHUB_ENV
+          echo "latest=${{ fromJSON(env.fetch-api-data)[0].latest }}" >> $GITHUB_OUTPUT
+          echo "penultimate=${{ fromJSON(env.fetch-api-data)[1].latest }}" >> $GITHUB_OUTPUT
+
+
+  create-prs:
+    permissions:
+      contents: write
+      pull-requests: write
+    needs: check-go-eol
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ["v7", "v8"]
+      fail-fast: false
+    env:
+      officialLatestVersion: ${{ needs.check-go-eol.outputs.latest }}
+      officialPenultimateVersion: ${{ needs.check-go-eol.outputs.penultimate }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Get current Go versions
+        id: go-versions
+        run:  cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
 
       - name: Run update script
-        if: needs.go-versions.outputs.latest != env.officialLatestVersion
+        if: steps.go-versions.outputs.latest != env.officialLatestVersion
         id: update
         run: ./scripts/update-go-release-version.sh ${{ env.officialLatestVersion }} ${{ env.officialPenultimateVersion }} \
 
@@ -48,7 +68,7 @@ jobs:
           author: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
           committer: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
           title: "fix(deps): bump supported Go versions to ${{ env.officialLatestVersion }} and ${{ env.officialPenultimateVersion }}"
-          commit-message: "Bumps from Go ${{ needs.go-versions.outputs.latest }} -> ${{ env.officialLatestVersion }} and ${{ needs.go-versions.outputs.penultimate }} -> ${{ env.officialPenultimateVersion }}."
+          commit-message: "Bumps from Go ${{ steps.go-versions.outputs.latest }} -> ${{ env.officialLatestVersion }} and ${{ steps.go-versions.outputs.penultimate }} -> ${{ env.officialPenultimateVersion }}."
           body: |
             It's time to update Relay's supported Go versions, due to a recent upstream Go release.
 
@@ -58,8 +78,8 @@ jobs:
             
             |             | Current repo configuration         | Desired repo configuration                                                                                          |
             |-------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-            | Latest      | ${{ needs.go-versions.outputs.latest }}      | [${{ env.officialLatestVersion }}](https://go.dev/doc/devel/release#go${{ env.officialLatestVersion }})           |
-            | Penultimate | ${{ needs.go-versions.outputs.penultimate }}| [${{ env.officialPenultimateVersion }}](https://go.dev/doc/devel/release#go${{ env.officialPenultimateVersion }}) |
+            | Latest      | ${{ steps.go-versions.outputs.latest }}      | [${{ env.officialLatestVersion }}](https://go.dev/doc/devel/release#go${{ env.officialLatestVersion }})           |
+            | Penultimate | ${{ steps.go-versions.outputs.penultimate }}| [${{ env.officialPenultimateVersion }}](https://go.dev/doc/devel/release#go${{ env.officialPenultimateVersion }}) |
 
 
             Run locally:

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -64,7 +64,7 @@ jobs:
           add-paths: |
             Dockerfile
             .github/variables/go-versions.env
-          branch: "launchdarklyreleasebot/update-to-go-${{ env.officialLatestVersion }}"
+          branch: "launchdarklyreleasebot/update-to-go${{ env.officialLatestVersion }}-${{ matrix.branch }}"
           author: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
           committer: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
           title: "fix(deps): bump supported Go versions to ${{ env.officialLatestVersion }} and ${{ env.officialPenultimateVersion }}"


### PR DESCRIPTION
Currently the automated PRs to update Go versions only runs on the v8 branch (because Github only triggers schedule events for the default branch.)

This refactors the workflow with an explicit matrix job so that we can get automated PRs on both branches.