### PR TITLE
feat: Add FDv2 client-side streaming and polling routes

### DIFF
--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -45,8 +45,14 @@ var (
 	// ServerRequests is a Measure representing the number of HTTP requests from server-side SDKs.
 	ServerRequests = Measure{recordRequests: true, platformCategory: ServerPlatformCategory}
 
-	// PollingRequests is a Measure representing the total number of polling style requests received from server-side SDKs.
-	PollingRequests = Measure{recordPolling: true, platformCategory: ServerPlatformCategory}
+	// ServerPollingRequests is a Measure representing the total number of polling style requests received from server-side SDKs.
+	ServerPollingRequests = Measure{recordPolling: true, platformCategory: ServerPlatformCategory}
+
+	// MobilePollingRequests is a Measure representing the total number of polling requests from mobile SDKs.
+	MobilePollingRequests = Measure{recordPolling: true, platformCategory: MobilePlatformCategory}
+
+	// BrowserPollingRequests is a Measure representing the total number of polling requests from browser SDKs.
+	BrowserPollingRequests = Measure{recordPolling: true, platformCategory: BrowserPlatformCategory}
 )
 
 // NewInstrumentsForTest creates Instruments backed by the given OTel meter.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -142,7 +142,7 @@ func (m *Manager) SetInstrumentsForTest(instruments *Instruments) {
 	m.instruments = instruments
 }
 
-func (m *Manager) UsageActivityCountMessage(envName, userAgent, platformCategory, instanceID string) {
+func (m *Manager) TrackUsageActivityMessage(envName, userAgent, platformCategory, instanceID string) {
 	m.usageChan <- &usageActivityMessage{
 		kind: UsageActivityKindCount, envName: envName, userAgent: userAgent, platformCategory: platformCategory, instanceID: instanceID,
 	}

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/metrics"
 	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
 
@@ -26,6 +28,14 @@ func (cr *countingReader) Read(p []byte) (int, error) {
 
 func (cr *countingReader) Close() error {
 	return cr.reader.Close()
+}
+
+// clientPlatformCategory returns the platform category based on the credential type.
+func clientPlatformCategory(cred credential.SDKCredential) string {
+	if _, ok := cred.(config.MobileKey); ok {
+		return metrics.MobilePlatformCategory
+	}
+	return metrics.BrowserPlatformCategory
 }
 
 func getInstruments(env relayenv.EnvContext) *metrics.Instruments {
@@ -92,7 +102,52 @@ func CountServerConns(handler http.Handler) http.Handler {
 
 // PollingRequestCount is a middleware function that increments the total number of server-side polling requests.
 func PollingRequestCount(handler http.Handler) http.Handler {
-	return withCount(handler, metrics.PollingRequests)
+	return withCount(handler, metrics.ServerPollingRequests)
+}
+
+// DynamicPollingRequestCount is a middleware function for FDv2 client-side endpoints that dynamically
+// determines the polling request metric based on the credential type.
+func DynamicPollingRequestCount(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cred := GetEnvContextInfo(req.Context()).Credential
+		var measure metrics.Measure
+		if _, ok := cred.(config.MobileKey); ok {
+			measure = metrics.MobilePollingRequests
+		} else {
+			measure = metrics.BrowserPollingRequests
+		}
+		withCount(handler, measure).ServeHTTP(w, req)
+	})
+}
+
+// CountClientConns is a middleware function for FDv2 client-side endpoints that dynamically
+// determines whether to count as mobile or browser connections based on the credential type.
+func CountClientConns(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cred := GetEnvContextInfo(req.Context()).Credential
+		if _, ok := cred.(config.MobileKey); ok {
+			CountMobileConns(handler).ServeHTTP(w, req)
+		} else {
+			CountBrowserConns(handler).ServeHTTP(w, req)
+		}
+	})
+}
+
+// DynamicRequestMetrics is a middleware function for FDv2 client-side endpoints that dynamically
+// determines the request metrics based on the credential type.
+func DynamicRequestMetrics() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			cred := GetEnvContextInfo(req.Context()).Credential
+			var measure metrics.Measure
+			if _, ok := cred.(config.MobileKey); ok {
+				measure = metrics.MobileRequests
+			} else {
+				measure = metrics.BrowserRequests
+			}
+			RequestMetrics(measure)(next).ServeHTTP(w, req)
+		})
+	}
 }
 
 // RequestMetrics is a middleware function that increments the request counter

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -100,8 +100,8 @@ func CountServerConns(handler http.Handler) http.Handler {
 	return withGauge(handler, metrics.ServerConns)
 }
 
-// PollingRequestCount is a middleware function that increments the total number of server-side polling requests.
-func PollingRequestCount(handler http.Handler) http.Handler {
+// ServerPollingRequestCount is a middleware function that increments the total number of server-side polling requests.
+func ServerPollingRequestCount(handler http.Handler) http.Handler {
 	return withCount(handler, metrics.ServerPollingRequests)
 }
 

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -15,6 +15,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/basictypes"
 	"github.com/launchdarkly/ld-relay/v8/internal/browser"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 
@@ -161,6 +162,67 @@ func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayE
 			if sdkKind == basictypes.JSClientSDK {
 				req = req.WithContext(browser.WithCORSContext(req.Context(), clientCtx.GetJSClientContext()))
 			}
+			next.ServeHTTP(w, req)
+		})
+	}
+}
+
+// SelectEnvironmentByClientSideAuth creates a middleware function that authenticates the request
+// using either a mobile key or environment ID. The credential type is determined by inspecting the
+// token value: tokens starting with "mob-" are treated as mobile keys, otherwise as environment IDs.
+// The token is extracted from the Authorization header or the "auth" query parameter.
+func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			token, err := sdks.FetchClientSideAuthToken(req)
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
+				return
+			}
+
+			var cred credential.SDKCredential
+			if strings.HasPrefix(token, "mob-") {
+				cred = config.MobileKey(token)
+			} else {
+				cred = config.EnvironmentID(token)
+			}
+
+			queryValues := req.URL.Query()
+			filterKey := config.FilterKey(queryValues.Get("filter"))
+
+			clientCtx, err := envs.GetEnvironment(sdkauth.NewScoped(filterKey, cred))
+
+			if envs.IsNotReady(err) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(httpStatusMessageNotFullyConfigured))
+				return
+			}
+
+			if envs.IsPayloadFilterNotFound(err) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(httpStatusMessagePayloadFilterNotFound))
+				return
+			}
+
+			if err != nil || clientCtx.GetInitError() == ld.ErrInitializationFailed {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
+				return
+			}
+
+			if clientCtx.GetClient() == nil {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(httpStatusMessageSDKClientNotInited))
+				return
+			}
+
+			contextInfo := EnvContextInfo{
+				Env:        clientCtx,
+				Credential: cred,
+			}
+			req = req.WithContext(WithEnvContextInfo(req.Context(), contextInfo))
+			req = req.WithContext(browser.WithCORSContext(req.Context(), clientCtx.GetJSClientContext()))
 			next.ServeHTTP(w, req)
 		})
 	}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -174,6 +174,13 @@ func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayE
 func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			// OPTIONS preflight requests don't carry Authorization headers, so skip auth.
