### PR TITLE
fix: Drop windows/arm support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,8 @@ builds:
   ignore: # Go 1.15+ doesn't support 32-bit Darwin
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm
 
 nfpms:
   -


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes release packaging configuration by excluding `windows/arm` from builds, with no runtime code impact.
> 
> **Overview**
> **GoReleaser no longer attempts to build `windows/arm` artifacts.** This adds a `builds.ignore` entry for `goos: windows` + `goarch: arm`, preventing unsupported/undesired Windows ARM releases from being produced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7434953952760ef2bd28772c5ba6faafc15c30b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->