### PR TITLE
chore: Add Valkey testing coverage

### DIFF
--- a/.github/actions/benchmarks/action.yml
+++ b/.github/actions/benchmarks/action.yml
@@ -4,6 +4,10 @@ inputs:
   go-version:
     description: 'Go version to use for build & test.'
     required: true
+  suffix:
+    description: 'Suffix for artifact names to differentiate test runs.'
+    required: false
+    default: ''
 
 
 runs:
@@ -23,5 +27,5 @@ runs:
         if: steps.benchmarks.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-            name: Benchmarks-go${{ inputs.go-version }}
+            name: Benchmarks-go${{ inputs.go-version }}${{ inputs.suffix && format('-{0}', inputs.suffix) || '' }}
             path: benchmarks.txt

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Whether to run coverage.'
     required: false
     default: 'false'
+  suffix:
+    description: 'Suffix for artifact names to differentiate test runs.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -45,12 +49,12 @@ runs:
       if: steps.process-test.outcome == 'success'
       uses: actions/upload-artifact@v4
       with:
-        name: Test-result-${{ steps.go-version.outputs.version }}
+        name: Test-result-${{ steps.go-version.outputs.version }}${{ inputs.suffix && format('-{0}', inputs.suffix) || '' }}
         path: junit_report.xml
 
     - name: Upload coverage results
       if: steps.test-coverage.outcome == 'success'
       uses: actions/upload-artifact@v4
       with:
-        name: Coverage-result-${{ steps.go-version.outputs.version }}
+        name: Coverage-result-${{ steps.go-version.outputs.version }}${{ inputs.suffix && format('-{0}', inputs.suffix) || '' }}
         path: build/coverage*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,30 @@ jobs:
   # Runs the common tasks (unit tests, lint, benchmarks, installation test)
   # against each Go version in the matrix.
   go-matrix:
-    name: ${{ format('Go {0}', matrix.go-version) }}
+    name: ${{ format('Go {0}, {1}', matrix.go-version, matrix.store) }}
     needs: go-versions
     strategy:
       # Let jobs fail independently, in case it's a single version that's broken.
       fail-fast: false
       matrix:
         go-version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
+        store: [Redis, Valkey]
+        include:
+          - store: Redis
+            redis: true
+            suffix: redis
+          - store: Valkey
+            valkey: true
+            valkey_port: 6379
+            suffix: valkey
     uses: ./.github/workflows/common_ci.yml
     with:
       go-version: ${{ matrix.go-version }}
+      store: ${{ matrix.store }}
+      redis: ${{ matrix.redis || false }}
+      valkey: ${{ matrix.valkey || false }}
+      valkey_port: ${{ matrix.valkey_port || '' }}
+      suffix: ${{ matrix.suffix }}
 
   # Integration tests run only on the latest Go version since they are more
   # time intensive, and we'd likely be rate-limited by LaunchDarkly SaaS if we

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -63,10 +63,11 @@ jobs:
         run: ./scripts/test-prometheus-endpoint.sh
 
   benchmarks:
