### PR TITLE
ci: avoid Trivy action rate limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
     needs: go-versions
     runs-on: ubuntu-latest
     name: "Trivy Scan of Docker Image"
+    env:
+      # Avoid rate-limiting on ghcr.io (https://github.com/aquasecurity/trivy-action/issues/389)
+      TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/daily-security-scan-alpine.yml
+++ b/.github/workflows/daily-security-scan-alpine.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: aquasecurity/trivy-action@master
+        env:
+          # Avoid rate-limiting on ghcr.io (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
           image-ref: launchdarkly/ld-relay:${{ matrix.tag }}
           format: 'table'

--- a/.github/workflows/daily-security-scan-distroless.yml
+++ b/.github/workflows/daily-security-scan-distroless.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: aquasecurity/trivy-action@master
+        env:
+          # Avoid rate-limiting on ghcr.io (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
           image-ref: launchdarkly/ld-relay:${{ matrix.tag }}
           format: 'table'


### PR DESCRIPTION
Trivy's ghcr.io container is globally rate limited. I guess that mean's Trivy is pretty popular! 

This PR switches to a different database location so that we can avoid the ratelimit, which was causing the daily security scans to fail.