### PR TITLE
chore: Support offline mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/launchdarkly/go-server-sdk-dynamodb/v4 v4.0.0
 	github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1
 	github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0
-	github.com/launchdarkly/go-server-sdk/v7 v7.14.2
+	github.com/launchdarkly/go-server-sdk/v7 v7.14.3
 	github.com/launchdarkly/go-test-helpers/v3 v3.1.0
 	github.com/launchdarkly/opencensus-go-exporter-stackdriver v0.14.5
 	github.com/pborman/uuid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1 h1:rTgcYAFraGFj7sBMB2
 github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1/go.mod h1:fPS5d+zOsgFnMunj+Ki6jjlZtFvo4h9iNbtNXxzYn58=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0 h1:ItkPbTEzz0ObNzIpA3DfPqgEgeNyqno/Lnfd7BjC0Ns=
 github.com/launchdarkly/go-server-sdk-redis-redigo/v3 v3.0.0/go.mod h1:ho3n0ML1YbV0QRnidDNF9ooFIC66FiVzZGW0u4behG0=
-github.com/launchdarkly/go-server-sdk/v7 v7.14.2 h1:9LOCC9U1l8WcYLBg/TbJUTiwLW/1Ti61UikpD+4gttk=
-github.com/launchdarkly/go-server-sdk/v7 v7.14.2/go.mod h1:0CUdE5PI0SVG1Tb6CwKz8wZ9zEHUzfMutl6wY2MzUF0=
+github.com/launchdarkly/go-server-sdk/v7 v7.14.3 h1:a+0hA9Jk2bg+LgfXl8o7xeAolK1bOf6BY/j83MlmmSI=
+github.com/launchdarkly/go-server-sdk/v7 v7.14.3/go.mod h1:0CUdE5PI0SVG1Tb6CwKz8wZ9zEHUzfMutl6wY2MzUF0=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2 h1:WX6qSzt7v8xz6d94nVcoil9ljuLTC/6OzQt0MhWYxsQ=
 github.com/launchdarkly/go-test-helpers/v2 v2.3.2/go.mod h1:L7+th5govYp5oKU9iN7To5PgznBuIjBPn+ejqKR0avw=
 github.com/launchdarkly/go-test-helpers/v3 v3.1.0 h1:E3bxJMzMoA+cJSF3xxtk2/chr1zshl1ZWa0/oR+8bvg=

