### PR TITLE
feat: Add SDK wrapper metric tagging

### DIFF
--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -34,10 +34,11 @@ var (
 	relayIDTagKey, _          = tag.NewKey("relayId")          //nolint:gochecknoglobals
 	platformCategoryTagKey, _ = tag.NewKey("platformCategory") //nolint:gochecknoglobals
 	userAgentTagKey, _        = tag.NewKey("userAgent")        //nolint:gochecknoglobals
+	sdkWrapperTagKey, _       = tag.NewKey("sdkWrapper")       //nolint:gochecknoglobals
 	routeTagKey, _            = tag.NewKey("route")            //nolint:gochecknoglobals
 	methodTagKey, _           = tag.NewKey("method")           //nolint:gochecknoglobals
 	envNameTagKey, _          = tag.NewKey("env")              //nolint:gochecknoglobals
 
-	publicTags  = []tag.Key{platformCategoryTagKey, userAgentTagKey, envNameTagKey}                //nolint:gochecknoglobals
-	privateTags = []tag.Key{platformCategoryTagKey, userAgentTagKey, relayIDTagKey, envNameTagKey} //nolint:gochecknoglobals
+	publicTags  = []tag.Key{platformCategoryTagKey, userAgentTagKey, sdkWrapperTagKey, envNameTagKey}                //nolint:gochecknoglobals
+	privateTags = []tag.Key{platformCategoryTagKey, userAgentTagKey, sdkWrapperTagKey, relayIDTagKey, envNameTagKey} //nolint:gochecknoglobals
 )