+			// The CORS middleware later in the chain will handle the response.
+			if req.Method == "OPTIONS" {
+				next.ServeHTTP(w, req)
+				return
+			}
+
 			token, err := sdks.FetchClientSideAuthToken(req)
 			if err != nil {
 				w.WriteHeader(http.StatusUnauthorized)

--- a/internal/middleware/usage_middleware.go
+++ b/internal/middleware/usage_middleware.go
@@ -6,7 +6,48 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func UsageActivityCount(platformCategory string) mux.MiddlewareFunc {
+// DynamicTrackUsageActivity is like TrackUsageActivity but determines the platform category
+// at request time based on the credential type, for FDv2 unified client-side endpoints.
+func DynamicTrackUsageActivity() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := GetEnvContextInfo(req.Context())
+			userAgent := getUserAgent(req)
+			instanceID := getInstanceID(req)
+			platformCategory := clientPlatformCategory(ctx.Credential)
+			mu := ctx.Env.GetMetricsManager()
+
+			mu.TrackUsageActivityMessage(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+
+			next.ServeHTTP(w, req)
+		})
+	}
+}
+
+// DynamicUsageActivityStreamMonitoring is like UsageActivityStreamMonitoring but determines the
+// platform category at request time based on the credential type, for FDv2 unified client-side endpoints.
+func DynamicUsageActivityStreamMonitoring(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := GetEnvContextInfo(req.Context())
+		userAgent := getUserAgent(req)
+		instanceID := getInstanceID(req)
+		platformCategory := clientPlatformCategory(ctx.Credential)
+
+		if mu := ctx.Env.GetMetricsManager(); mu != nil {
+			mu.UsageActivityStreamConnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+		}
+
+		defer func() {
+			if mu := ctx.Env.GetMetricsManager(); mu != nil {
+				mu.UsageActivityStreamDisconnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+			}
+		}()
+
+		next.ServeHTTP(w, req)
+	})
+}
+
+func TrackUsageActivity(platformCategory string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ctx := GetEnvContextInfo(req.Context())
@@ -14,7 +55,7 @@ func UsageActivityCount(platformCategory string) mux.MiddlewareFunc {
 			instanceID := getInstanceID(req)
 			mu := ctx.Env.GetMetricsManager()
 
-			mu.UsageActivityCountMessage(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+			mu.TrackUsageActivityMessage(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
 
 			next.ServeHTTP(w, req)
 		})

--- a/internal/sdks/sdk_kinds.go
+++ b/internal/sdks/sdk_kinds.go
@@ -46,6 +46,19 @@ func GetCredential(k basictypes.SDKKind, req *http.Request) (credential.SDKCrede
 	return nil, errUnknownSDKKind
 }
 
+// FetchClientSideAuthToken extracts a client-side auth token from the request.
+// It first checks the Authorization header, then falls back to the "auth" query parameter.
+func FetchClientSideAuthToken(req *http.Request) (string, error) {
+	token, err := fetchAuthToken(req)
+	if err == nil {
+		return token, nil
+	}
+	if authParam := req.URL.Query().Get("auth"); authParam != "" {
+		return authParam, nil
+	}
+	return "", errNoAuthToken
+}
+
 func fetchAuthToken(req *http.Request) (string, error) {
 	authHdr := req.Header.Get("Authorization")
 	if strings.HasPrefix(authHdr, "api_key ") {

--- a/internal/sdks/sdk_kinds_test.go
+++ b/internal/sdks/sdk_kinds_test.go
@@ -53,3 +53,42 @@ func TestGetCredential(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, c)
 }
+
+func TestFetchClientSideAuthToken(t *testing.T) {
+	t.Run("from Authorization header", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://fake", nil)
+		req.Header.Set("Authorization", "my-token")
+		token, err := FetchClientSideAuthToken(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-token", token)
+	})
+
+	t.Run("from Authorization header with api_key prefix", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://fake", nil)
+		req.Header.Set("Authorization", "api_key my-token")
+		token, err := FetchClientSideAuthToken(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-token", token)
+	})
+
+	t.Run("from auth query param when no header", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://fake?auth=query-token", nil)
+		token, err := FetchClientSideAuthToken(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "query-token", token)
+	})
+
+	t.Run("header takes precedence over query param", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://fake?auth=query-token", nil)
+		req.Header.Set("Authorization", "header-token")
+		token, err := FetchClientSideAuthToken(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "header-token", token)
+	})
+
+	t.Run("error when neither header nor query param", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://fake", nil)
+		_, err := FetchClientSideAuthToken(req)
+		assert.Error(t, err)
+	})
+}

