### PR TITLE
fix: Bump go-server-sdk from v7.14.1 to v7.14.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/launchdarkly/go-server-sdk-dynamodb/v4 v4.0.0
 	github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1
 	github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0
-	github.com/launchdarkly/go-server-sdk/v7 v7.14.1
+	github.com/launchdarkly/go-server-sdk/v7 v7.14.2
 	github.com/launchdarkly/go-test-helpers/v3 v3.1.0
 	github.com/launchdarkly/opencensus-go-exporter-stackdriver v0.14.5
 	github.com/pborman/uuid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1 h1:rTgcYAFraGFj7sBMB2
 github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1/go.mod h1:fPS5d+zOsgFnMunj+Ki6jjlZtFvo4h9iNbtNXxzYn58=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0 h1:ItkPbTEzz0ObNzIpA3DfPqgEgeNyqno/Lnfd7BjC0Ns=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0/go.mod h1:ho3n0ML1YbV0QRnidDNF9ooFIC66FiVzZGW0u4behG0=
-github.com/launchdarkly/go-server-sdk/v7 v7.14.1 h1:DoeCatbnnJztcZZGbCx2pT3yTnRZpD49RhtW1r5QDAM=
-github.com/launchdarkly/go-server-sdk/v7 v7.14.1/go.mod h1:0CUdE5PI0SVG1Tb6CwKz8wZ9zEHUzfMutl6wY2MzUF0=
+github.com/launchdarkly/go-server-sdk/v7 v7.14.2 h1:9LOCC9U1l8WcYLBg/TbJUTiwLW/1Ti61UikpD+4gttk=
+github.com/launchdarkly/go-server-sdk/v7 v7.14.2/go.mod h1:0CUdE5PI0SVG1Tb6CwKz8wZ9zEHUzfMutl6wY2MzUF0=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2 h1:WX6qSzt7v8xz6d94nVcoil9ljuLTC/6OzQt0MhWYxsQ=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2/go.mod h1:L7+th5govYp5oKU9iN7To5PgznBuIjBPn+ejqKR0avw=
 github.com/launchdarkly/go-test-helpers/v3 v3.1.0 h1:E3bxJMzMoA+cJSF3xxtk2/chr1zshl1ZWa0/oR+8bvg=
@@ -849,6 +849,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
+gopkg.in/ghodss/yaml.v1 v1.0.0 h1:JlY4R6oVz+ZSvcDhVfNQ/k/8Xo6yb2s1PBhslPZPX4c=
+gopkg.in/ghodss/yaml.v1 v1.0.0/go.mod h1:HDvRMPQLqycKPs9nWLuzZWxsxRzISLCRORiDpBUOMqg=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=

--- a/internal/datadestination/datadestination.go
+++ b/internal/datadestination/datadestination.go
@@ -46,12 +46,7 @@ func (d *DataDestinationWrapper) SetDataSystemPieces(ro subsystems.ReadOnlyDataS
 				continue
 			}
 
-			switch changeSet.IntentCode() {
-			case subsystems.IntentTransferFull:
-				d.updates.SetBasis(changeSet.Changes(), changeSet.Selector())
-			case subsystems.IntentTransferChanges:
-				d.updates.ApplyDelta(changeSet.Changes(), changeSet.Selector())
-			}
+			d.updates.Apply(changeSet)
 		}
 	}()
 }

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -846,14 +846,9 @@ func (u *envContextStreamUpdates) handleBigSegments(events []subsystems.Change) 
 	}
 }
 
