### PR TITLE
fix: Manually create tag on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Create release tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ needs.release-please.outputs.tag_name }}"
+          git push origin "${{ needs.release-please.outputs.tag_name }}"
+
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         name: 'Get Docker token'
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,10 +47,10 @@ jobs:
             echo "Tag ${TAG_NAME} already exists, skipping creation."
           else
             echo "Creating tag ${TAG_NAME}."
-            gh api "repos/${{ github.repository }}/git/refs" \
-              --method POST \
-              -f ref="refs/tags/${TAG_NAME}" \
-              -f sha="$(git rev-parse HEAD)"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
           fi
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,11 +39,19 @@ jobs:
           fetch-depth: 0
 
       - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "${{ needs.release-please.outputs.tag_name }}"
-          git push origin "${{ needs.release-please.outputs.tag_name }}"
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            gh api "repos/${{ github.repository }}/git/refs" \
+              --method POST \
+              -f ref="refs/tags/${TAG_NAME}" \
+              -f sha="$(git rev-parse HEAD)"
+          fi
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         name: 'Get Docker token'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
       "versioning": "default",
       "bootstrap-sha": "21866d02812c93457097540ee49f098bc405fdec",
       "draft": true,
-      "force-tag-creation": true,
       "include-component-in-tag" : false,
       "extra-files": [
         "relay/version/version.go"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since this only changes the release automation path, but it can affect whether releases/publish steps run correctly if tag creation fails or diverges from Release Please behavior.
> 
> **Overview**
> **Release tags are now created explicitly in CI.** The `release-relay` workflow adds a step that checks for `${TAG_NAME}` and creates/pushes it when missing.
> 
> `release-please-config.json` removes `force-tag-creation`, shifting responsibility for tag creation from Release Please to the workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66882f8f032c03244d1aaa834ba02feed0b839cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->