### PR TITLE
feat: Add HTTP client transport configuration options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -298,11 +298,11 @@ type ProxyConfig struct {
 // variables, individual fields are not documented here; instead, see the `README.md` section on
 // configuration.
 type HTTPConfig struct {
-	EnableCompression     bool           `conf:"HTTP_ENABLE_COMPRESSION"`
-	IdleConnTimeout       ct.OptDuration `conf:"HTTP_IDLE_CONN_TIMEOUT"`
-	MaxIdleConns          int            `conf:"HTTP_MAX_IDLE_CONNS"`
-	MaxIdleConnsPerHost   int            `conf:"HTTP_MAX_IDLE_CONNS_PER_HOST"`
-	DisableKeepAlives     bool           `conf:"HTTP_DISABLE_KEEPALIVE"`
+	EnableCompression   bool           `conf:"HTTP_ENABLE_COMPRESSION"`
+	IdleConnTimeout     ct.OptDuration `conf:"HTTP_IDLE_CONN_TIMEOUT"`
+	MaxIdleConns        ct.OptInt      `conf:"HTTP_MAX_IDLE_CONNS"`
+	MaxIdleConnsPerHost int            `conf:"HTTP_MAX_IDLE_CONNS_PER_HOST"`
+	DisableKeepAlives   bool           `conf:"HTTP_DISABLE_KEEPALIVE"`
 }
 
 // MetricsConfig contains configurations for optional metrics integrations.

--- a/config/config.go
+++ b/config/config.go
@@ -298,11 +298,11 @@ type ProxyConfig struct {
 // variables, individual fields are not documented here; instead, see the `README.md` section on
 // configuration.
 type HTTPConfig struct {
-	EnableCompression     bool          `conf:"HTTP_ENABLE_COMPRESSION"`
-	IdleConnTimeout       time.Duration `conf:"HTTP_IDLE_CONN_TIMEOUT"`
-	MaxIdleConns          int           `conf:"HTTP_MAX_IDLE_CONNS"`
-	MaxIdleConnsPerHost   int           `conf:"HTTP_MAX_IDLE_CONNS_PER_HOST"`
-	DisableKeepAlives     bool          `conf:"HTTP_DISABLE_KEEPALIVE"`
+	EnableCompression     bool           `conf:"HTTP_ENABLE_COMPRESSION"`
+	IdleConnTimeout       ct.OptDuration `conf:"HTTP_IDLE_CONN_TIMEOUT"`
+	MaxIdleConns          int            `conf:"HTTP_MAX_IDLE_CONNS"`
+	MaxIdleConnsPerHost   int            `conf:"HTTP_MAX_IDLE_CONNS_PER_HOST"`
+	DisableKeepAlives     bool           `conf:"HTTP_DISABLE_KEEPALIVE"`
 }
 
 // MetricsConfig contains configurations for optional metrics integrations.

--- a/config/config.go
+++ b/config/config.go
@@ -298,7 +298,11 @@ type ProxyConfig struct {
 // variables, individual fields are not documented here; instead, see the `README.md` section on
 // configuration.
 type HTTPConfig struct {
-	EnableCompression bool `conf:"HTTP_ENABLE_COMPRESSION"`
+	EnableCompression     bool          `conf:"HTTP_ENABLE_COMPRESSION"`
+	IdleConnTimeout       time.Duration `conf:"HTTP_IDLE_CONN_TIMEOUT"`
+	MaxIdleConns          int           `conf:"HTTP_MAX_IDLE_CONNS"`
+	MaxIdleConnsPerHost   int           `conf:"HTTP_MAX_IDLE_CONNS_PER_HOST"`
+	DisableKeepAlives     bool          `conf:"HTTP_DISABLE_KEEPALIVE"`
 }
 
 // MetricsConfig contains configurations for optional metrics integrations.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,6 +298,10 @@ To learn more, read [Metrics integrations](./metrics.md).
 | Property in file | Environment var        |  Type   | Default | Description                                                                                                 |
 |------------------|------------------------|:-------:|:--------|-------------------------------------------------------------------------------------------------------------|
 | `enableCompression` | `HTTP_ENABLE_COMPRESSION` | Boolean | `false` | When enabled, the Relay Proxy will compress HTTP responses using gzip compression. This can reduce bandwidth usage but may increase CPU usage. |
+| `idleConnTimeout` | `HTTP_IDLE_CONN_TIMEOUT` | Duration |  | Maximum amount of time an idle (keep-alive) HTTP connection will remain idle before closing. Examples: `30s`, `5m`. If not set, uses Go's default of 90 seconds. Reducing this can help prevent EOF errors when intermediate load balancers or NAT gateways close idle connections. |
+| `maxIdleConns` | `HTTP_MAX_IDLE_CONNS` | Integer |  | Maximum number of idle (keep-alive) HTTP connections across all hosts. If not set, uses Go's default of 100. Increase this value for high-concurrency scenarios with many environments. |
+| `maxIdleConnsPerHost` | `HTTP_MAX_IDLE_CONNS_PER_HOST` | Integer |  | Maximum number of idle (keep-alive) HTTP connections to keep per-host. If not set, uses Go's default of 2. Increase this if you have multiple environments connecting to the same LaunchDarkly endpoints. |
+| `disableKeepAlive` | `HTTP_DISABLE_KEEPALIVE` | Boolean | `false` | When enabled, disables HTTP keep-alive connections. This forces the relay to use a new connection for each HTTP request. Use this only for debugging connection issues, as it significantly increases overhead. |
 
 ### Experimental/testing variables
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/launchdarkly/go-server-sdk-dynamodb/v4 v4.0.0
 	github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1
 	github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0
-	github.com/launchdarkly/go-server-sdk/v7 v7.13.5-0.20251110185214-43752e37168d
+	github.com/launchdarkly/go-server-sdk/v7 v7.14.0
 	github.com/launchdarkly/go-test-helpers/v3 v3.1.0
 	github.com/launchdarkly/opencensus-go-exporter-stackdriver v0.14.5
 	github.com/pborman/uuid v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/launchdarkly/go-server-sdk-dynamodb/v4 v4.0.0
 	github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1
 	github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0
-	github.com/launchdarkly/go-server-sdk/v7 v7.11.0
+	github.com/launchdarkly/go-server-sdk/v7 v7.13.5-0.20251110185214-43752e37168d
 	github.com/launchdarkly/go-test-helpers/v3 v3.1.0
 	github.com/launchdarkly/opencensus-go-exporter-stackdriver v0.14.5
 	github.com/pborman/uuid v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/launchdarkly/eventsource v1.10.0
 	github.com/launchdarkly/go-configtypes v1.2.0
 	github.com/launchdarkly/go-jsonstream/v3 v3.1.0
-	github.com/launchdarkly/go-sdk-common/v3 v3.3.0
+	github.com/launchdarkly/go-sdk-common/v3 v3.4.0
 	github.com/launchdarkly/go-sdk-events/v3 v3.5.0
 	github.com/launchdarkly/go-server-sdk-consul/v3 v3.0.0
 	github.com/launchdarkly/go-server-sdk-dynamodb/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/launchdarkly/go-ntlm-proxy-auth v1.0.2 h1:LnChqC/CulrA+N26DF4rjbDjAAR
 github.com/launchdarkly/go-ntlm-proxy-auth v1.0.2/go.mod h1:JClffYrl6+qpGXCmWQQA5UNu7xYxPOXo2HzdyYcUcao=
 github.com/launchdarkly/go-ntlmssp v1.0.2 h1:cZU0o9Q9wnlTH8Vw3pex0+/sGyNIsj7T1lCzC2gqAcM=
 github.com/launchdarkly/go-ntlmssp v1.0.2/go.mod h1:6ZSwvQs+WBrFEsgKFjrRod8Bj/D4WHHSoo7qJGdgD8g=
-github.com/launchdarkly/go-sdk-common/v3 v3.3.0 h1:kkf78wcKX+DOXzNjG29i+py/P+XMIw8/mXS7eEWGQwU=
-github.com/launchdarkly/go-sdk-common/v3 v3.3.0/go.mod h1:mXFmDGEh4ydK3QilRhrAyKuf9v44VZQWnINyhqbbOd0=
+github.com/launchdarkly/go-sdk-common/v3 v3.4.0 h1:GTRulE0G43xdWY1QdjAXJ7QnZ8PMFU8pOWZICCydEtM=
+github.com/launchdarkly/go-sdk-common/v3 v3.4.0/go.mod h1:6MNeeP8b2VtsM6I3TbShCHW/+tYh2c+p5dB+ilS69sg=
 github.com/launchdarkly/go-sdk-events/v3 v3.5.0 h1:Yav8Thm70dZbO8U1foYwZPf3w60n/lNBRaYeeNM/qg4=
 github.com/launchdarkly/go-sdk-events/v3 v3.5.0/go.mod h1:oepYWQ2RvvjfL2WxkE1uJJIuRsIMOP4WIVgUpXRPcNI=
 github.com/launchdarkly/go-semver v1.0.3 h1:agIy/RN3SqeQDIfKkl+oFslEdeIs7pgsJBs3CdCcGQM=
@@ -347,8 +347,6 @@ github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1 h1:rTgcYAFraGFj7sBMB2
 github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1/go.mod h1:fPS5d+zOsgFnMunj+Ki6jjlZtFvo4h9iNbtNXxzYn58=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0 h1:ItkPbTEzz0ObNzIpA3DfPqgEgeNyqno/Lnfd7BjC0Ns=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0/go.mod h1:ho3n0ML1YbV0QRnidDNF9ooFIC66FiVzZGW0u4behG0=
-github.com/launchdarkly/go-server-sdk/v7 v7.11.0 h1:MSCDYjAJyihlvf9JX8TKSNPhIUcacgiLGXGUKHMCOFE=
-github.com/launchdarkly/go-server-sdk/v7 v7.11.0/go.mod h1:eWesEHaYyH5Qr7CEexRP4PK3Qoru8c1bHBqilga3jB4=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2 h1:WX6qSzt7v8xz6d94nVcoil9ljuLTC/6OzQt0MhWYxsQ=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2/go.mod h1:L7+th5govYp5oKU9iN7To5PgznBuIjBPn+ejqKR0avw=
 github.com/launchdarkly/go-test-helpers/v3 v3.1.0 h1:E3bxJMzMoA+cJSF3xxtk2/chr1zshl1ZWa0/oR+8bvg=

--- a/go.sum
+++ b/go.sum
@@ -347,6 +347,8 @@ github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1 h1:rTgcYAFraGFj7sBMB2
 github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1/go.mod h1:fPS5d+zOsgFnMunj+Ki6jjlZtFvo4h9iNbtNXxzYn58=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0 h1:ItkPbTEzz0ObNzIpA3DfPqgEgeNyqno/Lnfd7BjC0Ns=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0/go.mod h1:ho3n0ML1YbV0QRnidDNF9ooFIC66FiVzZGW0u4behG0=
+github.com/launchdarkly/go-server-sdk/v7 v7.13.5-0.20251110185214-43752e37168d h1:W1/Vt/F/GB3NaSq9p9ycJYx10ad3Vbd7ZIRffRl6BMM=
+github.com/launchdarkly/go-server-sdk/v7 v7.13.5-0.20251110185214-43752e37168d/go.mod h1:EEUSX/bc1mVq+3pwrRzTfu8LFRWRI1UL4XMgzsKWmbE=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2 h1:WX6qSzt7v8xz6d94nVcoil9ljuLTC/6OzQt0MhWYxsQ=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2/go.mod h1:L7+th5govYp5oKU9iN7To5PgznBuIjBPn+ejqKR0avw=
 github.com/launchdarkly/go-test-helpers/v3 v3.1.0 h1:E3bxJMzMoA+cJSF3xxtk2/chr1zshl1ZWa0/oR+8bvg=

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1 h1:rTgcYAFraGFj7sBMB2
 github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1/go.mod h1:fPS5d+zOsgFnMunj+Ki6jjlZtFvo4h9iNbtNXxzYn58=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0 h1:ItkPbTEzz0ObNzIpA3DfPqgEgeNyqno/Lnfd7BjC0Ns=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0/go.mod h1:ho3n0ML1YbV0QRnidDNF9ooFIC66FiVzZGW0u4behG0=
-github.com/launchdarkly/go-server-sdk/v7 v7.13.5-0.20251110185214-43752e37168d h1:W1/Vt/F/GB3NaSq9p9ycJYx10ad3Vbd7ZIRffRl6BMM=
-github.com/launchdarkly/go-server-sdk/v7 v7.13.5-0.20251110185214-43752e37168d/go.mod h1:EEUSX/bc1mVq+3pwrRzTfu8LFRWRI1UL4XMgzsKWmbE=
+github.com/launchdarkly/go-server-sdk/v7 v7.14.0 h1:fY5V249PsHrey8b48/9UCs4fW/5fILO7RRO/7ivwkGw=
+github.com/launchdarkly/go-server-sdk/v7 v7.14.0/go.mod h1:EEUSX/bc1mVq+3pwrRzTfu8LFRWRI1UL4XMgzsKWmbE=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2 h1:WX6qSzt7v8xz6d94nVcoil9ljuLTC/6OzQt0MhWYxsQ=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2/go.mod h1:L7+th5govYp5oKU9iN7To5PgznBuIjBPn+ejqKR0avw=
 github.com/launchdarkly/go-test-helpers/v3 v3.1.0 h1:E3bxJMzMoA+cJSF3xxtk2/chr1zshl1ZWa0/oR+8bvg=

--- a/internal/autoconfig/stream_manager_test_base_test.go
+++ b/internal/autoconfig/stream_manager_test_base_test.go
@@ -224,7 +224,7 @@ func streamManagerTestWithStreamHandler(
 	mockLog.Loggers.SetMinLevel(ldlog.Debug)
 
 	handler, requestsCh := httphelpers.RecordingHandler(autoConfigEndpointHandler(streamHandler))
-	httpConfig, err := httpconfig.NewHTTPConfig(config.ProxyConfig{}, nil, "", mockLog.Loggers)
+	httpConfig, err := httpconfig.NewHTTPConfig(config.ProxyConfig{}, config.HTTPConfig{}, nil, "", mockLog.Loggers)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/events/event-relay_test.go
+++ b/internal/events/event-relay_test.go
@@ -97,7 +97,7 @@ func eventRelayTestWithOptions(
 	mockLog.Loggers.SetMinLevel(ldlog.Debug)
 	defer mockLog.DumpIfTestFailed(t)
 
-	httpConfig, _ := httpconfig.NewHTTPConfig(config.ProxyConfig{}, nil, "", mockLog.Loggers)
+	httpConfig, _ := httpconfig.NewHTTPConfig(config.ProxyConfig{}, config.HTTPConfig{}, nil, "", mockLog.Loggers)
 
 	store := st.NewInMemoryStore()
 

--- a/internal/events/event_publisher_test.go
+++ b/internal/events/event_publisher_test.go
@@ -25,7 +25,7 @@ import (
 const testSDKKey = config.SDKKey("my-key")
 
 func defaultHTTPConfig() httpconfig.HTTPConfig {
-	hc, err := httpconfig.NewHTTPConfig(config.ProxyConfig{}, nil, "", ldlog.NewDisabledLoggers())
+	hc, err := httpconfig.NewHTTPConfig(config.ProxyConfig{}, config.HTTPConfig{}, nil, "", ldlog.NewDisabledLoggers())
 	if err != nil {
 		panic(err)
 	}

--- a/internal/httpconfig/httpconfig.go
+++ b/internal/httpconfig/httpconfig.go
@@ -3,7 +3,9 @@ package httpconfig
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 
@@ -20,6 +22,45 @@ var (
 	errNTLMProxyAuthWithoutCredentials = errors.New("NTLM proxy authentication requires username and password")
 	errProxyAuthWithoutProxyURL        = errors.New("cannot specify proxy authentication without a proxy URL")
 )
+
+// applyCustomTransportSettings applies custom HTTP transport settings to the given transport.
+// Only non-zero/non-default values are applied.
+func applyCustomTransportSettings(transport *http.Transport, httpConfig config.HTTPConfig) {
+	if httpConfig.IdleConnTimeout > 0 {
+		transport.IdleConnTimeout = httpConfig.IdleConnTimeout
+	}
+	if httpConfig.MaxIdleConns > 0 {
+		transport.MaxIdleConns = httpConfig.MaxIdleConns
+	}
+	if httpConfig.MaxIdleConnsPerHost > 0 {
+		transport.MaxIdleConnsPerHost = httpConfig.MaxIdleConnsPerHost
+	}
+	if httpConfig.DisableKeepAlives {
+		transport.DisableKeepAlives = true
+	}
+}
+
+// formatTransportSettings returns a human-readable string of configured HTTP transport settings.
+// Only non-zero/non-default values are included in the output.
+func formatTransportSettings(httpConfig config.HTTPConfig) string {
+	var settings []string
+	if httpConfig.IdleConnTimeout > 0 {
+		settings = append(settings, fmt.Sprintf("IdleConnTimeout=%s", httpConfig.IdleConnTimeout))
+	}
+	if httpConfig.MaxIdleConns > 0 {
+		settings = append(settings, fmt.Sprintf("MaxIdleConns=%d", httpConfig.MaxIdleConns))
+	}
+	if httpConfig.MaxIdleConnsPerHost > 0 {
+		settings = append(settings, fmt.Sprintf("MaxIdleConnsPerHost=%d", httpConfig.MaxIdleConnsPerHost))
+	}
+	if httpConfig.DisableKeepAlives {
+		settings = append(settings, "DisableKeepAlives=true")
+	}
+	if len(settings) == 0 {
+		return "none"
+	}
+	return strings.Join(settings, ", ")
+}
 
 // HTTPConfig encapsulates ProxyConfig plus any other HTTP options we may support in the future (currently none).
 type HTTPConfig struct {
@@ -83,28 +124,15 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 			configBuilder.HTTPClientFactory(func() *http.Client {
 				client := baseFactory()
 				if transport, ok := client.Transport.(*http.Transport); ok {
-					// Apply custom transport settings
-					if httpConfig.IdleConnTimeout > 0 {
-						transport.IdleConnTimeout = httpConfig.IdleConnTimeout
-					}
-					if httpConfig.MaxIdleConns > 0 {
-						transport.MaxIdleConns = httpConfig.MaxIdleConns
-					}
-					if httpConfig.MaxIdleConnsPerHost > 0 {
-						transport.MaxIdleConnsPerHost = httpConfig.MaxIdleConnsPerHost
-					}
-					if httpConfig.DisableKeepAlives {
-						transport.DisableKeepAlives = true
-					}
-					loggers.Debug("Applied custom HTTP transport settings to NTLM proxy client")
+					applyCustomTransportSettings(transport, httpConfig)
 				} else {
 					// This should never happen based on ldntlm implementation, but defend against it
 					loggers.Warn("Unable to apply custom HTTP transport settings to NTLM proxy - unexpected transport type")
 				}
 				return client
 			})
-			loggers.Infof("NTLM proxy authentication enabled with custom HTTP transport (IdleConnTimeout=%s, MaxIdleConns=%d, MaxIdleConnsPerHost=%d, DisableKeepAlives=%t)",
-				httpConfig.IdleConnTimeout, httpConfig.MaxIdleConns, httpConfig.MaxIdleConnsPerHost, httpConfig.DisableKeepAlives)
+			loggers.Infof("NTLM proxy authentication enabled with custom HTTP transport (%s)",
+				formatTransportSettings(httpConfig))
 		} else {
 			configBuilder.HTTPClientFactory(factory)
 			loggers.Info("NTLM proxy authentication enabled")
@@ -125,27 +153,14 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 				}
 
 				// Apply custom transport settings
-				if httpConfig.IdleConnTimeout > 0 {
-					transport.IdleConnTimeout = httpConfig.IdleConnTimeout
-				}
-				if httpConfig.MaxIdleConns > 0 {
-					transport.MaxIdleConns = httpConfig.MaxIdleConns
-				}
-				if httpConfig.MaxIdleConnsPerHost > 0 {
-					transport.MaxIdleConnsPerHost = httpConfig.MaxIdleConnsPerHost
-				}
-				if httpConfig.DisableKeepAlives {
-					transport.DisableKeepAlives = true
-				}
+				applyCustomTransportSettings(transport, httpConfig)
 
-				loggers.Debug("Applied custom HTTP transport settings")
 				return &http.Client{Transport: transport}
 			})
 
 			// Log settings on initialization (not per client creation)
 			if hasCustomTransportSettings {
-				loggers.Infof("Custom HTTP transport configured (IdleConnTimeout=%s, MaxIdleConns=%d, MaxIdleConnsPerHost=%d, DisableKeepAlives=%t)",
-					httpConfig.IdleConnTimeout, httpConfig.MaxIdleConns, httpConfig.MaxIdleConnsPerHost, httpConfig.DisableKeepAlives)
+				loggers.Infof("Custom HTTP transport configured: %s", formatTransportSettings(httpConfig))
 			}
 		}
 	}

--- a/internal/httpconfig/httpconfig.go
+++ b/internal/httpconfig/httpconfig.go
@@ -29,7 +29,7 @@ type HTTPConfig struct {
 }
 
 // NewHTTPConfig validates all of the HTTP-related options and returns an HTTPConfig if successful.
-func NewHTTPConfig(proxyConfig config.ProxyConfig, authKey credential.SDKCredential, userAgent string, loggers ldlog.Loggers) (HTTPConfig, error) {
+func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig, authKey credential.SDKCredential, userAgent string, loggers ldlog.Loggers) (HTTPConfig, error) {
 	configBuilder := ldcomponents.HTTPConfiguration()
 	configBuilder.UserAgent(userAgent)
 
@@ -49,17 +49,27 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, authKey credential.SDKCredent
 
 	caCertFiles := proxyConfig.CACertFiles.Values()
 
+	// Build base transport options
+	transportOpts := []ldhttp.TransportOption{
+		ldhttp.ConnectTimeoutOption(ldcomponents.DefaultConnectTimeout),
+	}
+
+	// Add CA certificates if specified
+	for _, filePath := range caCertFiles {
+		if filePath != "" {
+			transportOpts = append(transportOpts, ldhttp.CACertFileOption(filePath))
+		}
+	}
+
+	// Check if custom HTTP transport settings are configured
+	hasCustomTransportSettings := httpConfig.IdleConnTimeout > 0 ||
+		httpConfig.MaxIdleConns > 0 ||
+		httpConfig.MaxIdleConnsPerHost > 0 ||
+		httpConfig.DisableKeepAlives
+
 	if proxyConfig.NTLMAuth {
 		if proxyConfig.User == "" || proxyConfig.Password == "" {
 			return ret, errNTLMProxyAuthWithoutCredentials
-		}
-		transportOpts := []ldhttp.TransportOption{
-			ldhttp.ConnectTimeoutOption(ldcomponents.DefaultConnectTimeout),
-		}
-		for _, filePath := range caCertFiles {
-			if filePath != "" {
-				transportOpts = append(transportOpts, ldhttp.CACertFileOption(filePath))
-			}
 		}
 		factory, err := ldntlm.NewNTLMProxyHTTPClientFactory(proxyConfig.URL.String(),
 			proxyConfig.User, proxyConfig.Password, proxyConfig.Domain, transportOpts...)
@@ -72,10 +82,32 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, authKey credential.SDKCredent
 		if proxyConfig.URL.IsDefined() {
 			configBuilder.ProxyURL(proxyConfig.URL.String())
 		}
-		for _, filePath := range caCertFiles {
-			if filePath != "" {
-				configBuilder.CACertFile(filePath)
-			}
+		// Apply custom HTTP transport settings if specified
+		if hasCustomTransportSettings || len(caCertFiles) > 0 {
+			configBuilder.HTTPClientFactory(func() *http.Client {
+				// Create base transport with cert files if needed
+				transport, _, err := ldhttp.NewHTTPTransport(transportOpts...)
+				if err != nil {
+					// Fall back to default client
+					return &http.Client{}
+				}
+
+				// Apply custom transport settings
+				if httpConfig.IdleConnTimeout > 0 {
+					transport.IdleConnTimeout = httpConfig.IdleConnTimeout
+				}
+				if httpConfig.MaxIdleConns > 0 {
+					transport.MaxIdleConns = httpConfig.MaxIdleConns
+				}
+				if httpConfig.MaxIdleConnsPerHost > 0 {
+					transport.MaxIdleConnsPerHost = httpConfig.MaxIdleConnsPerHost
+				}
+				if httpConfig.DisableKeepAlives {
+					transport.DisableKeepAlives = true
+				}
+
+				return &http.Client{Transport: transport}
+			})
 		}
 	}
 

--- a/internal/httpconfig/httpconfig.go
+++ b/internal/httpconfig/httpconfig.go
@@ -76,7 +76,31 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 		if err != nil {
 			return ret, err
 		}
-		configBuilder.HTTPClientFactory(factory)
+
+		// Wrap the NTLM factory to apply custom HTTP transport settings if configured
+		if hasCustomTransportSettings {
+			baseFactory := factory
+			configBuilder.HTTPClientFactory(func() *http.Client {
+				client := baseFactory()
+				if transport, ok := client.Transport.(*http.Transport); ok {
+					if httpConfig.IdleConnTimeout > 0 {
+						transport.IdleConnTimeout = httpConfig.IdleConnTimeout
+					}
+					if httpConfig.MaxIdleConns > 0 {
+						transport.MaxIdleConns = httpConfig.MaxIdleConns
+					}
+					if httpConfig.MaxIdleConnsPerHost > 0 {
+						transport.MaxIdleConnsPerHost = httpConfig.MaxIdleConnsPerHost
+					}
+					if httpConfig.DisableKeepAlives {
+						transport.DisableKeepAlives = true
+					}
+				}
+				return client
+			})
+		} else {
+			configBuilder.HTTPClientFactory(factory)
+		}
 		loggers.Info("NTLM proxy authentication enabled")
 	} else {
 		if proxyConfig.URL.IsDefined() {

--- a/internal/httpconfig/httpconfig.go
+++ b/internal/httpconfig/httpconfig.go
@@ -3,9 +3,7 @@ package httpconfig
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 
@@ -23,45 +21,6 @@ var (
 	errProxyAuthWithoutProxyURL        = errors.New("cannot specify proxy authentication without a proxy URL")
 )
 
-// applyCustomTransportSettings applies custom HTTP transport settings to the given transport.
-// Only configured values are applied.
-func applyCustomTransportSettings(transport *http.Transport, httpConfig config.HTTPConfig) {
-	if httpConfig.IdleConnTimeout.IsDefined() {
-		transport.IdleConnTimeout = httpConfig.IdleConnTimeout.GetOrElse(0)
-	}
-	if httpConfig.MaxIdleConns > 0 {
-		transport.MaxIdleConns = httpConfig.MaxIdleConns
-	}
-	if httpConfig.MaxIdleConnsPerHost > 0 {
-		transport.MaxIdleConnsPerHost = httpConfig.MaxIdleConnsPerHost
-	}
-	if httpConfig.DisableKeepAlives {
-		transport.DisableKeepAlives = true
-	}
-}
-
-// formatTransportSettings returns a human-readable string of configured HTTP transport settings.
-// Only configured values are included in the output.
-func formatTransportSettings(httpConfig config.HTTPConfig) string {
-	var settings []string
-	if httpConfig.IdleConnTimeout.IsDefined() {
-		settings = append(settings, fmt.Sprintf("IdleConnTimeout=%s", httpConfig.IdleConnTimeout.GetOrElse(0)))
-	}
-	if httpConfig.MaxIdleConns > 0 {
-		settings = append(settings, fmt.Sprintf("MaxIdleConns=%d", httpConfig.MaxIdleConns))
-	}
-	if httpConfig.MaxIdleConnsPerHost > 0 {
-		settings = append(settings, fmt.Sprintf("MaxIdleConnsPerHost=%d", httpConfig.MaxIdleConnsPerHost))
-	}
-	if httpConfig.DisableKeepAlives {
-		settings = append(settings, "DisableKeepAlives=true")
-	}
-	if len(settings) == 0 {
-		return "none"
-	}
-	return strings.Join(settings, ", ")
-}
-
 // HTTPConfig encapsulates ProxyConfig plus any other HTTP options we may support in the future (currently none).
 type HTTPConfig struct {
 	config.ProxyConfig
@@ -71,8 +30,32 @@ type HTTPConfig struct {
 
 // NewHTTPConfig validates all of the HTTP-related options and returns an HTTPConfig if successful.
 func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig, authKey credential.SDKCredential, userAgent string, loggers ldlog.Loggers) (HTTPConfig, error) {
+	transportOpts := []ldhttp.TransportOption{
+		ldhttp.ConnectTimeoutOption(ldcomponents.DefaultConnectTimeout),
+		ldhttp.MaxIdleConnsPerHostOption(httpConfig.MaxIdleConnsPerHost),
+		ldhttp.DisableKeepAlivesOption(httpConfig.DisableKeepAlives),
+	}
+
+	if httpConfig.IdleConnTimeout.IsDefined() {
+		transportOpts = append(transportOpts, ldhttp.IdleConnTimeoutOption(httpConfig.IdleConnTimeout.GetOrElse(0)))
+	}
+
+	if httpConfig.MaxIdleConns.IsDefined() {
+		transportOpts = append(transportOpts, ldhttp.MaxIdleConnsOption(httpConfig.MaxIdleConns.GetOrElse(0)))
+	}
+
+	caCertFiles := proxyConfig.CACertFiles.Values()
+
+	// Add CA certificates if specified
+	for _, filePath := range caCertFiles {
+		if filePath != "" {
+			transportOpts = append(transportOpts, ldhttp.CACertFileOption(filePath))
+		}
+	}
+
 	configBuilder := ldcomponents.HTTPConfiguration()
 	configBuilder.UserAgent(userAgent)
+	configBuilder.HTTPOptions(transportOpts)
 
 	ret := HTTPConfig{ProxyConfig: proxyConfig}
 
@@ -88,80 +71,22 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 		loggers.Infof("Using proxy server at %s", proxyConfig.URL.Get().Redacted())
 	}
 
-	caCertFiles := proxyConfig.CACertFiles.Values()
-
-	// Build base transport options
-	transportOpts := []ldhttp.TransportOption{
-		ldhttp.ConnectTimeoutOption(ldcomponents.DefaultConnectTimeout),
-	}
-
-	// Add CA certificates if specified
-	for _, filePath := range caCertFiles {
-		if filePath != "" {
-			transportOpts = append(transportOpts, ldhttp.CACertFileOption(filePath))
-		}
-	}
-
-	// Check if custom HTTP transport settings are configured
-	hasCustomTransportSettings := httpConfig.IdleConnTimeout.IsDefined() ||
-		httpConfig.MaxIdleConns > 0 ||
-		httpConfig.MaxIdleConnsPerHost > 0 ||
-		httpConfig.DisableKeepAlives
-
 	if proxyConfig.NTLMAuth {
 		if proxyConfig.User == "" || proxyConfig.Password == "" {
 			return ret, errNTLMProxyAuthWithoutCredentials
 		}
+
 		factory, err := ldntlm.NewNTLMProxyHTTPClientFactory(proxyConfig.URL.String(),
 			proxyConfig.User, proxyConfig.Password, proxyConfig.Domain, transportOpts...)
 		if err != nil {
 			return ret, err
 		}
 
-		// Wrap the NTLM factory to apply custom HTTP transport settings if configured
-		if hasCustomTransportSettings {
-			baseFactory := factory
-			configBuilder.HTTPClientFactory(func() *http.Client {
-				client := baseFactory()
-				if transport, ok := client.Transport.(*http.Transport); ok {
-					applyCustomTransportSettings(transport, httpConfig)
-				} else {
-					// This should never happen based on ldntlm implementation, but defend against it
-					loggers.Warn("Unable to apply custom HTTP transport settings to NTLM proxy - unexpected transport type")
-				}
-				return client
-			})
-			loggers.Infof("NTLM proxy authentication enabled with custom HTTP transport (%s)",
-				formatTransportSettings(httpConfig))
-		} else {
-			configBuilder.HTTPClientFactory(factory)
-			loggers.Info("NTLM proxy authentication enabled")
-		}
+		configBuilder.HTTPClientFactory(factory)
+		loggers.Info("NTLM proxy authentication enabled")
 	} else {
 		if proxyConfig.URL.IsDefined() {
 			configBuilder.ProxyURL(proxyConfig.URL.String())
-		}
-		// Apply custom HTTP transport settings if specified
-		if hasCustomTransportSettings || len(caCertFiles) > 0 {
-			configBuilder.HTTPClientFactory(func() *http.Client {
-				// Create base transport with cert files if needed
-				transport, _, err := ldhttp.NewHTTPTransport(transportOpts...)
-				if err != nil {
-					// This should rarely happen, but log it if transport creation fails
-					loggers.Warnf("Failed to create custom HTTP transport: %v - using default client", err)
-					return &http.Client{}
-				}
-
-				// Apply custom transport settings
-				applyCustomTransportSettings(transport, httpConfig)
-
-				return &http.Client{Transport: transport}
-			})
-
-			// Log settings on initialization (not per client creation)
-			if hasCustomTransportSettings {
-				loggers.Infof("Custom HTTP transport configured: %s", formatTransportSettings(httpConfig))
-			}
 		}
 	}
 

--- a/internal/httpconfig/httpconfig.go
+++ b/internal/httpconfig/httpconfig.go
@@ -83,6 +83,7 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 			configBuilder.HTTPClientFactory(func() *http.Client {
 				client := baseFactory()
 				if transport, ok := client.Transport.(*http.Transport); ok {
+					// Apply custom transport settings
 					if httpConfig.IdleConnTimeout > 0 {
 						transport.IdleConnTimeout = httpConfig.IdleConnTimeout
 					}
@@ -95,13 +96,19 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 					if httpConfig.DisableKeepAlives {
 						transport.DisableKeepAlives = true
 					}
+					loggers.Debug("Applied custom HTTP transport settings to NTLM proxy client")
+				} else {
+					// This should never happen based on ldntlm implementation, but defend against it
+					loggers.Warn("Unable to apply custom HTTP transport settings to NTLM proxy - unexpected transport type")
 				}
 				return client
 			})
+			loggers.Infof("NTLM proxy authentication enabled with custom HTTP transport (IdleConnTimeout=%s, MaxIdleConns=%d, MaxIdleConnsPerHost=%d, DisableKeepAlives=%t)",
+				httpConfig.IdleConnTimeout, httpConfig.MaxIdleConns, httpConfig.MaxIdleConnsPerHost, httpConfig.DisableKeepAlives)
 		} else {
 			configBuilder.HTTPClientFactory(factory)
+			loggers.Info("NTLM proxy authentication enabled")
 		}
-		loggers.Info("NTLM proxy authentication enabled")
 	} else {
 		if proxyConfig.URL.IsDefined() {
 			configBuilder.ProxyURL(proxyConfig.URL.String())
@@ -112,7 +119,8 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 				// Create base transport with cert files if needed
 				transport, _, err := ldhttp.NewHTTPTransport(transportOpts...)
 				if err != nil {
-					// Fall back to default client
+					// This should rarely happen, but log it if transport creation fails
+					loggers.Warnf("Failed to create custom HTTP transport: %v - using default client", err)
 					return &http.Client{}
 				}
 
@@ -130,8 +138,15 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 					transport.DisableKeepAlives = true
 				}
 
+				loggers.Debug("Applied custom HTTP transport settings")
 				return &http.Client{Transport: transport}
 			})
+
+			// Log settings on initialization (not per client creation)
+			if hasCustomTransportSettings {
+				loggers.Infof("Custom HTTP transport configured (IdleConnTimeout=%s, MaxIdleConns=%d, MaxIdleConnsPerHost=%d, DisableKeepAlives=%t)",
+					httpConfig.IdleConnTimeout, httpConfig.MaxIdleConns, httpConfig.MaxIdleConnsPerHost, httpConfig.DisableKeepAlives)
+			}
 		}
 	}
 

--- a/internal/httpconfig/httpconfig.go
+++ b/internal/httpconfig/httpconfig.go
@@ -84,10 +84,8 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 
 		configBuilder.HTTPClientFactory(factory)
 		loggers.Info("NTLM proxy authentication enabled")
-	} else {
-		if proxyConfig.URL.IsDefined() {
-			configBuilder.ProxyURL(proxyConfig.URL.String())
-		}
+	} else if proxyConfig.URL.IsDefined() {
+		configBuilder.ProxyURL(proxyConfig.URL.String())
 	}
 
 	var err error

--- a/internal/httpconfig/httpconfig.go
+++ b/internal/httpconfig/httpconfig.go
@@ -24,10 +24,10 @@ var (
 )
 
 // applyCustomTransportSettings applies custom HTTP transport settings to the given transport.
-// Only non-zero/non-default values are applied.
+// Only configured values are applied.
 func applyCustomTransportSettings(transport *http.Transport, httpConfig config.HTTPConfig) {
-	if httpConfig.IdleConnTimeout > 0 {
-		transport.IdleConnTimeout = httpConfig.IdleConnTimeout
+	if httpConfig.IdleConnTimeout.IsDefined() {
+		transport.IdleConnTimeout = httpConfig.IdleConnTimeout.GetOrElse(0)
 	}
 	if httpConfig.MaxIdleConns > 0 {
 		transport.MaxIdleConns = httpConfig.MaxIdleConns
@@ -41,11 +41,11 @@ func applyCustomTransportSettings(transport *http.Transport, httpConfig config.H
 }
 
 // formatTransportSettings returns a human-readable string of configured HTTP transport settings.
-// Only non-zero/non-default values are included in the output.
+// Only configured values are included in the output.
 func formatTransportSettings(httpConfig config.HTTPConfig) string {
 	var settings []string
-	if httpConfig.IdleConnTimeout > 0 {
-		settings = append(settings, fmt.Sprintf("IdleConnTimeout=%s", httpConfig.IdleConnTimeout))
+	if httpConfig.IdleConnTimeout.IsDefined() {
+		settings = append(settings, fmt.Sprintf("IdleConnTimeout=%s", httpConfig.IdleConnTimeout.GetOrElse(0)))
 	}
 	if httpConfig.MaxIdleConns > 0 {
 		settings = append(settings, fmt.Sprintf("MaxIdleConns=%d", httpConfig.MaxIdleConns))
@@ -103,7 +103,7 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 	}
 
 	// Check if custom HTTP transport settings are configured
-	hasCustomTransportSettings := httpConfig.IdleConnTimeout > 0 ||
+	hasCustomTransportSettings := httpConfig.IdleConnTimeout.IsDefined() ||
 		httpConfig.MaxIdleConns > 0 ||
 		httpConfig.MaxIdleConnsPerHost > 0 ||
 		httpConfig.DisableKeepAlives

--- a/internal/httpconfig/httpconfig_test.go
+++ b/internal/httpconfig/httpconfig_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestUserAgentHeader(t *testing.T) {
-	hc, err := NewHTTPConfig(config.ProxyConfig{}, nil, "abc", ldlog.NewDefaultLoggers())
+	hc, err := NewHTTPConfig(config.ProxyConfig{}, config.HTTPConfig{}, nil, "abc", ldlog.NewDefaultLoggers())
 	require.NoError(t, err)
 	require.NotNil(t, hc)
 	headers := hc.SDKHTTPConfig.DefaultHeaders
@@ -29,7 +29,7 @@ func TestUserAgentHeader(t *testing.T) {
 }
 
 func TestNoAuthorizationHeader(t *testing.T) {
-	hc, err := NewHTTPConfig(config.ProxyConfig{}, nil, "", ldlog.NewDefaultLoggers())
+	hc, err := NewHTTPConfig(config.ProxyConfig{}, config.HTTPConfig{}, nil, "", ldlog.NewDefaultLoggers())
 	require.NoError(t, err)
 	require.NotNil(t, hc)
 	headers := hc.SDKHTTPConfig.DefaultHeaders
@@ -37,7 +37,7 @@ func TestNoAuthorizationHeader(t *testing.T) {
 }
 
 func TestAuthorizationHeader(t *testing.T) {
-	hc, err := NewHTTPConfig(config.ProxyConfig{}, config.SDKKey("key"), "", ldlog.NewDefaultLoggers())
+	hc, err := NewHTTPConfig(config.ProxyConfig{}, config.HTTPConfig{}, config.SDKKey("key"), "", ldlog.NewDefaultLoggers())
 	require.NoError(t, err)
 	require.NotNil(t, hc)
 	headers := hc.SDKHTTPConfig.DefaultHeaders
@@ -52,7 +52,7 @@ func TestSimpleProxy(t *testing.T) {
 	httphelpers.WithServer(handler, func(server *httptest.Server) {
 		proxyConfig := config.ProxyConfig{}
 		proxyConfig.URL, _ = configtypes.NewOptURLAbsoluteFromString(server.URL)
-		hc, err := NewHTTPConfig(proxyConfig, nil, "", mockLog.Loggers)
+		hc, err := NewHTTPConfig(proxyConfig, config.HTTPConfig{}, nil, "", mockLog.Loggers)
 
 		mockLog.AssertMessageMatch(t, true, ldlog.Info, "Using proxy server at "+server.URL)
 
@@ -77,7 +77,7 @@ func TestSimpleProxyWithCACert(t *testing.T) {
 			proxyConfig := config.ProxyConfig{}
 			proxyConfig.URL, _ = configtypes.NewOptURLAbsoluteFromString(server.URL)
 			proxyConfig.CACertFiles = configtypes.NewOptStringList([]string{certFilePath})
-			hc, err := NewHTTPConfig(proxyConfig, nil, "", mockLog.Loggers)
+			hc, err := NewHTTPConfig(proxyConfig, config.HTTPConfig{}, nil, "", mockLog.Loggers)
 
 			mockLog.AssertMessageMatch(t, true, ldlog.Info, "Using proxy server at "+server.URL)
 
@@ -99,7 +99,7 @@ func TestSimpleProxyCACertError(t *testing.T) {
 		proxyConfig := config.ProxyConfig{}
 		proxyConfig.URL, _ = configtypes.NewOptURLAbsoluteFromString("http://fake-proxy")
 		proxyConfig.CACertFiles = configtypes.NewOptStringList([]string{certFilePath})
-		_, err := NewHTTPConfig(proxyConfig, nil, "", mockLog.Loggers)
+		_, err := NewHTTPConfig(proxyConfig, config.HTTPConfig{}, nil, "", mockLog.Loggers)
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "invalid CA certificate data")
 		}

--- a/internal/httpconfig/httpconfig_test.go
+++ b/internal/httpconfig/httpconfig_test.go
@@ -111,28 +111,28 @@ func TestNTLMProxyInvalidConfigs(t *testing.T) {
 	// so here we're only testing that we validate the parameters correctly.
 
 	proxyConfig1 := config.ProxyConfig{NTLMAuth: true}
-	_, err := NewHTTPConfig(proxyConfig1, nil, "", ldlog.NewDisabledLoggers())
+	_, err := NewHTTPConfig(proxyConfig1, config.HTTPConfig{}, nil, "", ldlog.NewDisabledLoggers())
 	assert.Equal(t, errProxyAuthWithoutProxyURL, err)
 
 	proxyConfig2 := proxyConfig1
 	proxyConfig2.URL, _ = configtypes.NewOptURLAbsoluteFromString("http://fake-proxy")
-	_, err = NewHTTPConfig(proxyConfig2, nil, "", ldlog.NewDisabledLoggers())
+	_, err = NewHTTPConfig(proxyConfig2, config.HTTPConfig{}, nil, "", ldlog.NewDisabledLoggers())
 	assert.Equal(t, errNTLMProxyAuthWithoutCredentials, err)
 
 	proxyConfig3 := proxyConfig2
 	proxyConfig3.User = "user"
-	_, err = NewHTTPConfig(proxyConfig3, nil, "", ldlog.NewDisabledLoggers())
+	_, err = NewHTTPConfig(proxyConfig3, config.HTTPConfig{}, nil, "", ldlog.NewDisabledLoggers())
 	assert.Equal(t, errNTLMProxyAuthWithoutCredentials, err)
 
 	proxyConfig4 := proxyConfig3
 	proxyConfig4.Password = "pass"
-	_, err = NewHTTPConfig(proxyConfig4, nil, "", ldlog.NewDisabledLoggers())
+	_, err = NewHTTPConfig(proxyConfig4, config.HTTPConfig{}, nil, "", ldlog.NewDisabledLoggers())
 	assert.NoError(t, err)
 
 	proxyConfig5 := proxyConfig4
 	helpers.WithTempFile(func(certFileName string) {
 		proxyConfig5.CACertFiles = configtypes.NewOptStringList([]string{certFileName})
-		_, err = NewHTTPConfig(proxyConfig5, nil, "", ldlog.NewDisabledLoggers())
+		_, err = NewHTTPConfig(proxyConfig5, config.HTTPConfig{}, nil, "", ldlog.NewDisabledLoggers())
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "invalid CA certificate data")
 		}
@@ -144,7 +144,7 @@ func TestLogsRedactConnectionPassword(t *testing.T) {
 	url1, _ := configtypes.NewOptURLAbsoluteFromString("http://my-proxy")
 	proxyConfig1 := config.ProxyConfig{NTLMAuth: true, URL: url1, User: "my-user", Password: "my-pass"}
 	mockLog1 := ldlogtest.NewMockLog()
-	_, err := NewHTTPConfig(proxyConfig1, nil, "", mockLog1.Loggers)
+	_, err := NewHTTPConfig(proxyConfig1, config.HTTPConfig{}, nil, "", mockLog1.Loggers)
 	assert.NoError(t, err)
 	mockLog1.AssertMessageMatch(t, true, ldlog.Info, "Using proxy server at http://my-proxy$")
 
@@ -153,7 +153,7 @@ func TestLogsRedactConnectionPassword(t *testing.T) {
 	url2Absolute, _ := configtypes.NewOptURLAbsolute(url2)
 	proxyConfig2 := config.ProxyConfig{URL: url2Absolute}
 	mockLog2 := ldlogtest.NewMockLog()
-	_, err = NewHTTPConfig(proxyConfig2, nil, "", mockLog2.Loggers)
+	_, err = NewHTTPConfig(proxyConfig2, config.HTTPConfig{}, nil, "", mockLog2.Loggers)
 	assert.NoError(t, err)
 	mockLog2.AssertMessageMatch(t, true, ldlog.Info, "Using proxy server at http://my-user:xxxxx@my-proxy$")
 }

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -167,7 +167,7 @@ func NewEnvContext(
 		),
 	)
 
-	httpConfig, err := httpconfig.NewHTTPConfig(allConfig.Proxy, envConfig.SDKKey, params.UserAgent, params.Loggers)
+	httpConfig, err := httpconfig.NewHTTPConfig(allConfig.Proxy, allConfig.HTTP, envConfig.SDKKey, params.UserAgent, params.Loggers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sharedtest/configs.go
+++ b/internal/sharedtest/configs.go
@@ -21,7 +21,7 @@ func ExistingInstance[T any](instance T) subsystems.ComponentConfigurer[T] {
 }
 
 func MakeBasicHTTPConfig() httpconfig.HTTPConfig {
-	ret, err := httpconfig.NewHTTPConfig(config.ProxyConfig{}, nil, "", ldlog.NewDisabledLoggers())
+	ret, err := httpconfig.NewHTTPConfig(config.ProxyConfig{}, config.HTTPConfig{}, nil, "", ldlog.NewDisabledLoggers())
 	if err != nil {
 		panic(err)
 	}

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -188,6 +188,7 @@ func newRelayInternal(c config.Config, options relayInternalOptions) (*Relay, er
 	if hasAutoConfigKey {
 		httpConfig, err := httpconfig.NewHTTPConfig(
 			c.Proxy,
+			c.HTTP,
 			c.AutoConfig.Key,
 			userAgent,
 			loggers,


### PR DESCRIPTION
## Summary

This PR adds configurable HTTP client transport settings to address EOF errors caused by HTTP connection pool reuse issues (see #544).

## Problem

The relay proxy experiences frequent WARN-level errors when posting events:
```
WARN: [env: ...] (usage metrics) Unexpected error while sending events: Post "https://events.launchdarkly.com/bulk": EOF
```

This is a known Go HTTP client connection pooling issue where:
1. The HTTP client reuses an idle connection from its pool
2. An intermediate component (load balancer, NAT gateway) closes the idle connection
3. Go's `http.Transport` doesn't detect the closed connection before attempting reuse
4. Result: EOF error, followed by automatic retry

## Solution

Added four new configuration options under the `[Http]` section:

| Environment Variable | Purpose |
|---------------------|---------|
| `HTTP_IDLE_CONN_TIMEOUT` | Control how long idle connections stay open before being closed |
| `HTTP_MAX_IDLE_CONNS` | Set maximum idle connections across all hosts |
| `HTTP_MAX_IDLE_CONNS_PER_HOST` | Set per-host idle connection limit |
| `HTTP_DISABLE_KEEPALIVE` | Disable keep-alive for debugging |

## Example Configuration

```bash
# Reduce idle timeout to close connections before they're closed remotely
HTTP_IDLE_CONN_TIMEOUT=30s

# Increase connection pool size for high-concurrency scenarios  
HTTP_MAX_IDLE_CONNS=100
HTTP_MAX_IDLE_CONNS_PER_HOST=10
```

## Changes

- Added `HTTPConfig` struct fields in `config/config.go`
- Modified `httpconfig.NewHTTPConfig()` to accept and apply transport settings
- Updated all call sites to pass the new `HTTPConfig` parameter
- Added comprehensive documentation in `docs/configuration.md`
- Updated test files to include empty `HTTPConfig{}` where needed

## Testing

- ✅ All packages build successfully
- ✅ Backward compatible (defaults to Go's standard behavior when not configured)
- ✅ Works with both standard proxy configuration and NTLM proxy auth

## Related Issue

Fixes #544

## Notes

- Settings are optional and backward-compatible
- When not configured, uses Go's defaults (90s idle timeout, 100 max idle conns, 2 per-host)
- Particularly useful in cloud environments with NAT gateways or load balancers that aggressively close idle connections

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new `[Http]` transport settings (idle timeout, max idle conns, per-host idle conns, disable keep-alive) and applies them in the HTTP client; updates docs, call sites, and deps.
> 
> - **HTTP transport configuration**:
>   - Extend `config.HTTPConfig` with `idleConnTimeout`, `maxIdleConns`, `maxIdleConnsPerHost`, `disableKeepAlive`.
>   - Apply these via `ldhttp` in `internal/httpconfig.NewHTTPConfig(...)`; also move CA certs into transport options.
> - **Wiring and usage**:
>   - Change `NewHTTPConfig` signature to include `config.HTTPConfig`; update all call sites (`relay/relay.go`, `internal/relayenv/env_context_impl.go`, tests, shared helpers).
> - **Documentation**:
>   - Document new `[Http]` options in `docs/configuration.md` with env vars and descriptions.
> - **Dependencies**:
>   - Bump `github.com/launchdarkly/go-sdk-common/v3` to `v3.4.0` and `github.com/launchdarkly/go-server-sdk/v7` to `v7.14.0` (update `go.mod`/`go.sum`).
> - **Tests**:
>   - Adjust tests to pass `config.HTTPConfig{}` and validate behavior remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec15343cc7821b0ae3a86fc8b3d82aa24e71c71a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->