-func (u *envContextStreamUpdates) SetBasis(events []subsystems.Change, selector subsystems.Selector) {
-	u.context.envStreams.SetBasis(events, selector)
-	u.handleBigSegments(events)
-}
-
-func (u *envContextStreamUpdates) ApplyDelta(events []subsystems.Change, selector subsystems.Selector) {
-	u.context.envStreams.ApplyDelta(events, selector)
-	u.handleBigSegments(events)
+func (u *envContextStreamUpdates) Apply(changeSet subsystems.ChangeSet) {
+	u.context.envStreams.Apply(changeSet)
+	u.handleBigSegments(changeSet.Changes())
 }
 
 func (u *envContextStreamUpdates) InvalidateClientSideState() {

--- a/internal/sharedtest/testclient/fake_data_destination.go
+++ b/internal/sharedtest/testclient/fake_data_destination.go
@@ -14,10 +14,19 @@ func (d *FakeDataDestination) Selector() subsystems.Selector {
 	return d.store.Selector()
 }
 
+func (d *FakeDataDestination) Apply(changeSet subsystems.ChangeSet) {
+	switch changeSet.IntentCode() {
+	case subsystems.IntentTransferFull:
+		d.SetBasis(changeSet.Changes(), changeSet.Selector(), true)
+	case subsystems.IntentTransferChanges:
+		d.ApplyDelta(changeSet.Changes(), changeSet.Selector(), true)
+	}
+}
+
 func (d *FakeDataDestination) SetBasis(changes []subsystems.Change, selector subsystems.Selector, persist bool) {
-	d.store.SetBasis(changes, selector)
+	d.store.setBasis(changes, selector)
 }
 
 func (d *FakeDataDestination) ApplyDelta(changes []subsystems.Change, selector subsystems.Selector, persist bool) {
-	d.store.ApplyDelta(changes, selector)
+	d.store.applyDelta(changes, selector)
 }

--- a/internal/sharedtest/testclient/fake_store.go
+++ b/internal/sharedtest/testclient/fake_store.go
@@ -34,7 +34,16 @@ func (s *FakeStore) Selector() subsystems.Selector {
 	return selector
 }
 
-func (s *FakeStore) SetBasis(changes []subsystems.Change, selector subsystems.Selector) {
+func (s *FakeStore) Apply(changeSet subsystems.ChangeSet) {
+	switch changeSet.IntentCode() {
+	case subsystems.IntentTransferFull:
+		s.setBasis(changeSet.Changes(), changeSet.Selector())
+	case subsystems.IntentTransferChanges:
+		s.applyDelta(changeSet.Changes(), changeSet.Selector())
+	}
+}
+
+func (s *FakeStore) setBasis(changes []subsystems.Change, selector subsystems.Selector) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.collections = make([]ldstoretypes.Collection, 2)
@@ -77,7 +86,7 @@ func (s *FakeStore) SetBasis(changes []subsystems.Change, selector subsystems.Se
 	s.selector = selector
 }
 
-func (s *FakeStore) ApplyDelta(changes []subsystems.Change, selector subsystems.Selector) {
+func (s *FakeStore) applyDelta(changes []subsystems.Change, selector subsystems.Selector) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, change := range changes {

--- a/internal/store/relay_feature_store_testdata_test.go
+++ b/internal/store/relay_feature_store_testdata_test.go
@@ -122,12 +122,13 @@ func (f *mockStoreFactory) Build(
 	return f.instance, nil
 }
 
-func (m *mockEnvStreamsUpdates) SetBasis(events []subsystems.Change, selector subsystems.Selector, persist bool) {
-	m.allData = append(m.allData, events)
-}
-
-func (m *mockEnvStreamsUpdates) ApplyDelta(events []subsystems.Change, selector subsystems.Selector, persist bool) {
-	m.singleItem = append(m.singleItem, events...)
+func (m *mockEnvStreamsUpdates) Apply(changeSet subsystems.ChangeSet) {
+	switch changeSet.IntentCode() {
+	case subsystems.IntentTransferFull:
+		m.allData = append(m.allData, changeSet.Changes())
+	case subsystems.IntentTransferChanges:
+		m.singleItem = append(m.singleItem, changeSet.Changes()...)
+	}
 }
 
 func (m *mockEnvStreamsUpdates) InvalidateClientSideState() {}

--- a/internal/streams/env_streams.go
+++ b/internal/streams/env_streams.go
@@ -18,21 +18,11 @@ import (
 // components that publish updates to EnvStreams should use this interface rather than the implementation
 // type, both to clarify that they don't need other EnvStreams functionality and to simplify testing.
 type EnvStreamUpdates interface {
-	// SetBasis defines a new basis for the data store. This means the store must
-	// be emptied of any existing data before applying the events. This operation should be
-	// atomic with respect to any other operations that modify the store.
-	//
-	// The selector defines the version of the basis.
-	SetBasis(events []subsystems.Change, selector subsystems.Selector)
-
-	// ApplyDelta applies a set of changes to an existing basis. This operation should be atomic with
-	// respect to any other operations that modify the store.
-	//
-	// The selector defines the new version of the basis.
-	//
-	// If persist is true, it indicates that the changes should be propagated to any connected persistent
-	// store.
-	ApplyDelta(events []subsystems.Change, selector subsystems.Selector)
+	// Apply accepts a changeSet containing data store modifications (such as flag or segment updates)
+	// and forwards it to all active streams for broadcasting to connected SDK clients. The changeSet
+	// represents atomic changes to be applied to the data store and will be serialized appropriately
+	// for each stream type (server-side vs client-side SDKs).
+	Apply(changeSet subsystems.ChangeSet)
 
 	// InvalidateClientSideState signals an update that could affect client-side evaluations, but does
 	// not change any server-side data item. Updating big segment data is such an event, since the
@@ -156,24 +146,9 @@ func (es *EnvStreams) RemoveCredential(credential credential.SDKCredential) {
 	}
 }
 
-// SetBasis defines a new basis for the data store. This means the store must
-// be emptied of any existing data before applying the events. This operation should be
-// atomic with respect to any other operations that modify the store.
-//
-// The selector defines the version of the basis.
-func (es *EnvStreams) SetBasis(events []subsystems.Change, selector subsystems.Selector) {
+func (es *EnvStreams) Apply(changeSet subsystems.ChangeSet) {
 	for _, esp := range es.getEnvStreamProviders() {
-		esp.SetBasis(events, selector)
-	}
-}
-
-// ApplyDelta applies a set of changes to an existing basis. This operation should be atomic with
-// respect to any other operations that modify the store.
-//
-// The selector defines the new version of the basis.
-func (es *EnvStreams) ApplyDelta(events []subsystems.Change, selector subsystems.Selector) {
-	for _, esp := range es.getEnvStreamProviders() {
-		esp.ApplyDelta(events, selector)
+		esp.Apply(changeSet)
 	}
 }
 

--- a/internal/streams/env_streams_test.go
+++ b/internal/streams/env_streams_test.go
@@ -75,12 +75,13 @@ func (p *mockStreamProvider) RegisterV2(
 
 func (p *mockStreamProvider) Close() {}
 
-func (e *mockEnvStreamProvider) SetBasis(events []subsystems.Change, selector subsystems.Selector) {
-	e.allDataUpdates = append(e.allDataUpdates, events)
-}
-
-func (e *mockEnvStreamProvider) ApplyDelta(events []subsystems.Change, selector subsystems.Selector) {
-	e.itemUpdates = append(e.itemUpdates, events...)
+func (e *mockEnvStreamProvider) Apply(changeSet subsystems.ChangeSet) {
+	switch changeSet.IntentCode() {
+	case subsystems.IntentTransferFull:
+		e.allDataUpdates = append(e.allDataUpdates, changeSet.Changes())
+	case subsystems.IntentTransferChanges:
+		e.itemUpdates = append(e.itemUpdates, changeSet.Changes()...)
+	}
 }
 
 func (e *mockEnvStreamProvider) InvalidateClientSideState() {
@@ -231,7 +232,7 @@ func TestSetBasisGoesToAllStreams(t *testing.T) {
 
 	es.RemoveCredential(sdkKey2)
 
-	es.SetBasis(fdv2AllData, subsystems.Selector{})
+	es.Apply(*fdv2ChangeSet)
 	expected := [][]subsystems.Change{fdv2AllData}
 
 	assert.Equal(t, expected, esp1.allDataUpdates)
@@ -261,9 +262,19 @@ func TestApplyDeltaGoesToAllStreams(t *testing.T) {
 
 	es.RemoveCredential(sdkKey2)
 
-	es.ApplyDelta([]subsystems.Change{
-		{Action: subsystems.ChangeTypePut, Kind: subsystems.FlagKind, Key: testFlag1.Key, Object: testFlag1JSON},
-	}, subsystems.NoSelector())
+	changeSet, err := subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+		Payload: subsystems.Payload{
+			ID:     "state",
+			Target: 1,
+			Code:   subsystems.IntentTransferChanges,
+			Reason: "stale",
+		},
+	}).
+		AddPut(subsystems.FlagKind, testFlag1.Key, 0, testFlag1JSON).
+		Finish(subsystems.NewSelector("state", 1))
+	assert.NoError(t, err)
+
+	es.Apply(*changeSet)
 	expected := []subsystems.Change{
 		{Action: subsystems.ChangeTypePut, Kind: subsystems.FlagKind, Key: testFlag1.Key, Object: testFlag1JSON},
 	}

--- a/internal/streams/stream_provider.go
+++ b/internal/streams/stream_provider.go
@@ -54,7 +54,7 @@ type StreamProvider interface {
 // EnvStreamProvider is an abstraction of publishing events to a stream for a specific environment.
 // Implementations of this interface are created by StreamProvider.Register().
 type EnvStreamProvider interface {
-	EnvStreamUpdates // SetBasis, ApplyDelta
+	EnvStreamUpdates // Apply
 
 	// SendHeartbeat sends keep-alive data on the stream.
 	SendHeartbeat()

--- a/internal/streams/stream_provider_client_side_ping.go
+++ b/internal/streams/stream_provider_client_side_ping.go
@@ -96,6 +96,15 @@ func (s *clientSidePingStreamProvider) Close() {
 	})
 }
 
+func (e *clientSidePingEnvStreamProvider) Apply(changeSet subsystems.ChangeSet) {
+	switch changeSet.IntentCode() {
+	case subsystems.IntentTransferFull:
+		e.SetBasis(changeSet.Changes(), changeSet.Selector())
+	case subsystems.IntentTransferChanges:
+		e.ApplyDelta(changeSet.Changes(), changeSet.Selector())
+	}
+}
+
 func (e *clientSidePingEnvStreamProvider) SetBasis(events []subsystems.Change, selector subsystems.Selector) {
 	e.server.Publish(e.channels, MakePingEvent())
 }

--- a/internal/streams/stream_provider_client_side_ping_test.go
+++ b/internal/streams/stream_provider_client_side_ping_test.go
@@ -191,8 +191,8 @@ func TestStreamProviderAllClientSidePing(t *testing.T) {
 					Payload: subsystems.Payload{
 						ID:     "state",
 						Target: 1,
-						Code:   subsystems.IntentTransferFull,
-						Reason: "cant-catchup",
+						Code:   subsystems.IntentTransferChanges,
+						Reason: "stale",
 					},
 				}).
 				AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).

--- a/internal/streams/stream_provider_client_side_ping_test.go
+++ b/internal/streams/stream_provider_client_side_ping_test.go
@@ -153,14 +153,23 @@ func TestStreamProviderAllClientSidePing(t *testing.T) {
 			require.NotNil(t, esp)
 			defer esp.Close()
 
-			changes := []subsystems.Change{
-				{Action: subsystems.ChangeTypePut, Kind: subsystems.FlagKind, Key: testFlag1.Key, Version: 1, Object: testFlag1JSON},
-				{Action: subsystems.ChangeTypePut, Kind: subsystems.SegmentKind, Key: testSegment1.Key, Version: 1, Object: testSegment1JSON},
-			}
+			changeSet, err := subsystems.NewChangeSetBuilder().
+				Start(subsystems.ServerIntent{
+					Payload: subsystems.Payload{
+						ID:     "state",
+						Target: 1,
+						Code:   subsystems.IntentTransferFull,
+						Reason: "cant-catchup",
+					},
+				}).
+				AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+				AddPut(subsystems.SegmentKind, testSegment1.Key, 1, testSegment1JSON).
+				Finish(subsystems.NewSelector("state", 1))
+			require.NoError(t, err)
 
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakePingEvent(),
 				func() {
-					esp.SetBasis(changes, subsystems.Selector{})
+					esp.Apply(*changeSet)
 				},
 				MakePingEvent(),
 			)
@@ -175,21 +184,35 @@ func TestStreamProviderAllClientSidePing(t *testing.T) {
 			require.NotNil(t, esp)
 			defer esp.Close()
 
+			changeSetBuilder := subsystems.NewChangeSetBuilder()
+
+			changeSet, err := changeSetBuilder.
+				Start(subsystems.ServerIntent{
+					Payload: subsystems.Payload{
+						ID:     "state",
+						Target: 1,
+						Code:   subsystems.IntentTransferFull,
+						Reason: "cant-catchup",
+					},
+				}).
+				AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+				Finish(subsystems.NewSelector("state", 1))
+			assert.NoError(t, err)
+
+			assert.NoError(t, changeSetBuilder.ExpectChanges())
+
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakePingEvent(),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypePut, Kind: subsystems.FlagKind, Key: testFlag1.Key, Object: testFlag1JSON},
-					}, subsystems.NoSelector())
-				},
+				func() { esp.Apply(*changeSet) },
 				MakePingEvent(),
 			)
 
+			segmentChangeSet, err := changeSetBuilder.
+				AddPut(subsystems.SegmentKind, testSegment1.Key, 1, testSegment1JSON).
+				Finish(subsystems.NewSelector("state", 2))
+			assert.NoError(t, err)
+
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakePingEvent(),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypePut, Kind: subsystems.SegmentKind, Key: testSegment1.Key, Object: testSegment1JSON},
-					}, subsystems.NoSelector())
-				},
+				func() { esp.Apply(*segmentChangeSet) },
 				MakePingEvent(),
 			)
 		})