--- a/relay/endpoints_fdv2_client_poll_test.go
+++ b/relay/endpoints_fdv2_client_poll_test.go
@@ -1,0 +1,236 @@
+package relay
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+
+	c "github.com/launchdarkly/ld-relay/v8/config"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFDv2ClientSidePollingWithMobileKey(t *testing.T) {
+	env := st.EnvWithAllCredentials
+	mobileKey := env.Config.MobileKey
+	contextJSON := []byte(`{"kind":"user","key":"me"}`)
+	contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(env)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		t.Run("GET with context in URL", func(t *testing.T) {
+			req := st.BuildRequestWithAuth("GET", "/sdk/poll/eval/"+contextBase64, mobileKey, nil)
+			result, body := st.DoRequest(req, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+
+			// Should have server-intent + put-objects for mobile-visible flags + payload-transferred
+			assert.NotEmpty(t, payload.Events)
+			assert.Equal(t, "server-intent", payload.Events[0].Event)
+			assert.Equal(t, "payload-transferred", payload.Events[len(payload.Events)-1].Event)
+
+			// Verify put-objects use flag-eval kind
+			for _, event := range payload.Events {
+				if event.Event == "put-object" {
+					var putObj subsystems.PutObject
+					data, err := json.Marshal(event.EventData)
+					require.NoError(t, err)
+					require.NoError(t, json.Unmarshal(data, &putObj))
+					assert.Equal(t, subsystems.ObjectKind("flag-eval"), putObj.Kind)
+				}
+			}
+		})
+
+		t.Run("POST with context in body", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(mobileKey))
+			h.Set("Content-Type", "application/json")
+			req := st.BuildRequest("POST", "/sdk/poll/eval", contextJSON, h)
+			result, body := st.DoRequest(req, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.NotEmpty(t, payload.Events)
+			assert.Equal(t, "server-intent", payload.Events[0].Event)
+		})
+
+		t.Run("auth via query param", func(t *testing.T) {
+			req := st.BuildRequest("GET", "/sdk/poll/eval/"+contextBase64+"?auth="+string(mobileKey), nil, nil)
+			result, body := st.DoRequest(req, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.NotEmpty(t, payload.Events)
+		})
+
+		t.Run("invalid credential returns 401", func(t *testing.T) {
+			req := st.BuildRequestWithAuth("GET", "/sdk/poll/eval/"+contextBase64, st.UndefinedMobileKey, nil)
+			result, _ := st.DoRequest(req, p.relay)
+			assert.Equal(t, http.StatusUnauthorized, result.StatusCode)
+		})
+
+		t.Run("no credential returns 401", func(t *testing.T) {
+			req := st.BuildRequest("GET", "/sdk/poll/eval/"+contextBase64, nil, nil)
+			result, _ := st.DoRequest(req, p.relay)
+			assert.Equal(t, http.StatusUnauthorized, result.StatusCode)
+		})
+
+		t.Run("basis param returns up-to-date when matching", func(t *testing.T) {
+			req := st.BuildRequestWithAuth("GET", "/sdk/poll/eval/"+contextBase64+"?basis=initial-state", mobileKey, nil)
+			result, body := st.DoRequest(req, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.Len(t, payload.Events, 1)
+			assert.Equal(t, "server-intent", payload.Events[0].Event)
+		})
+	})
+}
+
+func TestFDv2ClientSidePollingWithEnvironmentID(t *testing.T) {
+	env := st.EnvWithAllCredentials
+	envID := env.Config.EnvID
+	contextJSON := []byte(`{"kind":"user","key":"me"}`)
+	contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(env)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		t.Run("GET with context in URL via header", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(envID))
+			req := st.BuildRequest("GET", "/sdk/poll/eval/"+contextBase64, nil, h)
+			result, body := st.DoRequest(req, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.NotEmpty(t, payload.Events)
+			assert.Equal(t, "server-intent", payload.Events[0].Event)
+
+			// Verify put-objects use flag-eval kind
+			for _, event := range payload.Events {
+				if event.Event == "put-object" {
+					var putObj subsystems.PutObject
+					data, err := json.Marshal(event.EventData)
+					require.NoError(t, err)
+					require.NoError(t, json.Unmarshal(data, &putObj))
+					assert.Equal(t, subsystems.ObjectKind("flag-eval"), putObj.Kind)
+				}
+			}
+		})
+
+		t.Run("POST with context in body", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(envID))
+			h.Set("Content-Type", "application/json")
+			req := st.BuildRequest("POST", "/sdk/poll/eval", contextJSON, h)
+			result, body := st.DoRequest(req, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.NotEmpty(t, payload.Events)
+		})
+
+		t.Run("auth via query param", func(t *testing.T) {
+			req := st.BuildRequest("GET", "/sdk/poll/eval/"+contextBase64+"?auth="+string(envID), nil, nil)
+			result, body := st.DoRequest(req, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.NotEmpty(t, payload.Events)
+		})
+
+		t.Run("invalid credential returns 401", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(st.UndefinedEnvID))
+			req := st.BuildRequest("GET", "/sdk/poll/eval/"+contextBase64, nil, h)
+			result, _ := st.DoRequest(req, p.relay)
+			assert.Equal(t, http.StatusUnauthorized, result.StatusCode)
+		})
+	})
+}
+
+func TestFDv2ClientSidePollingFiltersFlagsByCredentialType(t *testing.T) {
+	env := st.EnvWithAllCredentials
+	mobileKey := env.Config.MobileKey
+	envID := env.Config.EnvID
+	contextJSON := []byte(`{"kind":"user","key":"me"}`)
+	contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(env)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		t.Run("mobile key sees mobile-visible flags", func(t *testing.T) {
+			req := st.BuildRequestWithAuth("GET", "/sdk/poll/eval/"+contextBase64, mobileKey, nil)
+			_, body := st.DoRequest(req, p.relay)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+
+			flagKeys := collectFlagKeys(t, payload)
+			// MobileFlags includes: Flag1ServerSide, Flag2ServerSide, Flag4ClientSide, Flag5ClientSide, Flag7Mobile, Flag8ContextAware
+			// Flag3ServerSideNotMobile and Flag6ClientSideNotMobile should be excluded
+			assert.NotContains(t, flagKeys, st.Flag3ServerSideNotMobile.Flag.Key)
+			assert.NotContains(t, flagKeys, st.Flag6ClientSideNotMobile.Flag.Key)
+			assert.Contains(t, flagKeys, st.Flag7Mobile.Flag.Key)
+		})
+
+		t.Run("environment ID sees client-side-visible flags", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(envID))
+			req := st.BuildRequest("GET", "/sdk/poll/eval/"+contextBase64, nil, h)
+			_, body := st.DoRequest(req, p.relay)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+
+			flagKeys := collectFlagKeys(t, payload)
+			// ClientSideFlags includes: Flag4ClientSide, Flag5ClientSide, Flag6ClientSideNotMobile, Flag8ContextAware
+			// Server-side only and mobile-only flags should be excluded
+			assert.NotContains(t, flagKeys, st.Flag1ServerSide.Flag.Key)
+			assert.NotContains(t, flagKeys, st.Flag2ServerSide.Flag.Key)
+			assert.NotContains(t, flagKeys, st.Flag7Mobile.Flag.Key)
+			assert.Contains(t, flagKeys, st.Flag4ClientSide.Flag.Key)
+			assert.Contains(t, flagKeys, st.Flag6ClientSideNotMobile.Flag.Key)
+		})
+	})
+}
+
+func collectFlagKeys(t *testing.T, payload pollingPayload) []string {
+	t.Helper()
+	var keys []string
+	for _, event := range payload.Events {
+		if event.Event == "put-object" {
+			data, err := json.Marshal(event.EventData)
+			require.NoError(t, err)
+			var putObj subsystems.PutObject
+			require.NoError(t, json.Unmarshal(data, &putObj))
+			keys = append(keys, putObj.Key)
+		}
+	}
+	return keys
+}

