### PR TITLE
feat: Add REPORT method support for FDv2 client-side eval endpoints

### DIFF
--- a/internal/sharedtest/testdata_responses.go
+++ b/internal/sharedtest/testdata_responses.go
@@ -70,6 +70,32 @@ func AssertExpectedCORSHeaders(t *testing.T, resp *http.Response, endpointMethod
 	assert.Equal(t, host, resp.Header.Get("Access-Control-Allow-Origin"))
 }
 
+func AssertEndpointSupportsOptionsRequestMethods(
+	t *testing.T,
+	handler http.Handler,
+	url string,
+	expectedMethods []string,
+) {
+	host := "my-host.com"
+
+	r1, _ := http.NewRequest("OPTIONS", url, nil)
+	result1, _ := DoRequest(r1, handler)
+	if assert.Equal(t, http.StatusOK, result1.StatusCode) {
+		assert.ElementsMatch(t, expectedMethods,
+			strings.Split(result1.Header.Get("Access-Control-Allow-Methods"), ","))
+		assert.Equal(t, "*", result1.Header.Get("Access-Control-Allow-Origin"))
+	}
+
+	r2, _ := http.NewRequest("OPTIONS", url, nil)
+	r2.Header.Set("Origin", host)
+	result2, _ := DoRequest(r2, handler)
+	if assert.Equal(t, http.StatusOK, result2.StatusCode) {
+		assert.ElementsMatch(t, expectedMethods,
+			strings.Split(result2.Header.Get("Access-Control-Allow-Methods"), ","))
+		assert.Equal(t, host, result2.Header.Get("Access-Control-Allow-Origin"))
+	}
+}
+
 func MakeEvalBody(flags []TestFlag, reasons bool) string {
 	obj := make(map[string]interface{})
 	for _, f := range flags {

--- a/relay/endpoints_fdv2_client_poll_test.go
+++ b/relay/endpoints_fdv2_client_poll_test.go
@@ -66,6 +66,21 @@ func TestFDv2ClientSidePollingWithMobileKey(t *testing.T) {
 			assert.Equal(t, "server-intent", payload.Events[0].Event)
 		})
 
+		t.Run("REPORT with context in body", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(mobileKey))
+			h.Set("Content-Type", "application/json")
+			req := st.BuildRequest("REPORT", "/sdk/poll/eval", contextJSON, h)
+			result, body := st.DoRequest(req, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.NotEmpty(t, payload.Events)
+			assert.Equal(t, "server-intent", payload.Events[0].Event)
+		})
+
 		t.Run("auth via query param", func(t *testing.T) {
 			req := st.BuildRequest("GET", "/sdk/poll/eval/"+contextBase64+"?auth="+string(mobileKey), nil, nil)
 			result, body := st.DoRequest(req, p.relay)
@@ -143,6 +158,20 @@ func TestFDv2ClientSidePollingWithEnvironmentID(t *testing.T) {
 			h.Set("Authorization", string(envID))
 			h.Set("Content-Type", "application/json")
 			req := st.BuildRequest("POST", "/sdk/poll/eval", contextJSON, h)
+			result, body := st.DoRequest(req, p.relay)
+
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+
+			var payload pollingPayload
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.NotEmpty(t, payload.Events)
+		})
+
+		t.Run("REPORT with context in body", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(envID))
+			h.Set("Content-Type", "application/json")
+			req := st.BuildRequest("REPORT", "/sdk/poll/eval", contextJSON, h)
 			result, body := st.DoRequest(req, p.relay)
 
 			assert.Equal(t, http.StatusOK, result.StatusCode)

--- a/relay/endpoints_fdv2_client_stream_test.go
+++ b/relay/endpoints_fdv2_client_stream_test.go
@@ -50,6 +50,18 @@ func TestFDv2ClientSideStreamingWithMobileKey(t *testing.T) {
 			})
 		})
 
+		t.Run("REPORT with context in body", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(mobileKey))
+			h.Set("Content-Type", "application/json")
+			req := st.BuildRequest("REPORT", "/sdk/stream/eval", contextJSON, h)
+			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+				event := helpers.RequireValue(t, eventCh, 3*time.Second, "timed out waiting for event")
+				require.NotNil(t, event)
+				assert.Equal(t, "ping", event.Event())
+			})
+		})
+
 		t.Run("auth via query param", func(t *testing.T) {
 			req := st.BuildRequest("GET", "/sdk/stream/eval/"+contextBase64+"?auth="+string(mobileKey), nil, nil)
 			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
@@ -104,6 +116,18 @@ func TestFDv2ClientSideStreamingWithEnvironmentID(t *testing.T) {
 			h.Set("Authorization", string(envID))
 			h.Set("Content-Type", "application/json")
 			req := st.BuildRequest("POST", "/sdk/stream/eval", contextJSON, h)
+			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+				event := helpers.RequireValue(t, eventCh, 3*time.Second, "timed out waiting for event")
+				require.NotNil(t, event)
+				assert.Equal(t, "ping", event.Event())
+			})
+		})
+
+		t.Run("REPORT with context in body", func(t *testing.T) {
+			h := make(http.Header)
+			h.Set("Authorization", string(envID))
+			h.Set("Content-Type", "application/json")
+			req := st.BuildRequest("REPORT", "/sdk/stream/eval", contextJSON, h)
 			st.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
 				event := helpers.RequireValue(t, eventCh, 3*time.Second, "timed out waiting for event")
 				require.NotNil(t, event)
@@ -182,8 +206,9 @@ func TestFDv2ClientSideStreamingCORSPreflight(t *testing.T) {
 			st.AssertEndpointSupportsOptionsRequest(t, p.relay, "http://localhost/sdk/stream/eval/"+contextBase64, "GET")
 		})
 
-		t.Run("OPTIONS on POST path succeeds without auth", func(t *testing.T) {
-			st.AssertEndpointSupportsOptionsRequest(t, p.relay, "http://localhost/sdk/stream/eval", "POST")
+		t.Run("OPTIONS on POST/REPORT path succeeds without auth", func(t *testing.T) {
+			st.AssertEndpointSupportsOptionsRequestMethods(t, p.relay, "http://localhost/sdk/stream/eval",
+				[]string{"POST", "REPORT", "OPTIONS"})
 		})
 	})
 }
