### PR TITLE
fix: remove racy syncTimeCh length assertions in big segment sync tests

### DIFF
--- a/internal/bigsegments/sync_test.go
+++ b/internal/bigsegments/sync_test.go
@@ -226,7 +226,6 @@ func TestSyncSendsUpdates(t *testing.T) {
 			pollReq1 := helpers.RequireValue(t, requestsCh, time.Second)
 			assertPollRequest(t, pollReq1, "")
 			requirePatch(t, storeMock, poll1Patch1)
-			require.Equal(t, 0, len(storeMock.syncTimeCh))
 
 			pollReq2 := helpers.RequireValue(t, requestsCh, time.Second)
 			assertPollRequest(t, pollReq2, poll1Patch1.Version)
@@ -305,7 +304,6 @@ func TestSyncSkipsOutOfOrderUpdateFromPoll(t *testing.T) {
 			pollReq1 := helpers.RequireValue(t, requestsCh, time.Second)
 			assertPollRequest(t, pollReq1, "")
 			requirePatch(t, storeMock, patch1)
-			require.Equal(t, 0, len(storeMock.syncTimeCh))
 
 			pollReq2 := helpers.RequireValue(t, requestsCh, time.Second)
 			assertPollRequest(t, pollReq2, patch1.Version)
@@ -382,7 +380,6 @@ func TestSyncSkipsOutOfOrderUpdateFromStreamAndRestartsStream(t *testing.T) {
 			pollReq1 := helpers.RequireValue(t, requestsCh, time.Second)
 			assertPollRequest(t, pollReq1, "")
 			requirePatch(t, storeMock, patch1)
-			require.Equal(t, 0, len(storeMock.syncTimeCh))
 
 			pollReq2 := helpers.RequireValue(t, requestsCh, time.Second)
 			assertPollRequest(t, pollReq2, patch1.Version)
@@ -471,7 +468,6 @@ func TestSyncRetryIfStreamFails(t *testing.T) {
 			pollReq1 := helpers.RequireValue(t, requestsCh, time.Second)
 			assertPollRequest(t, pollReq1, "")
 			requirePatch(t, storeMock, patch1)
-			require.Equal(t, 0, len(storeMock.syncTimeCh))
 
 			pollReq2 := helpers.RequireValue(t, requestsCh, time.Second)
 			assertPollRequest(t, pollReq2, patch1.Version)


### PR DESCRIPTION
The `len(storeMock.syncTimeCh) == 0` checks race with the sync
goroutine which, after writing to patchCh, can complete remaining
polls, connect the stream, and call setSynced() before the test
checks the channel length. The meaningful behaviors are already
covered by patch, poll request, and sync time assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that removes flaky channel-length assertions; no production logic is modified.
> 
> **Overview**
> Removes `len(storeMock.syncTimeCh) == 0` assertions from `internal/bigsegments/sync_test.go` big segment synchronizer tests, since they can race with the sync goroutine.
> 
> The tests continue to validate behavior via poll/stream request expectations, applied patch assertions, and existing `syncTimeCh` timestamp checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c25fcf69994ba6227d118c32f06a8759a851672. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->