### PR TITLE
fix: avoid double-close of AutoConfig cache on init error

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -203,7 +203,6 @@ func newRelayInternal(c config.Config, options relayInternalOptions) (*Relay, er
 		if err != nil {
 			return nil, err
 		}
-		thingsToCleanUp.AddCloser(autoConfigCache)
 
 		projectRouter := projmanager.NewProjectRouter(&relayAutoConfigActions{r: r}, loggers)
 


### PR DESCRIPTION
The autoConfigCache was registered with thingsToCleanUp even though
Relay.Close already closes it via StreamManager.Close. On the init
error path this caused Close to run twice on the same store.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes redundant cleanup registration so `StreamManager.Close()` remains the single owner of `autoConfigCache` shutdown logic.
> 
> **Overview**
> Avoids registering `autoConfigCache` with `thingsToCleanUp` during Relay startup, since `autoconfig.StreamManager.Close()` already closes the cache. This prevents double-closing the same store on early-init error paths while preserving normal shutdown behavior via `Relay.Close()` -> `autoConfigStream.Close()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57aaecbd19af7ad7a5edd205a2d780597d584e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->