### PR TITLE
fix: don't panic if envContext is closed twice

### DIFF
--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -121,6 +121,7 @@ type envContextImpl struct {
 	doneMonitoringCredentials chan struct{}
 	connectionMapper          ConnectionMapper
 	offline                   bool
+	closed                    bool
 }
 
 // Implementation of the DataStoreQueries interface that the streams package uses as an abstraction of
@@ -701,6 +702,11 @@ func (c *envContextImpl) FlushMetricsEvents() {
 
 func (c *envContextImpl) Close() error {
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
 	for _, client := range c.clients {
 		_ = client.Close()
 	}


### PR DESCRIPTION
It was possible for `Close()` to be invoked concurrently, which would cause a data race on some of the cleanup tasks (including closing other channels.)

This specifically fixes a panic when using a combination of `exitAlways=1` and `ignoreConnectionErrors=1`.