--- a/relay/endpoints_fdv2_client_stream_test.go
+++ b/relay/endpoints_fdv2_client_stream_test.go
@@ -1,0 +1,208 @@
+package relay
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"testing"
+	"time"
+
+	c "github.com/launchdarkly/ld-relay/v8/config"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+
+	"github.com/launchdarkly/eventsource"
+	ct "github.com/launchdarkly/go-configtypes"
+	helpers "github.com/launchdarkly/go-test-helpers/v3"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFDv2ClientSideStreamingWithMobileKey(t *testing.T) {
+	env := st.EnvWithAllCredentials
+	mobileKey := env.Config.MobileKey
+	contextJSON := []byte(`{"kind":"user","key":"me"}`)
+	contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(env)
+	config.Main.MaxClientConnectionTime = ct.OptDuration{}
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		t.Run("GET with context in URL", func(t *testing.T) {
+			req := st.BuildRequestWithAuth("GET", "/sdk/stream/eval/"+contextBase64, mobileKey, nil)
+			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+				event := helpers.RequireValue(t, eventCh, 3*time.Second, "timed out waiting for event")
+				require.NotNil(t, event)
+				assert.Equal(t, "ping", event.Event())
+			})
+		})
+
+		t.Run("POST with context in body", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(mobileKey))
+			h.Set("Content-Type", "application/json")
+			req := st.BuildRequest("POST", "/sdk/stream/eval", contextJSON, h)
+			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+				event := helpers.RequireValue(t, eventCh, 3*time.Second, "timed out waiting for event")
+				require.NotNil(t, event)
+				assert.Equal(t, "ping", event.Event())
+			})
+		})
+
+		t.Run("auth via query param", func(t *testing.T) {
+			req := st.BuildRequest("GET", "/sdk/stream/eval/"+contextBase64+"?auth="+string(mobileKey), nil, nil)
+			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+				event := helpers.RequireValue(t, eventCh, 3*time.Second, "timed out waiting for event")
+				require.NotNil(t, event)
+				assert.Equal(t, "ping", event.Event())
+			})
+		})
+
+		t.Run("invalid credential returns 401", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			req := st.BuildRequestWithAuth("GET", "/sdk/stream/eval/"+contextBase64, st.UndefinedMobileKey, nil).WithContext(ctx)
+			status := st.CallHandlerAndAwaitStatus(t, p.relay, req, time.Second)
+			assert.Equal(t, http.StatusUnauthorized, status)
+		})
+
+		t.Run("no credential returns 401", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			req := st.BuildRequest("GET", "/sdk/stream/eval/"+contextBase64, nil, nil).WithContext(ctx)
+			status := st.CallHandlerAndAwaitStatus(t, p.relay, req, time.Second)
+			assert.Equal(t, http.StatusUnauthorized, status)
+		})
+	})
+}
+
+func TestFDv2ClientSideStreamingWithEnvironmentID(t *testing.T) {
+	env := st.EnvWithAllCredentials
+	envID := env.Config.EnvID
+	contextJSON := []byte(`{"kind":"user","key":"me"}`)
+	contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(env)
+	config.Main.MaxClientConnectionTime = ct.OptDuration{}
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		t.Run("GET with context in URL via header", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(envID))
+			req := st.BuildRequest("GET", "/sdk/stream/eval/"+contextBase64, nil, h)
+			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+				event := helpers.RequireValue(t, eventCh, 3*time.Second, "timed out waiting for event")
+				require.NotNil(t, event)
+				assert.Equal(t, "ping", event.Event())
+			})
+		})
+
+		t.Run("POST with context in body", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(envID))
+			h.Set("Content-Type", "application/json")
+			req := st.BuildRequest("POST", "/sdk/stream/eval", contextJSON, h)
+			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+				event := helpers.RequireValue(t, eventCh, 3*time.Second, "timed out waiting for event")
+				require.NotNil(t, event)
+				assert.Equal(t, "ping", event.Event())
+			})
+		})
+
+		t.Run("auth via query param", func(t *testing.T) {
+			req := st.BuildRequest("GET", "/sdk/stream/eval/"+contextBase64+"?auth="+string(envID), nil, nil)
+			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+				event := helpers.RequireValue(t, eventCh, 3*time.Second, "timed out waiting for event")
+				require.NotNil(t, event)
+				assert.Equal(t, "ping", event.Event())
+			})
+		})
+
+		t.Run("invalid credential returns 401", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			h := make(http.Header)
+			h.Set("Authorization", string(st.UndefinedEnvID))
+			req := st.BuildRequest("GET", "/sdk/stream/eval/"+contextBase64, nil, h).WithContext(ctx)
+			status := st.CallHandlerAndAwaitStatus(t, p.relay, req, time.Second)
+			assert.Equal(t, http.StatusUnauthorized, status)
+		})
+	})
+}
+
+func TestFDv2ClientSideStreamingConnectionTimeLimit(t *testing.T) {
+	env := st.EnvWithAllCredentials
+	mobileKey := env.Config.MobileKey
+	contextJSON := []byte(`{"kind":"user","key":"me"}`)
+	contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+	maxConnTime := 100 * time.Millisecond
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(env)
+	config.Main.MaxClientConnectionTime = ct.NewOptDuration(maxConnTime)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		req := st.BuildRequestWithAuth("GET", "/sdk/stream/eval/"+contextBase64, mobileKey, nil)
+		maxWait := time.NewTimer(maxConnTime + time.Second)
+		defer maxWait.Stop()
+		startTime := time.Now()
+		st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+			for {
+				select {
+				case event := <-eventCh:
+					if event == nil { // stream closed
+						timeUntilClosed := time.Since(startTime)
+						if timeUntilClosed < maxConnTime {
+							assert.Fail(t, "stream closed too soon", "expected %s but closed after %s",
+								maxConnTime, timeUntilClosed)
+						}
+						return
+					}
+				case <-maxWait.C:
+					assert.Fail(t, "timed out waiting for stream to close")
+					return
+				}
+			}
+		})
+	})
+}
+
+func TestFDv2ClientSideStreamingCORSPreflight(t *testing.T) {
+	env := st.EnvWithAllCredentials
+	contextJSON := []byte(`{"kind":"user","key":"me"}`)
+	contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(env)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		t.Run("OPTIONS on GET path succeeds without auth", func(t *testing.T) {
+			st.AssertEndpointSupportsOptionsRequest(t, p.relay, "http://localhost/sdk/stream/eval/"+contextBase64, "GET")
+		})
+
+		t.Run("OPTIONS on POST path succeeds without auth", func(t *testing.T) {
+			st.AssertEndpointSupportsOptionsRequest(t, p.relay, "http://localhost/sdk/stream/eval", "POST")
+		})
+	})
+}
+
+func TestFDv2ClientSidePollingCORSPreflight(t *testing.T) {
+	env := st.EnvWithAllCredentials
+	contextJSON := []byte(`{"kind":"user","key":"me"}`)
+	contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(env)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		t.Run("OPTIONS on GET path succeeds without auth", func(t *testing.T) {
+			st.AssertEndpointSupportsOptionsRequest(t, p.relay, "http://localhost/sdk/poll/eval/"+contextBase64, "GET")
+		})
+
+		t.Run("OPTIONS on POST path succeeds without auth", func(t *testing.T) {
+			st.AssertEndpointSupportsOptionsRequest(t, p.relay, "http://localhost/sdk/poll/eval", "POST")
+		})
+	})
+}

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -13,7 +13,9 @@ import (
 
 	ldeval "github.com/launchdarkly/go-server-sdk-evaluation/v3"
 
+	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/basictypes"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/logging"
 	"github.com/launchdarkly/ld-relay/v8/internal/middleware"
 	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
@@ -40,7 +42,7 @@ func getClientSideContextProperties(
 	var ldContext ldcontext.Context
 	var contextDecodeErr error
 
-	if req.Method == "REPORT" {
+	if req.Method == "REPORT" || req.Method == "POST" {
 		if req.Header.Get("Content-Type") != "application/json" {
 			w.WriteHeader(http.StatusUnsupportedMediaType)
 			_, _ = w.Write([]byte("Content-Type must be application/json."))
@@ -87,17 +89,15 @@ func pingStreamHandlerV1(streamProvider streams.StreamProvider) http.Handler {
 	})
 }
 
-//nolint: godox
-// TODO(fdv2): Hook this up to new routes
-// V2 stream endpoint that just sends "ping" events: clientstream.ld.com/mping (mobile)
-// or clientstream.ld.com/ping/{envId} (JS)
-// func pingStreamHandlerV2(streamProvider streams.StreamProvider) http.Handler {
-// 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-// 		clientCtx := middleware.GetEnvContextInfo(req.Context())
-// 		clientCtx.Env.GetLoggers().Debug("Application requested client-side ping stream")
-// 		clientCtx.Env.GetStreamHandlerV2(streamProvider, clientCtx.Credential).ServeHTTP(w, req)
-// 	})
-// }
+// sdkKindFromCredential determines the SDK kind based on the credential type.
+func sdkKindFromCredential(cred credential.SDKCredential) basictypes.SDKKind {
+	switch cred.(type) {
+	case config.MobileKey:
+		return basictypes.MobileSDK
+	default:
+		return basictypes.JSClientSDK
+	}
+}
 
 // This handler is used for client-side streaming endpoints that require context properties. Currently it is
 // implemented the same as the ping stream once we have validated the context.
@@ -112,20 +112,26 @@ func pingStreamHandlerWithContextV1(sdkKind basictypes.SDKKind, streamProvider s
 	})
 }
 
-//nolint: godox
-// TODO(fdv2): Hook this up to new routes
-// This handler is used for client-side streaming endpoints that require context properties. Currently it is
-// implemented the same as the ping stream once we have validated the context.
-// func pingStreamHandlerWithContextV2(sdkKind basictypes.SDKKind, streamProvider streams.StreamProvider) http.Handler {
-// 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-// 		clientCtx := middleware.GetEnvContextInfo(req.Context())
-// 		clientCtx.Env.GetLoggers().Debug("Application requested client-side ping stream")
-//
-// 		if _, ok := getClientSideContextProperties(clientCtx.Env, sdkKind, req, w); ok {
-// 			clientCtx.Env.GetStreamHandlerV2(streamProvider, clientCtx.Credential).ServeHTTP(w, req)
-// 		}
-// 	})
-// }
+// pingStreamHandlerWithContextV2 handles FDv2 client-side ping streams. It accepts two stream providers
+// (mobile and JS client) and selects the appropriate one based on the credential type.
+func pingStreamHandlerWithContextV2(mobileProvider, jsClientProvider streams.StreamProvider) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		clientCtx := middleware.GetEnvContextInfo(req.Context())
+		clientCtx.Env.GetLoggers().Debug("Application requested client-side ping stream (FDv2)")
+
+		sdkKind := sdkKindFromCredential(clientCtx.Credential)
+		var streamProvider streams.StreamProvider
+		if sdkKind == basictypes.MobileSDK {
+			streamProvider = mobileProvider
+		} else {
+			streamProvider = jsClientProvider
+		}
+
+		if _, ok := getClientSideContextProperties(clientCtx.Env, sdkKind, req, w); ok {
+			clientCtx.Env.GetStreamHandlerV2(streamProvider, clientCtx.Credential).ServeHTTP(w, req)
+		}
+	})
+}
 
 // Multi-purpose streaming handler; all details of the behavior of the particular type of stream are
 // abstracted in StreamProvider and EnvStreams
