### PR TITLE
feat: publish -alpine suffixed Docker images

### DIFF
--- a/.github/workflows/daily-security-scan-alpine.yml
+++ b/.github/workflows/daily-security-scan-alpine.yml
@@ -8,7 +8,7 @@ jobs:
   scan-relay:
     strategy:
       matrix:
-        tag: ['latest', 'v7', 'v8']
+        tag: ['latest', 'latest-alpine', 'v7', 'v8', 'v8-alpine']
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -213,7 +213,9 @@ dockers:
       - "--platform=linux/arm64/v8"
 
 docker_manifests:
-  # For the Alpine image
+  # For backwards compatibility, we publish the :latest, :vX, and :x.y.z tags for Alpine without any suffix
+  # indicating that the image is Alpine based (unlike the debian12 images). This is because it's what was done historically,
+  # and we cannot change it yet without breaking existing users.
   - name_template: "launchdarkly/ld-relay:{{ .Version}}"
     skip_push: false
     image_templates:
@@ -231,6 +233,32 @@ docker_manifests:
       - "launchdarkly/ld-relay:v{{ .Major }}-i386"
 
   - name_template: "launchdarkly/ld-relay:latest"
+    skip_push: false
+    image_templates:
+      - "launchdarkly/ld-relay:latest-amd64"
+      - "launchdarkly/ld-relay:latest-armv7"
+      - "launchdarkly/ld-relay:latest-arm64v8"
+      - "launchdarkly/ld-relay:latest-i386"
+
+  # We'll also create aliases for the Alpine-based image with the suffix "-alpine" to make it easier to distinguish
+  # from the debian12 image. This will also allow us to eventually deprecate the non-suffixed tags in a future major version.
+  - name_template: "launchdarkly/ld-relay:{{ .Version}}-alpine"
+    skip_push: false
+    image_templates:
+      - "launchdarkly/ld-relay:{{ .Version }}-amd64"
+      - "launchdarkly/ld-relay:{{ .Version }}-armv7"
+      - "launchdarkly/ld-relay:{{ .Version }}-arm64v8"
+      - "launchdarkly/ld-relay:{{ .Version }}-i386"
+
+  - name_template: "launchdarkly/ld-relay:v{{ .Major }}-alpine"
+    skip_push: false
+    image_templates:
+      - "launchdarkly/ld-relay:v{{ .Major }}-amd64"
+      - "launchdarkly/ld-relay:v{{ .Major }}-armv7"
+      - "launchdarkly/ld-relay:v{{ .Major }}-arm64v8"
+      - "launchdarkly/ld-relay:v{{ .Major }}-i386"
+
+  - name_template: "launchdarkly/ld-relay:latest-alpine"
     skip_push: false
     image_templates:
       - "launchdarkly/ld-relay:latest-amd64"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-integration-tests.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-security-scan.yml)
 [![Actions Status](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml/badge.svg)](https://github.com/launchdarkly/ld-relay/actions/workflows/daily-installation-test.yml)
+[![Docker Pulls](https://img.shields.io/docker/pulls/launchdarkly/ld-relay)](https://hub.docker.com/r/launchdarkly/ld-relay)
+
 
 ## About the LaunchDarkly Relay Proxy
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,9 +4,20 @@
 
 Using Docker is not required, but if you prefer using a Docker container we provide a Docker entrypoint to make this as easy as possible.
 
-We provide two distributions. The first is a based on Alpine Linux, while the second is based on Google's 
-["distroless"](https://github.com/GoogleContainerTools/distroless) debian12 images. 
+We provide images based on Alpine Linux and Google's 
+["distroless"](https://github.com/GoogleContainerTools/distroless) Debian12 images. 
 
+| Image              | Version                                                                                                             | Size                                                                                                                            | amd64 | armv7 | arm64v8 | i386 |
+|--------------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|-------|-------|---------|------|
+| Distroless         | ![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-nonroot)       | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-nonroot)       | ✅     | ✅     | ✅       | ❌    |                                                                                                   |
+| Distroless (debug) | ![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot) | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot) | ✅     | ✅     | ✅       | ❌    |
+| Alpine             | ![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest)                               | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest)                               | ✅     | ✅     | ✅       | ✅    |
+
+We recommend using the Distroless images, as automated security scanners regularly flag issues in Alpine even though 
+the Relay Proxy itself is unaffected. 
+
+Because Relay Proxy is a statically linked Go binary, it can take advantage of the reduced dependencies in the 
+Distroless base images.
 
 ## Local Development
 
@@ -50,10 +61,9 @@ $ docker run --name ld-relay --link redis:redis -e USE_REDIS=1 -e LD_ENV_test="s
 
 ## Production Deployment
 
-In production, you may choose between our Distroless or Alpine Linux images. We recommend using the Distroless
-images, as they present less of an attack surface, are smaller, and should require less continual patching.
+In production, you may choose between the Distroless or Alpine Linux images. 
 
-Please note that the default Distroless image does not contain a debug shell. 
+Please note that the default Distroless image does not contain a shell. 
 
 ### Distroless Variants
 
@@ -70,13 +80,3 @@ variant):
 ```shell
 docker exec -it [container name] /busybox/sh
 ```
-
-
-### Supported Architectures
-
-Alpine and Distroless are multi-arch images.
-
-| Image      | i386 | amd64 | armv7 | arm64v8 |
-|------------|------|-------|-------|---------|
-| Distroless | ❌    | ✅     | ✅     | ✅       |
-| Alpine     | ✅    | ✅     | ✅     | ✅       |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,11 +7,11 @@ Using Docker is not required, but if you prefer using a Docker container we prov
 We provide images based on Alpine Linux and Google's 
 ["distroless"](https://github.com/GoogleContainerTools/distroless) Debian12 images. 
 
-| Image              | Version                                                                                                             | Size                                                                                                                            | amd64 | armv7 | arm64v8 | i386 |
-|--------------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|-------|-------|---------|------|
-| Distroless         | ![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-nonroot)       | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-nonroot)       | ✅     | ✅     | ✅       | ❌    |                                                                                                   |
-| Distroless (debug) | ![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot) | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot) | ✅     | ✅     | ✅       | ❌    |
-| Alpine             | ![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest)                               | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest)                               | ✅     | ✅     | ✅       | ✅    |
+| Image              | Version                                                                                                                           | Size                                                                                                                                         | amd64 | armv7 | arm64v8 | i386 |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|-------|-------|---------|------|
+| Distroless         | [![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-nonroot)    ][dockerhub]    | [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-nonroot)][dockerhub]       | ✅     | ✅     | ✅       | ❌    |                                                                                                   |
+| Distroless (debug) | [![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot) ][dockerhub] | [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot)][dockerhub] | ✅     | ✅     | ✅       | ❌    |
+| Alpine             | [![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest)                    ][dockerhub]            | [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest)][dockerhub]                               | ✅     | ✅     | ✅       | ✅    |
 
 We recommend using the Distroless images, as automated security scanners regularly flag issues in Alpine even though 
 the Relay Proxy itself is unaffected. 