--- a/internal/streams/stream_provider_ping_jitter_test.go
+++ b/internal/streams/stream_provider_ping_jitter_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/launchdarkly/eventsource"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
-	helpers "github.com/launchdarkly/go-test-helpers/v3"
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
-	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	helpers "github.com/launchdarkly/go-test-helpers/v3"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,11 +30,11 @@ func TestPingStreamJitterDelaysPings(t *testing.T) {
 	defer sp.Close()
 
 	store := makeMockStore(nil, nil)
-	esp := sp.Register(validCredential, store, ldlog.NewDisabledLoggers())
+	esp := sp.RegisterV1(validCredential, store, ldlog.NewDisabledLoggers())
 	require.NotNil(t, esp)
 	defer esp.Close()
 
-	handler := sp.Handler(validCredential)
+	handler := sp.HandlerV1(validCredential)
 	require.NotNil(t, handler)
 
 	req, _ := http.NewRequest("GET", "", nil)
@@ -44,7 +44,17 @@ func TestPingStreamJitterDelaysPings(t *testing.T) {
 
 		// Trigger an update and measure how long it takes to receive the ping
 		start := time.Now()
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag1.Key, sharedtest.FlagDesc(testFlag1))
+		changes, err := subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changes)
 
 		// Should receive the ping after a delay
 		event := helpers.RequireValue(t, eventCh, jitterTime*2, "timed out waiting for delayed ping")
