### PR TITLE
chore: Fix DD HTTP OTEL port

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -65,7 +65,7 @@ Then configure the Relay Proxy:
 
 ```
 USE_OTLP=true
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
 ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating the Datadog OTLP endpoint port; no runtime code paths are affected.
> 
> **Overview**
> Updates the Datadog metrics setup docs to point `OTEL_EXPORTER_OTLP_ENDPOINT` at port `4318` instead of `4317` when configuring Relay Proxy OTLP export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e05dbcbddd79c0b62761ba1ff0d9d16f4fe8167b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->