### PR TITLE
fix: Dedupe event senders by instance ID

### DIFF
--- a/internal/browser/cors.go
+++ b/internal/browser/cors.go
@@ -27,11 +27,11 @@ var DefaultAllowedHeaders = strings.Join([]string{ //nolint:gochecknoglobals
 	"Content-Length",
 	"Accept-Encoding",
 	"X-LaunchDarkly-User-Agent",
-	"X-LaunchDarkly-Instance-Id",
 	"X-LaunchDarkly-Payload-ID",
 	"X-LaunchDarkly-Wrapper",
 	events.EventSchemaHeader,
 	events.TagsHeader,
+	events.InstanceIDHeader,
 }, ",")
 
 // CORSContext represents a scope that has a specific set of allowed origins for CORS requests. This

--- a/internal/events/event_constants.go
+++ b/internal/events/event_constants.go
@@ -17,4 +17,8 @@ const (
 	// TagsHeader is an HTTP header that may be sent by SDKs that support application metadata.
 	// We copy the value of this header when proxying events.
 	TagsHeader = "X-LaunchDarkly-Tags"
+
+	// InstanceIDHeader is an HTTP header that may be sent by SDKs that support instance ID.
+	// We copy the value of this header when proxying events.
+	InstanceIDHeader = "X-LaunchDarkly-Instance-Id"
 )

--- a/internal/events/event_publisher.go
+++ b/internal/events/event_publisher.go
@@ -66,12 +66,15 @@ type EventPayloadMetadata struct {
 	SchemaVersion int
 	// Tags is the value of the X-LaunchDarkly-Tags header, or "" if none.
 	Tags string
+	// InstanceID is the value of the X-LaunchDarkly-Instance-ID header, or "" if none.
+	InstanceID string
 }
 
 // GetEventPayloadMetadata parses EventPayloadMetadata values from an HTTP request.
 func GetEventPayloadMetadata(req *http.Request) EventPayloadMetadata {
 	ret := EventPayloadMetadata{
-		Tags: req.Header.Get(TagsHeader),
+		Tags:       req.Header.Get(TagsHeader),
+		InstanceID: req.Header.Get(InstanceIDHeader),
 	}
 	ret.SchemaVersion, _ = strconv.Atoi(req.Header.Get(EventSchemaHeader))
 	if ret.SchemaVersion <= 0 {
@@ -323,6 +326,7 @@ func (p *HTTPEventPublisher) flush() {
 
 		schemaVersion := metadata.SchemaVersion
 		tags := metadata.Tags
+		instanceID := metadata.InstanceID
 
 		getBaseHeaders := func() http.Header {
 			ret := make(http.Header)
@@ -335,6 +339,10 @@ func (p *HTTPEventPublisher) flush() {
 			if tags != "" {
 				ret.Set(TagsHeader, tags)
 			}
+			if instanceID != "" {
+				ret.Set(InstanceIDHeader, instanceID)
+			}
+
 			return ret
 		}
 

--- a/internal/events/summarizing-relay.go
+++ b/internal/events/summarizing-relay.go
@@ -290,6 +290,9 @@ func makeEventSender(
 	if metadata.Tags != "" {
 		headers.Set(TagsHeader, metadata.Tags)
 	}
+	if metadata.InstanceID != "" {
+		headers.Set(InstanceIDHeader, metadata.InstanceID)
+	}
 	if authKey.GetAuthorizationHeaderValue() != "" {
 		headers.Set("Authorization", authKey.GetAuthorizationHeaderValue())
 	}

--- a/internal/events/summarizing-relay_test.go
+++ b/internal/events/summarizing-relay_test.go
@@ -119,6 +119,59 @@ func TestSummarizingRelayProcessesEventsSeparatelyForDifferentTags(t *testing.T)
 	})
 }
 
+func TestSummarizingRelayProcessesEventsSeparatelyForInstanceIds(t *testing.T) {
+	customEventData1a := `{
+		"kind": "custom", "creationDate": 1000, "key": "eventkey1a", "user": { "key": "userkey" }
+	}`
+	customEventData1b := `{
+		"kind": "custom", "creationDate": 1001, "key": "eventkey1b", "user": { "key": "userkey" }
+	}`
+	customEventData2 := `{
+		"kind": "custom", "creationDate": 1001, "key": "eventkey2", "user": { "key": "userkey" }
+	}`
+	payload1a := `[` + customEventData1a + `]`
+	payload1b := `[` + customEventData1b + `]`
+	payload2 := `[` + customEventData2 + `]`
+	headers1, headers2 := headersWithEventSchema(0), headersWithEventSchema(0)
+	headers1.Set(InstanceIDHeader, "instance1")
+	headers2.Set(InstanceIDHeader, "instance2")
+
+	eventRelayTest(t, st.EnvMain, config.EventsConfig{}, func(p eventRelayTestParams) {
+		req1a := st.BuildRequest("POST", "/", []byte(payload1a), headers1)
+		req1b := st.BuildRequest("POST", "/", []byte(payload1b), headers1)
+		req2 := st.BuildRequest("POST", "/", []byte(payload2), headers2)
+		for _, req := range []*http.Request{req1a, req2, req1b} {
+			p.dispatcher.GetHandler(basictypes.ServerSDK, ldevents.AnalyticsEventDataKind)(httptest.NewRecorder(), req)
+		}
+		p.dispatcher.flush()
+
+		request1 := expectSummarizedPayloadRequest(t, p.requestsCh)
+		request2 := expectSummarizedPayloadRequest(t, p.requestsCh)
+		if request2.Request.Header.Get(TagsHeader) == "tags1" {
+			request1, request2 = request2, request1
+		}
+
+		assert.Equal(t, "instance1", request1.Request.Header.Get(InstanceIDHeader))
+		assert.Equal(t, "instance2", request2.Request.Header.Get(InstanceIDHeader))
+
+		decompressedBody1, err := util.DecompressGzipData(request1.Body)
+		assert.NoError(t, err)
+
+		decompressedBody2, err := util.DecompressGzipData(request2.Body)
+		assert.NoError(t, err)
+
+		m.In(t).Assert(json.RawMessage(decompressedBody1), m.JSONArray().Should(m.ItemsInAnyOrder(
+			m.MapIncluding(m.KV("kind", m.Equal("index"))),
+			m.MapIncluding(m.KV("kind", m.Equal("custom")), m.KV("key", m.Equal("eventkey1a"))),
+			m.MapIncluding(m.KV("kind", m.Equal("custom")), m.KV("key", m.Equal("eventkey1b"))),
+		)))
+		m.In(t).Assert(json.RawMessage(decompressedBody2), m.JSONArray().Should(m.ItemsInAnyOrder(
+			m.MapIncluding(m.KV("kind", m.Equal("index"))),
+			m.MapIncluding(m.KV("kind", m.Equal("custom")), m.KV("key", m.Equal("eventkey2"))),
+		)))
+	})
+}
+
 func TestSummarizingRelayPeriodicallyClosesInactiveEventProcessors(t *testing.T) {
 	customEventData1a := `{
 		"kind": "custom", "creationDate": 1000, "key": "eventkey1a", "user": { "key": "userkey" }


### PR DESCRIPTION
We currently create an event sender for each unique combination of schema version and application tags. With the introduction of instance IDs, we are going to want to report event traffic by this dimension as well.