@@ -75,11 +85,11 @@ func TestPingStreamJitterCoalescesMultiplePings(t *testing.T) {
 	defer sp.Close()
 
 	store := makeMockStore(nil, nil)
-	esp := sp.Register(validCredential, store, ldlog.NewDisabledLoggers())
+	esp := sp.RegisterV1(validCredential, store, ldlog.NewDisabledLoggers())
 	require.NotNil(t, esp)
 	defer esp.Close()
 
-	handler := sp.Handler(validCredential)
+	handler := sp.HandlerV1(validCredential)
 	require.NotNil(t, handler)
 
 	req, _ := http.NewRequest("GET", "", nil)
@@ -88,11 +98,56 @@ func TestPingStreamJitterCoalescesMultiplePings(t *testing.T) {
 		expectEvent(t, eventCh, MakePingEvent())
 
 		// Send multiple updates in quick succession
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag1.Key, sharedtest.FlagDesc(testFlag1))
+		changeSet, err := subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-1",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 		time.Sleep(10 * time.Millisecond)
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag2.Key, sharedtest.FlagDesc(testFlag2))
+
+		changeSet, err = subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-2",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag2.Key, 1, testFlag2JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 		time.Sleep(10 * time.Millisecond)
-		esp.SendSingleItemUpdate(ldstoreimpl.Segments(), testSegment1.Key, sharedtest.SegmentDesc(testSegment1))
+
+		changeSet, err = subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-3",
+			},
+		}).AddPut(subsystems.SegmentKind, testSegment1.Key, 1, testSegment1JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
+		time.Sleep(10 * time.Millisecond)
+
+		changeSet, err = subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-4",
+			},
+		}).AddPut(subsystems.SegmentKind, testSegment1.Key, 2, testSegment1JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 
 		// Should receive only ONE ping event after the jitter delay
 		event := helpers.RequireValue(t, eventCh, jitterTime*2, "timed out waiting for coalesced ping")
@@ -114,11 +169,11 @@ func TestPingStreamNoJitterSendsPingsImmediately(t *testing.T) {
 	defer sp.Close()
 
 	store := makeMockStore(nil, nil)
-	esp := sp.Register(validCredential, store, ldlog.NewDisabledLoggers())
+	esp := sp.RegisterV1(validCredential, store, ldlog.NewDisabledLoggers())
 	require.NotNil(t, esp)
 	defer esp.Close()
 
-	handler := sp.Handler(validCredential)
+	handler := sp.HandlerV1(validCredential)
 	require.NotNil(t, handler)
 
 	req, _ := http.NewRequest("GET", "", nil)
@@ -128,7 +183,17 @@ func TestPingStreamNoJitterSendsPingsImmediately(t *testing.T) {
 
 		// Send an update and verify it's received immediately (within a reasonable time)
 		start := time.Now()
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag1.Key, sharedtest.FlagDesc(testFlag1))
+		changeSet, err := subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 
 		event := helpers.RequireValue(t, eventCh, 100*time.Millisecond, "timed out waiting for immediate ping")
 		elapsed := time.Since(start)
@@ -152,11 +217,11 @@ func TestPingStreamNoJitterSendsMultiplePings(t *testing.T) {
 	defer sp.Close()
 
 	store := makeMockStore(nil, nil)
-	esp := sp.Register(validCredential, store, ldlog.NewDisabledLoggers())
+	esp := sp.RegisterV1(validCredential, store, ldlog.NewDisabledLoggers())
 	require.NotNil(t, esp)
 	defer esp.Close()
 
-	handler := sp.Handler(validCredential)
+	handler := sp.HandlerV1(validCredential)
 	require.NotNil(t, handler)
 
 	req, _ := http.NewRequest("GET", "", nil)
@@ -165,13 +230,43 @@ func TestPingStreamNoJitterSendsMultiplePings(t *testing.T) {
 		expectEvent(t, eventCh, MakePingEvent())
 
 		// Send multiple updates
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag1.Key, sharedtest.FlagDesc(testFlag1))
+		changeSet, err := subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-1",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 		expectEvent(t, eventCh, MakePingEvent())
 
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag2.Key, sharedtest.FlagDesc(testFlag2))
+		changeSet, err = subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-2",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag2.Key, 1, testFlag2JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 		expectEvent(t, eventCh, MakePingEvent())
 
-		esp.SendSingleItemUpdate(ldstoreimpl.Segments(), testSegment1.Key, sharedtest.SegmentDesc(testSegment1))
+		changeSet, err = subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-3",
+			},
+		}).AddPut(subsystems.SegmentKind, testSegment1.Key, 1, testSegment1JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 		expectEvent(t, eventCh, MakePingEvent())
 	})
 }