--- a/internal/metrics/events_exporter.go
+++ b/internal/metrics/events_exporter.go
@@ -14,18 +14,21 @@ import (
 
 type currentConnectionsMetric struct {
 	UserAgent        string `json:"userAgent"`
+	SDKWrapper       string `json:"sdkWrapper"`
 	PlatformCategory string `json:"platformCategory"`
 	Current          int64  `json:"current"`
 }
 
 type newConnectionsMetric struct {
 	UserAgent        string `json:"userAgent"`
+	SDKWrapper       string `json:"sdkWrapper"`
 	PlatformCategory string `json:"platformCategory"`
 	Count            int64  `json:"count"`
 }
 
 type pollingMetric struct {
 	UserAgent        string `json:"userAgent"`
+	SDKWrapper       string `json:"sdkWrapper"`
 	PlatformCategory string `json:"platformCategory"`
 	Count            int64  `json:"count"`
 }
@@ -44,6 +47,7 @@ type relayMetricsEvent struct {
 
 type connectionsKeyType struct {
 	userAgent        string
+	sdkWrapper       string
 	platformCategory string
 }
 
@@ -108,6 +112,7 @@ func (e *openCensusEventsExporter) ExportView(viewData *view.Data) {
 		for _, r := range viewData.Rows {
 			var platformCategory string
 			var userAgent string
+			var sdkWrapper string
 			relayIDFound := false
 			envNameFound := false
 			for _, t := range r.Tags {
@@ -126,6 +131,8 @@ func (e *openCensusEventsExporter) ExportView(viewData *view.Data) {
 					}
 				case userAgentTagKey:
 					userAgent = t.Value
+				case sdkWrapperTagKey:
+					sdkWrapper = t.Value
 				case platformCategoryTagKey:
 					platformCategory = t.Value
 				}
@@ -137,17 +144,17 @@ func (e *openCensusEventsExporter) ExportView(viewData *view.Data) {
 			if data, ok := r.Data.(*view.SumData); ok {
 				v = int64(data.Value)
 			}
-			e.updateValue(viewData.View.Name, platformCategory, userAgent, v)
+			e.updateValue(viewData.View.Name, platformCategory, userAgent, sdkWrapper, v)
 		}
 	}
 }
 
-func (e *openCensusEventsExporter) updateValue(name string, platformCategory string, userAgent string, value int64) {
+func (e *openCensusEventsExporter) updateValue(name string, platformCategory string, userAgent string, sdkWrapper string, value int64) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	switch name {
 	case privatePollingRequestsMeasureName:
-		key := connectionsKeyType{platformCategory: platformCategory, userAgent: userAgent}
+		key := connectionsKeyType{platformCategory: platformCategory, userAgent: userAgent, sdkWrapper: sdkWrapper}
 		if value == 0 {
 			delete(e.pollingCounts, key)
 			break
@@ -161,7 +168,7 @@ func (e *openCensusEventsExporter) updateValue(name string, platformCategory str
 		}
 
 	case privateConnMeasureName:
-		key := connectionsKeyType{platformCategory: platformCategory, userAgent: userAgent}
+		key := connectionsKeyType{platformCategory: platformCategory, userAgent: userAgent, sdkWrapper: sdkWrapper}
 		if value == 0 {
 			delete(e.currentConnections, key)
 		} else {
@@ -169,7 +176,7 @@ func (e *openCensusEventsExporter) updateValue(name string, platformCategory str
 		}
 
 	case privateNewConnMeasureName:
-		key := connectionsKeyType{platformCategory: platformCategory, userAgent: userAgent}
+		key := connectionsKeyType{platformCategory: platformCategory, userAgent: userAgent, sdkWrapper: sdkWrapper}
 		if value == 0 {
 			delete(e.newConnections, key) // COVERAGE: won't happen in practice since this measure is only ever incremented
 		} else {
@@ -225,6 +232,7 @@ func (e *openCensusEventsExporter) flush() {
 			if v.running != v.lastReported {
 				event.PollingCounts = append(event.PollingCounts, pollingMetric{
 					UserAgent:        k.userAgent,
+					SDKWrapper:       k.sdkWrapper,
 					PlatformCategory: k.platformCategory,
 					Count:            v.running - v.lastReported,
 				})
@@ -237,6 +245,7 @@ func (e *openCensusEventsExporter) flush() {
 	for k, v := range e.currentConnections {
 		event.Connections = append(event.Connections, currentConnectionsMetric{
 			UserAgent:        k.userAgent,
+			SDKWrapper:       k.sdkWrapper,
 			PlatformCategory: k.platformCategory,
 			Current:          v,
 		})
@@ -244,6 +253,7 @@ func (e *openCensusEventsExporter) flush() {
 	for k, v := range e.newConnections {
 		event.NewConnections = append(event.NewConnections, newConnectionsMetric{
 			UserAgent:        k.userAgent,
+			SDKWrapper:       k.sdkWrapper,
 			PlatformCategory: k.platformCategory,
 			Count:            v,
 		})

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -79,8 +79,8 @@ func makeServerTags() []tag.Mutator {
 
 // WithGauge increments the specified metric before running the function and then decrements it (for use with
 // the active connection metrics).
-func WithGauge(ctx context.Context, userAgent string, f func(), measure Measure) {
-	ctx, err := tag.New(ctx, tag.Insert(userAgentTagKey, sanitizeTagValue(userAgent)))
+func WithGauge(ctx context.Context, userAgent, sdkWrapper string, f func(), measure Measure) {
+	ctx, err := tag.New(ctx, tag.Insert(userAgentTagKey, sanitizeTagValue(userAgent)), tag.Insert(sdkWrapperTagKey, sanitizeTagValue(sdkWrapper)))
 	if err != nil { // COVERAGE: can't make this happen in unit tests
 		logging.GetGlobalContextLoggers(ctx).Errorf(`Failed to create tags: %s`, err)
 	} else {
@@ -94,8 +94,8 @@ func WithGauge(ctx context.Context, userAgent string, f func(), measure Measure)
 }
 
 // WithCount runs a function and records a single-unit increment for the specified metric.
-func WithCount(ctx context.Context, userAgent string, f func(), measure Measure) {
-	ctx, err := tag.New(ctx, tag.Insert(userAgentTagKey, sanitizeTagValue(userAgent)))
+func WithCount(ctx context.Context, userAgent, sdkWrapper string, f func(), measure Measure) {
+	ctx, err := tag.New(ctx, tag.Insert(userAgentTagKey, sanitizeTagValue(userAgent)), tag.Insert(sdkWrapperTagKey, sanitizeTagValue(sdkWrapper)))
 	if err != nil { // COVERAGE: can't make this happen in unit tests
 		logging.GetGlobalContextLoggers(ctx).Errorf(`Failed to create tag for user agent : %s`, err)
 	} else {
@@ -108,7 +108,7 @@ func WithCount(ctx context.Context, userAgent string, f func(), measure Measure)
 }
 
 // WithRouteCount records a route hit and starts a trace. For stream connections, the duration of the stream connection is recorded
-func WithRouteCount(ctx context.Context, userAgent, route, method string, f func(), measure Measure) {
+func WithRouteCount(ctx context.Context, userAgent, sdkWrapper, route, method string, f func(), measure Measure) {
 	tagCtx, err := tag.New(ctx, tag.Insert(routeTagKey, sanitizeTagValue(route)), tag.Insert(methodTagKey, sanitizeTagValue(method)))
 	if err != nil { // COVERAGE: can't make this happen in unit tests
 		logging.GetGlobalContextLoggers(ctx).Errorf(`Failed to create tags for route "%s %s": %s`, method, route, err)
@@ -118,5 +118,5 @@ func WithRouteCount(ctx context.Context, userAgent, route, method string, f func
 	ctx, span := trace.StartSpan(ctx, route)
 	defer span.End()
 
-	WithCount(ctx, userAgent, f, measure)
+	WithCount(ctx, userAgent, sdkWrapper, f, measure)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -255,10 +255,12 @@ func (em *EnvironmentManager) close() {
 	})
 }
 
-// Pad empty keys to match tag keyset cardinality since empty strings are dropped
+// sanitizeTagValue ensures tag values are valid for OpenCensus metrics.
+// OpenCensus drops empty tag values, which causes cardinality mismatches in views.
+// We use descriptive default values instead of generic placeholders.
 func sanitizeTagValue(v string) string {
 	if strings.TrimSpace(v) == "" {
-		return "_"
+		return "not-provided"
 	}
 	return strings.ReplaceAll(v, "/", "_")
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -26,6 +26,7 @@ func (m measureAndPlatform) getExpectedTagsMap(relayID string, envName string, u
 		envNameTagKey.Name():          envName,
 		platformCategoryTagKey.Name(): m.platform,
 		userAgentTagKey.Name():        userAgent,
+		sdkWrapperTagKey.Name():       "not-provided", // empty wrapper defaults to "not-provided"
 	}
 	if relayID != "" {
 		ret[relayIDTagKey.Name()] = relayID
@@ -111,7 +112,7 @@ func TestConnectionMetrics(t *testing.T) {
 				expectedTags := tt.getExpectedTagsMap("", p.envName, userAgentValue)
 				expectedPrivateTags := tt.getExpectedTagsMap(p.relayID, p.envName, userAgentValue)
 
-				WithGauge(p.env.GetOpenCensusContext(), userAgentValue, func() {
+				WithGauge(p.env.GetOpenCensusContext(), userAgentValue, "", func() {
 					p.exporter.AwaitData(t, time.Second, p.mockLog.Loggers, func(d st.TestMetricsData) bool {
 						return d.HasRow(publicConnView.Name, st.TestMetricsRow{
 							Tags: expectedTags,
@@ -150,7 +151,7 @@ func TestNewConnectionMetrics(t *testing.T) {
 				expectedTags := tt.getExpectedTagsMap("", p.envName, userAgentValue)
 				expectedPrivateTags := tt.getExpectedTagsMap(p.relayID, p.envName, userAgentValue)
 
-				WithCount(p.env.GetOpenCensusContext(), userAgentValue, func() {}, tt.measure)
+				WithCount(p.env.GetOpenCensusContext(), userAgentValue, "", func() {}, tt.measure)
 
 				p.exporter.AwaitData(t, time.Second, p.mockLog.Loggers, func(d st.TestMetricsData) bool {
 					return d.HasRow(publicNewConnView.Name, st.TestMetricsRow{
@@ -168,7 +169,7 @@ func TestNewConnectionMetrics(t *testing.T) {
 
 func TestWithRouteCount(t *testing.T) {
 	testWithExporter(t, func(p testWithExporterParams) {
-		WithRouteCount(p.env.GetOpenCensusContext(), userAgentValue, "someRoute", "GET", func() {
+		WithRouteCount(p.env.GetOpenCensusContext(), userAgentValue, "", "someRoute", "GET", func() {
 			p.exporter.AwaitData(t, time.Second, p.mockLog.Loggers, func(d st.TestMetricsData) bool {
 				return d.HasRow(requestView.Name, st.TestMetricsRow{
 					Tags: map[string]string{
@@ -189,5 +190,7 @@ func TestWithRouteCount(t *testing.T) {
 
 func TestSanitizeTagValue(t *testing.T) {
 	assert.Equal(t, "abc", sanitizeTagValue("abc"))
-	assert.Equal(t, "_", sanitizeTagValue(""))
+	assert.Equal(t, "not-provided", sanitizeTagValue(""))
+	assert.Equal(t, "not-provided", sanitizeTagValue("   "))
+	assert.Equal(t, "react_2.0.0", sanitizeTagValue("react/2.0.0"))
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -178,6 +178,7 @@ func TestWithRouteCount(t *testing.T) {
 						"platformCategory": "server",
 						"route":            "someRoute",
 						"userAgent":        userAgentValue,
+						"sdkWrapper":       "not-provided",
 					},
 					Count: 1,
 				})

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -12,7 +12,8 @@ func withCount(handler http.Handler, measure metrics.Measure) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := GetEnvContextInfo(req.Context()).Env
 		userAgent := getUserAgent(req)
-		metrics.WithCount(ctx.GetMetricsContext(), userAgent, func() {
+		sdkWrapper := getSDKWrapper(req)
+		metrics.WithCount(ctx.GetMetricsContext(), userAgent, sdkWrapper, func() {
 			handler.ServeHTTP(w, req)
 		}, measure)
 	})
@@ -22,7 +23,8 @@ func withGauge(handler http.Handler, measure metrics.Measure) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := GetEnvContextInfo(req.Context())
 		userAgent := getUserAgent(req)
-		metrics.WithGauge(ctx.Env.GetMetricsContext(), userAgent, func() {
+		sdkWrapper := getSDKWrapper(req)
+		metrics.WithGauge(ctx.Env.GetMetricsContext(), userAgent, sdkWrapper, func() {
 			handler.ServeHTTP(w, req)
 		}, measure)
 	})
@@ -57,9 +59,10 @@ func RequestCount(measure metrics.Measure) mux.MiddlewareFunc {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ctx := GetEnvContextInfo(req.Context())
 			userAgent := getUserAgent(req)
+			sdkWrapper := getSDKWrapper(req)
 			// Ignoring internal routing error that would have been ignored anyway
 			route, _ := mux.CurrentRoute(req).GetPathTemplate()
-			metrics.WithRouteCount(ctx.Env.GetMetricsContext(), userAgent, route, req.Method, func() {
+			metrics.WithRouteCount(ctx.Env.GetMetricsContext(), userAgent, sdkWrapper, route, req.Method, func() {
 				next.ServeHTTP(w, req)
 			}, measure)
 		})

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -86,6 +86,7 @@ func testCountConnections(t *testing.T, countFn func(http.Handler) http.Handler,
 			"env":              p.envName,
 			"platformCategory": category,
 			"userAgent":        metricsTestUserAgent,
+			"sdkWrapper":       "not-provided",
 		}
 
 		req, _ := http.NewRequest("GET", "", nil)
@@ -142,6 +143,7 @@ func testCountRequests(t *testing.T, measure metrics.Measure, category string) {
 			"route":            "_test-route",
 			"platformCategory": category,
 			"userAgent":        metricsTestUserAgent,
+			"sdkWrapper":       "not-provided",
 		}
 
 		makeRequest := func() *http.Request {

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -28,6 +28,7 @@ const (
 	userAgentHeader    = "user-agent"
 	ldUserAgentHeader  = "X-LaunchDarkly-User-Agent"
 	ldInstanceIDHeader = "X-LaunchDarkly-Instance-Id"
+	ldWrapperHeader    = "X-LaunchDarkly-Wrapper"
 
 	httpStatusMessageInvalidEnvCredential  = "Relay Proxy does not recognize the client credential (missing or invalid Authorization header)"
 	httpStatusMessageNotFullyConfigured    = "Relay Proxy is not yet fully initialized, does not have list of environments yet"
@@ -67,6 +68,11 @@ func getUserAgent(req *http.Request) string {
 // getInstanceID returns the X-LaunchDarkly-Instance-Id if available
 func getInstanceID(req *http.Request) string {
 	return req.Header.Get(ldInstanceIDHeader)
+}
+
+// getSDKWrapper returns the X-LaunchDarkly-Wrapper if available
+func getSDKWrapper(req *http.Request) string {
+	return req.Header.Get(ldWrapperHeader)
 }
 
 // Chain combines a series of middleware functions that will be applied in the same order.

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -147,6 +147,22 @@ func TestGetUserAgent(t *testing.T) {
 		req.Header.Set(userAgentHeader, "my-agent")
 		assert.Equal(t, "my-agent", getUserAgent(req))
 	})
+	t.Run("returns empty string when no user-agent headers are present", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/", nil)
+		assert.Equal(t, "", getUserAgent(req))
+	})
+}
+
+func TestGetSDKWrapper(t *testing.T) {
+	t.Run("returns X-LaunchDarkly-Wrapper header value", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/", nil)
+		req.Header.Set(ldWrapperHeader, "react/2.0.0")
+		assert.Equal(t, "react/2.0.0", getSDKWrapper(req))
+	})
+	t.Run("returns empty string when X-LaunchDarkly-Wrapper header is not present", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/", nil)
+		assert.Equal(t, "", getSDKWrapper(req))
+	})
 }
 
 func TestSelectEnvironmentByAuthorizationKey(t *testing.T) {

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -350,7 +350,7 @@ func TestMetricsAreExportedForEnvironment(t *testing.T) {
 		require.NoError(t, err)
 		defer env.Close()
 		envImpl := env.(*envContextImpl)
-		metrics.WithCount(env.GetMetricsContext(), fakeUserAgent, func() {
+		metrics.WithCount(env.GetMetricsContext(), fakeUserAgent, "", func() {
 			require.Eventually(t, func() bool {
 				flushMetricsEvents(envImpl)
 				select {
@@ -406,7 +406,7 @@ func testMetricsDisabled(t *testing.T, allConfig config.Config) {
 		require.NoError(t, err)
 		defer env.Close()
 		envImpl := env.(*envContextImpl)
-		metrics.WithCount(env.GetMetricsContext(), fakeUserAgent, func() {
+		metrics.WithCount(env.GetMetricsContext(), fakeUserAgent, "", func() {
 			require.Never(t, func() bool {
 				flushMetricsEvents(envImpl)
 				select {


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Add a tag named `sdkWrapper` populated by the `x-launchdarkly-wrapper` header when provided

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Tagging metrics by wrapper name/version requested by customer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `sdkWrapper` metric tag (from `X-LaunchDarkly-Wrapper`) across measures, middleware, and events exporter, and changes empty tag sanitization to `not-provided`.
> 
> - **Metrics**:
>   - Add `sdkWrapper` tag key and include in `publicTags`/`privateTags` in `internal/metrics/constants.go`.
>   - Extend `WithGauge`, `WithCount`, and `WithRouteCount` to accept `sdkWrapper` and tag it.
>   - Update `sanitizeTagValue` to return `"not-provided"` for empty/whitespace and replace `/` with `_`.
>   - Events exporter: parse `sdkWrapper` tag, include it in connection keys, and emit it in `connections`, `newConnections`, and `pollingCounts` payloads.
> - **Middleware**:
>   - Read `X-LaunchDarkly-Wrapper` via `getSDKWrapper` and pass to metrics helpers in connection/request counters.
> - **Tests**:
>   - Update metrics and middleware tests to expect `sdkWrapper` tag (defaulting to `"not-provided"`) and new sanitization behavior; add tests for `getSDKWrapper`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bc475d2568596b21f538dcc4ed52eecaf99a394. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->