### PR TITLE
chore: Add explicit target branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           skip-github-pull-request: true
+          target-branch: ${{ github.ref_name }}
 
 
       # Need the repository content to be able to create and push a tag.
@@ -52,6 +53,7 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           skip-github-release: true
+          target-branch: ${{ github.ref_name }}
 
   release-relay:
     permissions:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it just makes `release-please` explicitly operate against the current branch name, which could affect where release PRs/releases are targeted if misconfigured.
> 
> **Overview**
> **Release automation now explicitly targets the branch that triggered the workflow.** The `googleapis/release-please-action` steps in `release-please.yml` were updated to pass `target-branch: ${{ github.ref_name }}` for both the release and release-PR creation paths, avoiding implicit/default branch targeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbe555d24a7de87fc643a59139ab663038ec1a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->