### PR TITLE
feat: add windows binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
   goos: # Goreleaser's default for this is darwin + linux, but let's be explicit
     - darwin
     - linux
+    - windows
   goarch: # Goreleaser's default for this is 386 + amd64, but let's be explicit
     - '386'
     - amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,11 +8,11 @@ builds:
   # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}`.
   ldflags:
   - -s -w -X internal.version.Version={{.Version}}
-  goos: # Goreleaser's default for this is darwin + linux, but let's be explicit
+  goos:
     - darwin
     - linux
     - windows
-  goarch: # Goreleaser's default for this is 386 + amd64, but let's be explicit
+  goarch:
     - '386'
     - amd64
     - arm


### PR DESCRIPTION
Customer requests Windows builds of Relay. 

Looks like the test run was successful: https://github.com/launchdarkly/ld-relay/releases/tag/v8.10.0-beta.1

- [x] sanity check run the binary on Windows


BEGIN_COMMIT_OVERRIDE
fix(build): add windows binaries
END_COMMIT_OVERRIDE
