### PR TITLE
ci: do not specify release-type in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          release-type: simple
           token: ${{secrets.GITHUB_TOKEN}}
           target-branch: v7
 


### PR DESCRIPTION
Specifying it in the workflow and configuration file makes it use the wrong release type. It should only be specified in one place (the `release-please-config.json`.)