### PR TITLE
chore: manually bump version constant

### DIFF
--- a/relay/version/version.go
+++ b/relay/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version is the package version
-const Version = "7.4.4" // {{ x-release-please-version }}
+const Version = "7.5.0" // {{ x-release-please-version }}


### PR DESCRIPTION
It turns out the last release-please run for `v7` branch didn't update `versions.go`. Not entirely sure why, but it didn't happen again - and this time it's probably because the `x-release-please-version` is now out of date. 

By manually fixing it, I'll re-run release-please and see if it bumps as expected. 