@@ -267,6 +273,167 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 	}
 
 	writeCacheableJSONResponse(w, req, clientCtx.Env, json, selector.State())
+}
+
+// FDv2 client-side polling endpoint that evaluates flags against a context.
+func pollEvalHandlerV2(w http.ResponseWriter, req *http.Request) {
+	clientCtx := middleware.GetEnvContextInfo(req.Context())
+	client := clientCtx.Env.GetClient()
+	store := clientCtx.Env.GetStore()
+	loggers := clientCtx.Env.GetLoggers()
+
+	sdkKind := sdkKindFromCredential(clientCtx.Credential)
+
+	ldContext, ok := getClientSideContextProperties(clientCtx.Env, sdkKind, req, w)
+	if !ok {
+		return
+	}
+
+	withReasons := req.URL.Query().Get("withReasons") == "true"
+
+	if !client.Initialized() {
+		if store.IsInitialized() {
+			loggers.Warn("Called before client initialization; using last known values from feature store")
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			loggers.Warn("Called before client initialization. Feature store not available")
+			_, _ = w.Write(util.ErrorJSONMsg("Service not initialized"))
+			return
+		}
+	}
+
+	if !ldContext.Multiple() && ldContext.Key() == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(util.ErrorJSONMsg("User must have a 'key' attribute"))
+		return
+	}
+
+	collection, selector, err := store.Snapshot()
+	if err != nil {
+		loggers.Errorf("Error reading feature store: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	} else if collection == nil || !selector.IsDefined() {
+		loggers.Error("Snapshot selector is not defined; no data to return")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	pollingPayload := pollingPayload{
+		Events: make([]payloadEvent, 0),
+	}
+
+	basis := req.URL.Query().Get("basis")
+	if selector.IsDefined() && basis != "" && selector.State() == basis {
+		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+			Event: "server-intent",
+			EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
+				ID:     selector.State(),
+				Target: selector.Version(),
+				Code:   subsystems.IntentNone,
+				Reason: "up-to-date",
+			}},
+		})
+	} else {
+		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+			Event: "server-intent",
+			EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
+				ID:     selector.State(),
+				Target: selector.Version(),
+				Code:   subsystems.IntentTransferFull,
+				Reason: "cant-catchup",
+			}},
+		})
+
+		evaluator := clientCtx.Env.GetEvaluator()
+		flagEvalKind := subsystems.ObjectKind("flag-eval")
+
+		for kind, keyedItems := range collection {
+			if kind != ldstoreimpl.Features() {
+				continue
+			}
+			for _, keyedItem := range keyedItems {
+				if keyedItem.Item.Item == nil {
+					continue
+				}
+				flag, ok := keyedItem.Item.Item.(*ldmodel.FeatureFlag)
+				if !ok {
+					loggers.Error("Error casting keyed item to feature flag")
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+
+				switch sdkKind {
+				case basictypes.JSClientSDK:
+					if !flag.ClientSideAvailability.UsingEnvironmentID {
+						continue
+					}
+				case basictypes.MobileSDK:
+					if !flag.ClientSideAvailability.UsingMobileKey {
+						continue
+					}
+				}
+
+				var prerequisites []string
+				result := evaluator.Evaluate(flag, ldContext, func(event ldeval.PrerequisiteFlagEvent) {
+					if event.TargetFlagKey == flag.Key {
+						prerequisites = append(prerequisites, event.PrerequisiteFlag.Key)
+					}
+				})
+
+				detail := result.Detail
+				isExperiment := result.IsExperiment
+
+				evalWriter := jwriter.NewWriter()
+				evalObj := evalWriter.Object()
+				detail.Value.WriteToJSONWriter(evalObj.Name("value"))
+				detail.VariationIndex.WriteToJSONWriter(evalObj.Name("variation"))
+				evalObj.Name("flagVersion").Int(flag.Version)
+				if len(prerequisites) > 0 {
+					prereqArray := evalObj.Name("prerequisites").Array()
+					for _, p := range prerequisites {
+						prereqArray.String(p)
+					}
+					prereqArray.End()
+				}
+				evalObj.Maybe("trackEvents", flag.TrackEvents || isExperiment).Bool(true)
+				evalObj.Maybe("trackReason", isExperiment).Bool(true)
+				if withReasons || isExperiment {
+					detail.Reason.WriteToJSONWriter(evalObj.Name("reason"))
+				}
+				evalObj.Maybe("debugEventsUntilDate", flag.DebugEventsUntilDate != 0).
+					Float64(float64(flag.DebugEventsUntilDate))
+				if flag.SamplingRatio.IsDefined() {
+					evalObj.Name("samplingRatio").Int(flag.SamplingRatio.IntValue())
+				}
+				evalObj.End()
+
+				pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+					Event: "put-object",
+					EventData: subsystems.PutObject{
+						Version: keyedItem.Item.Version,
+						Kind:    flagEvalKind,
+						Key:     keyedItem.Key,
+						Object:  evalWriter.Bytes(),
+					},
+				})
+			}
+		}
+
+		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+			Event:     "payload-transferred",
+			EventData: selector,
+		})
+	}
+
+	jsonData, err := json.Marshal(pollingPayload)
+	if err != nil {
+		loggers.Errorf("Error marshaling polling response: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	writeCacheableJSONResponse(w, req, clientCtx.Env, jsonData, selector.State())
 }
 
 // PHP SDK polling endpoint for all flags: app.ld.com/sdk/flags

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/launchdarkly/go-jsonstream/v3/jwriter"
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldreason"
 	ldevents "github.com/launchdarkly/go-sdk-events/v3"
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
@@ -348,76 +349,43 @@ func pollEvalHandlerV2(w http.ResponseWriter, req *http.Request) {
 		evaluator := clientCtx.Env.GetEvaluator()
 		flagEvalKind := subsystems.ObjectKind("flag-eval")
 
+		var allItems []ldstoretypes.KeyedItemDescriptor
 		for kind, keyedItems := range collection {
-			if kind != ldstoreimpl.Features() {
-				continue
+			if kind == ldstoreimpl.Features() {
+				allItems = keyedItems
+				break
 			}
-			for _, keyedItem := range keyedItems {
-				if keyedItem.Item.Item == nil {
-					continue
-				}
-				flag, ok := keyedItem.Item.Item.(*ldmodel.FeatureFlag)
-				if !ok {
-					loggers.Error("Error casting keyed item to feature flag")
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
+		}
 
-				switch sdkKind {
-				case basictypes.JSClientSDK:
-					if !flag.ClientSideAvailability.UsingEnvironmentID {
-						continue
-					}
-				case basictypes.MobileSDK:
-					if !flag.ClientSideAvailability.UsingMobileKey {
-						continue
-					}
-				}
-
-				var prerequisites []string
-				result := evaluator.Evaluate(flag, ldContext, func(event ldeval.PrerequisiteFlagEvent) {
-					if event.TargetFlagKey == flag.Key {
-						prerequisites = append(prerequisites, event.PrerequisiteFlag.Key)
-					}
-				})
-
-				detail := result.Detail
-				isExperiment := result.IsExperiment
-
-				evalWriter := jwriter.NewWriter()
-				evalObj := evalWriter.Object()
-				detail.Value.WriteToJSONWriter(evalObj.Name("value"))
-				detail.VariationIndex.WriteToJSONWriter(evalObj.Name("variation"))
-				evalObj.Name("flagVersion").Int(flag.Version)
-				if len(prerequisites) > 0 {
-					prereqArray := evalObj.Name("prerequisites").Array()
-					for _, p := range prerequisites {
-						prereqArray.String(p)
-					}
-					prereqArray.End()
-				}
-				evalObj.Maybe("trackEvents", flag.TrackEvents || isExperiment).Bool(true)
-				evalObj.Maybe("trackReason", isExperiment).Bool(true)
-				if withReasons || isExperiment {
-					detail.Reason.WriteToJSONWriter(evalObj.Name("reason"))
-				}
-				evalObj.Maybe("debugEventsUntilDate", flag.DebugEventsUntilDate != 0).
-					Float64(float64(flag.DebugEventsUntilDate))
-				if flag.SamplingRatio.IsDefined() {
-					evalObj.Name("samplingRatio").Int(flag.SamplingRatio.IntValue())
-				}
-				evalObj.End()
-
-				pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-					Event: "put-object",
-					EventData: subsystems.PutObject{
-						Version: keyedItem.Item.Version,
-						Kind:    flagEvalKind,
-						Key:     keyedItem.Key,
-						Object:  evalWriter.Bytes(),
-					},
-				})
+		evalResults := evaluateFlags(evaluator, allItems, sdkKind, ldContext)
+		for _, er := range evalResults {
+			evalWriter := jwriter.NewWriter()
+			evalObj := evalWriter.Object()
+			er.Detail.Value.WriteToJSONWriter(evalObj.Name("value"))
+			er.Detail.VariationIndex.WriteToJSONWriter(evalObj.Name("variation"))
+			evalObj.Name("flagVersion").Int(er.Flag.Version)
+			writePrerequisites(&evalObj, er.Prerequisites)
+			evalObj.Maybe("trackEvents", er.Flag.TrackEvents || er.IsExperiment).Bool(true)
+			evalObj.Maybe("trackReason", er.IsExperiment).Bool(true)
+			if withReasons || er.IsExperiment {
+				er.Detail.Reason.WriteToJSONWriter(evalObj.Name("reason"))
 			}
+			evalObj.Maybe("debugEventsUntilDate", er.Flag.DebugEventsUntilDate != 0).
+				Float64(float64(er.Flag.DebugEventsUntilDate))
+			if er.Flag.SamplingRatio.IsDefined() {
+				evalObj.Name("samplingRatio").Int(er.Flag.SamplingRatio.IntValue())
+			}
+			evalObj.End()
+
+			pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+				Event: "put-object",
+				EventData: subsystems.PutObject{
+					Version: er.Flag.Version,
+					Kind:    flagEvalKind,
+					Key:     er.Flag.Key,
+					Object:  evalWriter.Bytes(),
+				},
+			})
 		}
 
 		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
@@ -517,6 +485,68 @@ func evaluateAllFeatureFlags(sdkKind basictypes.SDKKind) func(w http.ResponseWri
 	}
 }
 
