### PR TITLE
chore: Fix release process

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -43,6 +43,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ needs.go-versions.outputs.latest }}
+      - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0.2.0
+        with:
+          dynamodb: true
+          redis: true
       - name: Build and Test
         uses: ./.github/actions/unit-tests
       - name: 'Get Docker token'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,6 +46,10 @@ jobs:
         with:
           go-version: ${{ needs.go-versions.outputs.latest }}
 
+      - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0.2.0
+        with:
+          dynamodb: true
+          redis: true
       - uses: ./.github/actions/unit-tests
 
       - name: Set IS_DEFAULT_BRANCH


### PR DESCRIPTION
- **chore: Add documentation acknowledging Valkey support**
- **chore: Fix release process**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets up DynamoDB and Redis via the persistent-stores action in publish and release workflows to support unit tests.
> 
> - **CI/Workflows**:
>   - **Persistent Stores Setup**:
>     - Add `launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0.2.0` with `dynamodb: true` and `redis: true` before unit tests in:
>       - `.github/workflows/manual-publish.yml`
>       - `.github/workflows/release-please.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 139a51b0f38d39558a0c69521a8b2ad3fec19752. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->