### PR TITLE
feat: add HOST config to control which network interface ld-relay binds to

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -133,6 +133,7 @@ type MainConfig struct {
 	StreamURI                  ct.OptURLAbsolute        `conf:"STREAM_URI"`
 	BaseURI                    ct.OptURLAbsolute        `conf:"BASE_URI"`
 	ClientSideBaseURI          ct.OptURLAbsolute        `conf:"CLIENT_SIDE_BASE_URI"`
+	Host                       string                   `conf:"HOST"`
 	Port                       ct.OptIntGreaterThanZero `conf:"PORT"`
 	InitTimeout                ct.OptDuration           `conf:"INIT_TIMEOUT"`
 	HeartbeatInterval          ct.OptDuration           `conf:"HEARTBEAT_INTERVAL"`

--- a/internal/application/server.go
+++ b/internal/application/server.go
@@ -14,6 +14,7 @@ import (
 // StartHTTPServer starts the server, with or without TLS. It returns immediately, starting the server
 // on a separate goroutine; if the server fails to start up, it sends an error to the error channel.
 func StartHTTPServer(
+	host string,
 	port int,
 	handler http.Handler,
 	tlsEnabled bool,
@@ -22,7 +23,7 @@ func StartHTTPServer(
 	loggers ldlog.Loggers,
 ) (*http.Server, <-chan error) {
 	srv := &http.Server{
-		Addr:              fmt.Sprintf(":%d", port),
+		Addr:              fmt.Sprintf("%s:%d", host, port),
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}

--- a/ld-relay.go
+++ b/ld-relay.go
@@ -60,8 +60,10 @@ func main() {
 	}
 
 	port := c.Main.Port.GetOrElse(config.DefaultPort)
+	host := c.Main.Host
 
 	_, errs := application.StartHTTPServer(
+		host,
 		port,
 		r,
 		c.Main.TLSEnabled,


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/ld-relay/issues/353

**Describe the solution you've provided**

By default, the existing behavior is preserved of binding all to network interfaces. However, if the config HOST is provided, ld-relay will attempt to bind that host on given PORT.

**Describe alternatives you've considered**

We could offer a boolean flag "BIND_LOCALHOST" or similar that would explicitly set the bind address to `localhost:PORT`. The provided option seemed more inline what I've seen in other projects, but I've no strong personal preference for either.

ALternatively we could allow users to specify a fully formed bind address including port and hostname in a single string. I don't like that option because we'd potentially break how folks configure how they instruct ld-relay where to run if they tried to provide both a fully formed address and a port. Keeping HOST and PORT distinct seems simpler to implement and reason about AFAICT.

**Additional context**

I'm not sure what this new config should be called 🤔 
