### PR TITLE
chore: Remove EOL v7 branch from daily integration test matrix

### DIFF
--- a/.github/workflows/daily-integration-tests.yml
+++ b/.github/workflows/daily-integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         environment: ['staging', 'production']
-        branch: ['v7', 'v8']
+        branch: ['v8']
 
     uses: ./.github/workflows/integration-test.yml
     with:


### PR DESCRIPTION
## Summary
- Removes the EOL `v7` branch from the daily integration test matrix
- `v7` reached EOL on 2024-10-12 but is still included in the nightly scheduled workflow, which runs integration tests against both `v7` and `v8` across staging and production
- The v7 integration tests still write deprecated `excluded` big segment membership data (fixed on v8 in #591), causing daily `excluded_used` drop metrics in the Big Segment CDC Lambda across all regions

## Test plan
- [ ] Daily integration tests continue to pass (now only running against v8)
- [ ] `excluded_used` drop metrics from the nightly run cease after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that reduces the test matrix by removing the EOL `v7` branch; no production code paths are affected.
> 
> **Overview**
> Updates the scheduled `Daily Integration Tests` GitHub Actions workflow to stop running integration tests against the EOL `v7` branch, leaving only `v8` across `staging` and `production`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90379d204502fe65cdf5703d6162f3b8a9df3704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->