### PR TITLE
feat: Remove "new connections" usage metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -9,7 +9,6 @@ The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://o
 | Metric | Type | Description |
 |--------|------|-------------|
 | `launchdarkly.relay.connections` | UpDownCounter | The number of currently active stream connections from SDKs to the Relay Proxy. |
-| `launchdarkly.relay.newconnections` | Counter | The cumulative number of stream connections made to the Relay Proxy since startup. |
 | `launchdarkly.relay.requests` | Counter | The cumulative number of requests received by the Relay Proxy's [service endpoints](./endpoints.md) since startup. |
 
 ## Attributes
@@ -41,7 +40,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://<prometheus-host>:9090/api/v1/otlp/v1/metrics
 OTEL_EXPORTER_OTLP_PROTOCOL=http
 ```
 
-Prometheus converts OpenTelemetry metric names by replacing dots with underscores, so the metrics will appear as `launchdarkly_relay_connections`, `launchdarkly_relay_newconnections_total`, and `launchdarkly_relay_requests_total`.
+Prometheus converts OpenTelemetry metric names by replacing dots with underscores, so the metrics will appear as `launchdarkly_relay_connections` and `launchdarkly_relay_requests_total`.
 
 ### OpenTelemetry Collector
 

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -10,7 +10,6 @@ import (
 const (
 	// Metric instrument names.
 	connMeasureName    = "launchdarkly.relay.connections"
-	newConnMeasureName = "launchdarkly.relay.newconnections"
 	requestMeasureName = "launchdarkly.relay.requests"
 
 	defaultFlushInterval = time.Minute

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -8,19 +8,17 @@ import (
 
 // Instruments holds the OTel metric instruments used for recording metrics.
 type Instruments struct {
-	connections    metric.Int64UpDownCounter // active connections (+1/-1)
-	newConnections metric.Int64Counter       // cumulative new connections
-	requests       metric.Int64Counter       // cumulative HTTP requests
+	connections metric.Int64UpDownCounter // active connections (+1/-1)
+	requests    metric.Int64Counter       // cumulative HTTP requests
 }
 
 // Measure identifies what to record. Each pre-defined Measure var specifies which
 // instruments should be incremented and what platform category to use.
 type Measure struct {
-	recordConnections    bool
-	recordNewConnections bool
-	recordRequests       bool
-	recordPolling        bool
-	platformCategory     string
+	recordConnections bool
+	recordRequests    bool
+	recordPolling     bool
+	platformCategory  string
 }
 
 // To avoid having to put nolint:gochecknoglobals on everything here, that linter is excluded
@@ -34,15 +32,6 @@ var (
 
 	// ServerConns is a Measure representing the current number of active stream connections from server-side SDKs.
 	ServerConns = Measure{recordConnections: true, platformCategory: ServerPlatformCategory}
-
-	// NewBrowserConns is a Measure representing the cumulative number of stream connections from browsers.
-	NewBrowserConns = Measure{recordNewConnections: true, platformCategory: BrowserPlatformCategory}
-
-	// NewMobileConns is a Measure representing the cumulative number of stream connections from mobile SDKs.
-	NewMobileConns = Measure{recordNewConnections: true, platformCategory: MobilePlatformCategory}
-
-	// NewServerConns is a Measure representing the cumulative number of stream connections from server-side SDKs.
-	NewServerConns = Measure{recordNewConnections: true, platformCategory: ServerPlatformCategory}
 
 	// BrowserRequests is a Measure representing the number of HTTP requests from browsers.
 	BrowserRequests = Measure{recordRequests: true, platformCategory: BrowserPlatformCategory}
@@ -64,18 +53,13 @@ func NewInstrumentsForTest(meter metric.Meter) (*Instruments, error) {
 	if err != nil {
 		return nil, err
 	}
-	newConnections, err := meter.Int64Counter(newConnMeasureName)
-	if err != nil {
-		return nil, err
-	}
 	requests, err := meter.Int64Counter(requestMeasureName)
 	if err != nil {
 		return nil, err
 	}
 	return &Instruments{
-		connections:    connections,
-		newConnections: newConnections,
-		requests:       requests,
+		connections: connections,
+		requests:    requests,
 	}, nil
 }
 
@@ -115,14 +99,6 @@ func WithCount(em *EnvironmentManager, instruments *Instruments, userAgent, sdkW
 	sanitizedWrapper := sanitizeTagValue(sdkWrapper)
 	attrs := buildAttributes(em.envKVs, measure.platformCategory, sanitizedUA, sanitizedWrapper)
 
-	if measure.recordNewConnections {
-		if instruments != nil {
-			instruments.newConnections.Add(context.Background(), 1, metric.WithAttributeSet(attrs))
-		}
-		if em.collector != nil {
-			em.collector.RecordNewConnection(measure.platformCategory, sanitizedUA, sanitizedWrapper)
-		}
-	}
 	if measure.recordRequests && instruments != nil {
 		instruments.requests.Add(context.Background(), 1, metric.WithAttributeSet(attrs))
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -93,15 +93,12 @@ func NewManager(
 
 	connections, _ := meter.Int64UpDownCounter(connMeasureName,
 		otelmetric.WithDescription("current number of connections"))
-	newConnections, _ := meter.Int64Counter(newConnMeasureName,
-		otelmetric.WithDescription("total number of connections"))
 	requests, _ := meter.Int64Counter(requestMeasureName,
 		otelmetric.WithDescription("number of hits to a route"))
 
 	instruments := &Instruments{
-		connections:    connections,
-		newConnections: newConnections,
-		requests:       requests,
+		connections: connections,
+		requests:    requests,
 	}
 
 	usageChan := make(chan any, 256)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -31,7 +31,6 @@ func TestNewManagerReturnsInstruments(t *testing.T) {
 	instruments := manager.GetInstruments()
 	assert.NotNil(t, instruments)
 	assert.NotNil(t, instruments.connections)
-	assert.NotNil(t, instruments.newConnections)
 	assert.NotNil(t, instruments.requests)
 }
 
@@ -128,31 +127,6 @@ func TestConnectionMetrics(t *testing.T) {
 	}
 }
 
-func TestNewConnectionMetrics(t *testing.T) {
-	specs := []struct {
-		platform string
-		measure  Measure
-	}{
-		{platform: BrowserPlatformCategory, measure: NewBrowserConns},
-		{platform: MobilePlatformCategory, measure: NewMobileConns},
-		{platform: ServerPlatformCategory, measure: NewServerConns},
-	}
-
-	for _, tt := range specs {
-		t.Run(tt.platform, func(t *testing.T) {
-			testWithOTel(t, func(p testWithOTelParams) {
-				WithCount(p.env, p.instruments, userAgentValue, "", func() {}, tt.measure)
-
-				rm, err := p.collectMetrics()
-				require.NoError(t, err)
-				m := findMetric(rm, newConnMeasureName)
-				require.NotNil(t, m, "newconnections metric not found")
-				assertCounterValue(t, m, p.envName, tt.platform, 1)
-			})
-		})
-	}
-}
-
 func TestWithRouteCount(t *testing.T) {
 	testWithOTel(t, func(p testWithOTelParams) {
 		WithRouteCount(context.Background(), p.env, p.instruments, userAgentValue, "", "someRoute", "GET", func() {}, ServerRequests)
@@ -201,22 +175,6 @@ func findMetric(rm *metricdata.ResourceMetrics, name string) *metricdata.Metrics
 }
 
 func assertGaugeValue(t *testing.T, m *metricdata.Metrics, envName, platform string, expected int64) {
-	t.Helper()
-	sum, ok := m.Data.(metricdata.Sum[int64])
-	require.True(t, ok, "expected Sum[int64] data for %s", m.Name)
-	found := false
-	for _, dp := range sum.DataPoints {
-		platVal, platOK := dp.Attributes.Value(platformCategoryAttrKey)
-		envVal, envOK := dp.Attributes.Value(envNameAttrKey)
-		if platOK && envOK && platVal.AsString() == platform && envVal.AsString() == envName {
-			assert.Equal(t, expected, dp.Value, "unexpected value for %s (platform=%s, env=%s)", m.Name, platform, envName)
-			found = true
-		}
-	}
-	assert.True(t, found, "no data point found for %s with platform=%s, env=%s", m.Name, platform, envName)
-}
-
-func assertCounterValue(t *testing.T, m *metricdata.Metrics, envName, platform string, expected int64) {
 	t.Helper()
 	sum, ok := m.Data.(metricdata.Sum[int64])
 	require.True(t, ok, "expected Sum[int64] data for %s", m.Name)

--- a/internal/metrics/relay_metrics_collector.go
+++ b/internal/metrics/relay_metrics_collector.go
@@ -17,13 +17,6 @@ type currentConnectionsMetric struct {
 	Current          int64  `json:"current"`
 }
 
-type newConnectionsMetric struct {
-	UserAgent        string `json:"userAgent"`
-	SDKWrapper       string `json:"sdkWrapper"`
-	PlatformCategory string `json:"platformCategory"`
-	Count            int64  `json:"count"`
-}
-
 type pollingMetric struct {
 	UserAgent        string `json:"userAgent"`
 	SDKWrapper       string `json:"sdkWrapper"`
@@ -38,9 +31,8 @@ type relayMetricsEvent struct {
 	RelayID        string                     `json:"relayId"`
 	StartDate      ldtime.UnixMillisecondTime `json:"startDate"`
 	EndDate        ldtime.UnixMillisecondTime `json:"endDate"`
-	Connections    []currentConnectionsMetric `json:"connections,omitempty"`
-	NewConnections []newConnectionsMetric     `json:"newConnections,omitempty"`
-	PollingCounts  []pollingMetric            `json:"pollingCounts,omitempty"`
+	Connections   []currentConnectionsMetric `json:"connections,omitempty"`
+	PollingCounts []pollingMetric            `json:"pollingCounts,omitempty"`
 }
 
 type connectionsKeyType struct {
@@ -66,7 +58,6 @@ type RelayMetricsCollector struct {
 	intervalStartTime time.Time
 
 	currentConnections map[connectionsKeyType]int64
-	newConnections     map[connectionsKeyType]int64
 
 	pollingDataIsDirty bool
 	pollingCounts      map[connectionsKeyType]pollingCounts
@@ -84,7 +75,6 @@ func newRelayMetricsCollector(relayID, envName string, publisher events.EventPub
 		intervalStartTime:  time.Now(),
 		pollingDataIsDirty: false,
 		currentConnections: make(map[connectionsKeyType]int64),
-		newConnections:     make(map[connectionsKeyType]int64),
 		pollingCounts:      make(map[connectionsKeyType]pollingCounts),
 	}
 
@@ -121,14 +111,6 @@ func (c *RelayMetricsCollector) RecordConnectionChange(platform, userAgent, sdkW
 	}
 }
 
-// RecordNewConnection records a new connection (cumulative counter).
-func (c *RelayMetricsCollector) RecordNewConnection(platform, userAgent, sdkWrapper string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	key := connectionsKeyType{platformCategory: platform, userAgent: userAgent, sdkWrapper: sdkWrapper}
-	c.newConnections[key]++
-}
-
 // RecordPollingRequest records a polling request.
 func (c *RelayMetricsCollector) RecordPollingRequest(platform, userAgent, sdkWrapper string) {
 	c.mu.Lock()
@@ -145,9 +127,6 @@ func (c *RelayMetricsCollector) hasMetricDataToReport() bool {
 		return true
 	}
 	if len(c.currentConnections) > 0 {
-		return true
-	}
-	if len(c.newConnections) > 0 {
 		return true
 	}
 	return false
@@ -192,14 +171,6 @@ func (c *RelayMetricsCollector) flush() {
 			SDKWrapper:       k.sdkWrapper,
 			PlatformCategory: k.platformCategory,
 			Current:          v,
-		})
-	}
-	for k, v := range c.newConnections {
-		event.NewConnections = append(event.NewConnections, newConnectionsMetric{
-			UserAgent:        k.userAgent,
-			SDKWrapper:       k.sdkWrapper,
-			PlatformCategory: k.platformCategory,
-			Count:            v,
 		})
 	}
 	c.mu.Unlock()

--- a/internal/metrics/relay_metrics_collector_test.go
+++ b/internal/metrics/relay_metrics_collector_test.go
@@ -33,11 +33,9 @@ func TestRelayMetricsCollector(t *testing.T) {
 		start := ldtime.UnixMillisNow()
 		withCollector(publisher, func(c *RelayMetricsCollector, relayID string) {
 			c.RecordConnectionChange(platformValue, userAgentValue, "", 1)
-			c.RecordNewConnection(platformValue, userAgentValue, "")
 			c.RecordPollingRequest(platformValue, userAgentValue, "")
 
 			expectedConn := currentConnectionsMetric{UserAgent: userAgentValue, PlatformCategory: platformValue, Current: 1}
-			expectedNewConn := newConnectionsMetric{UserAgent: userAgentValue, PlatformCategory: platformValue, Count: 1}
 			expectedPollingMetric := pollingMetric{UserAgent: userAgentValue, PlatformCategory: platformValue, Count: 1}
 
 			require.Eventually(t, func() bool {
@@ -52,7 +50,6 @@ func TestRelayMetricsCollector(t *testing.T) {
 				assert.True(t, metricsEvent.EndDate <= ldtime.UnixMillisNow())
 				assert.Equal(t, relayID, metricsEvent.RelayID)
 				return len(metricsEvent.Connections) == 1 && metricsEvent.Connections[0] == expectedConn &&
-					len(metricsEvent.NewConnections) == 1 && metricsEvent.NewConnections[0] == expectedNewConn &&
 					len(metricsEvent.PollingCounts) == 1 && metricsEvent.PollingCounts[0] == expectedPollingMetric
 			}, time.Second*5, time.Millisecond*10, "did not receive expected metrics")
 		})

--- a/internal/metrics/test_utils_test.go
+++ b/internal/metrics/test_utils_test.go
@@ -53,13 +53,11 @@ func testWithOTel(t *testing.T, action func(testWithOTelParams)) {
 	meter := meterProvider.Meter("ld-relay")
 
 	connections, _ := meter.Int64UpDownCounter(connMeasureName)
-	newConnections, _ := meter.Int64Counter(newConnMeasureName)
 	requests, _ := meter.Int64Counter(requestMeasureName)
 
 	instruments := &Instruments{
-		connections:    connections,
-		newConnections: newConnections,
-		requests:       requests,
+		connections: connections,
+		requests:    requests,
 	}
 
 	manager, err := NewManager(config.OpenTelemetryConfig{}, time.Millisecond*10, mockLog.Loggers)

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -38,22 +38,22 @@ func withGauge(handler http.Handler, measure metrics.Measure) http.Handler {
 	})
 }
 
-// CountMobileConns is a middleware function that increments the total number of mobile connections,
-// and also increments the number of active mobile connections until the handler ends.
+// CountMobileConns is a middleware function that increments the number of active mobile connections
+// until the handler ends.
 func CountMobileConns(handler http.Handler) http.Handler {
-	return withCount(withGauge(handler, metrics.MobileConns), metrics.NewMobileConns)
+	return withGauge(handler, metrics.MobileConns)
 }
 
-// CountBrowserConns is a middleware function that increments the total number of browser connections,
-// and also increments the number of active browser connections until the handler ends.
+// CountBrowserConns is a middleware function that increments the number of active browser connections
+// until the handler ends.
 func CountBrowserConns(handler http.Handler) http.Handler {
-	return withCount(withGauge(handler, metrics.BrowserConns), metrics.NewBrowserConns)
+	return withGauge(handler, metrics.BrowserConns)
 }
 
-// CountServerConns is a middleware function that increments the total number of server-side connections,
-// and also increments the number of active server-side connections until the handler ends.
+// CountServerConns is a middleware function that increments the number of active server-side connections
+// until the handler ends.
 func CountServerConns(handler http.Handler) http.Handler {
-	return withCount(withGauge(handler, metrics.ServerConns), metrics.NewServerConns)
+	return withGauge(handler, metrics.ServerConns)
 }
 
 // PollingRequestCount is a middleware function that increments the total number of server-side polling requests.

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -107,21 +107,13 @@ func testCountConnections(t *testing.T, countFn func(http.Handler) http.Handler,
 			connMetric := st.FindMetricByName(rm, "launchdarkly.relay.connections")
 			require.NotNil(t, connMetric, "connections metric not found")
 			assertMetricHasValue(t, connMetric, p.envName, category, 1)
-
-			newConnMetric := st.FindMetricByName(rm, "launchdarkly.relay.newconnections")
-			require.NotNil(t, newConnMetric, "newconnections metric not found")
-			assertMetricHasValue(t, newConnMetric, p.envName, category, 1)
 		})).ServeHTTP(rr, req)
 
-		// After handler returns, connection gauge should be 0 but new connections stays at 1
+		// After handler returns, connection gauge should be 0
 		rm := p.collectMetrics(t)
 		connMetric := st.FindMetricByName(rm, "launchdarkly.relay.connections")
 		require.NotNil(t, connMetric, "connections metric not found")
 		assertMetricHasValue(t, connMetric, p.envName, category, 0)
-
-		newConnMetric := st.FindMetricByName(rm, "launchdarkly.relay.newconnections")
-		require.NotNil(t, newConnMetric, "newconnections metric not found")
-		assertMetricHasValue(t, newConnMetric, p.envName, category, 1)
 	})
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this removes a single metric and its related event payload fields, primarily affecting observability/telemetry rather than request handling logic. Main risk is downstream dashboards/alerts or consumers expecting `launchdarkly.relay.newconnections` / `newConnections` in relay metrics events.
> 
> **Overview**
> Removes the cumulative “new connections” metric (`launchdarkly.relay.newconnections`) from OpenTelemetry instrumentation, middleware counting, and emitted `relayMetrics` events.
> 
> Updates tests and documentation accordingly, leaving only the active connections gauge and request counters (plus polling counts) as the supported metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ddae541c595f824b4f700a2666d7f611d33298e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->