@@ -186,11 +281,11 @@ func TestJSClientPingStreamJitter(t *testing.T) {
 	defer sp.Close()
 
 	store := makeMockStore(nil, nil)
-	esp := sp.Register(validCredential, store, ldlog.NewDisabledLoggers())
+	esp := sp.RegisterV1(validCredential, store, ldlog.NewDisabledLoggers())
 	require.NotNil(t, esp)
 	defer esp.Close()
 
-	handler := sp.Handler(validCredential)
+	handler := sp.HandlerV1(validCredential)
 	require.NotNil(t, handler)
 
 	req, _ := http.NewRequest("GET", "", nil)
@@ -199,9 +294,30 @@ func TestJSClientPingStreamJitter(t *testing.T) {
 		expectEvent(t, eventCh, MakePingEvent())
 
 		// Send multiple updates in quick succession
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag1.Key, sharedtest.FlagDesc(testFlag1))
+		changeSet, err := subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-1",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 		time.Sleep(10 * time.Millisecond)
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag2.Key, sharedtest.FlagDesc(testFlag2))
+
+		changeSet, err = subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-2",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag2.Key, 1, testFlag2JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 
 		// Should receive only ONE ping event after the jitter delay
 		event := helpers.RequireValue(t, eventCh, jitterTime*2, "timed out waiting for coalesced ping")
@@ -224,11 +340,11 @@ func TestServerSideStreamNoJitter(t *testing.T) {
 	defer sp.Close()
 
 	store := makeMockStore([]ldmodel.FeatureFlag{testFlag1}, []ldmodel.Segment{testSegment1})
-	esp := sp.Register(validCredential, store, ldlog.NewDisabledLoggers())
+	esp := sp.RegisterV1(validCredential, store, ldlog.NewDisabledLoggers())
 	require.NotNil(t, esp)
 	defer esp.Close()
 
-	handler := sp.Handler(validCredential)
+	handler := sp.HandlerV1(validCredential)
 	require.NotNil(t, handler)
 
 	req, _ := http.NewRequest("GET", "", nil)
@@ -240,7 +356,17 @@ func TestServerSideStreamNoJitter(t *testing.T) {
 
 		// Send an update - should receive a "patch" event immediately
 		start := time.Now()
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag2.Key, sharedtest.FlagDesc(testFlag2))
+		changeSet, err := subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag2.Key, 1, testFlag2JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
 
 		event = helpers.RequireValue(t, eventCh, 100*time.Millisecond, "timed out waiting for patch event")
 		elapsed := time.Since(start)
@@ -265,11 +391,11 @@ func TestPingStreamJitterSubsequentUpdatesAfterDelay(t *testing.T) {
 	defer sp.Close()
 
 	store := makeMockStore(nil, nil)
-	esp := sp.Register(validCredential, store, ldlog.NewDisabledLoggers())
+	esp := sp.RegisterV1(validCredential, store, ldlog.NewDisabledLoggers())
 	require.NotNil(t, esp)
 	defer esp.Close()
 
-	handler := sp.Handler(validCredential)
+	handler := sp.HandlerV1(validCredential)
 	require.NotNil(t, handler)
 
 	req, _ := http.NewRequest("GET", "", nil)
@@ -278,7 +404,18 @@ func TestPingStreamJitterSubsequentUpdatesAfterDelay(t *testing.T) {
 		expectEvent(t, eventCh, MakePingEvent())
 
 		// First update - should be jittered
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag1.Key, sharedtest.FlagDesc(testFlag1))
+		changeSet, err := subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-1",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
+
 		event1 := helpers.RequireValue(t, eventCh, jitterTime*2, "timed out waiting for first ping")
 		require.NotNil(t, event1)
 
@@ -287,7 +424,18 @@ func TestPingStreamJitterSubsequentUpdatesAfterDelay(t *testing.T) {
 
 		// Second update - should also be jittered
 		start := time.Now()
-		esp.SendSingleItemUpdate(ldstoreimpl.Features(), testFlag2.Key, sharedtest.FlagDesc(testFlag2))
+		changeSet, err = subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferChanges,
+				Reason: "test-update-2",
+			},
+		}).AddPut(subsystems.FlagKind, testFlag2.Key, 1, testFlag2JSON).
+			Finish(subsystems.NewSelector("state", 1))
+		require.NoError(t, err)
+		esp.Apply(*changeSet)
+
 		event2 := helpers.RequireValue(t, eventCh, jitterTime*2, "timed out waiting for second ping")
 		elapsed := time.Since(start)
 

