### PR TITLE
ci: Split the release process into independent PR and release process.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,10 +18,40 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      # Create any releases in release, then create tags, and then optionally create any new PRs.
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           token: ${{secrets.GITHUB_TOKEN}}
+          skip-github-pull-request: true
+
+
+      # Need the repository content to be able to create and push a tag.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true'}}
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true'}}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true'}}
+        id: release-prs
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          skip-github-release: true
 
   release-relay:
     permissions:
@@ -37,21 +67,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Create release tag
-        env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         name: 'Get Docker token'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions release automation (release/tag creation and PR generation), which could affect tagging and publishing if conditions/outputs are miswired, but does not touch runtime code.
> 
> **Overview**
> **Refactors the `release-please` workflow to separate release/tag creation from release-PR generation.** The workflow now pins `googleapis/release-please-action` to a specific v4.4.0 commit and runs it in two modes: create GitHub releases (skipping PRs), then if no release was created, run a second step that only opens/updates release PRs (skipping releases).
> 
> When a release is created, the job conditionally checks out the repo and creates/pushes the git tag using `steps.release.outputs.tag_name` (instead of `needs.*`). The `release-relay` publish job remains gated on `release_created` and is defined as its own job after this split.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5bf8245032b7ca21b072eafd31d5c2919444d1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->