### PR TITLE
ci: fix alpine version checker & remove v7 branch PRs

### DIFF
--- a/.github/workflows/check-alpine-version.yml
+++ b/.github/workflows/check-alpine-version.yml
@@ -10,19 +10,15 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: ["v7", "v8"]
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.branch }}
+          ref: v8
 
       - name: Get current Alpine version
         id: alpine-current
         run: |
-          version=$(sed -n 's/^FROM \(.*\)/\1/p' Dockerfile.goreleaser)
+          version=$(sed -n 's/^FROM alpine:\(.*\)/\1/p' Dockerfile.goreleaser)
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Get latest Alpine tag semantic version, not 'latest'
         id: alpine-latest


### PR DESCRIPTION
The Alpine version checker workflow was comparing a string prefixed with `alpine:` (like `alpine:3.20.3`) with a version fetched from the Docker API (like `3.20.3`). 

This comparison fails, so the workflow ends up trying to bump the alpine version (which is already up-to-date.)

This fixes the comparison so the workflow doesn't proceed to the next step.

I've also turned off updates for the v7 branch, which is now EOL. 

- [x] Successful run https://github.com/launchdarkly/ld-relay/actions/runs/11446898641/job/31847067259