### PR TITLE
chore: Fixing persistent store tests

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -28,10 +28,9 @@ runs:
       run: make lint
 
     - name: Test
-      if: inputs.coverage == 'false'
       shell: bash
       id: test
-      run: make test | tee raw_report.txt
+      run: TAGS='big_segment_external_store_tests,redis_unit_tests' make test | tee raw_report.txt
 
     - name: Process test results
       if: steps.test.outcome == 'success'

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -25,28 +25,24 @@ on:
         description: "Port for Valkey."
         required: false
         type: string
-        default: ''
+        default: ""
       suffix:
         description: "Suffix for test/coverage artifacts."
         required: false
         type: string
-        default: ''
+        default: ""
 
 jobs:
   unit-test:
     runs-on: ubuntu-latest
     name: ${{ format('Unit Tests ({0})', inputs.store) }}
-    services:
-      dynamodb:
-        image: amazon/dynamodb-local
-        ports:
-          - 8000:8000
     steps:
-      - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0.2.0
-        with:
-          redis: ${{ inputs.redis }}
-          valkey: ${{ inputs.valkey }}
-          valkey_port: ${{ inputs.valkey_port }}
+      # - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0.2.0
+      #   with:
+      #     dynamodb: true
+      #     redis: ${{ inputs.redis }}
+      #     valkey: ${{ inputs.valkey }}
+      #     valkey_port: ${{ inputs.valkey_port }}
       - uses: actions/checkout@v4
       - name: Setup Go ${{ inputs.go-version }}
         uses: actions/setup-go@v5

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -37,12 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ format('Unit Tests ({0})', inputs.store) }}
     steps:
-      # - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0.2.0
-      #   with:
-      #     dynamodb: true
-      #     redis: ${{ inputs.redis }}
-      #     valkey: ${{ inputs.valkey }}
-      #     valkey_port: ${{ inputs.valkey_port }}
+      - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0.2.0
+        with:
+          dynamodb: true
+          redis: ${{ inputs.redis }}
+          valkey: ${{ inputs.valkey }}
+          valkey_port: ${{ inputs.valkey_port }}
       - uses: actions/checkout@v4
       - name: Setup Go ${{ inputs.go-version }}
         uses: actions/setup-go@v5


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use the persistent-stores action (with DynamoDB) and run unit tests unconditionally with specific Go tags; normalize empty-string defaults.
> 
> - **CI Workflow (`.github/workflows/common_ci.yml`)**:
>   - Replace inline `dynamodb-local` service with `launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0.2.0` and enable `dynamodb: true`.
>   - Normalize empty string defaults to `""` for `valkey_port` and `suffix` inputs.
> - **Unit Test Action (`.github/actions/unit-tests/action.yml`)**:
>   - Run tests unconditionally with `TAGS='big_segment_external_store_tests,redis_unit_tests'` and pipe output to `raw_report.txt`.
>   - Retain separate coverage step and JUnit artifact processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 601a9896ee02a1c85caa00efee196b5f3fbcab3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->