### PR TITLE
feat: Add event processing OTEL metrics (#617)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -11,7 +11,7 @@ The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://o
 | `launchdarkly.relay.connections` | UpDownCounter | The number of currently active stream connections from SDKs to the Relay Proxy. |
 | `launchdarkly.relay.requests` | Counter | The cumulative number of requests received by the Relay Proxy's [service endpoints](./endpoints.md) since startup. |
 | `launchdarkly.relay.request.duration` | Histogram | The duration of requests to the Relay Proxy's service endpoints, in seconds. |
-| `launchdarkly.relay.events.ingested.bytes` | Counter | The cumulative number of event bytes ingested by the Relay Proxy (measured after decompression). |
+| `launchdarkly.relay.events.received.bytes` | Counter | The cumulative number of event bytes received by the Relay Proxy (measured after decompression). |
 
 ## Attributes
 
@@ -42,7 +42,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://<prometheus-host>:9090/api/v1/otlp/v1/metrics
 OTEL_EXPORTER_OTLP_PROTOCOL=http
 ```
 
-Prometheus converts OpenTelemetry metric names by replacing dots with underscores, so the metrics will appear as `launchdarkly_relay_connections`, `launchdarkly_relay_requests_total`, `launchdarkly_relay_request_duration_seconds`, and `launchdarkly_relay_events_ingested_bytes_total`.
+Prometheus converts OpenTelemetry metric names by replacing dots with underscores, so the metrics will appear as `launchdarkly_relay_connections`, `launchdarkly_relay_requests_total`, `launchdarkly_relay_request_duration_seconds`, and `launchdarkly_relay_events_received_bytes_total`.
 
 ### OpenTelemetry Collector
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/launchdarkly/go-configtypes v1.2.0
 	github.com/launchdarkly/go-jsonstream/v3 v3.1.0
 	github.com/launchdarkly/go-sdk-common/v3 v3.4.0
-	github.com/launchdarkly/go-sdk-events/v3 v3.5.0
+	github.com/launchdarkly/go-sdk-events/v3 v3.6.0
 	github.com/launchdarkly/go-server-sdk-consul/v3 v3.0.0
 	github.com/launchdarkly/go-server-sdk-dynamodb/v4 v4.0.0
 	github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1
@@ -33,7 +33,6 @@ require (
 	github.com/launchdarkly/go-server-sdk/v7 v7.14.3
 	github.com/launchdarkly/go-test-helpers/v3 v3.1.0
 	github.com/pborman/uuid v1.2.1
-	github.com/prometheus/client_golang v1.23.2 // override to address CVE-2022-21698
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.19.0
 	gopkg.in/gcfg.v1 v1.2.3
@@ -58,21 +57,16 @@ require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b
 	github.com/klauspost/compress v1.18.0
 	github.com/launchdarkly/api-client-go/v13 v13.0.1-0.20230420175109-f5469391a13e
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.67.0
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.62.0
 	go.opentelemetry.io/otel/metric v1.42.0
 	go.opentelemetry.io/otel/sdk v1.42.0
 	go.opentelemetry.io/otel/sdk/metric v1.42.0
-	go.opentelemetry.io/otel/trace v1.42.0
-	google.golang.org/grpc v1.78.0
 )
 
 require (
-	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -99,19 +93,12 @@ require (
 	github.com/miekg/dns v1.1.58 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/gomega v1.27.10 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
-	github.com/prometheus/otlptranslator v1.0.0 // indirect
-	github.com/prometheus/procfs v0.19.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/runtime v0.67.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
@@ -119,6 +106,7 @@ require (
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/bigsegments/sync.go
+++ b/internal/bigsegments/sync.go
@@ -325,7 +325,9 @@ func (s *defaultBigSegmentSynchronizer) poll() (bool, segmentChangesSummary, err
 	if err != nil {
 		return false, segmentChangesSummary{}, err
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 
 	if response.StatusCode != 200 {
 		return false, segmentChangesSummary{}, &httpStatusError{response.StatusCode}

--- a/internal/events/event-relay.go
+++ b/internal/events/event-relay.go
@@ -45,6 +45,7 @@ type analyticsEventEndpointDispatcher struct {
 	summarizingRelay          *eventSummarizingRelay
 	wrapper                   *datadestination.DataDestinationWrapper
 	eventQueueCleanupInterval time.Duration
+	eventMetrics              EventMetrics
 	loggers                   ldlog.Loggers
 	mu                        sync.Mutex
 }
@@ -170,7 +171,8 @@ func (r *analyticsEventEndpointDispatcher) getVerbatimRelay() *eventVerbatimRela
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.verbatimRelay == nil {
-		r.verbatimRelay = newEventVerbatimRelay(r.authKey, r.config, r.httpConfig, r.loggers, r.remotePath)
+		r.verbatimRelay = newEventVerbatimRelay(r.authKey, r.config, r.httpConfig, r.loggers, r.remotePath,
+			OptionEventMetrics{EventMetrics: r.eventMetrics})
 	}
 	return r.verbatimRelay
 }
@@ -180,7 +182,7 @@ func (r *analyticsEventEndpointDispatcher) getSummarizingRelay() *eventSummarizi
 	defer r.mu.Unlock()
 	if r.summarizingRelay == nil {
 		r.summarizingRelay = newEventSummarizingRelay(r.config, r.httpConfig, r.authKey, r.wrapper,
-			r.loggers, r.remotePath, r.eventQueueCleanupInterval)
+			r.loggers, r.remotePath, r.eventQueueCleanupInterval, r.eventMetrics)
 	}
 	return r.summarizingRelay
 }
@@ -206,11 +208,12 @@ func NewEventDispatcher(
 	httpConfig httpconfig.HTTPConfig,
 	wrapper *datadestination.DataDestinationWrapper,
 	eventQueueCleanupInterval time.Duration, // normally zero to use the default; overridden in tests
+	eventMetrics EventMetrics,
 ) *EventDispatcher {
 	ep := &EventDispatcher{
 		analyticsEndpoints: map[basictypes.SDKKind]*analyticsEventEndpointDispatcher{
 			basictypes.ServerSDK: newAnalyticsEventEndpointDispatcher(sdkKey,
-				config, httpConfig, wrapper, loggers, "/bulk", eventQueueCleanupInterval),
+				config, httpConfig, wrapper, loggers, "/bulk", eventQueueCleanupInterval, eventMetrics),
 		},
 		diagnosticEndpoints: map[basictypes.SDKKind]*diagnosticEventEndpointDispatcher{
 			basictypes.ServerSDK: newDiagnosticEventEndpointDispatcher(config, httpConfig, loggers, "/diagnostic"),
@@ -218,12 +221,12 @@ func NewEventDispatcher(
 	}
 	if mobileKey.Defined() {
 		ep.analyticsEndpoints[basictypes.MobileSDK] = newAnalyticsEventEndpointDispatcher(mobileKey,
-			config, httpConfig, wrapper, loggers, "/mobile", eventQueueCleanupInterval)
+			config, httpConfig, wrapper, loggers, "/mobile", eventQueueCleanupInterval, eventMetrics)
 		ep.diagnosticEndpoints[basictypes.MobileSDK] = newDiagnosticEventEndpointDispatcher(config, httpConfig, loggers, "/mobile/events/diagnostic")
 	}
 	if envID.Defined() {
 		ep.analyticsEndpoints[basictypes.JSClientSDK] = newAnalyticsEventEndpointDispatcher(envID, config, httpConfig, wrapper, loggers,
-			"/events/bulk/"+string(envID), eventQueueCleanupInterval)
+			"/events/bulk/"+string(envID), eventQueueCleanupInterval, eventMetrics)
 		ep.diagnosticEndpoints[basictypes.JSClientSDK] = newDiagnosticEventEndpointDispatcher(config, httpConfig, loggers,
 			"/events/diagnostic/"+string(envID))
 	}
@@ -280,6 +283,7 @@ func newAnalyticsEventEndpointDispatcher(
 	loggers ldlog.Loggers,
 	remotePath string,
 	eventQueueCleanupInterval time.Duration,
+	eventMetrics EventMetrics,
 ) *analyticsEventEndpointDispatcher {
 	return &analyticsEventEndpointDispatcher{
 		authKey:                   authKey,
@@ -290,6 +294,7 @@ func newAnalyticsEventEndpointDispatcher(
 		loggers:                   loggers,
 		remotePath:                remotePath,
 		eventQueueCleanupInterval: eventQueueCleanupInterval,
+		eventMetrics:              eventMetrics,
 	}
 }
 
@@ -299,14 +304,17 @@ func newEventVerbatimRelay(
 	httpConfig httpconfig.HTTPConfig,
 	loggers ldlog.Loggers,
 	remotePath string,
+	extraOptions ...OptionType,
 ) *eventVerbatimRelay {
 	eventsURI := getEventsURI(config)
-	opts := []OptionType{
+	opts := make([]OptionType, 0, 4+len(extraOptions))
+	opts = append(opts,
 		OptionCapacity(config.Capacity.GetOrElse(c.DefaultEventCapacity)),
 		OptionBaseURI(eventsURI),
 		OptionURIPath(remotePath),
 		OptionFlushInterval(config.FlushInterval.GetOrElse(c.DefaultEventsFlushInterval)),
-	}
+	)
+	opts = append(opts, extraOptions...)
 
 	publisher, _ := NewHTTPEventPublisher(authKey, httpConfig, loggers, opts...)
 

--- a/internal/events/event-relay_test.go
+++ b/internal/events/event-relay_test.go
@@ -122,6 +122,7 @@ func eventRelayTestWithOptions(
 			httpConfig,
 			wrapper,
 			opts.eventQueueCleanupInterval,
+			nil,
 		)
 		defer dispatcher.Close()
 

--- a/internal/events/event_metrics.go
+++ b/internal/events/event_metrics.go
@@ -1,0 +1,50 @@
+package events
+
+import (
+	ldevents "github.com/launchdarkly/go-sdk-events/v3"
+)
+
+// EventSendFailureMetadata is an alias for ldevents.EventSendFailureMetadata so that the
+// ld-relay EventMetrics interface is structurally identical to the go-sdk-events one.
+// This allows a single concrete type to satisfy both interfaces.
+type EventSendFailureMetadata = ldevents.EventSendFailureMetadata
+
+// EventMetrics defines an interface for receiving metrics about event processing. This is used by
+// the metrics package to record telemetry (e.g. via OpenTelemetry) about events that are dropped,
+// sent, or otherwise processed by the relay's event forwarding pipeline.
+//
+// This interface mirrors the one in go-sdk-events. The metrics package provides a single concrete
+// implementation that satisfies both via Go structural typing.
+type EventMetrics interface {
+	// RecordDroppedEvents is called when events are discarded because the event buffer has reached
+	// its configured capacity. The count parameter indicates how many events were dropped.
+	RecordDroppedEvents(count int)
+
+	// RecordEventsSent is called when a batch of events has been successfully delivered to the
+	// events service. The count parameter indicates how many events were in the batch.
+	RecordEventsSent(count int)
+
+	// RecordEventsFailedSend is called when a batch of events could not be delivered to the
+	// events service after all retry attempts. The count parameter indicates how many events
+	// were in the failed batch. The metadata parameter provides additional context about the failure.
+	RecordEventsFailedSend(count int, metadata EventSendFailureMetadata)
+
+	// RecordEventsBytesSent is called when a batch of events has been successfully delivered.
+	// The bytes parameter is the size of the serialized event payload before compression.
+	RecordEventsBytesSent(bytes int)
+
+	// RecordPendingEvents is called after any operation that changes the number of events
+	// buffered awaiting delivery. The count parameter is the current total number of events pending.
+	RecordPendingEvents(count int)
+}
+
+// NoOpEventMetrics is a default implementation of EventMetrics that does nothing.
+// It is used when no EventMetrics is provided, eliminating the need for nil checks
+// at every call site.
+type NoOpEventMetrics struct{}
+
+func (NoOpEventMetrics) RecordDroppedEvents(int)                              {}
+func (NoOpEventMetrics) RecordEventsSent(int)                                 {}
+func (NoOpEventMetrics) RecordEventsFailedSend(int, EventSendFailureMetadata) {}
+func (NoOpEventMetrics) RecordEventsBytesSent(int)                            {}
+func (NoOpEventMetrics) RecordPendingEvents(int)                              {}

--- a/internal/events/event_publisher.go
+++ b/internal/events/event_publisher.go
@@ -103,10 +103,11 @@ type HTTPEventPublisher struct {
 	disableQueue chan interface{}
 	disabled     bool
 
-	queues     map[EventPayloadMetadata]*publisherQueue
-	capacity   int
-	overflowed bool
-	lock       sync.RWMutex
+	queues       map[EventPayloadMetadata]*publisherQueue
+	capacity     int
+	overflowed   bool
+	eventMetrics EventMetrics
+	lock         sync.RWMutex
 }
 
 type eventBatch struct {
@@ -159,6 +160,17 @@ func (o OptionCapacity) apply(p *HTTPEventPublisher) error {
 	return nil
 }
 
+// OptionEventMetrics provides an EventMetrics implementation for recording metrics about event
+// processing such as dropped event counts.
+type OptionEventMetrics struct {
+	EventMetrics EventMetrics
+}
+
+func (o OptionEventMetrics) apply(p *HTTPEventPublisher) error {
+	p.eventMetrics = o.EventMetrics
+	return nil
+}
+
 // NewHTTPEventPublisher creates a new HTTPEventPublisher.
 func NewHTTPEventPublisher(authKey credential.SDKCredential, httpConfig httpconfig.HTTPConfig, loggers ldlog.Loggers, options ...OptionType) (*HTTPEventPublisher, error) {
 	closer := make(chan struct{})
@@ -197,6 +209,9 @@ func NewHTTPEventPublisher(authKey credential.SDKCredential, httpConfig httpconf
 		}
 	}
 
+	if p.eventMetrics == nil {
+		p.eventMetrics = NoOpEventMetrics{}
+	}
 	p.queues = make(map[EventPayloadMetadata]*publisherQueue)
 	p.wg.Add(1)
 
@@ -217,6 +232,7 @@ func NewHTTPEventPublisher(authKey credential.SDKCredential, httpConfig httpconf
 					// Ensure we free up as much memory as we can by clearing any pending events
 					p.queues = make(map[EventPayloadMetadata]*publisherQueue)
 					p.disabled = true
+					p.eventMetrics.RecordPendingEvents(0)
 				case e := <-inputQueue:
 					if p.disabled {
 						continue
@@ -257,10 +273,22 @@ func (p *HTTPEventPublisher) append(batch eventBatch) {
 			p.overflowed = true
 		}
 		taken = available
+		if dropped := len(batch.events) - taken; dropped > 0 {
+			p.eventMetrics.RecordDroppedEvents(dropped)
+		}
 	} else {
 		p.overflowed = false
 	}
 	queue.events = append(queue.events, batch.events[:taken]...)
+	p.eventMetrics.RecordPendingEvents(p.totalPendingEvents())
+}
+
+func (p *HTTPEventPublisher) totalPendingEvents() int {
+	total := 0
+	for _, q := range p.queues {
+		total += len(q.events)
+	}
+	return total
 }
 
 func (p *HTTPEventPublisher) ReplaceCredential(newCredential credential.SDKCredential) { //nolint:revive // method is already documented in interface
@@ -338,6 +366,7 @@ func (p *HTTPEventPublisher) flush() {
 			return ret
 		}
 
+		eventMetrics := p.eventMetrics
 		go func() {
 			// The EventSender created by ldevents.NewDefaultEventSender implements the standard retry behavior,
 			// and error logging, in its SendEventData method. Retries could cause this call to block for a while,
@@ -351,12 +380,21 @@ func (p *HTTPEventPublisher) flush() {
 				EnableCompression: true,
 			}
 			result := ldevents.SendEventDataWithRetry(sendConfig, ldevents.AnalyticsEventDataKind, p.uriPath, payload, count)
+			if result.Success {
+				eventMetrics.RecordEventsSent(count)
+				eventMetrics.RecordEventsBytesSent(len(payload))
+			} else {
+				eventMetrics.RecordEventsFailedSend(count, EventSendFailureMetadata{
+					StatusCode: result.StatusCode,
+				})
+			}
 			p.wg.Done()
 			if result.MustShutDown {
 				p.disableQueue <- struct{}{}
 			}
 		}()
 	}
+	p.eventMetrics.RecordPendingEvents(p.totalPendingEvents())
 }
 
 func (p *HTTPEventPublisher) Close() { //nolint:revive // method is already documented in interface

--- a/internal/events/event_publisher_test.go
+++ b/internal/events/event_publisher_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -185,6 +186,195 @@ func TestHTTPEventPublisherCapacity(t *testing.T) {
 		uncompressed, err := util.DecompressGzipData(r.Body)
 		assert.NoError(t, err)
 
+		m.In(t).Assert(uncompressed, m.JSONStrEqual(`["hello"]`))
+	})
+}
+
+type mockEventMetrics struct {
+	mu                 sync.Mutex
+	droppedCount       int
+	sentCount          int
+	failedSendCount    int
+	lastFailedSendMeta EventSendFailureMetadata
+	bytesSent          int
+	lastPendingEvents  int
+}
+
+func (m *mockEventMetrics) RecordDroppedEvents(count int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.droppedCount += count
+}
+
+func (m *mockEventMetrics) RecordEventsSent(count int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sentCount += count
+}
+
+func (m *mockEventMetrics) RecordEventsFailedSend(count int, metadata EventSendFailureMetadata) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failedSendCount += count
+	m.lastFailedSendMeta = metadata
+}
+
+func (m *mockEventMetrics) RecordEventsBytesSent(bytes int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bytesSent += bytes
+}
+
+func (m *mockEventMetrics) RecordPendingEvents(depth int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastPendingEvents = depth
+}
+
+func (m *mockEventMetrics) getDroppedCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.droppedCount
+}
+
+func (m *mockEventMetrics) getSentCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sentCount
+}
+
+func (m *mockEventMetrics) getFailedSendCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.failedSendCount
+}
+
+func (m *mockEventMetrics) getLastFailedSendMeta() EventSendFailureMetadata {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastFailedSendMeta
+}
+
+func (m *mockEventMetrics) getBytesSent() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.bytesSent
+}
+
+func (m *mockEventMetrics) getLastPendingEvents() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastPendingEvents
+}
+
+func TestHTTPEventPublisherDroppedEventsMetric(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(202))
+	httphelpers.WithServer(handler, func(server *httptest.Server) {
+		metrics := &mockEventMetrics{}
+		publisher, _ := NewHTTPEventPublisher(config.SDKKey("my-key"), defaultHTTPConfig(), mockLog.Loggers,
+			OptionBaseURI(server.URL), OptionCapacity(2), OptionEventMetrics{EventMetrics: metrics})
+		defer publisher.Close()
+
+		// Publish 5 events with capacity 2 — should drop 3
+		publisher.Publish(EventPayloadMetadata{},
+			json.RawMessage(`"a"`), json.RawMessage(`"b"`),
+			json.RawMessage(`"c"`), json.RawMessage(`"d"`), json.RawMessage(`"e"`))
+		publisher.Flush()
+
+		r := helpers.RequireValue(t, requestsCh, time.Second)
+		uncompressed, err := util.DecompressGzipData(r.Body)
+		assert.NoError(t, err)
+		m.In(t).Assert(uncompressed, m.JSONStrEqual(`["a","b"]`))
+
+		assert.Equal(t, 3, metrics.getDroppedCount())
+	})
+}
+
+func TestHTTPEventPublisherEventsSentMetric(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(202))
+	httphelpers.WithServer(handler, func(server *httptest.Server) {
+		metrics := &mockEventMetrics{}
+		publisher, _ := NewHTTPEventPublisher(config.SDKKey("my-key"), defaultHTTPConfig(), mockLog.Loggers,
+			OptionBaseURI(server.URL), OptionEventMetrics{EventMetrics: metrics})
+		defer publisher.Close()
+
+		publisher.Publish(EventPayloadMetadata{}, json.RawMessage(`"a"`), json.RawMessage(`"b"`), json.RawMessage(`"c"`))
+		publisher.Flush()
+
+		_ = helpers.RequireValue(t, requestsCh, time.Second)
+		// Wait for the goroutine to record the metric after the send completes
+		assert.Eventually(t, func() bool { return metrics.getSentCount() == 3 }, time.Second, 10*time.Millisecond)
+		assert.Greater(t, metrics.getBytesSent(), 0)
+	})
+}
+
+func TestHTTPEventPublisherPendingEventsMetric(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(202))
+	httphelpers.WithServer(handler, func(server *httptest.Server) {
+		metrics := &mockEventMetrics{}
+		publisher, _ := NewHTTPEventPublisher(config.SDKKey("my-key"), defaultHTTPConfig(), mockLog.Loggers,
+			OptionBaseURI(server.URL), OptionEventMetrics{EventMetrics: metrics})
+		defer publisher.Close()
+
+		// Publish 3 events — queue depth should be 3 after processing
+		publisher.Publish(EventPayloadMetadata{}, json.RawMessage(`"a"`), json.RawMessage(`"b"`), json.RawMessage(`"c"`))
+		// Flush will clear the queue — depth should go to 0
+		publisher.Flush()
+
+		_ = helpers.RequireValue(t, requestsCh, time.Second)
+		assert.Eventually(t, func() bool { return metrics.getLastPendingEvents() == 0 }, time.Second, 10*time.Millisecond)
+	})
+}
+
+func TestHTTPEventPublisherEventsFailedSendMetric(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+	// Return 500 twice (exhausts retries) so the send fails
+	handler, requestsCh := httphelpers.RecordingHandler(
+		httphelpers.SequentialHandler(
+			httphelpers.HandlerWithStatus(503),
+			httphelpers.HandlerWithStatus(503),
+		),
+	)
+	httphelpers.WithServer(handler, func(server *httptest.Server) {
+		metrics := &mockEventMetrics{}
+		publisher, _ := NewHTTPEventPublisher(config.SDKKey("my-key"), defaultHTTPConfig(), mockLog.Loggers,
+			OptionBaseURI(server.URL), OptionEventMetrics{EventMetrics: metrics})
+		defer publisher.Close()
+
+		publisher.Publish(EventPayloadMetadata{}, json.RawMessage(`"a"`), json.RawMessage(`"b"`))
+		publisher.Flush()
+
+		// Wait for both retry attempts
+		_ = helpers.RequireValue(t, requestsCh, 5*time.Second)
+		_ = helpers.RequireValue(t, requestsCh, 5*time.Second)
+
+		assert.Eventually(t, func() bool { return metrics.getFailedSendCount() == 2 }, 5*time.Second, 10*time.Millisecond)
+		assert.Equal(t, 0, metrics.getSentCount())
+		assert.Equal(t, 503, metrics.getLastFailedSendMeta().StatusCode)
+	})
+}
+
+func TestHTTPEventPublisherDroppedEventsMetricNilIsNoOp(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(202))
+	httphelpers.WithServer(handler, func(server *httptest.Server) {
+		// No EventMetrics option — should not panic
+		publisher, _ := NewHTTPEventPublisher(config.SDKKey("my-key"), defaultHTTPConfig(), mockLog.Loggers,
+			OptionBaseURI(server.URL), OptionCapacity(1))
+		defer publisher.Close()
+		publisher.Publish(EventPayloadMetadata{}, json.RawMessage(`"hello"`), json.RawMessage(`"goodbye"`))
+		publisher.Flush()
+		r := helpers.RequireValue(t, requestsCh, time.Second)
+		uncompressed, err := util.DecompressGzipData(r.Body)
+		assert.NoError(t, err)
 		m.In(t).Assert(uncompressed, m.JSONStrEqual(`["hello"]`))
 	})
 }

--- a/internal/events/summarizing-relay.go
+++ b/internal/events/summarizing-relay.go
@@ -65,6 +65,7 @@ func newEventSummarizingRelay(
 	loggers ldlog.Loggers,
 	remotePath string,
 	eventQueueCleanupInterval time.Duration,
+	eventMetrics EventMetrics,
 ) *eventSummarizingRelay {
 	eventsConfig := ldevents.EventsConfiguration{
 		Capacity:              config.Capacity.GetOrElse(c.DefaultEventCapacity),
@@ -72,6 +73,7 @@ func newEventSummarizingRelay(
 		Loggers:               loggers,
 		UserKeysCapacity:      ldcomponents.DefaultContextKeysCapacity,
 		UserKeysFlushInterval: ldcomponents.DefaultContextKeysFlushInterval,
+		EventMetrics:          eventMetrics,
 	}
 	baseHeaders := make(http.Header)
 	for k, v := range httpConfig.SDKHTTPConfig.DefaultHeaders {

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -12,7 +12,12 @@ const (
 	connMeasureName                = "launchdarkly.relay.connections"
 	requestMeasureName             = "launchdarkly.relay.requests"
 	requestDurationMeasureName     = "launchdarkly.relay.request.duration"
-	eventsIngestedBytesMeasureName = "launchdarkly.relay.events.ingested.bytes"
+	eventsReceivedBytesMeasureName = "launchdarkly.relay.events.received.bytes"
+	eventsSentCountMeasureName     = "launchdarkly.relay.events.sent.count"
+	eventsSentBytesMeasureName     = "launchdarkly.relay.events.sent.bytes"
+	eventsSentFailuresMeasureName  = "launchdarkly.relay.events.sent.failures"
+	eventsSentDroppedMeasureName   = "launchdarkly.relay.events.sent.dropped"
+	eventsSentPendingMeasureName   = "launchdarkly.relay.events.sent.pending"
 
 	defaultFlushInterval = time.Minute
 
@@ -32,6 +37,7 @@ var (
 	applicationIDAttrKey      = attribute.Key("application.id")      //nolint:gochecknoglobals
 	applicationVersionAttrKey = attribute.Key("application.version") //nolint:gochecknoglobals
 	instanceIDAttrKey         = attribute.Key("instanceId")          //nolint:gochecknoglobals
+	statusCodeAttrKey         = attribute.Key("statusCode")          //nolint:gochecknoglobals
 )
 
 // buildAttributes creates an OTel attribute set from base key-values plus per-request attributes.

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -2,8 +2,11 @@ package metrics
 
 import (
 	"context"
+	"strconv"
 	"time"
 
+	ldevents "github.com/launchdarkly/go-sdk-events/v3"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -12,7 +15,12 @@ type Instruments struct {
 	connections         metric.Int64UpDownCounter // active connections (+1/-1)
 	requests            metric.Int64Counter       // cumulative HTTP requests
 	requestDuration     metric.Float64Histogram   // request duration in seconds
-	eventsIngestedBytes metric.Int64Counter       // cumulative bytes of event data ingested
+	eventsReceivedBytes metric.Int64Counter       // cumulative bytes of event data received
+	eventsDropped       metric.Int64Counter       // cumulative count of events dropped due to capacity overflow
+	eventsSent          metric.Int64Counter       // cumulative count of events successfully sent
+	eventsFailedSend    metric.Int64Counter       // cumulative count of events that failed to send
+	eventsBytesSent     metric.Int64Counter       // cumulative bytes of event payloads successfully sent
+	pendingEvents       metric.Int64Gauge         // current number of events pending delivery
 }
 
 // Measure identifies what to record. Each pre-defined Measure var specifies which
@@ -70,7 +78,27 @@ func NewInstrumentsForTest(meter metric.Meter) (*Instruments, error) {
 	if err != nil {
 		return nil, err
 	}
-	eventsIngestedBytes, err := meter.Int64Counter(eventsIngestedBytesMeasureName)
+	eventsReceivedBytes, err := meter.Int64Counter(eventsReceivedBytesMeasureName)
+	if err != nil {
+		return nil, err
+	}
+	eventsDropped, err := meter.Int64Counter(eventsSentDroppedMeasureName)
+	if err != nil {
+		return nil, err
+	}
+	eventsSent, err := meter.Int64Counter(eventsSentCountMeasureName)
+	if err != nil {
+		return nil, err
+	}
+	eventsFailedSend, err := meter.Int64Counter(eventsSentFailuresMeasureName)
+	if err != nil {
+		return nil, err
+	}
+	eventsBytesSent, err := meter.Int64Counter(eventsSentBytesMeasureName)
+	if err != nil {
+		return nil, err
+	}
+	pendingEvents, err := meter.Int64Gauge(eventsSentPendingMeasureName)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +106,12 @@ func NewInstrumentsForTest(meter metric.Meter) (*Instruments, error) {
 		connections:         connections,
 		requests:            requests,
 		requestDuration:     requestDuration,
-		eventsIngestedBytes: eventsIngestedBytes,
+		eventsReceivedBytes: eventsReceivedBytes,
+		eventsDropped:       eventsDropped,
+		eventsSent:          eventsSent,
+		eventsFailedSend:    eventsFailedSend,
+		eventsBytesSent:     eventsBytesSent,
+		pendingEvents:       pendingEvents,
 	}, nil
 }
 
@@ -158,14 +191,14 @@ func WithRouteCount(ctx context.Context, em *EnvironmentManager, instruments *In
 	f()
 }
 
-// RecordEventsIngestedBytes records the number of event bytes ingested.
-func RecordEventsIngestedBytes(ctx context.Context, instruments *Instruments, em *EnvironmentManager, platformCategory string, ri RequestInfo, bytes int64) {
+// RecordEventsReceivedBytes records the number of event bytes received.
+func RecordEventsReceivedBytes(ctx context.Context, instruments *Instruments, em *EnvironmentManager, platformCategory string, ri RequestInfo, bytes int64) {
 	if em == nil || instruments == nil || bytes <= 0 {
 		return
 	}
 	ua, wrapper, route, method, appID, appVersion, instanceID := ri.sanitized()
 	attrs := buildRequestAttributes(em.envKVs, platformCategory, ua, wrapper, route, method, appID, appVersion, instanceID)
-	instruments.eventsIngestedBytes.Add(ctx, bytes, metric.WithAttributeSet(attrs))
+	instruments.eventsReceivedBytes.Add(ctx, bytes, metric.WithAttributeSet(attrs))
 }
 
 // RecordRequestDuration records a request duration measurement with the given attributes.
@@ -176,4 +209,59 @@ func RecordRequestDuration(ctx context.Context, instruments *Instruments, em *En
 	ua, wrapper, route, method, appID, appVersion, instanceID := ri.sanitized()
 	attrs := buildRequestAttributes(em.envKVs, measure.platformCategory, ua, wrapper, route, method, appID, appVersion, instanceID)
 	instruments.requestDuration.Record(ctx, duration.Seconds(), metric.WithAttributeSet(attrs))
+}
+
+// EventMetricsRecorder implements the EventMetrics interface defined in both the events package
+// and go-sdk-events, recording event processing metrics via OTEL instruments. It uses
+// environment-level attributes only (relayId, env) since event drops occur asynchronously,
+// detached from any specific HTTP request context.
+type EventMetricsRecorder struct {
+	instruments *Instruments
+	envKVs      []attribute.KeyValue // private copy, safe for concurrent read
+	envAttrs    attribute.Set        // pre-computed to avoid concurrent sort in attribute.NewSet
+}
+
+// RecordDroppedEvents records the number of events dropped due to capacity overflow.
+func (r *EventMetricsRecorder) RecordDroppedEvents(count int) {
+	if r.instruments == nil || count <= 0 {
+		return
+	}
+	r.instruments.eventsDropped.Add(context.Background(), int64(count), metric.WithAttributeSet(r.envAttrs))
+}
+
+// RecordEventsSent records the number of events successfully delivered to the events service.
+func (r *EventMetricsRecorder) RecordEventsSent(count int) {
+	if r.instruments == nil || count <= 0 {
+		return
+	}
+	r.instruments.eventsSent.Add(context.Background(), int64(count), metric.WithAttributeSet(r.envAttrs))
+}
+
+// RecordPendingEvents records the current number of events pending delivery.
+func (r *EventMetricsRecorder) RecordPendingEvents(depth int) {
+	if r.instruments == nil {
+		return
+	}
+	r.instruments.pendingEvents.Record(context.Background(), int64(depth), metric.WithAttributeSet(r.envAttrs))
+}
+
+// RecordEventsBytesSent records the size of event payloads successfully delivered.
+func (r *EventMetricsRecorder) RecordEventsBytesSent(bytes int) {
+	if r.instruments == nil || bytes <= 0 {
+		return
+	}
+	r.instruments.eventsBytesSent.Add(context.Background(), int64(bytes), metric.WithAttributeSet(r.envAttrs))
+}
+
+// RecordEventsFailedSend records the number of events that could not be delivered after all retries.
+// The status code from the metadata is included as an attribute on the metric.
+func (r *EventMetricsRecorder) RecordEventsFailedSend(count int, metadata ldevents.EventSendFailureMetadata) {
+	if r.instruments == nil || count <= 0 {
+		return
+	}
+	kvs := make([]attribute.KeyValue, len(r.envKVs), len(r.envKVs)+1)
+	copy(kvs, r.envKVs)
+	kvs = append(kvs, statusCodeAttrKey.String(strconv.Itoa(metadata.StatusCode)))
+	attrs := attribute.NewSet(kvs...)
+	r.instruments.eventsFailedSend.Add(context.Background(), int64(count), metric.WithAttributeSet(attrs))
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -102,15 +102,32 @@ func NewManager(
 	requestDuration, _ := meter.Float64Histogram(requestDurationMeasureName,
 		otelmetric.WithDescription("request duration in seconds"),
 		otelmetric.WithUnit("s"))
-	eventsIngestedBytes, _ := meter.Int64Counter(eventsIngestedBytesMeasureName,
-		otelmetric.WithDescription("cumulative bytes of event data ingested"),
+	eventsReceivedBytes, _ := meter.Int64Counter(eventsReceivedBytesMeasureName,
+		otelmetric.WithDescription("cumulative bytes of event data received"),
 		otelmetric.WithUnit("By"))
+
+	eventsDropped, _ := meter.Int64Counter(eventsSentDroppedMeasureName,
+		otelmetric.WithDescription("cumulative count of events dropped due to capacity overflow"))
+	eventsSent, _ := meter.Int64Counter(eventsSentCountMeasureName,
+		otelmetric.WithDescription("cumulative count of events successfully sent"))
+	eventsFailedSend, _ := meter.Int64Counter(eventsSentFailuresMeasureName,
+		otelmetric.WithDescription("cumulative count of events that failed to send after all retries"))
+	eventsBytesSent, _ := meter.Int64Counter(eventsSentBytesMeasureName,
+		otelmetric.WithDescription("cumulative bytes of event payloads successfully sent"),
+		otelmetric.WithUnit("By"))
+	pendingEvents, _ := meter.Int64Gauge(eventsSentPendingMeasureName,
+		otelmetric.WithDescription("current number of events buffered in the queue"))
 
 	instruments := &Instruments{
 		connections:         connections,
 		requests:            requests,
 		requestDuration:     requestDuration,
-		eventsIngestedBytes: eventsIngestedBytes,
+		eventsReceivedBytes: eventsReceivedBytes,
+		eventsDropped:       eventsDropped,
+		eventsSent:          eventsSent,
+		eventsFailedSend:    eventsFailedSend,
+		eventsBytesSent:     eventsBytesSent,
+		pendingEvents:       pendingEvents,
 	}
 
 	usageChan := make(chan any, 256)
@@ -272,6 +289,22 @@ func (m *Manager) RemoveEnvironmentForUsage(envName string) {
 // GetAttributes returns the attribute set for this EnvironmentManager.
 func (em *EnvironmentManager) GetAttributes() attribute.Set {
 	return attribute.NewSet(em.envKVs...)
+}
+
+// NewEventMetricsRecorder creates an EventMetricsRecorder that records event processing metrics
+// with this environment's attributes. The returned recorder satisfies the EventMetrics interfaces
+// defined in both the events package and go-sdk-events.
+//
+// The recorder makes a private copy of the environment attributes to avoid data races with
+// attribute.NewSet's in-place sort.
+func (em *EnvironmentManager) NewEventMetricsRecorder(instruments *Instruments) *EventMetricsRecorder {
+	envKVsCopy := make([]attribute.KeyValue, len(em.envKVs))
+	copy(envKVsCopy, em.envKVs)
+	return &EventMetricsRecorder{
+		instruments: instruments,
+		envKVs:      envKVsCopy,
+		envAttrs:    attribute.NewSet(envKVsCopy...),
+	}
 }
 
 // FlushEventsExporter is used in testing to trigger the collector to post data to the event publisher.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -33,7 +33,7 @@ func TestNewManagerReturnsInstruments(t *testing.T) {
 	assert.NotNil(t, instruments.connections)
 	assert.NotNil(t, instruments.requests)
 	assert.NotNil(t, instruments.requestDuration)
-	assert.NotNil(t, instruments.eventsIngestedBytes)
+	assert.NotNil(t, instruments.eventsReceivedBytes)
 }
 
 func TestAddEnvironmentWithoutEventPublisher(t *testing.T) {
@@ -177,14 +177,14 @@ func TestWithRouteCount(t *testing.T) {
 	})
 }
 
-func TestRecordEventsIngestedBytes(t *testing.T) {
+func TestRecordEventsReceivedBytes(t *testing.T) {
 	testWithOTel(t, func(p testWithOTelParams) {
-		RecordEventsIngestedBytes(context.Background(), p.instruments, p.env, ServerPlatformCategory, RequestInfo{UserAgent: userAgentValue, Route: "/bulk", Method: "POST"}, 1024)
+		RecordEventsReceivedBytes(context.Background(), p.instruments, p.env, ServerPlatformCategory, RequestInfo{UserAgent: userAgentValue, Route: "/bulk", Method: "POST"}, 1024)
 
 		rm, err := p.collectMetrics()
 		require.NoError(t, err)
-		m := findMetric(rm, eventsIngestedBytesMeasureName)
-		require.NotNil(t, m, "events ingested bytes metric not found")
+		m := findMetric(rm, eventsReceivedBytesMeasureName)
+		require.NotNil(t, m, "events received bytes metric not found")
 		sum, ok := m.Data.(metricdata.Sum[int64])
 		require.True(t, ok, "expected Sum[int64] data")
 		require.NotEmpty(t, sum.DataPoints)
@@ -197,7 +197,33 @@ func TestRecordEventsIngestedBytes(t *testing.T) {
 				found = true
 			}
 		}
-		assert.True(t, found, "expected data point for events ingested bytes")
+		assert.True(t, found, "expected data point for events received bytes")
+	})
+}
+
+func TestEventMetricsRecorderViaTestHelper(t *testing.T) {
+	testWithOTel(t, func(p testWithOTelParams) {
+		recorder := p.env.NewEventMetricsRecorder(p.instruments)
+
+		recorder.RecordDroppedEvents(5)
+		recorder.RecordEventsSent(10)
+		recorder.RecordEventsBytesSent(2048)
+		recorder.RecordPendingEvents(3)
+
+		rm, err := p.collectMetrics()
+		require.NoError(t, err)
+
+		droppedMetric := findMetric(rm, eventsSentDroppedMeasureName)
+		require.NotNil(t, droppedMetric, "events dropped metric not found")
+
+		sentMetric := findMetric(rm, eventsSentCountMeasureName)
+		require.NotNil(t, sentMetric, "events sent metric not found")
+
+		bytesMetric := findMetric(rm, eventsSentBytesMeasureName)
+		require.NotNil(t, bytesMetric, "events bytes sent metric not found")
+
+		pendingMetric := findMetric(rm, eventsSentPendingMeasureName)
+		require.NotNil(t, pendingMetric, "events pending metric not found")
 	})
 }
 

--- a/internal/metrics/test_utils_test.go
+++ b/internal/metrics/test_utils_test.go
@@ -52,17 +52,8 @@ func testWithOTel(t *testing.T, action func(testWithOTelParams)) {
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	meter := meterProvider.Meter("ld-relay")
 
-	connections, _ := meter.Int64UpDownCounter(connMeasureName)
-	requests, _ := meter.Int64Counter(requestMeasureName)
-	requestDuration, _ := meter.Float64Histogram(requestDurationMeasureName)
-	eventsIngestedBytes, _ := meter.Int64Counter(eventsIngestedBytesMeasureName)
-
-	instruments := &Instruments{
-		connections:         connections,
-		requests:            requests,
-		requestDuration:     requestDuration,
-		eventsIngestedBytes: eventsIngestedBytes,
-	}
+	instruments, err := NewInstrumentsForTest(meter)
+	require.NoError(t, err)
 
 	manager, err := NewManager(config.OpenTelemetryConfig{}, time.Millisecond*10, mockLog.Loggers)
 	require.NoError(t, err)

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -168,7 +168,7 @@ func RequestMetrics(measure metrics.Measure) mux.MiddlewareFunc {
 	}
 }
 
-// EventBytesMetrics is a middleware function that records the number of event bytes ingested.
+// EventBytesMetrics is a middleware function that records the number of event bytes received.
 // This should be applied after GzipMiddleware so that it measures decompressed bytes.
 func EventBytesMetrics(platformCategory string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
@@ -182,7 +182,7 @@ func EventBytesMetrics(platformCategory string) mux.MiddlewareFunc {
 			next.ServeHTTP(w, req)
 			env := GetEnvContextInfo(req.Context()).Env
 			ri := requestInfoFromHTTP(req)
-			metrics.RecordEventsIngestedBytes(req.Context(), getInstruments(env), env.GetMetricsEnv(), platformCategory, ri, cr.bytesRead.Load())
+			metrics.RecordEventsReceivedBytes(req.Context(), getInstruments(env), env.GetMetricsEnv(), platformCategory, ri, cr.bytesRead.Load())
 		})
 	}
 }

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -198,8 +198,8 @@ func TestEventBytesMetrics(t *testing.T) {
 		router.ServeHTTP(httptest.NewRecorder(), req)
 
 		rm := p.collectMetrics(t)
-		bytesMetric := st.FindMetricByName(rm, "launchdarkly.relay.events.ingested.bytes")
-		require.NotNil(t, bytesMetric, "events ingested bytes metric not found")
+		bytesMetric := st.FindMetricByName(rm, "launchdarkly.relay.events.received.bytes")
+		require.NotNil(t, bytesMetric, "events received bytes metric not found")
 		assertMetricHasValue(t, bytesMetric, p.envName, "server", 35)
 	})
 }

--- a/internal/middleware/usage_middleware.go
+++ b/internal/middleware/usage_middleware.go
@@ -15,10 +15,11 @@ func DynamicTrackUsageActivity() mux.MiddlewareFunc {
 			ctx := GetEnvContextInfo(req.Context())
 			userAgent := getUserAgent(req)
 			instanceID := getInstanceID(req)
+			tagsHeader := req.Header.Get(events.TagsHeader)
 			platformCategory := clientPlatformCategory(ctx.Credential)
 			mu := ctx.Env.GetMetricsManager()
 
-			mu.TrackUsageActivityMessage(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+			mu.UsageActivityCountMessage(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID, tagsHeader)
 
 			next.ServeHTTP(w, req)
 		})
@@ -32,15 +33,16 @@ func DynamicUsageActivityStreamMonitoring(next http.Handler) http.Handler {
 		ctx := GetEnvContextInfo(req.Context())
 		userAgent := getUserAgent(req)
 		instanceID := getInstanceID(req)
+		tagsHeader := req.Header.Get(events.TagsHeader)
 		platformCategory := clientPlatformCategory(ctx.Credential)
 
 		if mu := ctx.Env.GetMetricsManager(); mu != nil {
-			mu.UsageActivityStreamConnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+			mu.UsageActivityStreamConnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID, tagsHeader)
 		}
 
 		defer func() {
 			if mu := ctx.Env.GetMetricsManager(); mu != nil {
-				mu.UsageActivityStreamDisconnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID)
+				mu.UsageActivityStreamDisconnected(ctx.Env.GetIdentifiers().GetDisplayName(), userAgent, platformCategory, instanceID, tagsHeader)
 			}
 		}()
 

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -286,28 +286,6 @@ func NewEnvContext(
 	wrapper := datadestination.NewDataDesinationWrapper(envStreamUpdates)
 	envContext.wrapper = wrapper
 
-	var eventDispatcher *events.EventDispatcher
-	if allConfig.Events.SendEvents {
-		if offlineMode {
-			envLoggers.Info("Events will be accepted for this environment, but will be discarded, since offline mode is enabled")
-		} else {
-			envLoggers.Info("Proxying events for this environment")
-			eventLoggers := envLoggers
-			eventLoggers.SetPrefix(logPrefix + " (event proxy)")
-			eventDispatcher = events.NewEventDispatcher(
-				envConfig.SDKKey,
-				envConfig.MobileKey,
-				envConfig.EnvID,
-				envLoggers,
-				allConfig.Events,
-				httpConfig,
-				wrapper,
-				0, // 0 here means "use the default interval for any periodic cleanup task you may need to run"
-			)
-		}
-	}
-	envContext.eventDispatcher = eventDispatcher
-
 	streamURI := allConfig.Main.StreamURI.String() // config.ValidateConfig has ensured that this has a value
 	baseURI := allConfig.Main.BaseURI.String()
 	eventsURI := allConfig.Events.EventsURI.String() // ditto
@@ -342,6 +320,37 @@ func NewEnvContext(
 	}
 
 	envContext.metricsEnv = em
+
+	// Create an EventMetrics recorder for the event dispatchers to use when reporting
+	// internal metrics like dropped events. This must be done after the EnvironmentManager
+	// is created so we have access to the environment-level OTEL attributes.
+	var eventMetrics events.EventMetrics
+	if em != nil {
+		eventMetrics = em.NewEventMetricsRecorder(params.MetricsManager.GetInstruments())
+	}
+
+	var eventDispatcher *events.EventDispatcher
+	if allConfig.Events.SendEvents {
+		if offlineMode {
+			envLoggers.Info("Events will be accepted for this environment, but will be discarded, since offline mode is enabled")
+		} else {
+			envLoggers.Info("Proxying events for this environment")
+			eventLoggers := envLoggers
+			eventLoggers.SetPrefix(logPrefix + " (event proxy)")
+			eventDispatcher = events.NewEventDispatcher(
+				envConfig.SDKKey,
+				envConfig.MobileKey,
+				envConfig.EnvID,
+				envLoggers,
+				allConfig.Events,
+				httpConfig,
+				wrapper,
+				0, // 0 here means "use the default interval for any periodic cleanup task you may need to run"
+				eventMetrics,
+			)
+		}
+	}
+	envContext.eventDispatcher = eventDispatcher
 
 	disconnectedStatusTime := allConfig.Main.DisconnectedStatusTime.GetOrElse(config.DefaultDisconnectedStatusTime)
 

--- a/internal/sharedtest/listener.go
+++ b/internal/sharedtest/listener.go
@@ -13,7 +13,9 @@ import (
 // and the port number, and then closes the listener.
 func WithListenerForAnyPort(t *testing.T, fn func(net.Listener, int)) {
 	l, port := startListenerForAnyAvailablePort(t)
-	defer l.Close()
+	defer func() {
+		_ = l.Close()
+	}()
 	fn(l, port)
 }
 
@@ -21,7 +23,7 @@ func WithListenerForAnyPort(t *testing.T, fn func(net.Listener, int)) {
 // returns the port number.
 func GetAvailablePort(t *testing.T) int {
 	l, port := startListenerForAnyAvailablePort(t)
-	l.Close()
+	_ = l.Close()
 	return port
 }
 

--- a/internal/streams/stream_provider.go
+++ b/internal/streams/stream_provider.go
@@ -73,14 +73,14 @@ func NewStreamProvider(kind basictypes.StreamKind, maxConnTime, pingStreamJitter
 		}
 	case basictypes.MobilePingStream:
 		return &clientSidePingStreamProvider{
-			fdv1Server: newSSEServer(maxConnTime),
-			fdv2Server: newSSEServer(maxConnTime),
+			fdv1Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime),
+			fdv2Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime),
 			isJSClient: false,
 		}
 	case basictypes.JSClientPingStream:
 		return &clientSidePingStreamProvider{
-			fdv1Server: newSSEServer(maxConnTime),
-			fdv2Server: newSSEServer(maxConnTime),
+			fdv1Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime),
+			fdv2Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime),
 			isJSClient: true,
 		}
 	default:

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -10,10 +10,10 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 
+	"github.com/gorilla/mux"
 	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	ld "github.com/launchdarkly/go-server-sdk/v7"
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
-	"github.com/gorilla/mux"
 )
 
 const (

--- a/relay/filedata_actions_test.go
+++ b/relay/filedata_actions_test.go
@@ -290,9 +290,10 @@ func TestOfflineModeDeprecatedSDKKeyIsRespectedIfExpiryInFuture(t *testing.T) {
 //			assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.EnvID}, env.GetCredentials())
 //			assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.ExpiringSDKKey.Key}, env.GetDeprecatedCredentials())
 //
-//			time.Sleep(minimumCleanupInterval)
+//			assert.Eventually(t, func() bool {
+//				return len(env.GetDeprecatedCredentials()) == 0
+//			}, time.Second, 10*time.Millisecond, "deprecated credentials should be cleaned up after expiry")
 //			assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.EnvID}, env.GetCredentials())
-//			assert.Empty(t, env.GetDeprecatedCredentials())
 //		}
 //	})
 //}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: introduces new asynchronous metric recording in the event forwarding pipeline and renames an existing metric, which could affect telemetry dashboards and has concurrency/overhead implications.
> 
> **Overview**
> Adds new OpenTelemetry metrics for the event forwarding pipeline, including **events received bytes** (renamed from `events.ingested.bytes`) plus counts for events *sent*, *failed*, *dropped*, *pending*, and bytes sent; documentation and middleware/tests are updated to match the new metric names.
> 
> Wires a new `events.EventMetrics` interface from `relayenv` into both verbatim and summarizing event relays, records metrics in `HTTPEventPublisher` (drop/queue depth/success/failure with status code), and introduces a `metrics.EventMetricsRecorder` that emits these metrics with environment-level attributes.
> 
> Also updates usage tracking middleware to forward the `X-LaunchDarkly-Tags` header, enables jittered SSE servers for ping streams, bumps `go-sdk-events` to `v3.6.0`, and makes a few minor robustness tweaks (ignoring `Close()` errors, test timing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 502032cecf5394d13ffe12d9e51ec9a950d91e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->