### PR TITLE
fix: Redact Redis password from Big Segment logs

### DIFF
--- a/internal/sdks/big_segments.go
+++ b/internal/sdks/big_segments.go
@@ -2,6 +2,7 @@ package sdks
 
 import (
 	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
@@ -24,7 +25,8 @@ func ConfigureBigSegments(
 
 	if allConfig.Redis.URL.IsDefined() {
 		redisBuilder, redisURL := makeRedisDataStoreBuilder(ldredis.BigSegmentStore, allConfig, envConfig)
-		loggers.Infof("Using Redis big segment store: %s with prefix: %s", redisURL, envConfig.Prefix)
+		redactedURL := util.RedactURL(redisURL)
+		loggers.Infof("Using Redis big segment store: %s with prefix: %s", redactedURL, envConfig.Prefix)
 		storeFactory = redisBuilder
 	} else if allConfig.DynamoDB.Enabled {
 		dynamoDBBuilder, tableName, err := makeDynamoDBDataStoreBuilder(lddynamodb.BigSegmentStore, allConfig, envConfig)

--- a/internal/sdks/big_segments_test.go
+++ b/internal/sdks/big_segments_test.go
@@ -52,11 +52,10 @@ func TestBigSegmentsRedis(t *testing.T) {
 
 	t.Run("password is redacted in log", func(t *testing.T) {
 		urlWithPassword := "redis://username:very-secret-password@redishost:3000"
-		redactedURL := "redis://username:xxxxx@redishost:3000"
 		var c config.Config
 		c.Redis.URL, _ = configtypes.NewOptURLAbsoluteFromString(urlWithPassword)
 		log := assertBigSegmentsConfigured(t, c, config.EnvConfig{})
-		log.AssertMessageMatch(t, true, ldlog.Info, "Using Redis big segment store: "+redactedURL)
+		log.AssertMessageMatch(t, false, ldlog.Info, "very-secret-password")
 	})
 
 	t.Run("prefix", func(t *testing.T) {

--- a/internal/sdks/big_segments_test.go
+++ b/internal/sdks/big_segments_test.go
@@ -50,6 +50,15 @@ func TestBigSegmentsRedis(t *testing.T) {
 		log.AssertMessageMatch(t, true, ldlog.Info, "Using Redis big segment store: "+redisURL)
 	})
 
+	t.Run("password is redacted in log", func(t *testing.T) {
+		urlWithPassword := "redis://username:very-secret-password@redishost:3000"
+		redactedURL := "redis://username:xxxxx@redishost:3000"
+		var c config.Config
+		c.Redis.URL, _ = configtypes.NewOptURLAbsoluteFromString(urlWithPassword)
+		log := assertBigSegmentsConfigured(t, c, config.EnvConfig{})
+		log.AssertMessageMatch(t, true, ldlog.Info, "Using Redis big segment store: "+redactedURL)
+	})
+
 	t.Run("prefix", func(t *testing.T) {
 		c := config.Config{
 			Redis: config.RedisConfig{


### PR DESCRIPTION
fixes #550

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redacts Redis credentials in Big Segments Redis log messages and adds a test to verify redaction.
> 
> - **Logging**:
>   - Use `util.RedactURL` to redact credentials in Redis Big Segments log message in `internal/sdks/big_segments.go`.
> - **Tests**:
>   - Add test ensuring Redis password is not present in logs in `internal/sdks/big_segments_test.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24a663504a9a91e21716fdceb8268ff8c58bc315. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->