### PR TITLE
fix: Bump minimum go to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/ld-relay/v8
 
-go 1.23.0
+go 1.24.0
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Raise minimum Go version to 1.24 in `go.mod`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a193e4d779bd7efe7c68573f28406f3b651e73b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->