--- a/internal/streams/stream_provider_server_side.go
+++ b/internal/streams/stream_provider_server_side.go
@@ -104,13 +104,23 @@ func (s *serverSideStreamProvider) Close() {
 	})
 }
 
-func (e *serverSideEnvStreamProvider) SetBasis(changes []subsystems.Change, selector subsystems.Selector) {
+func (e *serverSideEnvStreamProvider) Apply(changeSet subsystems.ChangeSet) {
+	switch changeSet.IntentCode() {
+	case subsystems.IntentTransferFull:
+		e.SetBasis(changeSet)
+	case subsystems.IntentTransferChanges:
+		e.ApplyDelta(changeSet)
+	}
+}
+
+func (e *serverSideEnvStreamProvider) SetBasis(changeSet subsystems.ChangeSet) {
 	if e.isV2 {
+		changes, selector := changeSet.Changes(), changeSet.Selector()
 		for _, event := range MakeEventsForSetBasis(changes, selector) {
 			e.server.Publish(e.channels, event)
 		}
 	} else {
-		allData, err := subsystems.ToStorableItems(changes)
+		allData, err := changeSet.Collections()
 		if err != nil {
 			return
 		}
@@ -118,16 +128,18 @@ func (e *serverSideEnvStreamProvider) SetBasis(changes []subsystems.Change, sele
 	}
 }
 
-func (e *serverSideEnvStreamProvider) ApplyDelta(events []subsystems.Change, selector subsystems.Selector) {
+func (e *serverSideEnvStreamProvider) ApplyDelta(changeSet subsystems.ChangeSet) {
 	if e.isV2 {
-		for _, event := range MakeEventsForApplyDelta(events, selector) {
+		changes, selector := changeSet.Changes(), changeSet.Selector()
+		for _, event := range MakeEventsForApplyDelta(changes, selector) {
 			e.server.Publish(e.channels, event)
 		}
 	} else {
-		allData, err := subsystems.ToStorableItems(events)
+		allData, err := changeSet.Collections()
 		if err != nil {
 			return
 		}
+
 		for _, collection := range allData {
 			for _, item := range collection.Items {
 				if item.Item.Item == nil {

--- a/internal/streams/stream_provider_server_side_flags.go
+++ b/internal/streams/stream_provider_server_side_flags.go
@@ -84,16 +84,25 @@ func (s *serverSideFlagsOnlyStreamProvider) Close() {
 	})
 }
 
-func (e *serverSideFlagsOnlyEnvStreamProvider) SetBasis(events []subsystems.Change, selector subsystems.Selector) {
-	allData, err := subsystems.ToStorableItems(events)
+func (e *serverSideFlagsOnlyEnvStreamProvider) Apply(changeSet subsystems.ChangeSet) {
+	switch changeSet.IntentCode() {
+	case subsystems.IntentTransferFull:
+		e.setBasis(changeSet)
+	case subsystems.IntentTransferChanges:
+		e.applyDelta(changeSet)
+	}
+}
+
+func (e *serverSideFlagsOnlyEnvStreamProvider) setBasis(changeSet subsystems.ChangeSet) {
+	allData, err := changeSet.Collections()
 	if err != nil {
 		return
 	}
 	e.server.Publish(e.channels, MakeServerSideFlagsOnlyPutEvent(allData))
 }
 
-func (e *serverSideFlagsOnlyEnvStreamProvider) ApplyDelta(events []subsystems.Change, selector subsystems.Selector) {
-	allData, err := subsystems.ToStorableItems(events)
+func (e *serverSideFlagsOnlyEnvStreamProvider) applyDelta(changeSet subsystems.ChangeSet) {
+	allData, err := changeSet.Collections()
 	if err != nil {
 		return
 	}

--- a/internal/streams/stream_provider_server_side_flags_test.go
+++ b/internal/streams/stream_provider_server_side_flags_test.go
@@ -131,10 +131,19 @@ func TestStreamProviderServerSideFlagsOnly(t *testing.T) {
 			require.NotNil(t, esp)
 			defer esp.Close()
 
-			changes := []subsystems.Change{
-				{Action: subsystems.ChangeTypePut, Kind: subsystems.FlagKind, Key: testFlag1.Key, Version: 1, Object: testFlag1JSON},
-				{Action: subsystems.ChangeTypePut, Kind: subsystems.SegmentKind, Key: testSegment1.Key, Version: 1, Object: testSegment1JSON},
-			}
+			changeSet, err := subsystems.NewChangeSetBuilder().
+				Start(subsystems.ServerIntent{
+					Payload: subsystems.Payload{
+						ID:     "state",
+						Target: 1,
+						Code:   subsystems.IntentTransferFull,
+						Reason: "cant-catchup",
+					},
+				}).
+				AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+				AddPut(subsystems.SegmentKind, testSegment1.Key, 1, testSegment1JSON).
+				Finish(subsystems.NewSelector("state", 1))
+			require.NoError(t, err)
 
 			newData := []ldstoretypes.Collection{
 				{Kind: ldstoreimpl.Features(), Items: []ldstoretypes.KeyedItemDescriptor{
@@ -146,9 +155,7 @@ func TestStreamProviderServerSideFlagsOnly(t *testing.T) {
 			}
 
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSideFlagsOnlyPutEvent(nil),
-				func() {
-					esp.SetBasis(changes, subsystems.Selector{})
-				},
+				func() { esp.Apply(*changeSet) },
 				MakeServerSideFlagsOnlyPutEvent(newData),
 			)
 		})
@@ -162,39 +169,57 @@ func TestStreamProviderServerSideFlagsOnly(t *testing.T) {
 			require.NotNil(t, esp)
 			defer esp.Close()
 
+			changeSetBuilder := subsystems.NewChangeSetBuilder()
+			flagChangeSet, err := changeSetBuilder.
+				Start(subsystems.ServerIntent{
+					Payload: subsystems.Payload{
+						ID:     "state",
+						Target: 1,
+						Code:   subsystems.IntentTransferChanges,
+						Reason: "stale",
+					},
+				}).
+				AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+				Finish(subsystems.NewSelector("state", 1))
+			require.NoError(t, err)
+
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSideFlagsOnlyPutEvent(nil),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypePut, Kind: subsystems.FlagKind, Key: testFlag1.Key, Version: testFlag1.Version, Object: testFlag1JSON},
-					}, subsystems.NoSelector())
-				},
+				func() { esp.Apply(*flagChangeSet) },
 				MakeServerSideFlagsOnlyPatchEvent(testFlag1.Key, sharedtest.FlagDesc(testFlag1)),
 			)
 
+			assert.NoError(t, changeSetBuilder.ExpectChanges())
+
+			segmentChangeSet, err := changeSetBuilder.
+				AddPut(subsystems.SegmentKind, testSegment1.Key, 1, testSegment1JSON).
+				Finish(subsystems.NewSelector("state", 2))
+			require.NoError(t, err)
+
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSideFlagsOnlyPutEvent(nil),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypePut, Kind: subsystems.SegmentKind, Key: testSegment1.Key, Version: testSegment1.Version, Object: testSegment1JSON},
-					}, subsystems.NoSelector())
-				},
+				func() { esp.Apply(*segmentChangeSet) },
 				nil,
 			)
 
+			assert.NoError(t, changeSetBuilder.ExpectChanges())
+
+			deleteFlagChangeSet, err := changeSetBuilder.
+				AddDelete(subsystems.FlagKind, testFlag1.Key, 2).
+				Finish(subsystems.NewSelector("state", 3))
+			require.NoError(t, err)
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSideFlagsOnlyPutEvent(nil),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypeDelete, Kind: subsystems.FlagKind, Key: testFlag1.Key, Version: testFlag1.Version},
-					}, subsystems.NoSelector())
-				},
-				MakeServerSideFlagsOnlyDeleteEvent(testFlag1.Key, testFlag1.Version),
+				func() { esp.Apply(*deleteFlagChangeSet) },
+				MakeServerSideFlagsOnlyDeleteEvent(testFlag1.Key, 2),
 			)
 
