### PR TITLE
feat: Expose environment ID via X-LD-EnvId response header

### DIFF
--- a/internal/autoconfig/stream_manager_test_base_test.go
+++ b/internal/autoconfig/stream_manager_test_base_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/launchdarkly/ld-relay/v9/internal/envfactory"
 	"github.com/launchdarkly/ld-relay/v9/internal/httpconfig"
 
-	"github.com/launchdarkly/ld-relay/v9/internal/logging/logtest"
 	helpers "github.com/launchdarkly/go-test-helpers/v3"
 	"github.com/launchdarkly/go-test-helpers/v3/httphelpers"
+	"github.com/launchdarkly/ld-relay/v9/internal/logging/logtest"
 
 	"github.com/stretchr/testify/require"
 )

--- a/internal/bigsegments/sync_test.go
+++ b/internal/bigsegments/sync_test.go
@@ -12,10 +12,10 @@ import (
 
 	"log/slog"
 
-	"github.com/launchdarkly/ld-relay/v9/internal/logging/logtest"
 	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	helpers "github.com/launchdarkly/go-test-helpers/v3"
 	"github.com/launchdarkly/go-test-helpers/v3/httphelpers"
+	"github.com/launchdarkly/ld-relay/v9/internal/logging/logtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/browser/cors.go
+++ b/internal/browser/cors.go
@@ -68,5 +68,5 @@ func SetCORSHeaders(w http.ResponseWriter, origin string, extraAllowedHeaders []
 		allAllowedHeaders = allAllowedHeaders + "," + strings.Join(extraAllowedHeaders, ",")
 	}
 	w.Header().Set("Access-Control-Allow-Headers", allAllowedHeaders)
-	w.Header().Set("Access-Control-Expose-Headers", "Date")
+	w.Header().Set("Access-Control-Expose-Headers", "Date,X-LD-EnvId")
 }

--- a/internal/browser/cors_test.go
+++ b/internal/browser/cors_test.go
@@ -43,7 +43,7 @@ func TestCORSContext(t *testing.T) {
 		assert.Equal(t, "false", rr.Header().Get("Access-Control-Allow-Credentials"))
 		assert.Equal(t, maxAge, rr.Header().Get("Access-Control-Max-Age"))
 		assert.Equal(t, DefaultAllowedHeaders, rr.Header().Get("Access-Control-Allow-Headers"))
-		assert.Equal(t, "Date", rr.Header().Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Date,X-LD-EnvId", rr.Header().Get("Access-Control-Expose-Headers"))
 	})
 
 	t.Run("SetCORSHeaders with additionalHeaders", func(t *testing.T) {
@@ -56,6 +56,6 @@ func TestCORSContext(t *testing.T) {
 		assert.Equal(t, "false", rr.Header().Get("Access-Control-Allow-Credentials"))
 		assert.Equal(t, maxAge, rr.Header().Get("Access-Control-Max-Age"))
 		assert.Equal(t, expectedHeaders, rr.Header().Get("Access-Control-Allow-Headers"))
-		assert.Equal(t, "Date", rr.Header().Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Date,X-LD-EnvId", rr.Header().Get("Access-Control-Expose-Headers"))
 	})
 }

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -31,6 +31,7 @@ const (
 	ldInstanceIDHeader = "X-LaunchDarkly-Instance-Id"
 	ldWrapperHeader    = "X-LaunchDarkly-Wrapper"
 	ldTagsHeader       = "X-LaunchDarkly-Tags"
+	ldEnvIDHeader      = "X-LD-EnvId"
 
 	httpStatusMessageInvalidEnvCredential  = "Relay Proxy does not recognize the client credential (missing or invalid Authorization header)"
 	httpStatusMessageNotFullyConfigured    = "Relay Proxy is not yet fully initialized, does not have list of environments yet"
@@ -154,6 +155,10 @@ func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayE
 				return
 			}
 
+			if envID := relayenv.GetEnvironmentID(clientCtx); envID != "" {
+				w.Header().Set(ldEnvIDHeader, string(envID))
+			}
+
 			contextInfo := EnvContextInfo{
 				Env:        clientCtx,
 				Credential: credential,
@@ -222,6 +227,10 @@ func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFun
 				w.WriteHeader(http.StatusServiceUnavailable)
 				_, _ = w.Write([]byte(httpStatusMessageSDKClientNotInited))
 				return
+			}
+
+			if envID := relayenv.GetEnvironmentID(clientCtx); envID != "" {
+				w.Header().Set(ldEnvIDHeader, string(envID))
 			}
 
 			contextInfo := EnvContextInfo{

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -402,6 +402,206 @@ func TestSelectEnvironmentByAuthorizationKey(t *testing.T) {
 	})
 }
 
