### PR TITLE
chore: Fix contributing link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 **Requirements**
 
 - [ ] I have added test coverage for new or changed functionality
-- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
+- [ ] I have followed the repository's [pull request submission guidelines](../CONTRIBUTING.md#submitting-pull-requests)
 - [ ] I have validated my changes against all supported platform versions
 
 **Related issues**


### PR DESCRIPTION
Fixes #573

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a broken link in the PR template checklist.
> 
> - Updates the CONTRIBUTING link in `/.github/pull_request_template.md` to `../CONTRIBUTING.md#submitting-pull-requests` (was `../blob/master/CONTRIBUTING.md#submitting-pull-requests`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4a67a9e9963532450119d4ab9aa38ec41253ba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->