--- a/internal/filedata/offline_mode_synchronizer.go
+++ b/internal/filedata/offline_mode_synchronizer.go
@@ -1,0 +1,204 @@
+package filedata
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+)
+
+// simpleBroadcaster is a simple implementation of a broadcaster for changeSets and status updates.
+type simpleBroadcaster[T any] struct {
+	mu        sync.RWMutex
+	listeners []chan T
+}
+
+func newSimpleBroadcaster[T any]() *simpleBroadcaster[T] {
+	return &simpleBroadcaster[T]{
+		listeners: make([]chan T, 0),
+	}
+}
+
+func (b *simpleBroadcaster[T]) AddListener() <-chan T {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := make(chan T, 10)
+	b.listeners = append(b.listeners, ch)
+	return ch
+}
+
+func (b *simpleBroadcaster[T]) Broadcast(value T) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for _, ch := range b.listeners {
+		select {
+		case ch <- value:
+		default:
+			// If channel is full, skip this listener
+		}
+	}
+}
+
+// OfflineModeSynchronizerFactory creates a synchronizer that loads data from an external source
+// (the relay's archive file) without making any network connections.
+type OfflineModeSynchronizerFactory struct {
+	Synchronizer *OfflineModeSynchronizer
+}
+
+// OfflineModeSynchronizer implements subsystems.DataSynchronizer for offline mode.
+// It loads pre-populated data from the archive file without connecting to LaunchDarkly.
+type OfflineModeSynchronizer struct {
+	dataCh               <-chan []ldstoretypes.Collection
+	changeSetBroadcaster *simpleBroadcaster[subsystems.ChangeSet]
+	statusBroadcaster    *simpleBroadcaster[interfaces.DataSynchronizerStatus]
+	version              int32
+	quit                 chan struct{}
+	closed               atomic.Bool
+}
+
+func NewOfflineModeSynchronizer(dataCh <-chan []ldstoretypes.Collection) *OfflineModeSynchronizer {
+	return &OfflineModeSynchronizer{
+		dataCh:               dataCh,
+		changeSetBroadcaster: newSimpleBroadcaster[subsystems.ChangeSet](),
+		statusBroadcaster:    newSimpleBroadcaster[interfaces.DataSynchronizerStatus](),
+		quit:                 make(chan struct{}),
+	}
+}
+
+func (f OfflineModeSynchronizerFactory) Build(
+	ctx subsystems.ClientContext,
+) (subsystems.DataSynchronizer, error) {
+	return f.Synchronizer, nil
+}
+
+func (s *OfflineModeSynchronizer) Close() error {
+	if s.closed.Swap(true) {
+		return nil
+	}
+	close(s.quit)
+	return nil
+}
+
+func (s *OfflineModeSynchronizer) Name() string {
+	return "OfflineModeSynchronizer"
+}
+
+// Fetch returns the current basis (full dataset) from the offline data source.
+func (s *OfflineModeSynchronizer) Fetch(ds subsystems.DataSelector, ctx context.Context) (*subsystems.Basis, error) {
+	// Wait for data to arrive from the archive
+	select {
+	case data := <-s.dataCh:
+		changeSet, err := s.makeChangeSetFromCollections(data)
+		if err != nil {
+			return nil, err
+		}
+		return &subsystems.Basis{
+			ChangeSet: *changeSet,
+			Persist:   false,
+		}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.quit:
+		return nil, context.Canceled
+	}
+}
+
+// Sync starts the synchronizer and returns a channel for receiving updates.
+// For offline mode, this immediately provides the data from the archive file.
+func (s *OfflineModeSynchronizer) Sync(ds subsystems.DataSelector) <-chan subsystems.DataSynchronizerResult {
+	resultChan := make(chan subsystems.DataSynchronizerResult)
+	changeSetChan := s.changeSetBroadcaster.AddListener()
+	statusChan := s.statusBroadcaster.AddListener()
+
+	go func() {
+		defer close(resultChan)
+
+		result := subsystems.DataSynchronizerResult{
+			State: interfaces.DataSourceStateInitializing,
+		}
+
+		// Wait for initial data from archive
+		select {
+		case data := <-s.dataCh:
+			changeSet, err := s.makeChangeSetFromCollections(data)
+			if err != nil {
+				result.State = interfaces.DataSourceStateOff
+				result.Error = interfaces.DataSourceErrorInfo{
+					Kind:    interfaces.DataSourceErrorKindUnknown,
+					Message: err.Error(),
+				}
+			} else {
+				result.State = interfaces.DataSourceStateValid
+				result.ChangeSet = changeSet
+			}
+			resultChan <- result
+
+		case <-s.quit:
+			result.State = interfaces.DataSourceStateOff
+			resultChan <- result
+			return
+		}
+
+		// Listen for updates (in offline mode, these would be file changes)
+		for {
+			select {
+			case <-s.quit:
+				return
+			case changeSet, ok := <-changeSetChan:
+				if !ok {
+					return
+				}
+				result.ChangeSet = &changeSet
+				result.State = interfaces.DataSourceStateValid
+				resultChan <- result
+			case statusChange, ok := <-statusChan:
+				if !ok {
+					return
+				}
+				if statusChange.State != interfaces.DataSourceStateValid {
+					result.ChangeSet = nil
+				}
+				result.State = statusChange.State
+				result.Error = statusChange.Error
+				resultChan <- result
+			}
+		}
+	}()
+
+	return resultChan
+}
+
+// makeChangeSetFromCollections converts old-style Collection data to a new-style ChangeSet.
+// This uses the SDK's NewChangeSetFromCollections which pre-caches the collections,
+// avoiding redundant conversions when the data is accessed later.
+func (s *OfflineModeSynchronizer) makeChangeSetFromCollections(
+	collections []ldstoretypes.Collection,
+) (*subsystems.ChangeSet, error) {
+	version := int(atomic.AddInt32(&s.version, 1))
+
+	return subsystems.NewChangeSetFromCollections(
+		subsystems.ServerIntent{
+			Payload: subsystems.Payload{
+				ID:     "",
+				Target: version,
+				Code:   subsystems.IntentTransferFull,
+				Reason: "offline-mode-init",
+			},
+		},
+		subsystems.NewSelector("offline", version),
+		collections,
+	)
+}
+
+// UpdateData allows external updates to the data (e.g., when the archive file changes).
+func (s *OfflineModeSynchronizer) UpdateData(collections []ldstoretypes.Collection) error {
+	changeSet, err := s.makeChangeSetFromCollections(collections)
+	if err != nil {
+		return err
+	}
+	s.changeSetBroadcaster.Broadcast(*changeSet)
+	return nil
+}

