### PR TITLE
fix: Include expires header on 304 cache hit

### DIFF
--- a/relay/endpoints_php_test.go
+++ b/relay/endpoints_php_test.go
@@ -68,6 +68,7 @@ func TestEndpointsPHPPolling(t *testing.T) {
 							result, _ := st.DoRequest(r, p.relay)
 
 							assert.Equal(t, http.StatusNotModified, result.StatusCode)
+							assert.NotEmpty(t, result.Header.Get("Expires"))
 						})
 
 						t.Run("query with different ETag is cached", func(t *testing.T) {
@@ -76,6 +77,7 @@ func TestEndpointsPHPPolling(t *testing.T) {
 							result, _ := st.DoRequest(r, p.relay)
 
 							assert.Equal(t, http.StatusOK, result.StatusCode)
+							assert.NotEmpty(t, result.Header.Get("Expires"))
 						})
 					}
 				}


### PR DESCRIPTION
When configured with a TTL, the relay proxy will include an `expires` header when a flag or segment is first requested. This informs the PHP SDK how long it can cache the response.

Once the SDK makes another request, it is possible the flag still hasn't changed. In that situation, we should return a new `expires` header. Otherwise, the PHP SDK will have no idea how long it should cache this new response for, resulting in it re-fetching on demand going forward.