+// flagEvalResult holds the result of evaluating a single flag against a context.
+type flagEvalResult struct {
+	Flag          *ldmodel.FeatureFlag
+	Detail        ldreason.EvaluationDetail
+	IsExperiment  bool
+	Prerequisites []string
+}
+
+// evaluateFlags evaluates all flags visible to the given SDK kind against the context.
+// It filters flags by ClientSideAvailability and collects prerequisites.
+func evaluateFlags(
+	evaluator ldeval.Evaluator,
+	items []ldstoretypes.KeyedItemDescriptor,
+	sdkKind basictypes.SDKKind,
+	ldContext ldcontext.Context,
+) []flagEvalResult {
+	var results []flagEvalResult
+	for _, item := range items {
+		flag, ok := item.Item.Item.(*ldmodel.FeatureFlag)
+		if !ok || flag == nil {
+			continue
+		}
+
+		switch sdkKind {
+		case basictypes.JSClientSDK:
+			if !flag.ClientSideAvailability.UsingEnvironmentID {
+				continue
+			}
+		case basictypes.MobileSDK:
+			if !flag.ClientSideAvailability.UsingMobileKey {
+				continue
+			}
+		}
+
+		var prerequisites []string
+		result := evaluator.Evaluate(flag, ldContext, func(event ldeval.PrerequisiteFlagEvent) {
+			if event.TargetFlagKey == flag.Key {
+				prerequisites = append(prerequisites, event.PrerequisiteFlag.Key)
+			}
+		})
+
+		results = append(results, flagEvalResult{
+			Flag:          flag,
+			Detail:        result.Detail,
+			IsExperiment:  result.IsExperiment,
+			Prerequisites: prerequisites,
+		})
+	}
+	return results
+}
+
+// writePrerequisites writes a prerequisites JSON array to the given object if non-empty.
+func writePrerequisites(obj *jwriter.ObjectState, prerequisites []string) {
+	if len(prerequisites) > 0 {
+		prereqArray := obj.Name("prerequisites").Array()
+		for _, p := range prerequisites {
+			prereqArray.String(p)
+		}
+		prereqArray.End()
+	}
+}
+
 func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basictypes.SDKKind) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
 	client := clientCtx.Env.GetClient()
@@ -560,54 +590,24 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 	}
 
 	evaluator := clientCtx.Env.GetEvaluator()
