### PR TITLE
feat: Add environment specific status endpoints

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -114,6 +114,100 @@ The status properties are defined as follows:
 
 The JSON property names within `"environments"` (`"environment1"` and `"environment2"` in this example) are normally the environment names as defined in the Relay Proxy configuration. When using Relay Proxy Enterprise in automatic configuration mode, these will instead be the same as the `envId`, since the environment names may not always stay the same.
 
+### Per-environment status
+
+For querying the status of a specific environment without fetching data for all environments, the Relay Proxy provides granular status endpoints. These are useful for monitoring specific environments or for debugging. There is no authentication required for these requests.
+
+**Endpoints:**
+
+```
+GET /status/{identifier}
+GET /status/{identifier}/filters/{filterKey}
+GET /status/{projKey}/{envKey}
+GET /status/{projKey}/{envKey}/filters/{filterKey}
+```
+
+**Identifier formats:**
+
+The `{identifier}` parameter supports different formats depending on your configuration mode:
+
+**Manual configuration mode:**
+- **Configured name** (e.g., `My%20Production%20Env`) - The environment name as defined in your Relay Proxy configuration file. URL-encode spaces and special characters.
+- **Environment ID** (e.g., `507f1f77bcf86cd799439011`) - Only available if you explicitly configured the `envId` field for the environment (typically used when supporting client-side JavaScript SDKs).
+
+**Automatic configuration mode:**
+- **Environment ID** (e.g., `507f1f77bcf86cd799439011`) - Always available. This is a stable identifier, ideal for automation and monitoring scripts.
+- **Project/environment key route**: `/status/{projKey}/{envKey}` (e.g., `/status/my-app/production`) - Human-readable hierarchical identifiers.
+
+**Filter support:**
+
+When [payload filters](./configuration.md#payload-filtering) are configured, you can query the status of specific filtered variants:
+
+- `/status/{identifier}/filters/{filterKey}` - Status for a filtered variant by environment ID or configured name
+- `/status/{projKey}/{envKey}/filters/{filterKey}` - Status for a filtered variant by project/environment keys
+
+**Response format:**
+
+The response is a single environment status object (not wrapped in an `"environments"` map):
+
+```json
+{
+  "sdkKey": "sdk-********-****-****-****-*******99999",
+  "envId": "507f1f77bcf86cd799439011",
+  "envKey": "production",
+  "envName": "Production",
+  "projKey": "my-app",
+  "projName": "My Application",
+  "mobileKey": "mob-********-****-****-****-*******99999",
+  "status": "connected",
+  "connectionStatus": {
+    "state": "VALID",
+    "stateSince": 10000000
+  },
+  "dataStoreStatus": {
+    "state": "VALID",
+    "stateSince": 10000000,
+    "database": "redis",
+    "dbServer": "redis://my-redis-host",
+    "dbPrefix": "ld-507f1f77bcf86cd799439011"
+  }
+}
+```
+
+The response structure matches the per-environment data returned by `/status`, with the same properties and meanings described above. The `envKey`, `envName`, `projKey`, and `projName` fields are only present when using automatic configuration mode.
+
+**HTTP status codes:**
+
+- `200 OK` - Environment found and status returned successfully
+- `404 Not Found` - The specified environment identifier or filter does not exist
+- `503 Service Unavailable` - The Relay Proxy has not yet fully initialized
+
+**Example requests:**
+
+```shell
+# Manual config mode - by configured name
+curl http://localhost:8030/status/production-env
+
+# Manual config mode - by environment ID (if envId is configured)
+curl http://localhost:8030/status/507f1f77bcf86cd799439011
+
+# Auto-config mode - by environment ID
+curl http://localhost:8030/status/507f1f77bcf86cd799439011
+
+# Auto-config mode - by project/environment keys
+curl http://localhost:8030/status/my-app/production
+
+# With filters (any mode)
+curl http://localhost:8030/status/507f1f77bcf86cd799439011/filters/microservice-a
+curl http://localhost:8030/status/my-app/production/filters/microservice-a
+```
+
+**Use cases:**
+
+- **Monitoring**: Poll specific environments without fetching data for all environments
+- **Debugging**: Quickly check the status of a single environment during troubleshooting
+- **Filtered environments**: Verify the status of specific payload filter variants
+
 ### Special flag evaluation endpoints
 
 If you're building an SDK for a language which isn't officially supported by LaunchDarkly, or want to evaluate feature flags internally without an SDK instance, the Relay Proxy provides endpoints for evaluating all feature flags for a given user.

--- a/relay/autoconfig_actions.go
+++ b/relay/autoconfig_actions.go
@@ -47,6 +47,9 @@ func (a *relayAutoConfigActions) UpdateEnvironment(params envfactory.Environment
 	}
 
 	env.SetIdentifiers(params.Identifiers)
+	// Refresh identifier-based indexes after identifiers change
+	a.r.envsByCredential.RefreshEnvironmentIndexes(env)
+
 	env.SetTTL(params.TTL)
 	env.SetSecureMode(params.SecureMode)
 

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -13,6 +13,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	ld "github.com/launchdarkly/go-server-sdk/v7"
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/gorilla/mux"
 )
 
 const (
@@ -37,101 +38,12 @@ func statusHandler(relay *Relay) http.Handler {
 
 		healthy := fullyConfigured
 		for _, clientCtx := range relay.getAllEnvironments() {
-			identifiers := clientCtx.GetIdentifiers()
-
-			status := api.EnvironmentStatusRep{
-				EnvKey:   identifiers.EnvKey, // these will only be non-empty if we're in auto-configured mode
-				EnvName:  identifiers.EnvName,
-				ProjKey:  identifiers.ProjKey,
-				ProjName: identifiers.ProjName,
-			}
-
-			for _, c := range clientCtx.GetCredentials() {
-				switch c := c.(type) {
-				case config.SDKKey:
-					status.SDKKey = sdks.ObscureKey(string(c))
-				case config.MobileKey:
-					status.MobileKey = sdks.ObscureKey(string(c))
-				case config.EnvironmentID:
-					status.EnvID = string(c)
-				}
-			}
-
-			for _, c := range clientCtx.GetDeprecatedCredentials() {
-				if key, ok := c.(config.SDKKey); ok {
-					status.ExpiringSDKKey = sdks.ObscureKey(string(key))
-				}
-			}
-
-			client := clientCtx.GetClient()
-			if client == nil {
-				status.Status = statusEnvDisconnected
-				status.ConnectionStatus.State = interfaces.DataSourceStateInitializing
-				status.ConnectionStatus.StateSince = ldtime.UnixMillisFromTime(clientCtx.GetCreationTime())
-				status.DataStoreStatus.State = "INITIALIZING"
+			status, envHealthy := relay.buildEnvironmentStatus(clientCtx)
+			if !envHealthy {
 				healthy = false
-			} else {
-				connected := client.Initialized()
-
-				sourceStatus := client.GetDataSourceStatus()
-				status.ConnectionStatus = api.ConnectionStatusRep{
-					State:      sourceStatus.State,
-					StateSince: ldtime.UnixMillisFromTime(sourceStatus.StateSince),
-				}
-				if sourceStatus.LastError.Kind != "" {
-					status.ConnectionStatus.LastError = &api.ConnectionErrorRep{
-						Kind: sourceStatus.LastError.Kind,
-						Time: ldtime.UnixMillisFromTime(sourceStatus.LastError.Time),
-					}
-				}
-				if sourceStatus.State != interfaces.DataSourceStateValid &&
-					time.Since(sourceStatus.StateSince) >=
-						relay.config.Main.DisconnectedStatusTime.GetOrElse(config.DefaultDisconnectedStatusTime) {
-					connected = false
-				}
-
-				storeStatus := client.GetDataStoreStatus()
-				status.DataStoreStatus.State = "VALID"
-				status.DataStoreStatus.StateSince = ldtime.UnixMillisFromTime(storeStatus.LastUpdated)
-				if !storeStatus.Available {
-					status.DataStoreStatus.State = "INTERRUPTED"
-				}
-
-				if connected {
-					status.Status = statusEnvConnected
-				} else {
-					status.Status = statusEnvDisconnected
-					healthy = false
-				}
 			}
 
-			bigSegmentStore := clientCtx.GetBigSegmentStore()
-			if bigSegmentStore != nil {
-				bigSegmentStatus := api.BigSegmentStatusRep{}
-				synchronizedOn, err := bigSegmentStore.GetSynchronizedOn()
-				if err != nil {
-					bigSegmentStatus.Available = false
-				} else {
-					bigSegmentStatus.Available = true
-					bigSegmentStatus.LastSynchronizedOn = synchronizedOn
-					now := ldtime.UnixMillisNow()
-					stalenessThreshold := relay.config.Main.BigSegmentsStaleThreshold.GetOrElse(config.DefaultBigSegmentsStaleThreshold)
-					if !synchronizedOn.IsDefined() || now > (synchronizedOn+ldtime.UnixMillisecondTime(stalenessThreshold.Milliseconds())) { //nolint: gosec
-						bigSegmentStatus.PotentiallyStale = true
-						if relay.config.Main.BigSegmentsStaleAsDegraded {
-							healthy = false
-						}
-					}
-				}
-				status.BigSegmentStatus = &bigSegmentStatus
-			}
-
-			storeInfo := clientCtx.GetDataStoreInfo()
-			status.DataStoreStatus.Database = storeInfo.DBType
-			status.DataStoreStatus.DBServer = storeInfo.DBServer
-			status.DataStoreStatus.DBPrefix = storeInfo.DBPrefix
-			status.DataStoreStatus.DBTable = storeInfo.DBTable
-
+			identifiers := clientCtx.GetIdentifiers()
 			statusKey := identifiers.GetDisplayName()
 			if relay.envLogNameMode == relayenv.LogNameIsEnvID {
 				// If we're identifying environments by environment ID in the log (which we do if there's any
@@ -151,4 +63,159 @@ func statusHandler(relay *Relay) http.Handler {
 
 		_, _ = w.Write(data)
 	})
+}
+
+// singleEnvironmentStatusHandler handles requests for the status of a single environment or filter.
+// Supports multiple route patterns:
+// - /status/{identifier}
+// - /status/{identifier}/filters/{filterKey}
+// - /status/{projKey}/{envKey}
+// - /status/{projKey}/{envKey}/filters/{filterKey}
+func singleEnvironmentStatusHandler(relay *Relay) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// Extract identifier from URL path
+		vars := mux.Vars(req)
+
+		// Check if this is a projKey/envKey route or a single identifier route
+		var identifier string
+		projKey := vars["projKey"]
+		envKey := vars["envKey"]
+		if projKey != "" && envKey != "" {
+			// Route: /status/{projKey}/{envKey}[/filters/{filterKey}]
+			identifier = projKey + "/" + envKey
+		} else {
+			// Route: /status/{identifier}[/filters/{filterKey}]
+			identifier = vars["identifier"]
+		}
+
+		filterKey := config.FilterKey(vars["filterKey"]) // empty string if not present
+
+		// Look up the environment
+		env, err := relay.getEnvironmentByIdentifier(identifier, filterKey)
+		if err != nil {
+			// Determine appropriate status code
+			statusCode := http.StatusNotFound
+			if err == errRelayNotReady {
+				statusCode = http.StatusServiceUnavailable
+			}
+
+			// Return error response
+			w.WriteHeader(statusCode)
+			errorResp := map[string]string{
+				"error": err.Error(),
+			}
+			data, _ := json.Marshal(errorResp)
+			_, _ = w.Write(data)
+			return
+		}
+
+		// Build and return status for the single environment
+		status, _ := relay.buildEnvironmentStatus(env)
+		data, _ := json.Marshal(status)
+		_, _ = w.Write(data)
+	})
+}
+
+// buildEnvironmentStatus constructs an EnvironmentStatusRep for a single environment.
+// Returns the status and a boolean indicating whether the environment is healthy.
+func (r *Relay) buildEnvironmentStatus(clientCtx relayenv.EnvContext) (api.EnvironmentStatusRep, bool) {
+	identifiers := clientCtx.GetIdentifiers()
+
+	status := api.EnvironmentStatusRep{
+		EnvKey:   identifiers.EnvKey, // these will only be non-empty if we're in auto-configured mode
+		EnvName:  identifiers.EnvName,
+		ProjKey:  identifiers.ProjKey,
+		ProjName: identifiers.ProjName,
+	}
+
+	for _, c := range clientCtx.GetCredentials() {
+		switch c := c.(type) {
+		case config.SDKKey:
+			status.SDKKey = sdks.ObscureKey(string(c))
+		case config.MobileKey:
+			status.MobileKey = sdks.ObscureKey(string(c))
+		case config.EnvironmentID:
+			status.EnvID = string(c)
+		}
+	}
+
+	for _, c := range clientCtx.GetDeprecatedCredentials() {
+		if key, ok := c.(config.SDKKey); ok {
+			status.ExpiringSDKKey = sdks.ObscureKey(string(key))
+		}
+	}
+
+	healthy := true
+	client := clientCtx.GetClient()
+	if client == nil {
+		status.Status = statusEnvDisconnected
+		status.ConnectionStatus.State = interfaces.DataSourceStateInitializing
+		status.ConnectionStatus.StateSince = ldtime.UnixMillisFromTime(clientCtx.GetCreationTime())
+		status.DataStoreStatus.State = "INITIALIZING"
+		healthy = false
+	} else {
+		connected := client.Initialized()
+
+		sourceStatus := client.GetDataSourceStatus()
+		status.ConnectionStatus = api.ConnectionStatusRep{
+			State:      sourceStatus.State,
+			StateSince: ldtime.UnixMillisFromTime(sourceStatus.StateSince),
+		}
+		if sourceStatus.LastError.Kind != "" {
+			status.ConnectionStatus.LastError = &api.ConnectionErrorRep{
+				Kind: sourceStatus.LastError.Kind,
+				Time: ldtime.UnixMillisFromTime(sourceStatus.LastError.Time),
+			}
+		}
+		if sourceStatus.State != interfaces.DataSourceStateValid &&
+			time.Since(sourceStatus.StateSince) >=
+				r.config.Main.DisconnectedStatusTime.GetOrElse(config.DefaultDisconnectedStatusTime) {
+			connected = false
+		}
+
+		storeStatus := client.GetDataStoreStatus()
+		status.DataStoreStatus.State = "VALID"
+		status.DataStoreStatus.StateSince = ldtime.UnixMillisFromTime(storeStatus.LastUpdated)
+		if !storeStatus.Available {
+			status.DataStoreStatus.State = "INTERRUPTED"
+		}
+
+		if connected {
+			status.Status = statusEnvConnected
+		} else {
+			status.Status = statusEnvDisconnected
+			healthy = false
+		}
+	}
+
+	bigSegmentStore := clientCtx.GetBigSegmentStore()
+	if bigSegmentStore != nil {
+		bigSegmentStatus := api.BigSegmentStatusRep{}
+		synchronizedOn, err := bigSegmentStore.GetSynchronizedOn()
+		if err != nil {
+			bigSegmentStatus.Available = false
+		} else {
+			bigSegmentStatus.Available = true
+			bigSegmentStatus.LastSynchronizedOn = synchronizedOn
+			now := ldtime.UnixMillisNow()
+			stalenessThreshold := r.config.Main.BigSegmentsStaleThreshold.GetOrElse(config.DefaultBigSegmentsStaleThreshold)
+			if !synchronizedOn.IsDefined() || now > (synchronizedOn+ldtime.UnixMillisecondTime(stalenessThreshold.Milliseconds())) { //nolint: gosec
+				bigSegmentStatus.PotentiallyStale = true
+				if r.config.Main.BigSegmentsStaleAsDegraded {
+					healthy = false
+				}
+			}
+		}
+		status.BigSegmentStatus = &bigSegmentStatus
+	}
+
+	storeInfo := clientCtx.GetDataStoreInfo()
+	status.DataStoreStatus.Database = storeInfo.DBType
+	status.DataStoreStatus.DBServer = storeInfo.DBServer
+	status.DataStoreStatus.DBPrefix = storeInfo.DBPrefix
+	status.DataStoreStatus.DBTable = storeInfo.DBTable
+
+	return status, healthy
 }

