### PR TITLE
fix: redact password in logs if specified as part of URL

### DIFF
--- a/internal/httpconfig/httpconfig.go
+++ b/internal/httpconfig/httpconfig.go
@@ -44,7 +44,7 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, authKey credential.SDKCredent
 		return ret, errProxyAuthWithoutProxyURL
 	}
 	if proxyConfig.URL.IsDefined() {
-		loggers.Infof("Using proxy server at %s", proxyConfig.URL)
+		loggers.Infof("Using proxy server at %s", proxyConfig.URL.Get().Redacted())
 	}
 
 	caCertFiles := proxyConfig.CACertFiles.Values()

--- a/internal/httpconfig/httpconfig_test.go
+++ b/internal/httpconfig/httpconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -115,25 +116,42 @@ func TestNTLMProxyInvalidConfigs(t *testing.T) {
 
 	proxyConfig2 := proxyConfig1
 	proxyConfig2.URL, _ = configtypes.NewOptURLAbsoluteFromString("http://fake-proxy")
-	_, err = NewHTTPConfig(proxyConfig2, nil, "", ldlog.NewDisabledLoggers())
+	mockLog2 := ldlogtest.NewMockLog()
+	_, err = NewHTTPConfig(proxyConfig2, nil, "", mockLog2.Loggers)
 	assert.Equal(t, errNTLMProxyAuthWithoutCredentials, err)
+	mockLog2.AssertMessageMatch(t, true, ldlog.Info, "Using proxy server at http://fake-proxy$")
 
 	proxyConfig3 := proxyConfig2
 	proxyConfig3.User = "user"
-	_, err = NewHTTPConfig(proxyConfig3, nil, "", ldlog.NewDisabledLoggers())
+	mockLog3 := ldlogtest.NewMockLog()
+	_, err = NewHTTPConfig(proxyConfig3, nil, "", mockLog3.Loggers)
 	assert.Equal(t, errNTLMProxyAuthWithoutCredentials, err)
+	mockLog3.AssertMessageMatch(t, true, ldlog.Info, "Using proxy server at http://fake-proxy$")
 
 	proxyConfig4 := proxyConfig3
 	proxyConfig4.Password = "pass"
-	_, err = NewHTTPConfig(proxyConfig4, nil, "", ldlog.NewDisabledLoggers())
+	mockLog4 := ldlogtest.NewMockLog()
+	_, err = NewHTTPConfig(proxyConfig4, nil, "", mockLog4.Loggers)
 	assert.NoError(t, err)
+	mockLog4.AssertMessageMatch(t, true, ldlog.Info, "Using proxy server at http://fake-proxy$")
 
 	proxyConfig5 := proxyConfig4
 	helpers.WithTempFile(func(certFileName string) {
 		proxyConfig5.CACertFiles = configtypes.NewOptStringList([]string{certFileName})
-		_, err = NewHTTPConfig(proxyConfig5, nil, "", ldlog.NewDisabledLoggers())
+		mockLog5 := ldlogtest.NewMockLog()
+		_, err = NewHTTPConfig(proxyConfig5, nil, "", mockLog5.Loggers)
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "invalid CA certificate data")
 		}
+		mockLog5.AssertMessageMatch(t, true, ldlog.Info, "Using proxy server at http://fake-proxy$")
 	})
+
+	proxyConfig6 := proxyConfig4
+	url6, _ := url.Parse("http://my-user:my-password@my-proxy")
+	proxyConfig6.URL, _ = configtypes.NewOptURLAbsolute(url6)
+	mockLog6 := ldlogtest.NewMockLog()
+	_, err = NewHTTPConfig(proxyConfig6, nil, "", mockLog6.Loggers)
+	assert.NoError(t, err)
+	mockLog6.AssertMessageMatch(t, true, ldlog.Info, "Using proxy server at http://my-user:xxxxx@my-proxy$")
+
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

(Internal: see sc-249267)

**Describe the solution you've provided**

When the connection URL is specified with a username and password, this was logged in full, for example "Using proxy server at http://my-user-name:my-password@my-proxy-server". This fix redacts any password specified as part of the URL from the logs.