+	evalResults := evaluateFlags(evaluator, items, sdkKind, ldContext)
 
 	responseWriter := jwriter.NewWriter()
 	responseObj := responseWriter.Object()
-	for _, item := range items {
-		if flag, ok := item.Item.Item.(*ldmodel.FeatureFlag); ok {
-			switch sdkKind {
-			case basictypes.JSClientSDK:
-				if !flag.ClientSideAvailability.UsingEnvironmentID {
-					continue
-				}
-			case basictypes.MobileSDK:
-				if !flag.ClientSideAvailability.UsingMobileKey {
-					continue
-				}
-			}
-
-			var prerequisites []string
-			result := evaluator.Evaluate(flag, ldContext, func(event ldeval.PrerequisiteFlagEvent) {
-				if event.TargetFlagKey == flag.Key {
-					prerequisites = append(prerequisites, event.PrerequisiteFlag.Key)
-				}
-			})
-
-			detail := result.Detail
-			isExperiment := result.IsExperiment
-
-			valueObj := responseObj.Name(flag.Key).Object()
-			detail.Value.WriteToJSONWriter(valueObj.Name("value"))
-			detail.VariationIndex.WriteToJSONWriter(valueObj.Name("variation"))
-			valueObj.Name("version").Int(flag.Version)
-			valueObj.Maybe("trackEvents", flag.TrackEvents || isExperiment).Bool(true)
-			valueObj.Maybe("trackReason", isExperiment).Bool(true)
-			if withReasons || isExperiment {
-				detail.Reason.WriteToJSONWriter(valueObj.Name("reason"))
-			}
-			valueObj.Maybe("debugEventsUntilDate", flag.DebugEventsUntilDate != 0).
-				Float64(float64(flag.DebugEventsUntilDate))
-
-			if len(prerequisites) > 0 {
-				prereqArray := valueObj.Name("prerequisites").Array()
-				for _, p := range prerequisites {
-					prereqArray.String(p)
-				}
-				prereqArray.End()
-			}
-
-			valueObj.End()
+	for _, er := range evalResults {
+		valueObj := responseObj.Name(er.Flag.Key).Object()
+		er.Detail.Value.WriteToJSONWriter(valueObj.Name("value"))
+		er.Detail.VariationIndex.WriteToJSONWriter(valueObj.Name("variation"))
+		valueObj.Name("version").Int(er.Flag.Version)
+		valueObj.Maybe("trackEvents", er.Flag.TrackEvents || er.IsExperiment).Bool(true)
+		valueObj.Maybe("trackReason", er.IsExperiment).Bool(true)
+		if withReasons || er.IsExperiment {
+			er.Detail.Reason.WriteToJSONWriter(valueObj.Name("reason"))
 		}
+		valueObj.Maybe("debugEventsUntilDate", er.Flag.DebugEventsUntilDate != 0).
+			Float64(float64(er.Flag.DebugEventsUntilDate))
+		writePrerequisites(&valueObj, er.Prerequisites)
+		valueObj.End()
 	}
 	responseObj.End()
 	result := responseWriter.Bytes()

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -60,7 +60,7 @@ func (r *Relay) makeRouter() *mux.Router {
 			mux.CORSMethodMiddleware(subrouter),
 			jsClientSelector, // selects an environment based on the client-side ID in the URL
 			middleware.CORS,  // must apply this after jsClientSelector because the CORS headers can be environment-specific
-			middleware.UsageActivityCount(metrics.BrowserPlatformCategory),
+			middleware.TrackUsageActivity(metrics.BrowserPlatformCategory),
 			middleware.RequestMetrics(metrics.BrowserRequests),
 		)
 	}
@@ -78,22 +78,50 @@ func (r *Relay) makeRouter() *mux.Router {
 
 	serverSideMiddlewareStack := middleware.Chain(
 		sdkKeySelector,
-		middleware.UsageActivityCount(metrics.ServerPlatformCategory),
+		middleware.TrackUsageActivity(metrics.ServerPlatformCategory),
 		middleware.RequestMetrics(metrics.ServerRequests),
 	)
 
-	serverSideSdkRouter := router.PathPrefix("/sdk/").Subrouter()
+	sdkRouter := router.PathPrefix("/sdk/").Subrouter()
 	// (?)TODO: there is a bug in gorilla mux (see see https://github.com/gorilla/mux/pull/378) that means the middleware below
 	// because it will not be run if it matches any earlier prefix.  Until it is fixed, we have to apply the middleware explicitly
-	// serverSideSdkRouter.Use(serverSideMiddlewareStack)
+	// sdkRouter.Use(sdkRouterMiddleware)
 
-	// FDv2 endpoints
-	serverSideSdkRouter.Handle("/stream", serverSideMiddlewareStack(middleware.UsageActivityStreamMonitoring(metrics.ServerPlatformCategory, middleware.CountServerConns(middleware.Streaming(
+	// FDv2 server-side endpoints
+	sdkRouter.Handle("/stream", serverSideMiddlewareStack(middleware.UsageActivityStreamMonitoring(metrics.ServerPlatformCategory, middleware.CountServerConns(middleware.Streaming(
 		streamHandlerV2(r.serverSideStreamProvider, serverSideStreamLogMessage),
 	))))).Methods("GET")
-	serverSideSdkRouter.Handle("/poll", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollHandlerV2)))).Methods("GET")
+	sdkRouter.Handle("/poll", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollHandlerV2)))).Methods("GET")
 
-	serverSideEvalXRouter := serverSideSdkRouter.PathPrefix("/evalx/").Subrouter()
+	// FDv2 client-side endpoints (unified mobile + JS client)
+	clientSideFDv2Selector := middleware.SelectEnvironmentByClientSideAuth(environmentGetters)
+
+	clientSideFDv2StreamRouter := sdkRouter.PathPrefix("/stream/eval").Subrouter()
+	clientSideFDv2StreamMiddleware := middleware.Chain(
+		mux.CORSMethodMiddleware(clientSideFDv2StreamRouter),
+		clientSideFDv2Selector,
+		middleware.CORS,
+		middleware.DynamicTrackUsageActivity(),
+		middleware.DynamicRequestMetrics(),
+	)
+	clientSideFDv2StreamRouter.Use(clientSideFDv2StreamMiddleware, middleware.Streaming)
+	clientSideFDv2PingHandler := pingStreamHandlerWithContextV2(r.mobileStreamProvider, r.jsClientStreamProvider)
+	clientSideFDv2StreamRouter.Handle("/{context}", middleware.DynamicUsageActivityStreamMonitoring(middleware.CountClientConns(clientSideFDv2PingHandler))).Methods("GET", "OPTIONS")
+	clientSideFDv2StreamRouter.Handle("", middleware.DynamicUsageActivityStreamMonitoring(middleware.CountClientConns(clientSideFDv2PingHandler))).Methods("POST", "OPTIONS")
+
+	clientSideFDv2PollRouter := sdkRouter.PathPrefix("/poll/eval").Subrouter()
+	clientSideFDv2PollMiddleware := middleware.Chain(
+		mux.CORSMethodMiddleware(clientSideFDv2PollRouter),
+		clientSideFDv2Selector,
+		middleware.CORS,
+		middleware.DynamicTrackUsageActivity(),
+		middleware.DynamicRequestMetrics(),
+	)
+	clientSideFDv2PollRouter.Use(clientSideFDv2PollMiddleware)
+	clientSideFDv2PollRouter.Handle("/{context}", middleware.DynamicPollingRequestCount(http.HandlerFunc(pollEvalHandlerV2))).Methods("GET", "OPTIONS")
+	clientSideFDv2PollRouter.Handle("", middleware.DynamicPollingRequestCount(http.HandlerFunc(pollEvalHandlerV2))).Methods("POST", "OPTIONS")
+
+	serverSideEvalXRouter := sdkRouter.PathPrefix("/evalx/").Subrouter()
 	serverSideEvalXRouter.Handle("/contexts/{context}", serverSideMiddlewareStack(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK)))).Methods("GET")
 	serverSideEvalXRouter.Handle("/context", serverSideMiddlewareStack(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK)))).Methods("REPORT")
 	// /users and /user are obsolete names for /contexts and /context, still used by some supported SDKs; the handler is
