### PR TITLE
fix: Include tags header in `relayUsage` metadata

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -110,21 +110,21 @@ func NewManager(
 	return m, nil
 }
 
-func (m *Manager) UsageActivityCountMessage(envName, userAgent, platformCategory, instanceID string) {
+func (m *Manager) UsageActivityCountMessage(envName, userAgent, platformCategory, instanceID, tagsHeader string) {
 	m.usageChan <- &usageActivityMessage{
-		kind: UsageActivityKindCount, envName: envName, userAgent: userAgent, platformCategory: platformCategory, instanceID: instanceID,
+		kind: UsageActivityKindCount, envName: envName, userAgent: userAgent, platformCategory: platformCategory, instanceID: instanceID, tagsHeader: tagsHeader,
 	}
 }
 
-func (m *Manager) UsageActivityStreamConnected(envName, userAgent, platformCategory, instanceID string) {
+func (m *Manager) UsageActivityStreamConnected(envName, userAgent, platformCategory, instanceID, tagsHeader string) {
 	m.usageChan <- &usageActivityMessage{
-		kind: UsageActivityKindStreamConnected, envName: envName, userAgent: userAgent, platformCategory: platformCategory, instanceID: instanceID,
+		kind: UsageActivityKindStreamConnected, envName: envName, userAgent: userAgent, platformCategory: platformCategory, instanceID: instanceID, tagsHeader: tagsHeader,
 	}
 }
 
-func (m *Manager) UsageActivityStreamDisconnected(envName, userAgent, platformCategory, instanceID string) {
+func (m *Manager) UsageActivityStreamDisconnected(envName, userAgent, platformCategory, instanceID, tagsHeader string) {
 	m.usageChan <- &usageActivityMessage{
-		kind: UsageActivityKindStreamDisconnected, envName: envName, userAgent: userAgent, platformCategory: platformCategory, instanceID: instanceID,
+		kind: UsageActivityKindStreamDisconnected, envName: envName, userAgent: userAgent, platformCategory: platformCategory, instanceID: instanceID, tagsHeader: tagsHeader,
 	}
 }
 

--- a/internal/metrics/usage.go
+++ b/internal/metrics/usage.go
@@ -18,6 +18,7 @@ type relayUsageEvent struct {
 	UserAgent        string `json:"userAgent"`
 	PlatformCategory string `json:"platformCategory"`
 	InstanceID       string `json:"instanceId,omitempty"`
+	TagsHeader       string `json:"tagsHeader,omitempty"`
 
 	FirstActive   ldtime.UnixMillisecondTime `json:"firstActive"`
 	LastActive    ldtime.UnixMillisecondTime `json:"lastActive"`
@@ -28,6 +29,7 @@ type usageKeyType struct {
 	userAgent        string
 	platformCategory string
 	instanceID       string
+	tagsHeader       string
 }
 
 type UsageActivityKind string
@@ -45,6 +47,7 @@ type usageActivityMessage struct {
 	userAgent        string
 	platformCategory string
 	instanceID       string
+	tagsHeader       string
 }
 
 type usageActivityFlush struct{}
@@ -178,7 +181,7 @@ func (e *environmentMetricUsage) run() {
 			case *usageActivityFlush:
 				e.flushInternal()
 			case *usageActivityMessage:
-				key := usageKeyType{userAgent: u.userAgent, platformCategory: u.platformCategory, instanceID: u.instanceID}
+				key := usageKeyType{userAgent: u.userAgent, platformCategory: u.platformCategory, instanceID: u.instanceID, tagsHeader: u.tagsHeader}
 				if e.publisher == nil {
 					continue
 				}
@@ -270,6 +273,7 @@ func (e *environmentMetricUsage) flushInternal() {
 			UserAgent:        key.userAgent,
 			PlatformCategory: key.platformCategory,
 			InstanceID:       key.instanceID,
+			TagsHeader:       key.tagsHeader,
 			FirstActive:      ldtime.UnixMillisFromTime(usage.firstActive),
 			LastActive:       ldtime.UnixMillisFromTime(lastActive),
 			TotalStreamMs:    (elapsedStreaming + usage.streamingDurationAdjustment).Milliseconds(),

--- a/internal/metrics/usage_test.go
+++ b/internal/metrics/usage_test.go
@@ -390,3 +390,53 @@ func TestMultipleUserStreams(t *testing.T) {
 	assert.Equal(t, "instanceID2", event2.InstanceID)
 	assert.InDeltaf(t, 300, event2.TotalStreamMs, 50, "stream time should be approximately 300ms")
 }
+
+func TestTagsHeaderIsIncludedInUsageEvent(t *testing.T) {
+	publisher := newTestEventsPublisher()
+	env := NewEnvironmentMetricUsage("relayID", publisher, 1*time.Hour)
+	env.usageActivityMessage(&usageActivityMessage{
+		kind:             UsageActivityKindCount,
+		userAgent:        "userAgent",
+		platformCategory: "platform",
+		instanceID:       "instanceID",
+		tagsHeader:       "application-id/my-app application-version/1.0",
+	})
+	env.close()
+
+	event := publisher.expectUsageEvent(t, time.Second)
+	assert.Equal(t, "userAgent", event.UserAgent)
+	assert.Equal(t, "platform", event.PlatformCategory)
+	assert.Equal(t, "instanceID", event.InstanceID)
+	assert.Equal(t, "application-id/my-app application-version/1.0", event.TagsHeader)
+}
+
+func TestDifferentTagsHeadersProduceSeparateEvents(t *testing.T) {
+	publisher := newTestEventsPublisher()
+	env := NewEnvironmentMetricUsage("relayID", publisher, 1*time.Hour)
+
+	env.usageActivityMessage(&usageActivityMessage{
+		kind:             UsageActivityKindCount,
+		userAgent:        "userAgent",
+		platformCategory: "platform",
+		instanceID:       "instanceID",
+		tagsHeader:       "application-id/app1",
+	})
+	env.usageActivityMessage(&usageActivityMessage{
+		kind:             UsageActivityKindCount,
+		userAgent:        "userAgent",
+		platformCategory: "platform",
+		instanceID:       "instanceID",
+		tagsHeader:       "application-id/app2",
+	})
+
+	env.flush()
+
+	firstEvent := publisher.expectUsageEvent(t, time.Second)
+	secondEvent := publisher.expectUsageEvent(t, time.Second)
+	if firstEvent.TagsHeader != "application-id/app1" {
+		firstEvent, secondEvent = secondEvent, firstEvent
+	}
+
+	assert.Equal(t, "application-id/app1", firstEvent.TagsHeader)
+	assert.Equal(t, "application-id/app2", secondEvent.TagsHeader)
+}

--- a/internal/middleware/usage_middleware.go
+++ b/internal/middleware/usage_middleware.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/launchdarkly/ld-relay/v8/internal/events"
 )
 
 func UsageActivityCount(platformCategory string) mux.MiddlewareFunc {
@@ -12,9 +13,10 @@ func UsageActivityCount(platformCategory string) mux.MiddlewareFunc {
 			ctx := GetEnvContextInfo(req.Context())
 			userAgent := getUserAgent(req)
 			instanceID := getInstanceID(req)
+			tagsHeader := req.Header.Get(events.TagsHeader)
 			mu := ctx.Env.GetMetricsManager()
 
-			mu.UsageActivityCountMessage(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+			mu.UsageActivityCountMessage(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID, tagsHeader)
 
 			next.ServeHTTP(w, req)
 		})
@@ -26,14 +28,15 @@ func UsageActivityStreamMonitoring(platformCategory string, next http.Handler) h
 		ctx := GetEnvContextInfo(req.Context())
 		userAgent := getUserAgent(req)
 		instanceID := getInstanceID(req)
+		tagsHeader := req.Header.Get(events.TagsHeader)
 
 		if mu := ctx.Env.GetMetricsManager(); mu != nil {
-			mu.UsageActivityStreamConnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+			mu.UsageActivityStreamConnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID, tagsHeader)
 		}
 
 		defer func() {
 			if mu := ctx.Env.GetMetricsManager(); mu != nil {
-				mu.UsageActivityStreamDisconnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+				mu.UsageActivityStreamDisconnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID, tagsHeader)
 			}
 		}()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds `X-LaunchDarkly-Tags` to the usage-event key and payload, which can increase usage-metric cardinality and event volume; otherwise it’s a straightforward metadata propagation change.
> 
> **Overview**
> **Propagates SDK application metadata into `relayUsage` telemetry.** The usage middleware now captures the `X-LaunchDarkly-Tags` request header and passes it through the metrics manager.
> 
> Usage aggregation and emitted `relayUsage` events now include `tagsHeader` (both as a JSON field and as part of the aggregation key), and tests were added to verify the header is emitted and that different tag values produce separate usage events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab5c9f92c38606fbd62e29a59069c8ee575b7784. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->