--- a/internal/filedata/offline_mode_synchronizer.go
+++ b/internal/filedata/offline_mode_synchronizer.go
@@ -71,7 +71,7 @@ type OfflineModeSynchronizer struct {
 	initError            error
 	changeSetBroadcaster *simpleBroadcaster[subsystems.ChangeSet]
 	statusBroadcaster    *simpleBroadcaster[interfaces.DataSynchronizerStatus]
-	version              int32
+	version              int // Protected by mu; no need for atomic since access is always under lock
 	quit                 chan struct{}
 	closed               atomic.Bool
 }
@@ -199,10 +199,15 @@ func (s *OfflineModeSynchronizer) Sync(ds subsystems.DataSelector) <-chan subsys
 // makeChangeSetFromCollections converts old-style Collection data to a new-style ChangeSet.
 // This uses the SDK's NewChangeSetFromCollections which pre-caches the collections,
 // avoiding redundant conversions when the data is accessed later.
+//
+// IMPORTANT: This method must be called either:
+// - With s.mu held (when updating existing data), OR
+// - Before the synchronizer is shared across goroutines (during construction)
 func (s *OfflineModeSynchronizer) makeChangeSetFromCollections(
 	collections []ldstoretypes.Collection,
 ) (*subsystems.ChangeSet, error) {
-	version := int(atomic.AddInt32(&s.version, 1))
+	s.version++
+	version := s.version
 
 	return subsystems.NewChangeSetFromCollections(
 		subsystems.ServerIntent{
@@ -220,12 +225,13 @@ func (s *OfflineModeSynchronizer) makeChangeSetFromCollections(
 
 // UpdateData allows external updates to the data (e.g., when the archive file changes).
 func (s *OfflineModeSynchronizer) UpdateData(collections []ldstoretypes.Collection) error {
+	// Acquire lock before version increment to ensure atomicity of the entire operation
+	s.mu.Lock()
 	changeSet, err := s.makeChangeSetFromCollections(collections)
 	if err != nil {
+		s.mu.Unlock()
 		return err
 	}
-
-	s.mu.Lock()
 	s.currentChangeSet = changeSet
 	s.initError = nil // Clear any previous initialization error
 	s.mu.Unlock()

--- a/internal/filedata/offline_mode_synchronizer.go
+++ b/internal/filedata/offline_mode_synchronizer.go
@@ -2,6 +2,7 @@ package filedata
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 
@@ -52,7 +53,8 @@ type OfflineModeSynchronizerFactory struct {
 // It loads pre-populated data from the archive file without connecting to LaunchDarkly.
 type OfflineModeSynchronizer struct {
 	mu                   sync.RWMutex
-	currentData          []ldstoretypes.Collection
+	currentChangeSet     *subsystems.ChangeSet
+	initError            error
 	changeSetBroadcaster *simpleBroadcaster[subsystems.ChangeSet]
 	statusBroadcaster    *simpleBroadcaster[interfaces.DataSynchronizerStatus]
 	version              int32
@@ -61,12 +63,21 @@ type OfflineModeSynchronizer struct {
 }
 
 func NewOfflineModeSynchronizer(initialData []ldstoretypes.Collection) *OfflineModeSynchronizer {
-	return &OfflineModeSynchronizer{
-		currentData:          initialData,
+	s := &OfflineModeSynchronizer{
 		changeSetBroadcaster: newSimpleBroadcaster[subsystems.ChangeSet](),
 		statusBroadcaster:    newSimpleBroadcaster[interfaces.DataSynchronizerStatus](),
 		quit:                 make(chan struct{}),
 	}
+
+	// Convert initial data to ChangeSet
+	changeSet, err := s.makeChangeSetFromCollections(initialData)
+	if err != nil {
+		s.initError = err
+	} else {
+		s.currentChangeSet = changeSet
+	}
+
+	return s
 }
 
 func (f OfflineModeSynchronizerFactory) Build(
@@ -90,13 +101,17 @@ func (s *OfflineModeSynchronizer) Name() string {
 // Fetch returns the current basis (full dataset) from the offline data source.
 func (s *OfflineModeSynchronizer) Fetch(ds subsystems.DataSelector, ctx context.Context) (*subsystems.Basis, error) {
 	s.mu.RLock()
-	data := s.currentData
+	changeSet := s.currentChangeSet
+	initError := s.initError
 	s.mu.RUnlock()
 
-	changeSet, err := s.makeChangeSetFromCollections(data)
-	if err != nil {
-		return nil, err
+	if initError != nil {
+		return nil, initError
 	}
+	if changeSet == nil {
+		return nil, errors.New("no data available in offline mode")
+	}
+
 	return &subsystems.Basis{
 		ChangeSet: *changeSet,
 		Persist:   false,
@@ -115,19 +130,19 @@ func (s *OfflineModeSynchronizer) Sync(ds subsystems.DataSelector) <-chan subsys
 
 		// Get initial data from stored state
 		s.mu.RLock()
-		data := s.currentData
+		changeSet := s.currentChangeSet
+		initError := s.initError
 		s.mu.RUnlock()
 
 		result := subsystems.DataSynchronizerResult{
 			State: interfaces.DataSourceStateInitializing,
 		}
 
-		changeSet, err := s.makeChangeSetFromCollections(data)
-		if err != nil {
+		if initError != nil {
 			result.State = interfaces.DataSourceStateOff
 			result.Error = interfaces.DataSourceErrorInfo{
 				Kind:    interfaces.DataSourceErrorKindUnknown,
-				Message: err.Error(),
+				Message: initError.Error(),
 			}
 		} else {
 			result.State = interfaces.DataSourceStateValid
@@ -188,14 +203,16 @@ func (s *OfflineModeSynchronizer) makeChangeSetFromCollections(
 
 // UpdateData allows external updates to the data (e.g., when the archive file changes).
 func (s *OfflineModeSynchronizer) UpdateData(collections []ldstoretypes.Collection) error {
-	s.mu.Lock()
-	s.currentData = collections
-	s.mu.Unlock()
-
 	changeSet, err := s.makeChangeSetFromCollections(collections)
 	if err != nil {
 		return err
 	}
+
+	s.mu.Lock()
+	s.currentChangeSet = changeSet
+	s.initError = nil // Clear any previous initialization error
+	s.mu.Unlock()
+
 	s.changeSetBroadcaster.Broadcast(*changeSet)
 	return nil
 }

--- a/internal/filedata/offline_mode_synchronizer.go
+++ b/internal/filedata/offline_mode_synchronizer.go
@@ -51,7 +51,8 @@ type OfflineModeSynchronizerFactory struct {
 // OfflineModeSynchronizer implements subsystems.DataSynchronizer for offline mode.
 // It loads pre-populated data from the archive file without connecting to LaunchDarkly.
 type OfflineModeSynchronizer struct {
-	dataCh               <-chan []ldstoretypes.Collection
+	mu                   sync.RWMutex
+	currentData          []ldstoretypes.Collection
 	changeSetBroadcaster *simpleBroadcaster[subsystems.ChangeSet]
 	statusBroadcaster    *simpleBroadcaster[interfaces.DataSynchronizerStatus]
 	version              int32
@@ -59,9 +60,9 @@ type OfflineModeSynchronizer struct {
 	closed               atomic.Bool
 }
 
-func NewOfflineModeSynchronizer(dataCh <-chan []ldstoretypes.Collection) *OfflineModeSynchronizer {
+func NewOfflineModeSynchronizer(initialData []ldstoretypes.Collection) *OfflineModeSynchronizer {
 	return &OfflineModeSynchronizer{
-		dataCh:               dataCh,
+		currentData:          initialData,
 		changeSetBroadcaster: newSimpleBroadcaster[subsystems.ChangeSet](),
 		statusBroadcaster:    newSimpleBroadcaster[interfaces.DataSynchronizerStatus](),
 		quit:                 make(chan struct{}),
@@ -88,22 +89,18 @@ func (s *OfflineModeSynchronizer) Name() string {
 
 // Fetch returns the current basis (full dataset) from the offline data source.
 func (s *OfflineModeSynchronizer) Fetch(ds subsystems.DataSelector, ctx context.Context) (*subsystems.Basis, error) {
-	// Wait for data to arrive from the archive
-	select {
-	case data := <-s.dataCh:
-		changeSet, err := s.makeChangeSetFromCollections(data)
-		if err != nil {
-			return nil, err
-		}
-		return &subsystems.Basis{
-			ChangeSet: *changeSet,
-			Persist:   false,
-		}, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-s.quit:
-		return nil, context.Canceled
+	s.mu.RLock()
+	data := s.currentData
+	s.mu.RUnlock()
+
+	changeSet, err := s.makeChangeSetFromCollections(data)
+	if err != nil {
+		return nil, err
 	}
+	return &subsystems.Basis{
+		ChangeSet: *changeSet,
+		Persist:   false,
+	}, nil
 }
 
 // Sync starts the synchronizer and returns a channel for receiving updates.
@@ -116,31 +113,27 @@ func (s *OfflineModeSynchronizer) Sync(ds subsystems.DataSelector) <-chan subsys
 	go func() {
 		defer close(resultChan)
 
+		// Get initial data from stored state
+		s.mu.RLock()
+		data := s.currentData
+		s.mu.RUnlock()
+
 		result := subsystems.DataSynchronizerResult{
 			State: interfaces.DataSourceStateInitializing,
 		}
 
-		// Wait for initial data from archive
-		select {
-		case data := <-s.dataCh:
-			changeSet, err := s.makeChangeSetFromCollections(data)
-			if err != nil {
-				result.State = interfaces.DataSourceStateOff
-				result.Error = interfaces.DataSourceErrorInfo{
-					Kind:    interfaces.DataSourceErrorKindUnknown,
-					Message: err.Error(),
-				}
-			} else {
-				result.State = interfaces.DataSourceStateValid
-				result.ChangeSet = changeSet
-			}
-			resultChan <- result
-
-		case <-s.quit:
+		changeSet, err := s.makeChangeSetFromCollections(data)
+		if err != nil {
 			result.State = interfaces.DataSourceStateOff
-			resultChan <- result
-			return
+			result.Error = interfaces.DataSourceErrorInfo{
+				Kind:    interfaces.DataSourceErrorKindUnknown,
+				Message: err.Error(),
+			}
+		} else {
+			result.State = interfaces.DataSourceStateValid
+			result.ChangeSet = changeSet
 		}
+		resultChan <- result
 
 		// Listen for updates (in offline mode, these would be file changes)
 		for {
@@ -195,6 +188,10 @@ func (s *OfflineModeSynchronizer) makeChangeSetFromCollections(
 
 // UpdateData allows external updates to the data (e.g., when the archive file changes).
 func (s *OfflineModeSynchronizer) UpdateData(collections []ldstoretypes.Collection) error {
+	s.mu.Lock()
+	s.currentData = collections
+	s.mu.Unlock()
+
 	changeSet, err := s.makeChangeSetFromCollections(collections)
 	if err != nil {
 		return err

--- a/internal/filedata/offline_mode_synchronizer.go
+++ b/internal/filedata/offline_mode_synchronizer.go
@@ -31,6 +31,20 @@ func (b *simpleBroadcaster[T]) AddListener() <-chan T {
 	return ch
 }
 
+func (b *simpleBroadcaster[T]) RemoveListener(ch <-chan T) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i, listener := range b.listeners {
+		if listener == ch {
+			// Remove by swapping with last element and truncating
+			b.listeners[i] = b.listeners[len(b.listeners)-1]
+			b.listeners = b.listeners[:len(b.listeners)-1]
+			close(listener)
+			break
+		}
+	}
+}
+
 func (b *simpleBroadcaster[T]) Broadcast(value T) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -127,6 +141,8 @@ func (s *OfflineModeSynchronizer) Sync(ds subsystems.DataSelector) <-chan subsys
 
 	go func() {
 		defer close(resultChan)
+		defer s.changeSetBroadcaster.RemoveListener(changeSetChan)
+		defer s.statusBroadcaster.RemoveListener(statusChan)
 
 		// Get initial data from stored state
 		s.mu.RLock()
@@ -161,6 +177,7 @@ func (s *OfflineModeSynchronizer) Sync(ds subsystems.DataSelector) <-chan subsys
 				}
 				result.ChangeSet = &changeSet
 				result.State = interfaces.DataSourceStateValid
+				result.Error = interfaces.DataSourceErrorInfo{} // Clear any previous error
 				resultChan <- result
 			case statusChange, ok := <-statusChan:
 				if !ok {

--- a/relay/filedata_actions.go
+++ b/relay/filedata_actions.go
@@ -12,7 +12,6 @@ import (
 
 	ld "github.com/launchdarkly/go-server-sdk/v7"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
-	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 )
 
 const (
@@ -31,11 +30,8 @@ type relayFileDataActions struct {
 }
 
 func (a *relayFileDataActions) AddEnvironment(ae filedata.ArchiveEnvironment) {
-	// Create a channel to pass the archive data to the offline synchronizer
-	dataCh := make(chan []ldstoretypes.Collection, 1)
-
-	// Create the synchronizer instance that we can later update when the file changes
-	synchronizer := filedata.NewOfflineModeSynchronizer(dataCh)
+	// Create the synchronizer with the initial archive data
+	synchronizer := filedata.NewOfflineModeSynchronizer(ae.SDKData)
 
 	transformConfig := func(baseConfig ld.Config) ld.Config {
 		config := baseConfig
@@ -44,7 +40,7 @@ func (a *relayFileDataActions) AddEnvironment(ae filedata.ArchiveEnvironment) {
 		syncFactory := filedata.OfflineModeSynchronizerFactory{Synchronizer: synchronizer}
 		config.DataSystem = ldcomponents.DataSystem().
 			Custom().
-			Synchronizers(syncFactory, nil) // primary and fallback use the same synchronizer
+			Synchronizers(syncFactory, nil)
 		config.Events = ldcomponents.NoEvents()
 		return config
 	}
@@ -66,10 +62,6 @@ func (a *relayFileDataActions) AddEnvironment(ae filedata.ArchiveEnvironment) {
 		a.envSynchronizers = make(map[config.EnvironmentID]*filedata.OfflineModeSynchronizer)
 	}
 	a.envSynchronizers[ae.Params.EnvID] = synchronizer
-
-	// Send the initial archive data to the synchronizer
-	// The synchronizer will be waiting for this data in its Sync() method
-	dataCh <- ae.SDKData
 }
 
 func (a *relayFileDataActions) UpdateEnvironment(ae filedata.ArchiveEnvironment) {

--- a/relay/filedata_actions.go
+++ b/relay/filedata_actions.go
@@ -44,7 +44,7 @@ func (a *relayFileDataActions) AddEnvironment(ae filedata.ArchiveEnvironment) {
 		syncFactory := filedata.OfflineModeSynchronizerFactory{Synchronizer: synchronizer}
 		config.DataSystem = ldcomponents.DataSystem().
 			Custom().
-			Synchronizers(syncFactory, syncFactory) // primary and fallback use the same synchronizer
+			Synchronizers(syncFactory, nil) // primary and fallback use the same synchronizer
 		config.Events = ldcomponents.NoEvents()
 		return config
 	}

--- a/relay/filedata_actions.go
+++ b/relay/filedata_actions.go
@@ -1,8 +1,6 @@
 package relay
 
 import (
-	"time"
-
 	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
 
 	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
@@ -13,9 +11,8 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/filedata"
 
 	ld "github.com/launchdarkly/go-server-sdk/v7"
-	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
-	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 )
 
 const (
@@ -29,48 +26,50 @@ const (
 // methods on this object to let us know when environments have been read from the file for the
 // first time and also if environments have changed due to a file update.
 type relayFileDataActions struct {
-	r          *Relay
-	envUpdates map[config.EnvironmentID]subsystems.DataSourceUpdateSink
-}
-
-type dataSourceFactoryToCaptureUpdates struct {
-	updatesCh chan<- subsystems.DataSourceUpdateSink
-}
-
-type stubDataSourceToCaptureUpdates struct {
-	dataSourceUpdates subsystems.DataSourceUpdateSink
-	updatesCh         chan<- subsystems.DataSourceUpdateSink
+	r                *Relay
+	envSynchronizers map[config.EnvironmentID]*filedata.OfflineModeSynchronizer
 }
 
 func (a *relayFileDataActions) AddEnvironment(ae filedata.ArchiveEnvironment) {
-	updatesCh := make(chan subsystems.DataSourceUpdateSink)
+	// Create a channel to pass the archive data to the offline synchronizer
+	dataCh := make(chan []ldstoretypes.Collection, 1)
+
+	// Create the synchronizer instance that we can later update when the file changes
+	synchronizer := filedata.NewOfflineModeSynchronizer(dataCh)
+
 	transformConfig := func(baseConfig ld.Config) ld.Config {
 		config := baseConfig
-		config.DataSource = dataSourceFactoryToCaptureUpdates{updatesCh}
+		// In offline mode, replace the DataSystem with our custom offline synchronizer.
+		// This synchronizer loads data from the archive file without making network connections.
+		syncFactory := filedata.OfflineModeSynchronizerFactory{Synchronizer: synchronizer}
+		config.DataSystem = ldcomponents.DataSystem().
+			Custom().
+			Synchronizers(syncFactory, syncFactory) // primary and fallback use the same synchronizer
 		config.Events = ldcomponents.NoEvents()
 		return config
 	}
+
 	envConfig := envfactory.NewEnvConfigFactoryForOfflineMode(a.r.config.OfflineMode).MakeEnvironmentConfig(ae.Params)
 	env, _, err := a.r.addEnvironment(ae.Params.Identifiers, envConfig, transformConfig)
 	if err != nil {
 		a.r.loggers.Errorf(logMsgAutoConfEnvInitError, ae.Params.Identifiers.GetDisplayName(), err)
 		return
 	}
+
 	if ae.Params.ExpiringSDKKey.Defined() {
 		update := relayenv.NewCredentialUpdate(ae.Params.SDKKey)
 		env.UpdateCredential(update.WithGracePeriod(ae.Params.ExpiringSDKKey.Key, ae.Params.ExpiringSDKKey.Expiration))
 	}
-	select {
-	case updates := <-updatesCh:
-		if a.envUpdates == nil {
-			a.envUpdates = make(map[config.EnvironmentID]subsystems.DataSourceUpdateSink)
-		}
-		a.envUpdates[ae.Params.EnvID] = updates
-		updates.Init(ae.SDKData)
-		updates.UpdateStatus(interfaces.DataSourceStateValid, interfaces.DataSourceErrorInfo{})
-	case <-time.After(time.Second * 2):
-		a.r.loggers.Errorf(logMsgOfflineEnvTimeoutError, ae.Params.Identifiers.GetDisplayName())
+
+	// Store the synchronizer so we can update it later when the file changes
+	if a.envSynchronizers == nil {
+		a.envSynchronizers = make(map[config.EnvironmentID]*filedata.OfflineModeSynchronizer)
 	}
+	a.envSynchronizers[ae.Params.EnvID] = synchronizer
+
+	// Send the initial archive data to the synchronizer
+	// The synchronizer will be waiting for this data in its Sync() method
+	dataCh <- ae.SDKData
 }
 
 func (a *relayFileDataActions) UpdateEnvironment(ae filedata.ArchiveEnvironment) {
@@ -79,8 +78,8 @@ func (a *relayFileDataActions) UpdateEnvironment(ae filedata.ArchiveEnvironment)
 		a.r.loggers.Errorf(logMsgInternalErrorUpdatedEnvNotFound, ae.Params.EnvID)
 		return
 	}
-	updates := a.envUpdates[ae.Params.EnvID]
-	if updates == nil { // COVERAGE: this should never happen and can't be covered in unit tests
+	synchronizer := a.envSynchronizers[ae.Params.EnvID]
+	if synchronizer == nil { // COVERAGE: this should never happen and can't be covered in unit tests
 		a.r.loggers.Errorf(logMsgInternalErrorNoUpdatesForEnv, ae.Params.EnvID)
 		return
 	}
@@ -102,7 +101,9 @@ func (a *relayFileDataActions) UpdateEnvironment(ae filedata.ArchiveEnvironment)
 
 	// SDKData will be non-nil only if the flag/segment data for the environment has actually changed.
 	if ae.SDKData != nil {
-		updates.Init(ae.SDKData)
+		if err := synchronizer.UpdateData(ae.SDKData); err != nil {
+			a.r.loggers.Errorf("Error updating offline environment data: %v", err)
+		}
 	}
 }
 
@@ -112,24 +113,5 @@ func (a *relayFileDataActions) EnvironmentFailed(id config.EnvironmentID, err er
 
 func (a *relayFileDataActions) DeleteEnvironment(id config.EnvironmentID, filter config.FilterKey) {
 	a.r.removeEnvironment(sdkauth.NewScoped(filter, id))
-	delete(a.envUpdates, id)
-}
-
-func (d dataSourceFactoryToCaptureUpdates) Build(
-	ctx subsystems.ClientContext,
-) (subsystems.DataSource, error) {
-	return stubDataSourceToCaptureUpdates{ctx.GetDataSourceUpdateSink(), d.updatesCh}, nil
-}
-
-func (s stubDataSourceToCaptureUpdates) Close() error {
-	return nil
-}
-
-func (s stubDataSourceToCaptureUpdates) IsInitialized() bool {
-	return true
-}
-
-func (s stubDataSourceToCaptureUpdates) Start(readyCh chan<- struct{}) {
-	s.updatesCh <- s.dataSourceUpdates
-	close(readyCh)
+	delete(a.envSynchronizers, id)
 }

--- a/relay/filedata_actions_test.go
+++ b/relay/filedata_actions_test.go
@@ -161,18 +161,16 @@ func (p offlineModeTestParams) shouldNotCreateClient(timeout time.Duration) {
 func TestOfflineModeDeleteEnvironment(t *testing.T) {
 	offlineModeTest(t, config.Config{}, func(p offlineModeTestParams) {
 		p.updateHandler.AddEnvironment(testFileDataEnv1)
-		p.updateHandler.AddEnvironment(testFileDataEnv2)
-
 		client1 := p.awaitClient()
-		client2 := p.awaitClient()
 		assert.Equal(t, testFileDataEnv1.Params.SDKKey, client1.Key)
-		assert.Equal(t, testFileDataEnv2.Params.SDKKey, client2.Key)
-
 		_ = p.awaitEnvironment(testFileDataEnv1.Params.EnvID)
+
+		p.updateHandler.AddEnvironment(testFileDataEnv2)
+		client2 := p.awaitClient()
+		assert.Equal(t, testFileDataEnv2.Params.SDKKey, client2.Key)
 		_ = p.awaitEnvironment(testFileDataEnv1.Params.EnvID)
 
 		p.updateHandler.DeleteEnvironment(testFileDataEnv1.Params.EnvID, testFileDataEnv1.Params.Identifiers.FilterKey)
-
 		p.shouldNotHaveEnvironment(testFileDataEnv1.Params.EnvID, time.Second)
 	})
 }

--- a/relay/filedata_actions_test.go
+++ b/relay/filedata_actions_test.go
@@ -168,7 +168,7 @@ func TestOfflineModeDeleteEnvironment(t *testing.T) {
 		p.updateHandler.AddEnvironment(testFileDataEnv2)
 		client2 := p.awaitClient()
 		assert.Equal(t, testFileDataEnv2.Params.SDKKey, client2.Key)
-		_ = p.awaitEnvironment(testFileDataEnv1.Params.EnvID)
+		_ = p.awaitEnvironment(testFileDataEnv2.Params.EnvID)
 
 		p.updateHandler.DeleteEnvironment(testFileDataEnv1.Params.EnvID, testFileDataEnv1.Params.Identifiers.FilterKey)
 		p.shouldNotHaveEnvironment(testFileDataEnv1.Params.EnvID, time.Second)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -30,9 +30,7 @@ import (
 	ld "github.com/launchdarkly/go-server-sdk/v7"
 )
 
-var (
-	errNoEnvironments = errors.New("you must specify at least one environment in your configuration")
-)
+var errNoEnvironments = errors.New("you must specify at least one environment in your configuration")
 
 // The Relay Proxy Auto-Config Protocol has two major versions.
 // For Relay < v8, that was '1'.
@@ -293,7 +291,8 @@ func makeFilteredEnvironments(c *config.Config) map[string]*config.EnvConfig {
 }
 
 func defaultArchiveManagerFactory(filePath string, monitoringInterval time.Duration, handler filedata.UpdateHandler, loggers ldlog.Loggers) (
-	filedata.ArchiveManagerInterface, error) {
+	filedata.ArchiveManagerInterface, error,
+) {
 	am, err := filedata.NewArchiveManager(filePath, handler, monitoringInterval, loggers)
 	return am, err
 }
@@ -345,9 +344,11 @@ func (r *Relay) allStreamProviders() []streams.StreamProvider {
 	}
 }
 
-var errRelayNotReady = errors.New("relay is not yet fully configured")
-var errUnrecognizedEnvironment = errors.New("no environment corresponds to given credentials")
-var errPayloadFilterNotFound = errors.New("credential corresponds to an environment but filter is unrecognized")
+var (
+	errRelayNotReady           = errors.New("relay is not yet fully configured")
+	errUnrecognizedEnvironment = errors.New("no environment corresponds to given credentials")
+	errPayloadFilterNotFound   = errors.New("credential corresponds to an environment but filter is unrecognized")
+)
 
 func IsNotReady(err error) bool {
 	return err == errRelayNotReady


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements offline mode using the SDK’s data system and removes ad-hoc wiring.
> 
> - **New** `OfflineModeSynchronizer` (+ factory) implementing `subsystems.DataSynchronizer` to serve archive-backed `ChangeSet`s, broadcast updates/status, and support `Fetch`/`Sync`/`UpdateData`
> - **Relay integration**: configure offline environments with `ldcomponents.DataSystem().Custom().Synchronizers(...)`; maintain per-env synchronizers for updates; clean up on delete
> - **Tests**: adjust offline-mode tests to cover env deletion and credential grace-period handling; other offline tests remain TODO/commented
> - **Deps**: bump `github.com/launchdarkly/go-server-sdk/v7` to `v7.14.3`
> - Minor relay code tidying (error var grouping/signature formatting)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74317a556ac56103321457c1711ad66a622af82d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->