### PR TITLE
chore: Fix payload transferred encoding for polling response

### DIFF
--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -253,15 +253,9 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 				}
 			}
 		}
-		j, err := selector.MarshalJSON()
-		if err != nil {
-			clientCtx.Env.GetLoggers().Errorf("Error marshaling selector: %s", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
 		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
 			Event:     "payload-transferred",
-			EventData: j,
+			EventData: selector,
 		})
 	}
 


### PR DESCRIPTION
The data field in the payload-transferred event was being double-encoded
for polling, resulting in invalid state comparisons between polling and
streaming.
