### PR TITLE
ci: stop daily security scans for v7 branch

### DIFF
--- a/.github/workflows/daily-security-scan-alpine.yml
+++ b/.github/workflows/daily-security-scan-alpine.yml
@@ -8,7 +8,7 @@ jobs:
   scan-relay:
     strategy:
       matrix:
-        tag: ['latest', 'latest-alpine', 'v7', 'v8', 'v8-alpine']
+        tag: ['latest', 'latest-alpine', 'v8', 'v8-alpine']
       fail-fast: false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Since v7 is EOL, we're no longer patching it. Therefore we can't fix the issues reported by Trivy. 