### PR TITLE
fix(deps): bump alpine to 3.19.1 (#366)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV GOPATH=/go
 
 RUN go build -a -o ldr .
 
-FROM alpine:3.19.0
+FROM alpine:3.19.1
 
 RUN addgroup -g 1000 -S ldr-user && \
     adduser -u 1000 -S ldr-user -G ldr-user && \

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,6 @@
 # This is the Dockerfile used for release (published to dockerhub by goreleaser)
 
-FROM alpine:3.19.0
+FROM alpine:3.19.1
 # See "Runtime platform versions" in CONTRIBUTING.md
 
 RUN apk add --no-cache \


### PR DESCRIPTION
Patches some CVEs in libcrypto and libssl3 in Alpine.
