### PR TITLE
build: fixing multiline GITHUB_OUTPUT variables

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -66,8 +66,8 @@ runs:
         image_and_digest=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Docker Manifest") | .path')
         image=$(echo "${image_and_digest}" | cut -d'@' -f1 | cut -d':' -f1)
         digest=$(echo "${image_and_digest}" | cut -d'@' -f2)
-        echo "name=$image" >> "$GITHUB_OUTPUT"
-        echo "digest=$digest" >> "$GITHUB_OUTPUT"
+        { echo 'name<<EOF'; echo $image; echo EOF } >> "$GITHUB_OUTPUT"
+        { echo 'digest<<EOF'; echo $digest; echo EOF } >> "$GITHUB_OUTPUT"
 
     - name: Upload Release Artifacts
       shell: bash

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -52,6 +52,7 @@ runs:
       env: 
         ARTIFACTS: ${{ steps.goreleaser.outputs.artifacts }}
       run: |
+        # Generate binary hashes
         set -euo pipefail
 
         checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
@@ -62,6 +63,7 @@ runs:
       env:
         ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
       run: |
+        # Generate image digest
         set -euo pipefail
         image_and_digest=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Docker Manifest") | .path')
         image=$(echo "${image_and_digest}" | cut -d'@' -f1 | cut -d':' -f1)


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

GITHUB_OUTPUT parameters don't work well with multiline strings. Following guidance here: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings to fix 

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
