### PR TITLE
fix: Remove deprecated big segment excluded usage from integration tests

### DIFF
--- a/integrationtests/api_helpers_test.go
+++ b/integrationtests/api_helpers_test.go
@@ -321,7 +321,6 @@ func (a *apiHelper) createBigSegment(
 	env environmentInfo,
 	segmentKey string,
 	userKeysIncluded []string,
-	userKeysExcluded []string,
 	userKeysIncludedViaRule []string,
 ) error {
 	userSegmentBody := ldapi.SegmentBody{
@@ -359,7 +358,6 @@ func (a *apiHelper) createBigSegment(
 
 	updates := ldapi.SegmentUserState{
 		Included: &ldapi.SegmentUserList{Add: userKeysIncluded},
-		Excluded: &ldapi.SegmentUserList{Add: userKeysExcluded},
 	}
 	_, err = a.apiClient.SegmentsApi.
 		UpdateBigSegmentTargets(a.apiContext, project.key, env.key, segmentKey).

--- a/integrationtests/big_segments_test.go
+++ b/integrationtests/big_segments_test.go
@@ -24,7 +24,6 @@ import (
 
 type bigSegmentTestData struct {
 	includedUserKeys          []string
-	excludedUserKeys          []string
 	includedByRuleUserKeys    []string
 	allUserKeys               []string
 	expectedFlagValuesForUser map[string]ldvalue.Value
@@ -41,24 +40,23 @@ func makeBigSegmentTestDataForEnvs(envs []environmentInfo) []bigSegmentTestData 
 		var info bigSegmentTestData
 		userKey1 := fmt.Sprintf("included-user1-%d", i)
 		userKey2 := fmt.Sprintf("included-user2-%d", i)
-		userKey3 := fmt.Sprintf("excluded-user-%d", i)
+		userKey3 := fmt.Sprintf("rule-matched-user-%d", i)
 		info.includedUserKeys = []string{userKey1, userKey2}
-		info.excludedUserKeys = []string{userKey3}
 		info.includedByRuleUserKeys = []string{userKey3, userKey2}
 		info.allUserKeys = []string{userKey1, userKey2, userKey3}
 		info.expectedFlagValuesForUser = map[string]ldvalue.Value{
 			userKey1: ldvalue.Bool(true),
 			userKey2: ldvalue.Bool(true),
-			userKey3: ldvalue.Bool(false),
+			userKey3: ldvalue.Bool(true),
 		}
 		info.explanationForUser = map[string]string{
-			userKey1: "this user should be included in the big segment and not excluded;" +
+			userKey1: "this user should be included in the big segment;" +
 				" a false value indicates that we did not receive the patch that included the user",
-			userKey2: "this user should be included in a segment rule and not excluded;" +
+			userKey2: "this user should be included in a segment rule;" +
 				" a false value indicates that we did not receive the patch that included the user," +
 				" and also did not receive the regular SDK data with the segment rule",
-			userKey3: "this user should be included in a segment rule but excluded from the big segment;" +
-				" a true value indicates that we did not receive the patch that excluded the user",
+			userKey3: "this user should be matched by a segment rule;" +
+				" a false value indicates that we did not receive the regular SDK data with the segment rule",
 		}
 		ret = append(ret, info)
 	}
@@ -179,15 +177,14 @@ func doBigSegmentsTestWithPreExistingSegment(
 ) {
 	// The test logic here is:
 	// 1. Create a project with two environments (so we can prove that they coexist OK in the store).
-	// 2. For each environment, create a big segment that has "included-user1" included and "excluded-user"
-	// excluded in its big segment data, and that also has a regular segment rule that matches "included-user2"
-	// *and* "excluded-user" (to prove that the SDK's matching logic checks these things in the right order,
-	// i.e. excluded-user should not be matched because it's excluded, regardless of the rule).
+	// 2. For each environment, create a big segment that has "included-user1" and "included-user2"
+	// included in its big segment data, and that also has a regular segment rule that matches
+	// "rule-matched-user" and "included-user2".
 	// 3. Also create a feature flag that (in every environment) returns true if the user matches that segment.
 	// 4. Start Relay, configured with those two environments and a persistent data store.
 	// 5. Using the evaluation endpoints, verify that the various user keys return the expected flag values
-	// for each environment (true for the "included-" users, false for the "excluded-" ones). Relay may not
-	// sync up immediately, so we'll keep polling the values till they're correct or we time out and give up.
+	// for each environment (true for all matched users). Relay may not sync up immediately, so we'll keep
+	// polling the values till they're correct or we time out and give up.
 	dbParams.withContainer(t, manager, func(dbContainer *docker.Container) {
 		projectInfo, environments, err := manager.apiHelper.createProject(2)
 		require.NoError(t, err)
@@ -201,7 +198,7 @@ func doBigSegmentsTestWithPreExistingSegment(
 		for i, env := range environments {
 			segmentInfo := segmentTestData[i]
 			require.NoError(t, manager.apiHelper.createBigSegment(projectInfo, env, segmentKey,
-				segmentInfo.includedUserKeys, segmentInfo.excludedUserKeys, segmentInfo.includedByRuleUserKeys))
+				segmentInfo.includedUserKeys, segmentInfo.includedByRuleUserKeys))
 		}
 
 		flagKey := flagKeyForProj(projectInfo)
@@ -244,7 +241,7 @@ func doBigSegmentsTestWithFirstSegmentAddedAfterStartup(
 			for i, env := range environments {
 				segmentInfo := segmentTestData[i]
 				require.NoError(t, manager.apiHelper.createBigSegment(projectInfo, env, segmentKey,
-					segmentInfo.includedUserKeys, segmentInfo.excludedUserKeys, segmentInfo.includedByRuleUserKeys))
+					segmentInfo.includedUserKeys, segmentInfo.includedByRuleUserKeys))
 			}
 
 			flagKey := flagKeyForProj(projectInfo)
@@ -281,7 +278,7 @@ func doBigSegmentsTestWithAnotherSegmentAddedAfterStartup(
 			for i, env := range environments {
 				segmentInfo := segmentTestData[i]
 				require.NoError(t, manager.apiHelper.createBigSegment(projectInfo, env, segmentKey1,
-					segmentInfo.includedUserKeys, segmentInfo.excludedUserKeys, segmentInfo.includedByRuleUserKeys))
+					segmentInfo.includedUserKeys, segmentInfo.includedByRuleUserKeys))
 			}
 			flagKey1 := flagKeyForProj(projectInfo) + "1"
 			err := manager.apiHelper.createBooleanFlagThatUsesSegment(flagKey1, projectInfo, environments, segmentKey1)
@@ -296,7 +293,7 @@ func doBigSegmentsTestWithAnotherSegmentAddedAfterStartup(
 			for i, env := range environments {
 				segmentInfo := segmentTestData[i]
 				require.NoError(t, manager.apiHelper.createBigSegment(projectInfo, env, segmentKey2,
-					segmentInfo.includedUserKeys, segmentInfo.excludedUserKeys, segmentInfo.includedByRuleUserKeys))
+					segmentInfo.includedUserKeys, segmentInfo.includedByRuleUserKeys))
 			}
 			flagKey2 := flagKeyForProj(projectInfo) + "2"
 			err = manager.apiHelper.createBooleanFlagThatUsesSegment(flagKey2, projectInfo, environments, segmentKey2)


### PR DESCRIPTION
## Summary
- Backport of #591 to v7
- Removes `excludedUserKeys` from big segment integration tests, which was writing deprecated `excluded` membership data to the unbounded segment revisions DDB table
- Internal processes monitoring for deprecated use are observing these writes from the v7 daily integration test runs

## Test plan
- [ ] CI integration tests pass (the tests themselves are what changed)
- [ ] Verify `excluded_used` drops cease from v7 daily integration test runs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that remove use of the deprecated big segment `Excluded` targeting field; primary risk is reduced coverage of exclude-precedence behavior in big segment integration tests.
> 
> **Overview**
> Removes deprecated big-segment exclusion targeting from integration tests by dropping `excludedUserKeys` throughout and no longer sending `SegmentUserState.Excluded` in `apiHelper.createBigSegment`.
> 
> Updates big segment test data and expectations so the third user is *rule-matched* (not excluded), and all asserted flag evaluations are `true`, along with corresponding comment/explanation text adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecfb32a0ef518c7c6d1aeebc69daafd05813f1e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->