+			assert.NoError(t, changeSetBuilder.ExpectChanges())
+
+			deleteSegmentChangeSet, err := changeSetBuilder.
+				AddDelete(subsystems.SegmentKind, testSegment1.Key, 2).
+				Finish(subsystems.NewSelector("state", 4))
+			require.NoError(t, err)
+
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSideFlagsOnlyPutEvent(nil),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypeDelete, Kind: subsystems.SegmentKind, Key: testSegment1.Key, Version: testSegment1.Version},
-					}, subsystems.NoSelector())
-				},
+				func() { esp.Apply(*deleteSegmentChangeSet) },
 				nil,
 			)
 		})

--- a/internal/streams/stream_provider_server_side_test.go
+++ b/internal/streams/stream_provider_server_side_test.go
@@ -139,10 +139,19 @@ func TestStreamProviderServerSide(t *testing.T) {
 			require.NotNil(t, esp)
 			defer esp.Close()
 
-			changes := []subsystems.Change{
-				{Action: subsystems.ChangeTypePut, Kind: subsystems.FlagKind, Key: testFlag1.Key, Version: 1, Object: testFlag1JSON},
-				{Action: subsystems.ChangeTypePut, Kind: subsystems.SegmentKind, Key: testSegment1.Key, Version: 1, Object: testSegment1JSON},
-			}
+			changeSet, err := subsystems.NewChangeSetBuilder().
+				Start(subsystems.ServerIntent{
+					Payload: subsystems.Payload{
+						ID:     "state",
+						Target: 1,
+						Code:   subsystems.IntentTransferFull,
+						Reason: "cant-catchup",
+					},
+				}).
+				AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+				AddPut(subsystems.SegmentKind, testSegment1.Key, 1, testSegment1JSON).
+				Finish(subsystems.NewSelector("state", 1))
+			require.NoError(t, err)
 
 			newData := []ldstoretypes.Collection{
 				{Kind: ldstoreimpl.Features(), Items: []ldstoretypes.KeyedItemDescriptor{
@@ -154,9 +163,7 @@ func TestStreamProviderServerSide(t *testing.T) {
 			}
 
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSidePutEvent(nil),
-				func() {
-					esp.SetBasis(changes, subsystems.Selector{})
-				},
+				func() { esp.Apply(*changeSet) },
 				MakeServerSidePutEvent(newData),
 			)
 		})
@@ -170,39 +177,58 @@ func TestStreamProviderServerSide(t *testing.T) {
 			require.NotNil(t, esp)
 			defer esp.Close()
 
+			changeSetBuilder := subsystems.NewChangeSetBuilder()
+			flagChangeSet, err := changeSetBuilder.
+				Start(subsystems.ServerIntent{
+					Payload: subsystems.Payload{
+						ID:     "state",
+						Target: 1,
+						Code:   subsystems.IntentTransferChanges,
+						Reason: "stale",
+					},
+				}).
+				AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+				Finish(subsystems.NewSelector("state", 1))
+			require.NoError(t, err)
+
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSidePutEvent(nil),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypePut, Kind: subsystems.FlagKind, Key: testFlag1.Key, Version: testFlag1.Version, Object: testFlag1JSON},
-					}, subsystems.NoSelector())
-				},
+				func() { esp.Apply(*flagChangeSet) },
 				MakeServerSidePatchEvent(ldstoreimpl.Features(), testFlag1.Key, sharedtest.FlagDesc(testFlag1)),
 			)
 
