### PR TITLE
ci: upgrade various github actions

### DIFF
--- a/.github/actions/benchmarks/action.yml
+++ b/.github/actions/benchmarks/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
       - name: Setup Go ${{ inputs.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
             go-version: ${{ inputs.go-version }}
 

--- a/.github/actions/install-relay/action.yml
+++ b/.github/actions/install-relay/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go ${{ inputs.go-version }}
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: 'true'
       - name: Setup Go ${{ inputs.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ needs.go-versions.outputs.latest }}
       - name: Set up QEMU

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ inputs.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
       - uses: ./.github/actions/unit-tests

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -54,7 +54,7 @@ jobs:
             echo "clientsdk=https://clientsdk.launchdarkly.com" >> $GITHUB_OUTPUT
           fi
       - name: Setup Go ${{ inputs.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
 
@@ -63,7 +63,7 @@ jobs:
         run: go install github.com/jstemmer/go-junit-report@v0.9.1
 
       - name: Fetch REST token
-        uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
+        uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: ${{ format('/development/relay-proxy/launchdarkly-rest-api/{0}_token = LD_API_TOKEN', inputs.environment) }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -30,13 +30,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Go ${{ needs.go-versions.outputs.latest }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ needs.go-versions.outputs.latest }}
       - name: Build and Test
         uses: ./.github/actions/unit-tests
       - name: 'Get Docker token'
-        uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.1
+        uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: '/global/services/docker/public/username = DOCKER_USERNAME, /global/services/docker/public/token = DOCKER_TOKEN'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,7 +61,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
       base64-subjects: "${{ needs.release-relay.outputs.hashes }}"
       upload-assets: true
@@ -74,9 +74,9 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
     strategy:
-      matrix: 
+      matrix:
         images_and_digests: ${{fromJson(needs.release-relay.outputs.images_and_digests)}}
     with:
       image: ${{ matrix.images_and_digests.image }}
@@ -84,4 +84,3 @@ jobs:
       registry-username: ${{ vars.DOCKER_USERNAME }}
     secrets:
       registry-password: ${{ secrets.DOCKER_TOKEN }}
-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,14 +35,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.1
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         name: 'Get Docker token'
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: '/global/services/docker/public/username = DOCKER_USERNAME, /global/services/docker/public/token = DOCKER_TOKEN'
 
       - name: Setup Go ${{ needs.go-versions.outputs.latest }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ needs.go-versions.outputs.latest }}
 


### PR DESCRIPTION
This updates actions that were using the old node16 version.

One of these is the generic slsa generator, which I've bumped from 1.10 to 2.0. I didn't see any interface breaking changes that were relevant to our usage of it.

Todo:
- [ ] Manual test release