@@ -80,3 +80,5 @@ variant):
 ```shell
 docker exec -it [container name] /busybox/sh
 ```
+
+[dockerhub]: https://hub.docker.com/r/launchdarkly/ld-relay

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,11 +7,11 @@ Using Docker is not required, but if you prefer using a Docker container we prov
 We provide images based on Alpine Linux and Google's 
 ["distroless"](https://github.com/GoogleContainerTools/distroless) Debian12 images. 
 
-| Image              | Version                                                                                                                           | Size                                                                                                                                         | amd64 | armv7 | arm64v8 | i386 |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|-------|-------|---------|------|
-| Distroless         | [![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-nonroot)    ][dockerhub]    | [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-nonroot)][dockerhub]       | ✅     | ✅     | ✅       | ❌    |                                                                                                   |
-| Distroless (debug) | [![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot) ][dockerhub] | [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot)][dockerhub] | ✅     | ✅     | ✅       | ❌    |
-| Alpine             | [![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest)                    ][dockerhub]            | [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest)][dockerhub]                               | ✅     | ✅     | ✅       | ✅    |
+| Image              | Version                                                                                                                                            | Size                                                                                                                                                          | amd64 | armv7 | arm64v8 | i386 |
+|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|-------|---------|------|
+| Distroless         | [![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-nonroot)    ][dockerhub-distroless]          | [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-nonroot)][dockerhub-distroless]             | ✅     | ✅     | ✅       | ❌    |                                                                                                   |
+| Distroless (debug) | [![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot) ][dockerhub-distroless-debug] | [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-static-debian12-debug-nonroot)][dockerhub-distroless-debug] | ✅     | ✅     | ✅       | ❌    |
+| Alpine             | [![Docker Image Version](https://img.shields.io/docker/v/launchdarkly/ld-relay/latest-alpine)                    ][dockerhub-alpine]               | [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/launchdarkly/ld-relay/latest-alpine)][dockerhub-alpine]                                  | ✅     | ✅     | ✅       | ✅    |
 
 We recommend using the Distroless images, as automated security scanners regularly flag issues in Alpine even though 
 the Relay Proxy itself is unaffected. 
@@ -81,4 +81,6 @@ variant):
 docker exec -it [container name] /busybox/sh
 ```
 
-[dockerhub]: https://hub.docker.com/r/launchdarkly/ld-relay
+[dockerhub-distroless]: https://hub.docker.com/r/launchdarkly/ld-relay/tags?page=&page_size=&ordering=&name=static-debian12-nonroot
+[dockerhub-distroless-debug]: https://hub.docker.com/r/launchdarkly/ld-relay/tags?page=&page_size=&ordering=&name=static-debian12-debug-nonroot
+[dockerhub-alpine]: https://hub.docker.com/r/launchdarkly/ld-relay/tags?page=&page_size=&ordering=&name=alpine


### PR DESCRIPTION
This begins publishing a new set of Docker image manifests for Alpine with an `-alpine` suffix. 

The purpose is to mirror the `-static-debian12` images (so there's no ambiguity which base image is being used), and also allow us to eventually retire the un-suffixed images. 

In this PR, the only change is publishing the new manifests - there is no deprecation notice for the un-suffixed images yet. We can do that as part of a patch release whenever appropriate. 