+			assert.NoError(t, changeSetBuilder.ExpectChanges())
+
+			segmentChangeSet, err := changeSetBuilder.
+				AddPut(subsystems.SegmentKind, testSegment1.Key, 1, testSegment1JSON).
+				Finish(subsystems.NewSelector("state", 2))
+			require.NoError(t, err)
+
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSidePutEvent(nil),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypePut, Kind: subsystems.SegmentKind, Key: testSegment1.Key, Version: testSegment1.Version, Object: testSegment1JSON},
-					}, subsystems.NoSelector())
-				},
+				func() { esp.Apply(*segmentChangeSet) },
 				MakeServerSidePatchEvent(ldstoreimpl.Segments(), testSegment1.Key, sharedtest.SegmentDesc(testSegment1)),
 			)
 
+			assert.NoError(t, changeSetBuilder.ExpectChanges())
+
+			deleteFlagChangeSet, err := changeSetBuilder.
+				AddDelete(subsystems.FlagKind, testFlag1.Key, testFlag1.Version).
+				Finish(subsystems.NewSelector("state", 3))
+			require.NoError(t, err)
+
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSidePutEvent(nil),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypeDelete, Kind: subsystems.FlagKind, Key: testFlag1.Key, Version: testFlag1.Version},
-					}, subsystems.NoSelector())
-				},
+				func() { esp.Apply(*deleteFlagChangeSet) },
 				MakeServerSideDeleteEvent(ldstoreimpl.Features(), testFlag1.Key, testFlag1.Version),
 			)
 
+			assert.NoError(t, changeSetBuilder.ExpectChanges())
+
+			deleteSegmentChangeSet, err := changeSetBuilder.
+				AddDelete(subsystems.SegmentKind, testSegment1.Key, testSegment1.Version).
+				Finish(subsystems.NewSelector("state", 4))
+			require.NoError(t, err)
+
 			verifyHandlerUpdateEvent(t, sp, validCredential, MakeServerSidePutEvent(nil),
-				func() {
-					esp.ApplyDelta([]subsystems.Change{
-						{Action: subsystems.ChangeTypeDelete, Kind: subsystems.SegmentKind, Key: testSegment1.Key, Version: testSegment1.Version},
-					}, subsystems.NoSelector())
-				},
+				func() { esp.Apply(*deleteSegmentChangeSet) },
 				MakeServerSideDeleteEvent(ldstoreimpl.Segments(), testSegment1.Key, testSegment1.Version),
 			)
 		})

--- a/internal/streams/stream_testdata_test.go
+++ b/internal/streams/stream_testdata_test.go
@@ -28,7 +28,20 @@ var (
 	testFlag1JSON, _    = ldmodel.NewJSONDataModelSerialization().MarshalFeatureFlag(testFlag1)
 	testFlag2JSON, _    = ldmodel.NewJSONDataModelSerialization().MarshalFeatureFlag(testFlag2)
 	testSegment1JSON, _ = ldmodel.NewJSONDataModelSerialization().MarshalSegment(testSegment1)
-	fdv2AllData         = []subsystems.Change{
+	fdv2ChangeSet, _    = subsystems.NewChangeSetBuilder().
+				Start(subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "state",
+				Target: 1,
+				Code:   subsystems.IntentTransferFull,
+				Reason: "cant-catchup",
+			},
+		}).
+		AddPut(subsystems.FlagKind, testFlag1.Key, 1, testFlag1JSON).
+		AddPut(subsystems.SegmentKind, testSegment1.Key, 1, testSegment1JSON).
+		Finish(subsystems.NewSelector("state", 1))
+
+	fdv2AllData = []subsystems.Change{
 		{Action: subsystems.ChangeTypePut, Kind: subsystems.FlagKind, Key: testFlag1.Key, Version: 1, Object: testFlag1JSON},
 		{Action: subsystems.ChangeTypePut, Kind: subsystems.SegmentKind, Key: testSegment1.Key, Version: 1, Object: testSegment1JSON},
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces SetBasis/ApplyDelta with a single Apply(ChangeSet) across data flow and stream providers, updates tests and fakes accordingly, and bumps go-server-sdk to v7.14.2.
> 
> - **Streams API**:
>   - Replace `EnvStreamUpdates`/`EnvStreamProvider` methods `SetBasis`/`ApplyDelta` with unified `Apply(changeSet subsystems.ChangeSet)`.
>   - `EnvStreams.Apply` now forwards `ChangeSet` to all providers; `InvalidateClientSideState` unchanged.
> - **Providers**:
>   - Server-side (`server_side` and `server_side_flags_only`) and client-side ping providers implement `Apply(ChangeSet)` and internally route to put/patch/delete events; FDv2 handlers support basis via `Last-Event-ID` unchanged.
> - **Relay Env/Data Destination**:
>   - `DataDestinationWrapper` and `envContextStreamUpdates` now consume `ChangeSet` and call `Apply`.
> - **Tests and Fakes**:
>   - Update tests to build and pass `ChangeSet` with `ChangeSetBuilder`.
>   - Revise test fakes (`FakeDataDestination`, `FakeStore`, mocks) to support `Apply(ChangeSet)` with internal `setBasis`/`applyDelta`.
> - **Dependencies**:
>   - Bump `github.com/launchdarkly/go-server-sdk/v7` to `v7.14.2`.
>   - Add `gopkg.in/ghodss/yaml.v1` to `go.sum`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47d7d7d4af41f5e027c836fa7972dc2f80d83a89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->