@@ -102,14 +130,14 @@ func (r *Relay) makeRouter() *mux.Router {
 	serverSideEvalXRouter.Handle("/user", serverSideMiddlewareStack(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK)))).Methods("REPORT")
 
 	// PHP SDK endpoints
-	serverSideSdkRouter.Handle("/flags", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollAllFlagsHandler)))).Methods("GET")
-	serverSideSdkRouter.Handle("/flags/{key}", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollFlagHandler)))).Methods("GET")
-	serverSideSdkRouter.Handle("/segments/{key}", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollSegmentHandler)))).Methods("GET")
+	sdkRouter.Handle("/flags", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollAllFlagsHandler)))).Methods("GET")
+	sdkRouter.Handle("/flags/{key}", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollFlagHandler)))).Methods("GET")
+	sdkRouter.Handle("/segments/{key}", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollSegmentHandler)))).Methods("GET")
 
 	// Mobile evaluation
 	mobileMiddlewareStack := middleware.Chain(
 		mobileKeySelector,
-		middleware.UsageActivityCount(metrics.MobilePlatformCategory),
+		middleware.TrackUsageActivity(metrics.MobilePlatformCategory),
 		middleware.RequestMetrics(metrics.MobileRequests))
 
 	msdkRouter := router.PathPrefix("/msdk/").Subrouter()

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -94,12 +94,12 @@ func (r *Relay) makeRouter() *mux.Router {
 	sdkRouter.Handle("/poll", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollHandlerV2)))).Methods("GET")
 
 	// FDv2 client-side endpoints (unified mobile + JS client)
-	clientSideFDv2Selector := middleware.SelectEnvironmentByClientSideAuth(environmentGetters)
+	clientSideFDv2EnvAuth := middleware.SelectEnvironmentByClientSideAuth(environmentGetters)
 
 	clientSideFDv2StreamRouter := sdkRouter.PathPrefix("/stream/eval").Subrouter()
 	clientSideFDv2StreamMiddleware := middleware.Chain(
 		mux.CORSMethodMiddleware(clientSideFDv2StreamRouter),
-		clientSideFDv2Selector,
+		clientSideFDv2EnvAuth,
 		middleware.CORS,
 		middleware.DynamicTrackUsageActivity(),
 		middleware.DynamicRequestMetrics(),
@@ -112,7 +112,7 @@ func (r *Relay) makeRouter() *mux.Router {
 	clientSideFDv2PollRouter := sdkRouter.PathPrefix("/poll/eval").Subrouter()
 	clientSideFDv2PollMiddleware := middleware.Chain(
 		mux.CORSMethodMiddleware(clientSideFDv2PollRouter),
-		clientSideFDv2Selector,
+		clientSideFDv2EnvAuth,
 		middleware.CORS,
 		middleware.DynamicTrackUsageActivity(),
 		middleware.DynamicRequestMetrics(),

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -91,7 +91,7 @@ func (r *Relay) makeRouter() *mux.Router {
 	sdkRouter.Handle("/stream", serverSideMiddlewareStack(middleware.UsageActivityStreamMonitoring(metrics.ServerPlatformCategory, middleware.CountServerConns(middleware.Streaming(
 		streamHandlerV2(r.serverSideStreamProvider, serverSideStreamLogMessage),
 	))))).Methods("GET")
-	sdkRouter.Handle("/poll", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollHandlerV2)))).Methods("GET")
+	sdkRouter.Handle("/poll", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollHandlerV2)))).Methods("GET")
 
 	// FDv2 client-side endpoints (unified mobile + JS client)
 	clientSideFDv2Selector := middleware.SelectEnvironmentByClientSideAuth(environmentGetters)
@@ -130,9 +130,9 @@ func (r *Relay) makeRouter() *mux.Router {
 	serverSideEvalXRouter.Handle("/user", serverSideMiddlewareStack(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK)))).Methods("REPORT")
 
 	// PHP SDK endpoints
-	sdkRouter.Handle("/flags", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollAllFlagsHandler)))).Methods("GET")
-	sdkRouter.Handle("/flags/{key}", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollFlagHandler)))).Methods("GET")
-	sdkRouter.Handle("/segments/{key}", serverSideMiddlewareStack(middleware.PollingRequestCount(http.HandlerFunc(pollSegmentHandler)))).Methods("GET")
+	sdkRouter.Handle("/flags", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollAllFlagsHandler)))).Methods("GET")
+	sdkRouter.Handle("/flags/{key}", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollFlagHandler)))).Methods("GET")
+	sdkRouter.Handle("/segments/{key}", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollSegmentHandler)))).Methods("GET")
 
 	// Mobile evaluation
 	mobileMiddlewareStack := middleware.Chain(


### PR DESCRIPTION
Implement unified client-side endpoints for the FDv2 protocol that serve
both mobile and JS client SDKs, distinguished by credential type (mobile-key
vs client-side-id) in the Authorization header or auth query param.

New routes under /sdk/:
- GET /sdk/stream/eval/{context} and POST /sdk/stream/eval (ping streams)
- GET /sdk/poll/eval/{context} and POST /sdk/poll/eval (evaluated flag polling)

Key additions:
- FetchClientSideAuthToken: extracts auth from header or query param
- SelectEnvironmentByClientSideAuth: unified auth middleware
- pingStreamHandlerWithContextV2: selects stream provider by credential type
- pollEvalHandlerV2: evaluates flags, returns flag-eval put-objects
- Dynamic metrics middleware for credential-based platform categorization


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client-facing `/sdk/stream/eval` and `/sdk/poll/eval` routes plus new auth parsing and flag-evaluation payload generation; mistakes could affect authorization, caching behavior, or response correctness for client SDKs.
> 
> **Overview**
> Adds FDv2 *unified client-side* streaming and polling routes under `/sdk/` that work for both mobile and JS clients by inferring credential type (mobile key vs environment ID) from the auth token (header or `auth` query param).
> 
> Implements a new FDv2 polling handler (`pollEvalHandlerV2`) that evaluates flags against a provided context and returns `flag-eval` `put-object` events, and updates context parsing to accept `POST` bodies where applicable.
> 
> Updates middleware and metrics to support credential-based platform categorization (dynamic request/connection/polling counters), renames usage tracking to `TrackUsageActivityMessage`, and introduces separate polling measures for server/mobile/browser; includes new integration tests covering auth modes, CORS preflight behavior, flag visibility filtering, and connection time limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34256b00cb4c8c10de896cf5a5fd5022d368ea77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->