### PR TITLE
chore: Add minimal support for FDv2 basis

### DIFF
--- a/internal/sharedtest/testclient/fake_store.go
+++ b/internal/sharedtest/testclient/fake_store.go
@@ -2,7 +2,6 @@ package testclient
 
 import (
 	"encoding/json"
-
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
@@ -11,10 +10,14 @@ import (
 
 type FakeStore struct {
 	collections []ldstoretypes.Collection
+	selector    subsystems.Selector
 }
 
 func NewFakeStore(collections []ldstoretypes.Collection) *FakeStore {
-	return &FakeStore{collections: collections}
+	return &FakeStore{
+		collections: collections,
+		selector:    subsystems.NewSelector("initial-state", 1),
+	}
 }
 
 func (s *FakeStore) Close() error {
@@ -22,7 +25,7 @@ func (s *FakeStore) Close() error {
 }
 
 func (s *FakeStore) Selector() subsystems.Selector {
-	return subsystems.NoSelector()
+	return s.selector
 }
 
 func (s *FakeStore) SetBasis(changes []subsystems.Change, selector subsystems.Selector, persist bool) {
@@ -55,6 +58,7 @@ func (s *FakeStore) SetBasis(changes []subsystems.Change, selector subsystems.Se
 			})
 		}
 	}
+	s.selector = selector
 }
 
 func (s *FakeStore) ApplyDelta(changes []subsystems.Change, selector subsystems.Selector, persist bool) {
@@ -97,6 +101,7 @@ func (s *FakeStore) ApplyDelta(changes []subsystems.Change, selector subsystems.
 			}
 		}
 	}
