### PR TITLE
fix: Remove double slash in diagnostic url debug message

### DIFF
--- a/internal/events/event-relay.go
+++ b/internal/events/event-relay.go
@@ -126,7 +126,7 @@ func (d *diagnosticEventEndpointDispatcher) dispatch(w http.ResponseWriter, req 
 	consumeEvents(w, req, d.loggers, func(body []byte) {
 		// We are just operating as a reverse proxy and passing the request on verbatim to LD; we do not
 		// need to parse the JSON.
-		d.loggers.Debugf("Received diagnostic event to be proxied to %s/%s", d.baseURI, d.uriPath)
+		d.loggers.Debugf("Received diagnostic event to be proxied to %s%s", d.baseURI, d.uriPath)
 
 		sendConfig := ldevents.EventSenderConfiguration{
 			Client:            d.httpClient,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes diagnostic event proxy debug log to concatenate base URI and path without inserting an extra slash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9afd95ab6dbc57a1f9b212bbaf0b080dec67b77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->