### PR TITLE
feat: Support gzip compression across serviced endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -126,6 +126,7 @@ type Config struct {
 	Environment map[string]*EnvConfig
 	Filters     map[string]*FiltersConfig
 	Proxy       ProxyConfig
+	Http        HttpConfig
 
 	// Optional configuration for metrics integrations. Note that unlike the other fields in Config,
 	// MetricsConfig is not the name of a configuration file section; the actual sections are the
@@ -287,6 +288,17 @@ type ProxyConfig struct {
 	Password    string            `conf:"PROXY_AUTH_PASSWORD"`
 	Domain      string            `conf:"PROXY_AUTH_DOMAIN"`
 	CACertFiles ct.OptStringList  `conf:"PROXY_CA_CERTS"`
+}
+
+// HttpConfig contains HTTP-related configuration options.
+//
+// This corresponds to the [Http] section in the configuration file.
+//
+// Since configuration options can be set either programmatically, or from a file, or from environment
+// variables, individual fields are not documented here; instead, see the `README.md` section on
+// configuration.
+type HttpConfig struct {
+	EnableCompression bool `conf:"HTTP_ENABLE_COMPRESSION"`
 }
 
 // MetricsConfig contains configurations for optional metrics integrations.

--- a/config/config.go
+++ b/config/config.go
@@ -126,7 +126,7 @@ type Config struct {
 	Environment map[string]*EnvConfig
 	Filters     map[string]*FiltersConfig
 	Proxy       ProxyConfig
-	Http        HttpConfig
+	HTTP        HTTPConfig
 
 	// Optional configuration for metrics integrations. Note that unlike the other fields in Config,
 	// MetricsConfig is not the name of a configuration file section; the actual sections are the
@@ -290,14 +290,14 @@ type ProxyConfig struct {
 	CACertFiles ct.OptStringList  `conf:"PROXY_CA_CERTS"`
 }
 
-// HttpConfig contains HTTP-related configuration options.
+// HTTPConfig contains HTTP-related configuration options.
 //
 // This corresponds to the [Http] section in the configuration file.
 //
 // Since configuration options can be set either programmatically, or from a file, or from environment
 // variables, individual fields are not documented here; instead, see the `README.md` section on
 // configuration.
-type HttpConfig struct {
+type HTTPConfig struct {
 	EnableCompression bool `conf:"HTTP_ENABLE_COMPRESSION"`
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -293,6 +293,12 @@ To learn more, read [Metrics integrations](./metrics.md).
 | `caCertFiles`    | `PROXY_CA_CERTS`      | String  |         | List of file paths to additional CA certificates that should be trusted (in PEM format). For multiple files, if using a configuration file, you can specify `caCertFiles` multiple times; if using environment variables, you can set `PROXY_CA_CERTS` to a comma-delimited list. |
 | `ntlmAuth`       | `PROXY_AUTH_NTLM`     | Boolean | `false` | Enables NTLM proxy authentication (requires user, password, and domain).                                                                                                                                                                                                          |
 
+### File section: `[Http]`
+
+| Property in file | Environment var        |  Type   | Default | Description                                                                                                 |
+|------------------|------------------------|:-------:|:--------|-------------------------------------------------------------------------------------------------------------|
+| `enableCompression` | `HTTP_ENABLE_COMPRESSION` | Boolean | `false` | When enabled, the Relay Proxy will compress HTTP responses using gzip compression. This can reduce bandwidth usage but may increase CPU usage. |
+
 ### Experimental/testing variables
 
 The current version of the Relay Proxy also supports the following environment variables. These do not have an equivalent in a configuration file; they are not intended for production use; and they are not guaranteed to work in any other Relay Proxy versions.

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
+	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
+github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
+github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -35,7 +35,7 @@ func (r *Relay) makeRouter() *mux.Router {
 	if r.loggers.GetMinLevel() == ldlog.Debug {
 		router.Use(logging.RequestLoggerMiddleware(r.loggers))
 	}
-	if r.config.Http.EnableCompression {
+	if r.config.HTTP.EnableCompression {
 		router.Use(h.CompressHandler)
 	}
 	router.Handle("/status", statusHandler(r)).Methods("GET")

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	ldevents "github.com/launchdarkly/go-sdk-events/v3"
 
+	h "github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 )
 
@@ -33,6 +34,9 @@ func (r *Relay) makeRouter() *mux.Router {
 	router.Use(logging.GlobalContextLoggersMiddleware(r.loggers))
 	if r.loggers.GetMinLevel() == ldlog.Debug {
 		router.Use(logging.RequestLoggerMiddleware(r.loggers))
+	}
+	if r.config.Http.EnableCompression {
+		router.Use(h.CompressHandler)
 	}
 	router.Handle("/status", statusHandler(r)).Methods("GET")
 

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -136,7 +136,8 @@ func TestMakeFilteredEnvironments_OneFilter_OneEnvironment(t *testing.T) {
 		},
 		Filters: map[string]*c.FiltersConfig{
 			"proj": {Keys: configtypes.NewOptStringList([]string{"foo", "bar"})},
-		}}
+		},
+	}
 	envs := makeFilteredEnvironments(cfg)
 	for _, id := range []string{"a", "a/foo", "a/bar"} {
 		require.Contains(t, envs, id)
@@ -162,7 +163,8 @@ func TestMakeFilteredEnvironments_ManyFilters_ManyEnvironments(t *testing.T) {
 		Filters: map[string]*c.FiltersConfig{
 			"projA": {Keys: configtypes.NewOptStringList([]string{"foo", "bar"})},
 			"projB": {Keys: configtypes.NewOptStringList([]string{"baz"})},
-		}}
+		},
+	}
 	envs := makeFilteredEnvironments(cfg)
 	for _, id := range []string{"a", "b", "c", "a/foo", "a/bar", "b/foo", "b/bar", "c/baz"} {
 		assert.Contains(t, envs, id)
@@ -172,7 +174,7 @@ func TestMakeFilteredEnvironments_ManyFilters_ManyEnvironments(t *testing.T) {
 func TestCompressionIsAppliedWhenEnabled(t *testing.T) {
 	// Test with compression enabled
 	configWithCompression := c.Config{
-		Http: c.HttpConfig{
+		HTTP: c.HTTPConfig{
 			EnableCompression: true,
 		},
 		Environment: map[string]*c.EnvConfig{
@@ -212,7 +214,7 @@ func TestCompressionIsAppliedWhenEnabled(t *testing.T) {
 func TestCompressionIsNotAppliedWhenDisabled(t *testing.T) {
 	// Test with compression disabled
 	configWithoutCompression := c.Config{
-		Http: c.HttpConfig{
+		HTTP: c.HTTPConfig{
 			EnableCompression: false,
 		},
 		Environment: map[string]*c.EnvConfig{

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -1,6 +1,10 @@
 package relay
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -163,4 +167,79 @@ func TestMakeFilteredEnvironments_ManyFilters_ManyEnvironments(t *testing.T) {
 	for _, id := range []string{"a", "b", "c", "a/foo", "a/bar", "b/foo", "b/bar", "c/baz"} {
 		assert.Contains(t, envs, id)
 	}
+}
+
+func TestCompressionIsAppliedWhenEnabled(t *testing.T) {
+	// Test with compression enabled
+	configWithCompression := c.Config{
+		Http: c.HttpConfig{
+			EnableCompression: true,
+		},
+		Environment: map[string]*c.EnvConfig{
+			"test": {
+				SDKKey: "test-key",
+			},
+		},
+	}
+
+	withStartedRelay(t, configWithCompression, func(p relayTestParams) {
+		// Create a request to the status endpoint
+		req, _ := http.NewRequest("GET", "/status", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		w := httptest.NewRecorder()
+		p.relay.ServeHTTP(w, req)
+
+		// Verify the response is compressed
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+		assert.Equal(t, "gzip", w.Header().Get("Content-Encoding"))
+
+		// Verify the content is actually compressed
+		body := w.Body.Bytes()
+		assert.Greater(t, len(body), 0, "Response body should not be empty")
+
+		// Try to decompress the body to verify it's actually gzipped
+		reader, err := gzip.NewReader(io.NopCloser(bytes.NewReader(body)))
+		require.NoError(t, err, "Response should be valid gzip content")
+		defer reader.Close()
+
+		decompressed, err := io.ReadAll(reader)
+		assert.NoError(t, err, "Should be able to read decompressed content")
+		assert.Greater(t, len(decompressed), 0, "Decompressed content should not be empty")
+	})
+}
+
+func TestCompressionIsNotAppliedWhenDisabled(t *testing.T) {
+	// Test with compression disabled
+	configWithoutCompression := c.Config{
+		Http: c.HttpConfig{
+			EnableCompression: false,
+		},
+		Environment: map[string]*c.EnvConfig{
+			"test": {
+				SDKKey: "test-key",
+			},
+		},
+	}
+
+	withStartedRelay(t, configWithoutCompression, func(p relayTestParams) {
+		// Create a request to the status endpoint
+		req, _ := http.NewRequest("GET", "/status", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		w := httptest.NewRecorder()
+		p.relay.ServeHTTP(w, req)
+
+		// Verify the response is not compressed
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+		assert.Equal(t, "", w.Header().Get("Content-Encoding"))
+
+		// Verify the content is not compressed
+		body := w.Body.Bytes()
+		assert.Greater(t, len(body), 0, "Response body should not be empty")
+
+		// Try to decompress the body - this should fail since it's not compressed
+		_, err := gzip.NewReader(io.NopCloser(bytes.NewReader(body)))
+		assert.Error(t, err, "Response should not be gzip content when compression is disabled")
+	})
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

No specific issues.

**Describe the solution you've provided**

Adds configurable gzip compression for HTTP responses in the LD Relay Proxy using the existing [`gorilla/handlers.CompressHandler`](https://pkg.go.dev/github.com/gorilla/handlers?utm_source=godoc#CompressHandler). When enabled via the new `HTTP_ENABLE_COMPRESSION` configuration option, responses are automatically compressed for clients that support gzip compression, reducing bandwidth usage.

**Describe alternatives you've considered**

- Custom implementation: I tried this approach in separate PR now closed and it was quite big and also supported Brotli compression. This one is small change with good enough results. Can be improved if required.

**Additional context**

The feature is backward compatible (defaults to disabled) and follows the same patterns as existing compression support in the codebase.