### PR TITLE
fix: offline mode would spam logs when file changes

### DIFF
--- a/internal/filedata/archive_manager.go
+++ b/internal/filedata/archive_manager.go
@@ -94,7 +94,7 @@ func (am *ArchiveManager) monitorForChanges(original os.FileInfo) {
 
 	prevInfo := original
 
-	am.loggers.Infof("Monitoring %s for changes (every %s) (size=%d, mtime=%s)", am.filePath, am.monitoringInterval, original.Size(), original.ModTime())
+	am.loggers.Infof(logMsgMonitoringStarted, am.filePath, am.monitoringInterval, original.Size(), original.ModTime())
 
 	for {
 		select {
@@ -104,14 +104,14 @@ func (am *ArchiveManager) monitorForChanges(original os.FileInfo) {
 			nextInfo, err := os.Stat(am.filePath)
 			if err != nil {
 				if os.IsNotExist(err) {
-					am.loggers.Errorf("File %s not found", am.filePath)
+					am.loggers.Errorf(logMsgReloadFileStatNotFound, am.filePath)
 				} else {
-					am.loggers.Errorf("Error: %s", err)
+					am.loggers.Errorf(logMsgReloadFileStatUnknownError, err)
 				}
 				continue
 			}
 			if fileMayHaveChanged(prevInfo, nextInfo) {
-				am.loggers.Infof("File %s has changed (size=%d, mtime=%s)", am.filePath, nextInfo.Size(), nextInfo.ModTime())
+				am.loggers.Infof(logMsgFileChanged, am.filePath, nextInfo.Size(), nextInfo.ModTime())
 				reader, err := newArchiveReader(am.filePath)
 				if err != nil {
 					// A failure here might be a real failure, or it might be that the file is being copied
@@ -119,12 +119,14 @@ func (am *ArchiveManager) monitorForChanges(original os.FileInfo) {
 					am.loggers.Warnf(logMsgReloadError, err.Error())
 					continue
 				}
-				am.loggers.Warnf("Reloaded data from %s", am.filePath)
+				am.loggers.Warnf(logMsgReloadedData, am.filePath)
 				am.updatedArchive(reader)
 				reader.Close()
 			} else {
-				am.loggers.Debugf("File %s has not changed (size=%d, mtime=%s)", am.filePath, nextInfo.Size(), nextInfo.ModTime())
+				am.loggers.Debugf(logMsgFileNotChanged, am.filePath, nextInfo.Size(), nextInfo.ModTime())
 			}
+
+			prevInfo = nextInfo
 		}
 	}
 }

--- a/internal/filedata/errors_and_messages.go
+++ b/internal/filedata/errors_and_messages.go
@@ -6,17 +6,18 @@ import "fmt"
 // except for debug logging.
 
 const (
-	logMsgAddEnv                       = "Added environment %s (%s)"
-	logMsgUpdateEnv                    = "Updated environment %s (%s)"
-	logMsgDeleteEnv                    = "Removed environment %s (%s)"
-	logMsgNoEnvs                       = "The data file does not contain any environments; check your configuration"
-	logMsgBadEnvData                   = "Found invalid data for environment %s; skipping this environment"
-	logMsgReloadedData                 = "Reloaded data from %s"
-	logMsgReloadFileNotFound           = "Data file reload failed; file not found"
-	logMsgReloadError                  = "Data file reload failed; file is invalid or possibly incomplete (error: %s)"
-	logMsgReloadUnchangedRetry         = "Data file has not changed since last failure, will wait in case it is still being copied"
-	logMsgReloadUnchangedNoMoreRetries = "Data file reload failed, and no further changes were detected; giving up until next change (error: %s)"
-	logMsgReloadWillRetry              = "Will retry in %s"
+	logMsgAddEnv                     = "Added environment %s (%s)"
+	logMsgUpdateEnv                  = "Updated environment %s (%s)"
+	logMsgDeleteEnv                  = "Removed environment %s (%s)"
+	logMsgNoEnvs                     = "The data file does not contain any environments; check your configuration"
+	logMsgBadEnvData                 = "Found invalid data for environment %s; skipping this environment"
+	logMsgReloadedData               = "Reloaded data from %s"
+	logMsgMonitoringStarted          = "Monitoring data file %s for changes (every %s) (size=%d, mtime=%s)"
+	logMsgReloadFileStatNotFound     = "Data file stat failed; file %s not found"
+	logMsgReloadFileStatUnknownError = "Data file stat failed: %v"
+	logMsgReloadError                = "Data file reload failed; file is invalid or possibly incomplete (error: %s)"
+	logMsgFileChanged                = "Data file %s has changed (size=%d, mtime=%s)"
+	logMsgFileNotChanged             = "Data file %s has not changed (size=%d, mtime=%s)"
 )
 
 func errBadItemJSON(key, namespace string) error {


### PR DESCRIPTION
When the offline mode archive changed for the first time, the file monitor would emit a spurious log subsequent times because it wasn't updating its cache of the latest info from `stat`.

I've also extracted some of the log messages into `const` strings to fit the existing paradigm. 