### PR TITLE
chore(deps): bump otlpmetric exporters to v1.43.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,8 +64,8 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -420,10 +420,10 @@ go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0 h1:Dn8rkudDz
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0/go.mod h1:gMk9F0xDgyN9M/3Ed5Y1wKcx/9mlU91NXY2SNq7RQuU=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 h1:HIBTQ3VO5aupLKjC90JgMqpezVXwFuq6Ryjn0/izoag=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0/go.mod h1:ji9vId85hMxqfvICA0Jt8JqEdrXaAkcpkI9HPXya0ro=
-go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0 h1:NOyNnS19BF2SUDApbOKbDtWZ0IK7b8FJ2uAGdIWOGb0=
-go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0/go.mod h1:VL6EgVikRLcJa9ftukrHu/ZkkhFBSo1lzvdBC9CF1ss=
-go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0 h1:9y5sHvAxWzft1WQ4BwqcvA+IFVUJ1Ya75mSAUnFEVwE=
-go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0/go.mod h1:eQqT90eR3X5Dbs1g9YSM30RavwLF725Ris5/XSXWvqE=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 h1:8UQVDcZxOJLtX6gxtDt3vY2WTgvZqMQRzjsqiIHQdkc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0/go.mod h1:2lmweYCiHYpEjQ/lSJBYhj9jP1zvCvQW4BqL9dnT7FQ=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 h1:w1K+pCJoPpQifuVpsKamUdn9U0zM3xUziVOqsGksUrY=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0/go.mod h1:HBy4BjzgVE8139ieRI75oXm3EcDN+6GhD88JT1Kjvxg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=


### PR DESCRIPTION
## Summary

Bumps the two `otlpmetric` OTLP exporters from `v1.40.0` to `v1.43.0` to clear a Docker Scout CVE finding that has been failing CI on `v9`.

## Background

This change is a follow-up to a comment on a previous pull request: https://github.com/launchdarkly/ld-relay/pull/650#issuecomment-4298553699

The `Docker Scout Scan` job in `.github/workflows/ci.yml` runs `docker/scout-action` with `command: cves`, `only-fixed: true`, and `exit-code: true` against the built images, and a follow-up step does `exit 1` if any of the three image scans report a vulnerability. As of recent pushes to `v9`, every run has failed on:

> **CVE-2026-39882** — Memory Allocation with Excessive Size Value (CVSS 5.3)
> Package: `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@1.40.0`
> Affected range: `< 1.43.0` — Fixed version: `1.43.0`

The two `otlpmetric/otlpmetric{grpc,http}` exporters were left pinned at `v1.40.0` while the rest of the OpenTelemetry stack (`otel`, `metric`, `sdk`, `sdk/metric`, `trace`, `otlptrace/*`) was already at `v1.43.0`. This brings them in line with the rest of the modules and fixes the reported CVE.

This is also blocking unrelated PRs against `v9` (e.g. [#650](https://github.com/launchdarkly/ld-relay/pull/650)) from going green on CI.

## Changes

- `go.mod`: bump `otlpmetric/otlpmetricgrpc` and `otlpmetric/otlpmetrichttp` from `v1.40.0` → `v1.43.0`
- `go.sum`: corresponding hash updates (no other transitive churn)

---

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change updating OpenTelemetry OTLP metric exporters; main risk is unexpected behavior/perf changes in metrics export from the upstream library.
> 
> **Overview**
> Updates OpenTelemetry OTLP metric exporters (`go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetric{grpc,http}`) from `v1.40.0` to `v1.43.0`, aligning them with the rest of the OTel stack.
> 
> `go.sum` is updated accordingly with no other dependency churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc8b5333dc9dada3e08d520c2119e2ce739111f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->