-    name: 'Benchmarks'
+    name: ${{ format('Benchmarks ({0})', inputs.store) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/benchmarks
         with:
           go-version: ${{ inputs.go-version }}
+          suffix: ${{ inputs.suffix }}

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -6,21 +6,47 @@ on:
         description: "Go version to use for the jobs."
         required: true
         type: string
+      store:
+        description: "Store type (Redis or Valkey)."
+        required: false
+        type: string
+        default: 'Redis'
+      redis:
+        description: "Whether to start Redis."
+        required: false
+        type: boolean
+        default: false
+      valkey:
+        description: "Whether to start Valkey."
+        required: false
+        type: boolean
+        default: false
+      valkey_port:
+        description: "Port for Valkey."
+        required: false
+        type: string
+        default: ''
+      suffix:
+        description: "Suffix for test/coverage artifacts."
+        required: false
+        type: string
+        default: ''
 
 jobs:
   unit-test:
     runs-on: ubuntu-latest
-    name: 'Unit Tests'
+    name: ${{ format('Unit Tests ({0})', inputs.store) }}
     services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
       dynamodb:
         image: amazon/dynamodb-local
         ports:
           - 8000:8000
     steps:
+      - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0.2.0
+        with:
+          redis: ${{ inputs.redis }}
+          valkey: ${{ inputs.valkey }}
+          valkey_port: ${{ inputs.valkey_port }}
       - uses: actions/checkout@v4
       - name: Setup Go ${{ inputs.go-version }}
         uses: actions/setup-go@v5
@@ -30,6 +56,7 @@ jobs:
         with:
           lint: 'true'
           coverage: 'true'
+          suffix: ${{ inputs.suffix }}
 
       - name: Prometheus Endpoint Test
         shell: bash

--- a/internal/application/commandline.go
+++ b/internal/application/commandline.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"time"
 )
 
 // DefaultConfigPath is the default configuration file path.
@@ -14,13 +13,10 @@ const DefaultConfigPath = "/etc/ld-relay.conf"
 
 // Options represents all options that can be set from the command line.
 type Options struct {
-	ConfigFile          string
-	AllowMissingFile    bool
-	UseEnvironment      bool
-	PrintVersion        bool
-	MemProfileDuration  time.Duration
-	MemProfileInterval  time.Duration
-	DisableMemProfiling bool
+	ConfigFile       string
+	AllowMissingFile bool
+	UseEnvironment   bool
+	PrintVersion     bool
 }
 
 func errConfigFileNotFound(filename string) error {
@@ -63,9 +59,6 @@ func ReadOptions(osArgs []string, errorOutput io.Writer) (Options, error) {
 	fs.BoolVar(&o.AllowMissingFile, "allow-missing-file", false, "suppress error if config file is not found")
 	fs.BoolVar(&o.UseEnvironment, "from-env", false, "read configuration from environment variables")
 	fs.BoolVar(&o.PrintVersion, "version", false, "print relay's version")
-	fs.DurationVar(&o.MemProfileDuration, "memprofile-duration", 15*time.Second, "duration to collect memory profiles")
-	fs.DurationVar(&o.MemProfileInterval, "memprofile-interval", 1*time.Second, "interval between memory profile snapshots")
-	fs.BoolVar(&o.DisableMemProfiling, "no-memprofile", false, "disable memory profiling")
 	err := fs.Parse(osArgs[1:])
 	if err != nil {
 		return o, err

--- a/internal/application/commandline.go
+++ b/internal/application/commandline.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 )
 
 // DefaultConfigPath is the default configuration file path.
@@ -13,10 +14,13 @@ const DefaultConfigPath = "/etc/ld-relay.conf"
 
 // Options represents all options that can be set from the command line.
 type Options struct {
-	ConfigFile       string
-	AllowMissingFile bool
-	UseEnvironment   bool
-	PrintVersion     bool
+	ConfigFile          string
+	AllowMissingFile    bool
+	UseEnvironment      bool
+	PrintVersion        bool
+	MemProfileDuration  time.Duration
+	MemProfileInterval  time.Duration
+	DisableMemProfiling bool
 }
 
 func errConfigFileNotFound(filename string) error {
@@ -59,6 +63,9 @@ func ReadOptions(osArgs []string, errorOutput io.Writer) (Options, error) {
 	fs.BoolVar(&o.AllowMissingFile, "allow-missing-file", false, "suppress error if config file is not found")
 	fs.BoolVar(&o.UseEnvironment, "from-env", false, "read configuration from environment variables")
 	fs.BoolVar(&o.PrintVersion, "version", false, "print relay's version")
+	fs.DurationVar(&o.MemProfileDuration, "memprofile-duration", 15*time.Second, "duration to collect memory profiles")
+	fs.DurationVar(&o.MemProfileInterval, "memprofile-interval", 1*time.Second, "interval between memory profile snapshots")
+	fs.BoolVar(&o.DisableMemProfiling, "no-memprofile", false, "disable memory profiling")
 	err := fs.Parse(osArgs[1:])
 	if err != nil {
 		return o, err


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Run CI against both Redis and Valkey using a persistent-stores action, and add optional suffixes to test/coverage/benchmark artifact names.
> 
> - **CI/Workflows**:
>   - Matrix runs per store: `Redis` and `Valkey`; job names include store; pass `redis`, `valkey`, `valkey_port`, and `suffix` through `common_ci.yml` to jobs.
>   - Replace inline Redis service with `launchdarkly/gh-actions/actions/persistent-stores` to start Redis/Valkey as needed.
> - **Actions**:
>   - `unit-tests` and `benchmarks` accept optional `suffix` and append it to artifact names for test, coverage, and benchmark results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e24a7da56f905062cc9cae8717b81b03e99e21b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->