+	s.selector = selector
 }
 
 func (s *FakeStore) Get(kind ldstoretypes.DataKind, key string) (ldstoretypes.ItemDescriptor, error) {
@@ -124,7 +129,7 @@ func (s *FakeStore) GetAll(kind ldstoretypes.DataKind) ([]ldstoretypes.KeyedItem
 }
 
 func (s *FakeStore) IsInitialized() bool {
-	return true
+	return s.selector.IsDefined()
 }
 
 func (s *FakeStore) Snapshot() (map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor, subsystems.Selector, error) {
@@ -133,5 +138,5 @@ func (s *FakeStore) Snapshot() (map[ldstoretypes.DataKind][]ldstoretypes.KeyedIt
 		result[collection.Kind] = collection.Items
 	}
 
-	return result, subsystems.NoSelector(), nil
+	return result, s.selector, nil
 }

--- a/internal/streams/stream_events.go
+++ b/internal/streams/stream_events.go
@@ -34,6 +34,23 @@ func (e deferredEvent) Event() string { return e.name }
 func (e deferredEvent) Id() string    { return "" } //nolint:golint,stylecheck
 func (e deferredEvent) Data() string  { return e.result.Get() }
 
+func MakeEventsForUpToDate(selector subsystems.Selector) []eventsource.Event {
+	// First create a new streaming protocol builder
+	protocol := ldservicesv2.NewStreamingProtocol()
+
+	// Add the server intent event
+	protocol = protocol.WithIntent(subsystems.ServerIntent{
+		Payload: subsystems.Payload{
+			ID:     selector.State(),
+			Target: selector.Version(),
+			Code:   subsystems.IntentNone,
+			Reason: "up-to-date",
+		},
+	})
+
+	return protocol.SSEEvents()
+}
+
 func MakeEventsForSetBasis(changes []subsystems.Change, selector subsystems.Selector) []eventsource.Event {
 	// First create a new streaming protocol builder
 	protocol := ldservicesv2.NewStreamingProtocol()
@@ -41,7 +58,7 @@ func MakeEventsForSetBasis(changes []subsystems.Change, selector subsystems.Sele
 	// Add the server intent event
 	protocol = protocol.WithIntent(subsystems.ServerIntent{
 		Payload: subsystems.Payload{
-			ID:     "relay-spoofed-id",
+			ID:     selector.State(),
 			Target: selector.Version(),
 			Code:   subsystems.IntentTransferFull,
 			Reason: "cant-catchup",

--- a/internal/streams/stream_provider_server_side.go
+++ b/internal/streams/stream_provider_server_side.go
@@ -50,7 +50,23 @@ func (s *serverSideStreamProvider) HandlerV2(credential sdkauth.ScopedCredential
 	if _, ok := credential.SDKCredential.(config.SDKKey); !ok {
 		return nil
 	}
-	return s.fdv2Server.Handler(credential.String())
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		// While FDv2 supports a basis parameter, the SSE spec and by proxy, the eventsource pkg, does not.
+		//
+		// To allow us to support the basis feature, we are going to send the basis value as the
+		// Last-Event-ID header. This is a standard feature of the SSE spec, and allows us to
+		// support the basis feature without having to modify the eventsource package.
+		//
+		// The Last-Event-ID header is passed back to the repository (defined in
+		// this pkg). We will interpret that value as a basis, and respond
+		// appropriately.
+		if basis := r.URL.Query().Get("basis"); basis != "" {
+			r.Header.Set("Last-Event-ID", basis)
+		}
+
+		s.fdv2Server.Handler(credential.String()).ServeHTTP(w, r)
+	}
 }
 
 func (s *serverSideStreamProvider) RegisterV1(
@@ -151,10 +167,9 @@ func (r *serverSideEnvStreamRepository) Replay(channel, id string) chan eventsou
 		var events []eventsource.Event
 		var err error
 		if r.isV2 {
-			//nolint:godox
-			// TODO(fdv2): Only send this if the provided selector doesn't match the
-			// current store.
-			events, err = r.getReplayEventsV2()
+			// See the note in HandlerV2 about how we use the Last-Event-ID header to
+			// pass the basis.
+			events, err = r.getReplayEventsV2(id)
 		} else {
 			events, err = r.getReplayEventsV1()
 		}
@@ -199,14 +214,16 @@ func (r *serverSideEnvStreamRepository) getReplayEventsV1() ([]eventsource.Event
 	return []eventsource.Event{event}, nil
 }
 
-func (r *serverSideEnvStreamRepository) getReplayEventsV2() ([]eventsource.Event, error) {
+func (r *serverSideEnvStreamRepository) getReplayEventsV2(basis string) ([]eventsource.Event, error) {
 	data, err, _ := r.flightGroup.Do("getReplayEventV2", func() (interface{}, error) {
-		//nolint:godox
-		// TODO(fdv2): Compare the selector and decide if we need a replay event.
 		snapshot, selector, err := r.store.Snapshot()
 		if err != nil {
 			r.loggers.Errorf("Error getting all flags: %s\n", err.Error())
 			return nil, err
+		}
+
+		if basis != "" && selector.IsDefined() && selector.State() == basis {
+			return MakeEventsForUpToDate(selector), nil
 		}
 
 		changes := []subsystems.Change{}

--- a/relay/endpoints_fdv2_streams_test.go
+++ b/relay/endpoints_fdv2_streams_test.go
@@ -58,7 +58,7 @@ func (s fdv2StreamEndpointTestParams) runBasicStreamTests(
 			require.Nil(t, err)
 
 			st.WithStreamRequest(t, s.request(), p.relay, func(eventCh <-chan eventsource.Event) {
-				expectedCount := 11 // = 1 intent + 8 flags + 1 segment + 1 payload transferred
+				expectedCount := len(s.expectedEvents)
 				actualCount := 0
 				timer := time.NewTimer(time.Second * 3)
 			L:
@@ -196,8 +196,8 @@ func TestFDv2EndpointsStreamingServerSide(t *testing.T) {
 
 	serverIntent := subsystems.ServerIntent{
 		Payload: subsystems.Payload{
-			ID:     "relay-spoofed-id",
-			Target: 0,
+			ID:     "initial-state",
+			Target: 1,
 			Code:   subsystems.IntentTransferFull,
 			Reason: "cant-catchup",
 		},
@@ -251,10 +251,22 @@ func TestFDv2EndpointsStreamingServerSide(t *testing.T) {
 		eventData = append(eventData, j)
 	}
 
-	selector := subsystems.NoSelector()
+	selector := subsystems.NewSelector("initial-state", 1)
 	j, err = selector.MarshalJSON()
 	assert.NoError(t, err)
 	eventData = append(eventData, j)
+
+	noChangeIntent := subsystems.ServerIntent{
+		Payload: subsystems.Payload{
+			ID:     "initial-state",
+			Target: 1,
+			Code:   subsystems.IntentNone,
+			Reason: "up-to-date",
+		},
+	}
+	noChangeIntentJSON, err := noChangeIntent.MarshalJSON()
+	assert.NoError(t, err)
+	noChangeEventData := [][]byte{noChangeIntentJSON}
 
 	specs := []fdv2StreamEndpointTestParams{
 		// TODO(fdv2): Re-enable once flag only streaming is enabled
@@ -274,6 +286,13 @@ func TestFDv2EndpointsStreamingServerSide(t *testing.T) {
 				"payload-transferred",
 			},
 			expectedEventData: eventData,
+		},
+		// Connecting with the same basis should result in a single event because we are up to date.
+		{
+			endpointTestParams: endpointTestParams{"all stream", "GET", "/sdk/stream?basis=initial-state", nil, sdkKey, 200, st.ExpectNoBody()}, expectedEvents: []string{
+				"server-intent",
+			},
+			expectedEventData: noChangeEventData,
 		},
 	}
 


### PR DESCRIPTION
The relay doesn't have the necessary information required to fully
support the basis feature of the FDv2 protocol. As a result, we can
never safely generate `xfer-changes` style server intents.

However, if the provided basis matches the current state, we can
generate a server intent of `none`, which would result in significant
savings.

This is going to become even more important as we implement a polling
endpoint as the last known state from polling is almost certain to match
the initial streaming state, at least within the same relay.