--- a/relay/endpoints_status_single_test.go
+++ b/relay/endpoints_status_single_test.go
@@ -1,0 +1,185 @@
+package relay
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	c "github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndpointsSingleEnvironmentStatus(t *testing.T) {
+	t.Run("status by environment ID", func(t *testing.T) {
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(st.EnvClientSide, st.EnvMobile)
+
+		withStartedRelay(t, config, func(p relayTestParams) {
+			// Request status for a specific environment by its environment ID
+			url := fmt.Sprintf("http://localhost/status/%s", st.EnvClientSide.Config.EnvID)
+			r, _ := http.NewRequest("GET", url, nil)
+			result, body := st.DoRequest(r, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+			status := ldvalue.Parse(body)
+
+			// Verify it returns a single environment object (not wrapped in map)
+			// The response should have environment fields directly, not under "environments" key
+			assert.Equal(t, ldvalue.NullType, status.GetByKey("environments").Type(),
+				"Response should not have 'environments' key - it should be a single environment object")
+
+			// Verify environment-specific fields
+			st.AssertJSONPathMatch(t, sdks.ObscureKey(string(st.EnvClientSide.Config.SDKKey)),
+				status, "sdkKey")
+			st.AssertJSONPathMatch(t, string(st.EnvClientSide.Config.EnvID),
+				status, "envId")
+			st.AssertJSONPathMatch(t, "connected", status, "status")
+			st.AssertJSONPathMatch(t, "VALID", status, "connectionStatus", "state")
+		})
+	})
+
+	t.Run("status by configured name", func(t *testing.T) {
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(st.EnvMain, st.EnvMobile)
+
+		withStartedRelay(t, config, func(p relayTestParams) {
+			// Request status for a specific environment by its configured name
+			url := fmt.Sprintf("http://localhost/status/%s", st.EnvMain.Name)
+			r, _ := http.NewRequest("GET", url, nil)
+			result, body := st.DoRequest(r, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+			status := ldvalue.Parse(body)
+
+			// Verify it returns a single environment object
+			assert.Equal(t, ldvalue.NullType, status.GetByKey("environments").Type())
+
+			// Verify environment-specific fields
+			st.AssertJSONPathMatch(t, sdks.ObscureKey(string(st.EnvMain.Config.SDKKey)),
+				status, "sdkKey")
+			st.AssertJSONPathMatch(t, "connected", status, "status")
+		})
+	})
+
+	t.Run("status with URL-encoded name", func(t *testing.T) {
+		var config c.Config
+		envWithSpaces := st.EnvMain
+		envWithSpaces.Name = "My Production Env"
+		config.Environment = st.MakeEnvConfigs(envWithSpaces)
+
+		withStartedRelay(t, config, func(p relayTestParams) {
+			// Request with URL-encoded name (spaces as %20)
+			url := "http://localhost/status/My%20Production%20Env"
+			r, _ := http.NewRequest("GET", url, nil)
+			result, body := st.DoRequest(r, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+			status := ldvalue.Parse(body)
+
+			// Verify it returns a single environment object
+			assert.Equal(t, ldvalue.NullType, status.GetByKey("environments").Type())
+			st.AssertJSONPathMatch(t, "connected", status, "status")
+		})
+	})
+
+	t.Run("404 for non-existent environment", func(t *testing.T) {
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+		withStartedRelay(t, config, func(p relayTestParams) {
+			// Request status for non-existent environment
+			url := "http://localhost/status/nonexistent-env-id"
+			r, _ := http.NewRequest("GET", url, nil)
+			result, body := st.DoRequest(r, p.relay)
+
+			assert.Equal(t, http.StatusNotFound, result.StatusCode)
+
+			// Verify error response format
+			errorResp := ldvalue.Parse(body)
+			assert.NotEqual(t, "", errorResp.GetByKey("error").StringValue())
+		})
+	})
+
+	t.Run("404 for non-existent filter", func(t *testing.T) {
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(st.EnvClientSide)
+
+		withStartedRelay(t, config, func(p relayTestParams) {
+			// Request status for environment with non-existent filter
+			url := fmt.Sprintf("http://localhost/status/%s/filters/nonexistent-filter", st.EnvClientSide.Config.EnvID)
+			r, _ := http.NewRequest("GET", url, nil)
+			result, body := st.DoRequest(r, p.relay)
+
+			assert.Equal(t, http.StatusNotFound, result.StatusCode)
+
+			// Verify error response
+			errorResp := ldvalue.Parse(body)
+			assert.NotEqual(t, "", errorResp.GetByKey("error").StringValue())
+		})
+	})
+
+	t.Run("response has expected structure", func(t *testing.T) {
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(st.EnvClientSide)
+
+		withStartedRelay(t, config, func(p relayTestParams) {
+			// Get status from single environment endpoint
+			url := fmt.Sprintf("http://localhost/status/%s", st.EnvClientSide.Config.EnvID)
+			r, _ := http.NewRequest("GET", url, nil)
+			result, body := st.DoRequest(r, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+			status := ldvalue.Parse(body)
+
+			// Verify response has expected structure (not wrapped in "environments" key)
+			assert.Equal(t, ldvalue.NullType, status.GetByKey("environments").Type(),
+				"Single environment response should not have 'environments' wrapper")
+
+			// Verify all expected fields are present
+			st.AssertJSONPathMatch(t, string(st.EnvClientSide.Config.EnvID), status, "envId")
+			assert.NotEqual(t, "", status.GetByKey("sdkKey").StringValue(), "Should have sdkKey")
+			assert.NotEqual(t, "", status.GetByKey("status").StringValue(), "Should have status")
+			assert.NotEqual(t, ldvalue.NullType, status.GetByKey("connectionStatus").Type(), "Should have connectionStatus")
+			assert.NotEqual(t, ldvalue.NullType, status.GetByKey("dataStoreStatus").Type(), "Should have dataStoreStatus")
+		})
+	})
+
+	t.Run("multiple environments - can query each individually", func(t *testing.T) {
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(st.EnvMain, st.EnvClientSide, st.EnvMobile)
+
+		withStartedRelay(t, config, func(p relayTestParams) {
+			// Query each environment individually
+			envs := []struct {
+				name string
+				id   string
+			}{
+				{st.EnvMain.Name, ""},
+				{st.EnvClientSide.Name, string(st.EnvClientSide.Config.EnvID)},
+				{st.EnvMobile.Name, string(st.EnvMobile.Config.EnvID)},
+			}
+
+			for _, env := range envs {
+				identifier := env.name
+				if env.id != "" {
+					identifier = env.id
+				}
+
+				url := fmt.Sprintf("http://localhost/status/%s", identifier)
+				r, _ := http.NewRequest("GET", url, nil)
+				result, body := st.DoRequest(r, p.relay)
+
+				assert.Equal(t, http.StatusOK, result.StatusCode,
+					"Expected 200 for environment %s", env.name)
+
+				status := ldvalue.Parse(body)
+				st.AssertJSONPathMatch(t, "connected", status, "status")
+			}
+		})
+	})
+}

--- a/relay/environment_lookup.go
+++ b/relay/environment_lookup.go
@@ -1,8 +1,10 @@
 package relay
 
 import (
+	"strings"
 	"sync"
 
+	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
 
 	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
@@ -53,12 +55,30 @@ import (
 //
 // As shown, given N environments in a project, and M filters for that project, then N*(M+1) environment connections are
 // maintained: N=2, M=1, count = 2*(1+1) = 4.
+
+// projEnvKey is a composite key for looking up environments by project key and environment key.
+// This is only available in auto-config mode where environments have project and environment metadata.
+type projEnvKey struct {
+	projKey string
+	envKey  string
+}
+
 type EnvironmentLookup struct {
 	// mapping maps {credential, filter} keys to environment connections.
 	mapping map[sdkauth.ScopedCredential]relayenv.EnvContext
 	// conns is the set of unique environment connections
 	conns map[relayenv.EnvContext]struct{}
-	// mu protects any access to 'mapping' and 'conns'
+
+	// Identifier-based indexes for status endpoint lookups.
+	// Each environment can have multiple filter variants, so values are slices.
+	// envIDIndex maps environment IDs to environments (auto-config mode)
+	envIDIndex map[config.EnvironmentID][]relayenv.EnvContext
+	// configNameIndex maps configured names to environments (manual config mode)
+	configNameIndex map[string][]relayenv.EnvContext
+	// projEnvKeyIndex maps {projKey, envKey} to environments (auto-config mode, human-readable)
+	projEnvKeyIndex map[projEnvKey][]relayenv.EnvContext
+
+	// mu protects access to all maps
 	mu sync.RWMutex
 }
 
@@ -66,8 +86,11 @@ type EnvironmentLookup struct {
 // are thread safe.
 func NewEnvironmentLookup() *EnvironmentLookup {
 	return &EnvironmentLookup{
-		mapping: make(map[sdkauth.ScopedCredential]relayenv.EnvContext),
-		conns:   make(map[relayenv.EnvContext]struct{}),
+		mapping:         make(map[sdkauth.ScopedCredential]relayenv.EnvContext),
+		conns:           make(map[relayenv.EnvContext]struct{}),
+		envIDIndex:      make(map[config.EnvironmentID][]relayenv.EnvContext),
+		configNameIndex: make(map[string][]relayenv.EnvContext),
+		projEnvKeyIndex: make(map[projEnvKey][]relayenv.EnvContext),
 	}
 }
 
@@ -85,6 +108,9 @@ func (e *EnvironmentLookup) InsertEnvironment(env relayenv.EnvContext) {
 	}
 
 	e.conns[env] = struct{}{}
+
+	// Populate identifier-based indexes for status endpoint lookups
+	e.addToIdentifierIndexes(env)
 }
 
 // MapRequestParams creates a mapping from connection parameters to an environment connection. It can be used
@@ -113,6 +139,56 @@ func (e *EnvironmentLookup) Lookup(params sdkauth.ScopedCredential) (relayenv.En
 	defer e.mu.RUnlock()
 
 	return e.lookup(params)
+}
+
+// LookupByIdentifier searches for an environment by a flexible identifier string and optional filter key.
+// The identifier can be:
+// - An environment ID (e.g., "507f1f77bcf86cd799439011")
+// - A project/environment key pair separated by "/" (e.g., "my-app/production")
+// - A configured name (e.g., "My Production Environment")
+//
+// Lookup precedence: envID → projKey/envKey (contains "/") → configuredName
+//
+// The filterKey parameter specifies which filter variant to return. Use an empty string for the
+// unfiltered (base) environment.
+//
+// If a matching environment is found, returns true; otherwise, returns false.
+func (e *EnvironmentLookup) LookupByIdentifier(identifier string, filterKey config.FilterKey) (relayenv.EnvContext, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	// Try environment ID first (most specific)
+	if envID := config.EnvironmentID(identifier); envID != "" {
+		// Note: A single envID can have multiple EnvContext instances when payload filters are configured.
+		// Each filter variant (base + filter1, filter2, etc.) is a separate EnvContext with the same envID.
+		// We use findEnvWithFilter to select the specific variant matching the requested filterKey.
+		if envs, ok := e.envIDIndex[envID]; ok {
+			if env := findEnvWithFilter(envs, filterKey); env != nil {
+				return env, true
+			}
+		}
+	}
+
+	// Try project/environment key pair (contains "/")
+	if idx := strings.Index(identifier, "/"); idx > 0 && idx < len(identifier)-1 {
+		projKey := identifier[:idx]
+		envKey := identifier[idx+1:]
+		key := projEnvKey{projKey: projKey, envKey: envKey}
+		if envs, ok := e.projEnvKeyIndex[key]; ok {
+			if env := findEnvWithFilter(envs, filterKey); env != nil {
+				return env, true
+			}
+		}
+	}
+
+	// Try configured name last (fallback)
+	if envs, ok := e.configNameIndex[identifier]; ok {
+		if env := findEnvWithFilter(envs, filterKey); env != nil {
+			return env, true
+		}
+	}
+
+	return nil, false
 }
 
 // DeleteEnvironment searches for an environment identified by the client request params, deletes it, and then
@@ -166,5 +242,93 @@ func (e *EnvironmentLookup) deleteEnvironment(env relayenv.EnvContext) (found bo
 		}
 	}
 	delete(e.conns, env)
+	e.removeFromIdentifierIndexes(env)
 	return
+}
+
+// addToIdentifierIndexes adds the environment to all applicable identifier-based indexes.
+// This must be called with the mutex already locked.
+func (e *EnvironmentLookup) addToIdentifierIndexes(env relayenv.EnvContext) {
+	identifiers := env.GetIdentifiers()
+
+	// Index by environment ID if present (auto-config mode)
+	var envID config.EnvironmentID
+	for _, cred := range env.GetCredentials() {
+		if id, ok := cred.(config.EnvironmentID); ok && id.Defined() {
+			envID = id
+			break
+		}
+	}
+	if envID != "" {
+		e.envIDIndex[envID] = append(e.envIDIndex[envID], env)
+	}
+
+	// Index by configured name if present (manual config mode)
+	if identifiers.ConfiguredName != "" {
+		e.configNameIndex[identifiers.ConfiguredName] = append(e.configNameIndex[identifiers.ConfiguredName], env)
+	}
+
+	// Index by project+environment keys if both present (auto-config mode)
+	if identifiers.ProjKey != "" && identifiers.EnvKey != "" {
+		key := projEnvKey{projKey: identifiers.ProjKey, envKey: identifiers.EnvKey}
+		e.projEnvKeyIndex[key] = append(e.projEnvKeyIndex[key], env)
+	}
+}
+
+// removeFromIdentifierIndexes removes the environment from all identifier-based indexes.
+// This must be called with the mutex already locked.
+func (e *EnvironmentLookup) removeFromIdentifierIndexes(env relayenv.EnvContext) {
+	identifiers := env.GetIdentifiers()
+
+	// Remove from environment ID index
+	var envID config.EnvironmentID
+	for _, cred := range env.GetCredentials() {
+		if id, ok := cred.(config.EnvironmentID); ok && id.Defined() {
+			envID = id
+			break
+		}
+	}
+	if envID != "" {
+		e.envIDIndex[envID] = removeEnvFromSlice(e.envIDIndex[envID], env)
+		if len(e.envIDIndex[envID]) == 0 {
+			delete(e.envIDIndex, envID)
+		}
+	}
+
+	// Remove from configured name index
+	if identifiers.ConfiguredName != "" {
+		e.configNameIndex[identifiers.ConfiguredName] = removeEnvFromSlice(e.configNameIndex[identifiers.ConfiguredName], env)
+		if len(e.configNameIndex[identifiers.ConfiguredName]) == 0 {
+			delete(e.configNameIndex, identifiers.ConfiguredName)
+		}
+	}
+
+	// Remove from project+environment key index
+	if identifiers.ProjKey != "" && identifiers.EnvKey != "" {
+		key := projEnvKey{projKey: identifiers.ProjKey, envKey: identifiers.EnvKey}
+		e.projEnvKeyIndex[key] = removeEnvFromSlice(e.projEnvKeyIndex[key], env)
+		if len(e.projEnvKeyIndex[key]) == 0 {
+			delete(e.projEnvKeyIndex, key)
+		}
+	}
+}
+
+// removeEnvFromSlice removes an environment from a slice and returns the updated slice.
+func removeEnvFromSlice(slice []relayenv.EnvContext, env relayenv.EnvContext) []relayenv.EnvContext {
+	for i, e := range slice {
+		if e == env {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+	return slice
+}
+
+// findEnvWithFilter searches a slice of environments for one matching the specified filter key.
+func findEnvWithFilter(envs []relayenv.EnvContext, filterKey config.FilterKey) relayenv.EnvContext {
+	for _, env := range envs {
+		if env.GetPayloadFilter() == filterKey {
+			return env
+		}
+	}
+	return nil
 }

--- a/relay/environment_lookup.go
+++ b/relay/environment_lookup.go
@@ -323,6 +323,40 @@ func removeEnvFromSlice(slice []relayenv.EnvContext, env relayenv.EnvContext) []
 	return slice
 }
 
+// RefreshEnvironmentIndexes updates the identifier-based indexes for an environment.
+// This should be called after the environment's identifiers have changed via SetIdentifiers.
+// It removes all existing index entries for this environment and re-adds them with current identifiers.
+func (e *EnvironmentLookup) RefreshEnvironmentIndexes(env relayenv.EnvContext) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Remove this environment from all identifier indexes by iterating through them
+	// and removing any entries that reference this specific environment instance
+	for envID, envs := range e.envIDIndex {
+		e.envIDIndex[envID] = removeEnvFromSlice(envs, env)
+		if len(e.envIDIndex[envID]) == 0 {
+			delete(e.envIDIndex, envID)
+		}
+	}
+
+	for name, envs := range e.configNameIndex {
+		e.configNameIndex[name] = removeEnvFromSlice(envs, env)
+		if len(e.configNameIndex[name]) == 0 {
+			delete(e.configNameIndex, name)
+		}
+	}
+
+	for key, envs := range e.projEnvKeyIndex {
+		e.projEnvKeyIndex[key] = removeEnvFromSlice(envs, env)
+		if len(e.projEnvKeyIndex[key]) == 0 {
+			delete(e.projEnvKeyIndex, key)
+		}
+	}
+
+	// Re-add using current identifiers
+	e.addToIdentifierIndexes(env)
+}
+
 // findEnvWithFilter searches a slice of environments for one matching the specified filter key.
 func findEnvWithFilter(envs []relayenv.EnvContext, filterKey config.FilterKey) relayenv.EnvContext {
 	for _, env := range envs {

--- a/relay/environment_lookup_identifier_test.go
+++ b/relay/environment_lookup_identifier_test.go
@@ -1,0 +1,129 @@
+package relay
+
+import (
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnvironmentLookup_LookupByIdentifier tests the identifier-based lookup functionality
+// for the status endpoint. These are unit tests focusing on the lookup logic itself.
+func TestEnvironmentLookup_LookupByIdentifier(t *testing.T) {
+	t.Run("lookup by environment ID", func(t *testing.T) {
+		var cfg config.Config
+		cfg.Environment = st.MakeEnvConfigs(st.EnvClientSide)
+
+		withStartedRelay(t, cfg, func(p relayTestParams) {
+			lookup := p.relay.envsByCredential
+
+			// Lookup by environment ID should succeed
+			result, found := lookup.LookupByIdentifier(string(st.EnvClientSide.Config.EnvID), "")
+			require.True(t, found, "Expected to find environment by ID")
+			assert.NotNil(t, result)
+		})
+	})
+
+	t.Run("lookup by configured name", func(t *testing.T) {
+		var cfg config.Config
+		cfg.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+		withStartedRelay(t, cfg, func(p relayTestParams) {
+			lookup := p.relay.envsByCredential
+
+			// Lookup by configured name should succeed
+			result, found := lookup.LookupByIdentifier(st.EnvMain.Name, "")
+			require.True(t, found, "Expected to find environment by configured name")
+			assert.NotNil(t, result)
+			assert.Equal(t, st.EnvMain.Name, result.GetIdentifiers().ConfiguredName)
+		})
+	})
+
+	t.Run("lookup not found", func(t *testing.T) {
+		var cfg config.Config
+		cfg.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+		withStartedRelay(t, cfg, func(p relayTestParams) {
+			lookup := p.relay.envsByCredential
+
+			// Lookup with non-existent identifier
+			_, found := lookup.LookupByIdentifier("nonexistent", "")
+			assert.False(t, found, "Expected not to find non-existent environment")
+		})
+	})
+
+	t.Run("lookup with wrong filter key", func(t *testing.T) {
+		var cfg config.Config
+		cfg.Environment = st.MakeEnvConfigs(st.EnvClientSide)
+
+		withStartedRelay(t, cfg, func(p relayTestParams) {
+			lookup := p.relay.envsByCredential
+
+			// Lookup with non-existent filter should fail
+			_, found := lookup.LookupByIdentifier(string(st.EnvClientSide.Config.EnvID), "nonexistent-filter")
+			assert.False(t, found, "Expected not to find environment with wrong filter")
+		})
+	})
+
+	t.Run("lookup with spaces in name", func(t *testing.T) {
+		var cfg config.Config
+		envWithSpaces := st.EnvMain
+		envWithSpaces.Name = "My Production Env"
+		cfg.Environment = st.MakeEnvConfigs(envWithSpaces)
+
+		withStartedRelay(t, cfg, func(p relayTestParams) {
+			lookup := p.relay.envsByCredential
+
+			// Lookup should work with exact name
+			result, found := lookup.LookupByIdentifier("My Production Env", "")
+			require.True(t, found, "Expected to find environment with spaces in name")
+			assert.NotNil(t, result)
+			assert.Equal(t, "My Production Env", result.GetIdentifiers().ConfiguredName)
+		})
+	})
+
+	t.Run("delete environment removes from identifier indexes", func(t *testing.T) {
+		var cfg config.Config
+		cfg.Environment = st.MakeEnvConfigs(st.EnvClientSide)
+
+		withStartedRelay(t, cfg, func(p relayTestParams) {
+			lookup := p.relay.envsByCredential
+			envID := st.EnvClientSide.Config.EnvID
+
+			// Verify it's in the index
+			_, found := lookup.LookupByIdentifier(string(envID), "")
+			require.True(t, found, "Environment should be in envID index")
+
+			// Delete environment by credential
+			params := sdkauth.New(st.EnvClientSide.Config.SDKKey)
+			deleted, ok := lookup.DeleteEnvironment(params)
+			require.True(t, ok, "Expected delete to succeed")
+			assert.NotNil(t, deleted)
+
+			// Verify it's removed from index
+			_, found = lookup.LookupByIdentifier(string(envID), "")
+			assert.False(t, found, "Environment should be removed from envID index")
+		})
+	})
+
+	t.Run("projKey/envKey pattern requires slash", func(t *testing.T) {
+		var cfg config.Config
+		cfg.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+		withStartedRelay(t, cfg, func(p relayTestParams) {
+			lookup := p.relay.envsByCredential
+
+			// Lookup without slash should not match anything (no projKey/envKey in manual config)
+			_, found := lookup.LookupByIdentifier("myprojectproduction", "")
+			assert.False(t, found, "Should not match non-existent identifier")
+
+			// Lookup with slash should also not match (manual config doesn't have projKey/envKey)
+			_, found = lookup.LookupByIdentifier("myproject/production", "")
+			assert.False(t, found, "Should not match non-existent projKey/envKey")
+		})
+	})
+}

--- a/relay/environment_lookup_identifier_test.go
+++ b/relay/environment_lookup_identifier_test.go
@@ -126,4 +126,44 @@ func TestEnvironmentLookup_LookupByIdentifier(t *testing.T) {
 			assert.False(t, found, "Should not match non-existent projKey/envKey")
 		})
 	})
+
+	t.Run("refresh indexes after identifier change", func(t *testing.T) {
+		var cfg config.Config
+		cfg.Environment = st.MakeEnvConfigs(st.EnvClientSide)
+
+		withStartedRelay(t, cfg, func(p relayTestParams) {
+			lookup := p.relay.envsByCredential
+			envID := st.EnvClientSide.Config.EnvID
+
+			// Verify environment is accessible by envID
+			env, found := lookup.LookupByIdentifier(string(envID), "")
+			require.True(t, found, "Environment should be found by envID")
+
+			// Verify it's accessible by configured name
+			_, found = lookup.LookupByIdentifier(st.EnvClientSide.Name, "")
+			require.True(t, found, "Environment should be found by configured name")
+
+			// Simulate identifier change (as happens in auto-config updates)
+			oldIdentifiers := env.GetIdentifiers()
+			newIdentifiers := oldIdentifiers
+			newIdentifiers.ConfiguredName = "New Name After Update"
+			newIdentifiers.ProjKey = "new-project"
+			newIdentifiers.EnvKey = "new-env"
+
+			env.SetIdentifiers(newIdentifiers)
+			lookup.RefreshEnvironmentIndexes(env)
+
+			// Old configured name should not work
+			_, found = lookup.LookupByIdentifier(st.EnvClientSide.Name, "")
+			assert.False(t, found, "Old configured name should not be found after refresh")
+
+			// New configured name should work
+			_, found = lookup.LookupByIdentifier("New Name After Update", "")
+			assert.True(t, found, "New configured name should be found after refresh")
+
+			// Environment ID should still work (doesn't change)
+			_, found = lookup.LookupByIdentifier(string(envID), "")
+			assert.True(t, found, "Environment ID lookup should still work after refresh")
+		})
+	})
 }

--- a/relay/filedata_actions.go
+++ b/relay/filedata_actions.go
@@ -86,6 +86,9 @@ func (a *relayFileDataActions) UpdateEnvironment(ae filedata.ArchiveEnvironment)
 	}
 
 	env.SetIdentifiers(ae.Params.Identifiers)
+	// Refresh identifier-based indexes after identifiers change
+	a.r.envsByCredential.RefreshEnvironmentIndexes(env)
+
 	env.SetTTL(ae.Params.TTL)
 	env.SetSecureMode(ae.Params.SecureMode)
 

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -391,6 +391,40 @@ func (r *Relay) getAllEnvironments() []relayenv.EnvContext {
 	return r.envsByCredential.Environments()
 }
 
+// getEnvironmentByIdentifier returns the environment object corresponding to the given identifier
+// and optional filter key. The identifier can be:
+// - An environment ID (e.g., "507f1f77bcf86cd799439011")
+// - A project/environment key pair (e.g., "my-app/production")
+// - A configured name (e.g., "My Production Environment")
+//
+// The filterKey parameter specifies which filter variant to return. Use an empty string for the
+// unfiltered (base) environment.
+//
+// Returns an error if Relay is not fully configured, if the environment is not found, or if the
+// filter is not found for an otherwise valid environment.
+func (r *Relay) getEnvironmentByIdentifier(identifier string, filterKey config.FilterKey) (relayenv.EnvContext, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	if !r.fullyConfigured {
+		return nil, errRelayNotReady
+	}
+
+	env, found := r.envsByCredential.LookupByIdentifier(identifier, filterKey)
+	if found {
+		return env, nil
+	}
+
+	// Check if the environment exists but the filter doesn't
+	if filterKey != "" {
+		if _, foundUnfiltered := r.envsByCredential.LookupByIdentifier(identifier, ""); foundUnfiltered {
+			return nil, errPayloadFilterNotFound
+		}
+	}
+
+	return nil, errUnrecognizedEnvironment
+}
+
 // addEnvironment attempts to add a new environment. It returns an error only if the configuration
 // is invalid; it does not wait to see whether the connection to LaunchDarkly succeeded.
 func (r *Relay) addEnvironment(

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -41,6 +41,12 @@ func (r *Relay) makeRouter() *mux.Router {
 		})
 	}
 	router.Handle("/status", statusHandler(r)).Methods("GET")
