### PR TITLE
docs: add badges for alpine/distroless daily security scans

### DIFF
--- a/.github/workflows/daily-security-scan-alpine.yml
+++ b/.github/workflows/daily-security-scan-alpine.yml
@@ -1,0 +1,21 @@
+name: Security Scan (Alpine)
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  scan-relay:
+    strategy:
+      matrix:
+        tag: ['latest', 'v7', 'v8']
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: launchdarkly/ld-relay:${{ matrix.tag }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true

--- a/.github/workflows/daily-security-scan-distroless.yml
+++ b/.github/workflows/daily-security-scan-distroless.yml
@@ -1,4 +1,4 @@
-name: Security Scan
+name: Security Scan (Distroless)
 
 on:
   schedule:
@@ -8,7 +8,7 @@ jobs:
   scan-relay:
     strategy:
       matrix:
-        tag: ['latest', 'v7', 'v8']
+        tag: ['latest-static-debian12-nonroot', 'v8-static-debian12-debug-nonroot']
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-alpine.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-alpine.yml)
-[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-distroless.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-alpine-distroless.yml)
+[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-distroless.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-distroless.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/launchdarkly/ld-relay)](https://hub.docker.com/r/launchdarkly/ld-relay)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/ci.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml)
-[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan.yml)
+[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-alpine.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-alpine.yml)
+[![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-distroless.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan-alpine-distroless.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/launchdarkly/ld-relay)](https://hub.docker.com/r/launchdarkly/ld-relay)
 


### PR DESCRIPTION
Since we now publish two sets of images (Alpine and Distroless), we should show badges for the daily security scan of both.

And, hopefully the Distroless badge will show green a higher % of the time than Alpine :) 