+func TestSelectEnvironmentByClientSideAuth(t *testing.T) {
+	envWithAllCreds := testenv.NewTestEnvContextWithEnvConfig("env-all", st.EnvWithAllCredentials.Config, false, nil)
+
+	t.Run("finds by environment ID", func(t *testing.T) {
+		envs := testEnvironments{
+			envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+				sdkauth.New(st.EnvWithAllCredentials.Config.EnvID): envWithAllCreds,
+			},
+		}
+		selector := SelectEnvironmentByClientSideAuth(envs)
+
+		headers := make(http.Header)
+		headers.Set("Authorization", string(st.EnvWithAllCredentials.Config.EnvID))
+		req := buildPreRoutedRequest("GET", nil, headers, nil, nil)
+		resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("finds by mobile key", func(t *testing.T) {
+		envs := testEnvironments{
+			envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+				sdkauth.New(st.EnvWithAllCredentials.Config.MobileKey): envWithAllCreds,
+			},
+		}
+		selector := SelectEnvironmentByClientSideAuth(envs)
+
+		headers := make(http.Header)
+		headers.Set("Authorization", string(st.EnvWithAllCredentials.Config.MobileKey))
+		req := buildPreRoutedRequest("GET", nil, headers, nil, nil)
+		resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("skips auth for OPTIONS preflight", func(t *testing.T) {
+		envs := testEnvironments{envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{}}
+		selector := SelectEnvironmentByClientSideAuth(envs)
+
+		req := buildPreRoutedRequest("OPTIONS", nil, nil, nil, nil)
+		resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("rejects unknown credential", func(t *testing.T) {
+		envs := testEnvironments{
+			envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+				sdkauth.New(st.EnvWithAllCredentials.Config.EnvID): envWithAllCreds,
+			},
+		}
+		selector := SelectEnvironmentByClientSideAuth(envs)
+
+		headers := make(http.Header)
+		headers.Set("Authorization", string(st.UndefinedEnvID))
+		req := buildPreRoutedRequest("GET", nil, headers, nil, nil)
+		resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("returns 503 if Relay has not been initialized", func(t *testing.T) {
+		envs := testEnvironments{notInited: true}
+		selector := SelectEnvironmentByClientSideAuth(envs)
+
+		headers := make(http.Header)
+		headers.Set("Authorization", string(st.EnvWithAllCredentials.Config.EnvID))
+		req := buildPreRoutedRequest("GET", nil, headers, nil, nil)
+		resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	})
+}
+
+func TestEnvIDHeader(t *testing.T) {
+	const testEnvID = config.EnvironmentID("507f1f77bcf86cd79943902a")
+
+	envWithEnvID := testenv.NewTestEnvContextWithEnvConfig("env-with-id", config.EnvConfig{
+		EnvID: testEnvID,
+	}, false, nil)
+
+	envWithoutEnvID := testenv.NewTestEnvContext("env-without-id", false, nil)
+
+	t.Run("SelectEnvironmentByAuthorizationKey", func(t *testing.T) {
+		t.Run("sets header for server-side SDK when env has env ID", func(t *testing.T) {
+			envs := testEnvironments{
+				envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+					sdkauth.New(st.EnvMain.Config.SDKKey): envWithEnvID,
+				},
+			}
+			selector := SelectEnvironmentByAuthorizationKey(basictypes.ServerSDK, envs)
+
+			req := buildPreRoutedRequestWithAuth(st.EnvMain.Config.SDKKey)
+			resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, string(testEnvID), resp.Header.Get(ldEnvIDHeader))
+		})
+
+		t.Run("sets header for mobile SDK when env has env ID", func(t *testing.T) {
+			envs := testEnvironments{
+				envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+					sdkauth.New(st.EnvMobile.Config.MobileKey): envWithEnvID,
+				},
+			}
+			selector := SelectEnvironmentByAuthorizationKey(basictypes.MobileSDK, envs)
+
+			req := buildPreRoutedRequestWithAuth(st.EnvMobile.Config.MobileKey)
+			resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, string(testEnvID), resp.Header.Get(ldEnvIDHeader))
+		})
+
+		t.Run("sets header for JS client SDK when env has env ID", func(t *testing.T) {
+			envs := testEnvironments{
+				envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+					sdkauth.New(st.EnvClientSide.Config.EnvID): envWithEnvID,
+				},
+			}
+			selector := SelectEnvironmentByAuthorizationKey(basictypes.JSClientSDK, envs)
+
+			vars := map[string]string{"envId": string(st.EnvClientSide.Config.EnvID)}
+			req := buildPreRoutedRequest("GET", nil, nil, vars, nil)
+			resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, string(testEnvID), resp.Header.Get(ldEnvIDHeader))
+		})
+
+		t.Run("does not set header when env has no env ID", func(t *testing.T) {
+			envs := testEnvironments{
+				envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+					sdkauth.New(st.EnvMain.Config.SDKKey): envWithoutEnvID,
+				},
+			}
+			selector := SelectEnvironmentByAuthorizationKey(basictypes.ServerSDK, envs)
+
+			req := buildPreRoutedRequestWithAuth(st.EnvMain.Config.SDKKey)
+			resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "", resp.Header.Get(ldEnvIDHeader))
+		})
+	})
+
+	t.Run("SelectEnvironmentByClientSideAuth", func(t *testing.T) {
+		t.Run("sets header when authenticating with env ID", func(t *testing.T) {
+			envs := testEnvironments{
+				envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+					sdkauth.New(st.EnvWithAllCredentials.Config.EnvID): envWithEnvID,
+				},
+			}
+			selector := SelectEnvironmentByClientSideAuth(envs)
+
+			headers := make(http.Header)
+			headers.Set("Authorization", string(st.EnvWithAllCredentials.Config.EnvID))
+			req := buildPreRoutedRequest("GET", nil, headers, nil, nil)
+			resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, string(testEnvID), resp.Header.Get(ldEnvIDHeader))
+		})
+
+		t.Run("sets header when authenticating with mobile key", func(t *testing.T) {
+			envs := testEnvironments{
+				envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+					sdkauth.New(st.EnvWithAllCredentials.Config.MobileKey): envWithEnvID,
+				},
+			}
+			selector := SelectEnvironmentByClientSideAuth(envs)
+
+			headers := make(http.Header)
+			headers.Set("Authorization", string(st.EnvWithAllCredentials.Config.MobileKey))
+			req := buildPreRoutedRequest("GET", nil, headers, nil, nil)
+			resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, string(testEnvID), resp.Header.Get(ldEnvIDHeader))
+		})
+
+		t.Run("does not set header when env has no env ID", func(t *testing.T) {
+			envs := testEnvironments{
+				envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+					sdkauth.New(st.EnvWithAllCredentials.Config.MobileKey): envWithoutEnvID,
+				},
+			}
+			selector := SelectEnvironmentByClientSideAuth(envs)
+
+			headers := make(http.Header)
+			headers.Set("Authorization", string(st.EnvWithAllCredentials.Config.MobileKey))
+			req := buildPreRoutedRequest("GET", nil, headers, nil, nil)
+			resp, _ := st.DoRequest(req, selector(nullHandler()))
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "", resp.Header.Get(ldEnvIDHeader))
+		})
+	})
+}
+
 func TestCORSMiddlewareSetsCorrectDefaultHeaders(t *testing.T) {
 	req := buildPreRoutedRequest("GET", nil, nil, nil, nil)
 	resp := httptest.NewRecorder()
@@ -412,7 +612,7 @@ func TestCORSMiddlewareSetsCorrectDefaultHeaders(t *testing.T) {
 	assert.Equal(t, "false", resp.Result().Header.Get("Access-Control-Allow-Credentials"))
 	assert.Equal(t, "300", resp.Result().Header.Get("Access-Control-Max-Age"))
 	assert.Equal(t, browser.DefaultAllowedHeaders, resp.Result().Header.Get("Access-Control-Allow-Headers"))
-	assert.Equal(t, "Date", resp.Result().Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Date,X-LD-EnvId", resp.Result().Header.Get("Access-Control-Expose-Headers"))
 }
 
 func TestCORSMiddlewareSetsCorrectDefaultHeadersWhenRequestHasOrigin(t *testing.T) {

--- a/internal/projmanager/environment_manager_test.go
+++ b/internal/projmanager/environment_manager_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/launchdarkly/ld-relay/v9/config"
-	"github.com/launchdarkly/ld-relay/v9/internal/logging/logtest"
 	"github.com/launchdarkly/ld-relay/v9/internal/envfactory"
+	"github.com/launchdarkly/ld-relay/v9/internal/logging/logtest"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -129,7 +129,7 @@ func TestConstructorWithJSClientContext(t *testing.T) {
 		EnvConfig:       envConfig,
 		ClientFactory:   testclient.FakeLDClientFactory(true),
 		JSClientContext: jsClientContext,
-		Logger:         slog.Default(),
+		Logger:          slog.Default(),
 	}, nil)
 	require.NoError(t, err)
 	defer env.Close()
@@ -154,8 +154,6 @@ func TestLogPrefix(t *testing.T) {
 
 func TestAddRemoveCredential(t *testing.T) {
 	envConfig := st.EnvMain.Config
-
-
 
 	env := makeBasicEnv(t, envConfig, testclient.FakeLDClientFactory(true), slog.Default(), nil)
 	defer env.Close()
@@ -182,8 +180,6 @@ func TestAddRemoveCredential(t *testing.T) {
 
 func TestAddExistingCredentialDoesNothing(t *testing.T) {
 	envConfig := st.EnvMain.Config
-
-
 
 	env := makeBasicEnv(t, envConfig, testclient.FakeLDClientFactory(true), slog.Default(), nil)
 	defer env.Close()
@@ -276,8 +272,6 @@ func TestSDKClientCreationFails(t *testing.T) {
 
 	fakeError := errors.New("sorry")
 
-
-
 	env := makeBasicEnv(t, envConfig, testclient.ClientFactoryThatFails(fakeError), slog.Default(), readyCh)
 	defer env.Close()
 
@@ -313,7 +307,7 @@ func TestMetricsAreExportedForEnvironment(t *testing.T) {
 			ClientFactory:  testclient.FakeLDClientFactory(true),
 			MetricsManager: metricsManager,
 			UserAgent:      fakeUserAgent,
-			Logger:        slog.Default(),
+			Logger:         slog.Default(),
 		}, nil)
 		require.NoError(t, err)
 		defer env.Close()
@@ -366,7 +360,7 @@ func testMetricsDisabled(t *testing.T, allConfig config.Config) {
 			AllConfig:      allConfig,
 			ClientFactory:  testclient.FakeLDClientFactory(true),
 			MetricsManager: metricsManager,
-			Logger:        slog.Default(),
+			Logger:         slog.Default(),
 		}, nil)
 		require.NoError(t, err)
 		defer env.Close()
@@ -388,7 +382,6 @@ func testMetricsDisabled(t *testing.T, allConfig config.Config) {
 
 func TestEventDispatcherIsCreatedIfSendEventsIsTrueAndNotInOfflineMode(t *testing.T) {
 
-
 	eventRecorderHandler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(202))
 	httphelpers.WithServer(eventRecorderHandler, func(server *httptest.Server) {
 		var allConfig config.Config
@@ -400,7 +393,7 @@ func TestEventDispatcherIsCreatedIfSendEventsIsTrueAndNotInOfflineMode(t *testin
 			EnvConfig:     st.EnvMain.Config,
 			AllConfig:     allConfig,
 			ClientFactory: testclient.FakeLDClientFactory(true),
-			Logger:       slog.Default(),
+			Logger:        slog.Default(),
 		}, nil)
 		require.NoError(t, err)
 		defer env.Close()
@@ -433,7 +426,6 @@ func TestEventDispatcherIsCreatedIfSendEventsIsTrueAndNotInOfflineMode(t *testin
 
 func TestEventDispatcherIsNotCreatedIfSendEventsIsTrueAndNotInOfflineMode(t *testing.T) {
 
-
 	eventRecorderHandler, _ := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(202))
 	httphelpers.WithServer(eventRecorderHandler, func(server *httptest.Server) {
 		var allConfig config.Config
@@ -446,7 +438,7 @@ func TestEventDispatcherIsNotCreatedIfSendEventsIsTrueAndNotInOfflineMode(t *tes
 			EnvConfig:     st.EnvMain.Config,
 			AllConfig:     allConfig,
 			ClientFactory: testclient.FakeLDClientFactory(true),
-			Logger:       slog.Default(),
+			Logger:        slog.Default(),
 		}, nil)
 		require.NoError(t, err)
 		defer env.Close()
@@ -465,8 +457,6 @@ func TestBigSegmentsSynchronizerIsCreatedIfBigSegmentStoreExists(t *testing.T) {
 		return bigsegments.NewNullBigSegmentStore(), nil
 	}
 	fakeSynchronizerFactory := &mockBigSegmentSynchronizerFactory{}
-
-
 
 	env, err := NewEnvContext(EnvContextImplParams{
 		Identifiers:                   EnvIdentifiers{ConfiguredName: st.EnvMain.Name},
@@ -504,8 +494,6 @@ func TestBigSegmentsSynchronizerIsStartedByFullDataUpdateWithBigSegment(t *testi
 		return bigsegments.NewNullBigSegmentStore(), nil
 	}
 	fakeSynchronizerFactory := &mockBigSegmentSynchronizerFactory{}
-
-
 
 	changeSetCh := make(chan subsystems.ChangeSet, 1)
 
@@ -583,8 +571,6 @@ func TestBigSegmentsSynchronizerIsStartedBySingleItemUpdateWithBigSegment(t *tes
 	}
 	fakeSynchronizerFactory := &mockBigSegmentSynchronizerFactory{}
 
-
-
 	changeSetCh := make(chan subsystems.ChangeSet, 1)
 	env, err := NewEnvContext(EnvContextImplParams{
 		Identifiers:                   EnvIdentifiers{ConfiguredName: st.EnvMain.Name},
@@ -654,8 +640,6 @@ func TestReceivingBigSegmentsUpdateCausesClientSideInvalidationEvent(t *testing.
 	}
 	fakeSynchronizerFactory := &mockBigSegmentSynchronizerFactory{}
 
-
-
 	jsClientStreams := streams.NewStreamProvider(basictypes.JSClientPingStream, time.Hour, 0)
 	sdkStartedCh := make(chan EnvContext)
 	env, err := NewEnvContext(EnvContextImplParams{
@@ -669,7 +653,7 @@ func TestReceivingBigSegmentsUpdateCausesClientSideInvalidationEvent(t *testing.
 			st.ExistingInstance[subsystems.BigSegmentStore](&st.NoOpSDKBigSegmentStore{}),
 		),
 		StreamProviders: []streams.StreamProvider{jsClientStreams},
-		Logger:         slog.Default(),
+		Logger:          slog.Default(),
 	}, sdkStartedCh)
 	require.NoError(t, err)
 	defer env.Close()

--- a/internal/sharedtest/testenv/test_env_context.go
+++ b/internal/sharedtest/testenv/test_env_context.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/launchdarkly/ld-relay/v9/config"
 	"github.com/launchdarkly/ld-relay/v9/internal/relayenv"
 	"github.com/launchdarkly/ld-relay/v9/internal/sdks"
 	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
@@ -32,6 +33,29 @@ func NewTestEnvContextWithClientFactory(
 	_, err := relayenv.NewEnvContext(relayenv.EnvContextImplParams{
 		Identifiers:      relayenv.EnvIdentifiers{ConfiguredName: name},
 		ClientFactory:    f,
+		DataStoreFactory: dataStoreFactory,
+		UserAgent:        "fake-user-agent",
+		Logger:           slog.Default(),
+	}, readyCh)
+	if err != nil {
+		panic(err)
+	}
+	if c, ok, _ := helpers.TryReceive(readyCh, time.Second); ok {
+		return c
+	}
+	panic("timed out waiting for client initialization")
+}
+
+func NewTestEnvContextWithEnvConfig(name string, envConfig config.EnvConfig, shouldBeInitialized bool, store subsystems.DataStore) relayenv.EnvContext {
+	var dataStoreFactory subsystems.ComponentConfigurer[subsystems.DataStore] = nil
+	if store != nil {
+		dataStoreFactory = sharedtest.ExistingInstance(store)
+	}
+	readyCh := make(chan relayenv.EnvContext)
+	_, err := relayenv.NewEnvContext(relayenv.EnvContextImplParams{
+		Identifiers:      relayenv.EnvIdentifiers{ConfiguredName: name},
+		EnvConfig:        envConfig,
+		ClientFactory:    testclient.FakeLDClientFactory(shouldBeInitialized),
 		DataStoreFactory: dataStoreFactory,
 		UserAgent:        "fake-user-agent",
 		Logger:           slog.Default(),


### PR DESCRIPTION
Adds an `X-LD-EnvId` header to SDK authentication responses, set from the
resolved environment's ID when one is available. Updates CORS configuration
to expose the header to browser SDKs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP response headers on core auth middleware paths and adjusts CORS exposure, which could affect client integrations or downstream proxies expecting previous headers.
> 
> **Overview**
> Adds a new `X-LD-EnvId` response header on successful SDK authentication, populated from the resolved environment’s ID when available (applies to both `SelectEnvironmentByAuthorizationKey` and `SelectEnvironmentByClientSideAuth`).
> 
> Updates CORS handling to expose `X-LD-EnvId` to browser clients via `Access-Control-Expose-Headers`, and extends middleware/test helpers and coverage to validate the new header behavior and client-side auth paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b6c77f6851568832849e3182633712253bd69d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->