### PR TITLE
chore: Disable payload filter tests

### DIFF
--- a/integrationtests/all_test.go
+++ b/integrationtests/all_test.go
@@ -31,29 +31,29 @@ func TestEndToEnd(t *testing.T) {
 		testStandardModeWithPrerequisites(t, manager)
 	})
 
-	t.Run("standard mode with payload filters", func(t *testing.T) {
-		t.Run("default filters", func(t *testing.T) {
-			// This case is similar to the "standard mode" test above, except with payload filtering in the picture.
-			// The test setup creates filters (with no rules), which should result in filtered environments that are
-			// *equivalent* to the normal, non-filtered ones.
-			//
-			// The purpose is to assert that Relay can connect to the right amount of filtered and unfiltered environments,
-			// with expected flag data present - e.g. "2 projects * 2 environments * 2 filters = 12 environments"
-			// (8 filtered, plus 4 unfiltered).
-			testStandardModeWithDefaultFilters(t, manager)
-		})
-
-		t.Run("specific filters", func(t *testing.T) {
-			// This case is intended to check that payload filtering functionality actually works - that is, subsets of
-			// flag data are downloaded, rather than all flags in an environment.
-			//
-			// It does so by setting up an "odd" filter and an "even" filter, which limit flags to those with keys like
-			// flag0246... and flag1357...
-			// It creates an odd and even flag, and then asserts that the flags present in the filtered environments are
-			// as expected.
-			testStandardModeWithSpecificFilters(t, manager)
-		})
-	})
+	// t.Run("standard mode with payload filters", func(t *testing.T) {
+	// 	t.Run("default filters", func(t *testing.T) {
+	// 		// This case is similar to the "standard mode" test above, except with payload filtering in the picture.
+	// 		// The test setup creates filters (with no rules), which should result in filtered environments that are
+	// 		// *equivalent* to the normal, non-filtered ones.
+	// 		//
+	// 		// The purpose is to assert that Relay can connect to the right amount of filtered and unfiltered environments,
+	// 		// with expected flag data present - e.g. "2 projects * 2 environments * 2 filters = 12 environments"
+	// 		// (8 filtered, plus 4 unfiltered).
+	// 		testStandardModeWithDefaultFilters(t, manager)
+	// 	})
+	//
+	// 	t.Run("specific filters", func(t *testing.T) {
+	// 		// This case is intended to check that payload filtering functionality actually works - that is, subsets of
+	// 		// flag data are downloaded, rather than all flags in an environment.
+	// 		//
+	// 		// It does so by setting up an "odd" filter and an "even" filter, which limit flags to those with keys like
+	// 		// flag0246... and flag1357...
+	// 		// It creates an odd and even flag, and then asserts that the flags present in the filtered environments are
+	// 		// as expected.
+	// 		testStandardModeWithSpecificFilters(t, manager)
+	// 	})
+	// })
 
 	t.Run("auto-configuration mode", func(t *testing.T) {
 		testAutoConfig(t, manager)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only disables execution of the payload filter end-to-end test cases, with no production code changes.
> 
> **Overview**
> Disables the "standard mode with payload filters" integration test suite in `integrationtests/all_test.go` by commenting out its `t.Run` blocks, so payload filtering scenarios (default and specific filters) are no longer exercised as part of the end-to-end test run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04c0f77a144deb65e55757a8f53e0973b82e781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->