+	// Register more specific routes first (with /filters/ literal)
+	router.Handle("/status/{identifier}/filters/{filterKey}", singleEnvironmentStatusHandler(r)).Methods("GET")
+	router.Handle("/status/{projKey}/{envKey}/filters/{filterKey}", singleEnvironmentStatusHandler(r)).Methods("GET")
+	// Then register the general routes
+	router.Handle("/status/{projKey}/{envKey}", singleEnvironmentStatusHandler(r)).Methods("GET")
+	router.Handle("/status/{identifier}", singleEnvironmentStatusHandler(r)).Methods("GET")
 
 	environmentGetters := relayEnvironmentGetters{r}
 	sdkKeySelector := middleware.SelectEnvironmentByAuthorizationKey(basictypes.ServerSDK, environmentGetters)


### PR DESCRIPTION
The `/status` endpoint shows the current status of the relay for all
environments. However, some customers may find it easier to monitor
individual environments without needing to parse complex JSON.

To combat this, we are supporting a few new routes:

- `/status/<envid>` :: Useful for auto-config, or when specified by the
  manual config
- `/status/<projectKey>/<envKey>` :: Stable, predictable path for use in
  auto-configs
- `/status/<identifer>` :: Useful human-readable path when used with
  manual config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds single-environment status queries to simplify monitoring and debugging.
> 
> - **New endpoints**: `GET /status/{identifier}`, `/status/{identifier}/filters/{filterKey}`, `/status/{projKey}/{envKey}`, and `/status/{projKey}/{envKey}/filters/{filterKey}` (no auth); returns a single environment status object with `200/404/503` handling
> - **Lookup enhancements**: `EnvironmentLookup` now indexes by `envId`, configured name, and `{projKey, envKey}`; supports `LookupByIdentifier` with optional filter; indexes refresh on identifier changes and deletions
> - **Refactor**: Extracted `buildEnvironmentStatus` for reuse; `/status` handler simplified to use it
> - **Routing**: Registered new Gorilla Mux routes for the per-environment endpoints
> - **Auto-config/offline updates**: Refresh identifier indexes after `SetIdentifiers` in `autoconfig_actions.go` and `filedata_actions.go`
> - **Docs and tests**: Updated `docs/endpoints.md` and added unit/integration tests for new endpoints and lookup behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aeefcb7095dffcf7d25374dee1e99ac26d5ce08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->