@@ -201,8 +226,9 @@ func TestFDv2ClientSidePollingCORSPreflight(t *testing.T) {
 			st.AssertEndpointSupportsOptionsRequest(t, p.relay, "http://localhost/sdk/poll/eval/"+contextBase64, "GET")
 		})
 
-		t.Run("OPTIONS on POST path succeeds without auth", func(t *testing.T) {
-			st.AssertEndpointSupportsOptionsRequest(t, p.relay, "http://localhost/sdk/poll/eval", "POST")
+		t.Run("OPTIONS on POST/REPORT path succeeds without auth", func(t *testing.T) {
+			st.AssertEndpointSupportsOptionsRequestMethods(t, p.relay, "http://localhost/sdk/poll/eval",
+				[]string{"POST", "REPORT", "OPTIONS"})
 		})
 	})
 }

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -109,7 +109,7 @@ func (r *Relay) makeRouter() *mux.Router {
 	clientSideFDv2StreamRouter.Use(clientSideFDv2StreamMiddleware, middleware.Streaming)
 	clientSideFDv2PingHandler := pingStreamHandlerWithContextV2(r.mobileStreamProvider, r.jsClientStreamProvider)
 	clientSideFDv2StreamRouter.Handle("/{context}", middleware.DynamicUsageActivityStreamMonitoring(middleware.CountClientConns(clientSideFDv2PingHandler))).Methods("GET", "OPTIONS")
-	clientSideFDv2StreamRouter.Handle("", middleware.DynamicUsageActivityStreamMonitoring(middleware.CountClientConns(clientSideFDv2PingHandler))).Methods("POST", "OPTIONS")
+	clientSideFDv2StreamRouter.Handle("", middleware.DynamicUsageActivityStreamMonitoring(middleware.CountClientConns(clientSideFDv2PingHandler))).Methods("POST", "REPORT", "OPTIONS")
 
 	clientSideFDv2PollRouter := sdkRouter.PathPrefix("/poll/eval").Subrouter()
 	clientSideFDv2PollMiddleware := middleware.Chain(
@@ -121,7 +121,7 @@ func (r *Relay) makeRouter() *mux.Router {
 	)
 	clientSideFDv2PollRouter.Use(clientSideFDv2PollMiddleware)
 	clientSideFDv2PollRouter.Handle("/{context}", middleware.DynamicPollingRequestCount(http.HandlerFunc(pollEvalHandlerV2))).Methods("GET", "OPTIONS")
-	clientSideFDv2PollRouter.Handle("", middleware.DynamicPollingRequestCount(http.HandlerFunc(pollEvalHandlerV2))).Methods("POST", "OPTIONS")
+	clientSideFDv2PollRouter.Handle("", middleware.DynamicPollingRequestCount(http.HandlerFunc(pollEvalHandlerV2))).Methods("POST", "REPORT", "OPTIONS")
 
 	serverSideEvalXRouter := sdkRouter.PathPrefix("/evalx/").Subrouter()
 	serverSideEvalXRouter.Handle("/contexts/{context}", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK))))).Methods("GET")


### PR DESCRIPTION
Allows SDKs to send context in the request body via the REPORT method
on the FDv2 /sdk/stream/eval and /sdk/poll/eval endpoints, matching
the existing POST behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands HTTP method support and CORS allow-lists on public SDK-facing routes, which can affect client/proxy behavior if misconfigured, but the change is small and covered by tests.
> 
> **Overview**
> Adds `REPORT` as an accepted method (alongside `POST`) for FDv2 client-side evaluation endpoints `/sdk/stream/eval` and `/sdk/poll/eval`, enabling SDKs to send context JSON in the request body while keeping the existing handlers/middleware.
> 
> Updates integration tests to exercise `REPORT` requests for both mobile-key and env-id auth, and adjusts CORS preflight expectations by introducing a shared test helper that can assert multiple allowed methods in `Access-Control-Allow-Methods`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06269e2c1745ad1a0d73010ee4e866f224b80e54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->