### PR TITLE
fix: Parse ldlog level prefix without trailing space

### DIFF
--- a/internal/logging/bridge.go
+++ b/internal/logging/bridge.go
@@ -10,7 +10,7 @@ import (
 )
 
 // slogBaseLogger implements ldlog.BaseLogger by delegating to a *slog.Logger.
-// The ldlog library prepends level prefixes ("DEBUG: ", "INFO: ", etc.) to messages
+// The ldlog library prepends level prefixes ("DEBUG:", "INFO:", etc.) to messages
 // before calling Println/Printf, so we parse those back out to determine the slog level.
 type slogBaseLogger struct {
 	logger *slog.Logger
@@ -29,16 +29,19 @@ func (b *slogBaseLogger) Printf(format string, values ...interface{}) {
 }
 
 // parseLDLogPrefix extracts the log level from an ldlog-formatted message.
-// ldlog prepends "DEBUG: ", "INFO: ", "WARN: ", or "ERROR: " to messages.
+// ldlog builds the prefix as "LEVEL:" (no trailing space) and applies it via
+// either Printf (which inserts " " between prefix and format) or Println via
+// fmt.Sprint (which inserts no separator between two string operands). Match
+// on the colon-terminated prefix and let TrimSpace deal with whatever follows.
 func parseLDLogPrefix(message string) (slog.Level, string) {
 	prefixes := []struct {
 		prefix string
 		level  slog.Level
 	}{
-		{"DEBUG: ", slog.LevelDebug},
-		{"INFO: ", slog.LevelInfo},
-		{"WARN: ", slog.LevelWarn},
-		{"ERROR: ", slog.LevelError},
+		{"DEBUG:", slog.LevelDebug},
+		{"INFO:", slog.LevelInfo},
+		{"WARN:", slog.LevelWarn},
+		{"ERROR:", slog.LevelError},
 	}
 	for _, p := range prefixes {
 		if strings.HasPrefix(message, p.prefix) {

--- a/internal/logging/bridge_test.go
+++ b/internal/logging/bridge_test.go
@@ -1,0 +1,103 @@
+package logging
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/logging/logtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseLDLogPrefix covers both shapes ldlog produces:
+//   - Printf path: format is "LEVEL: " + format, so the rendered prefix has a space.
+//   - Println path: baseLogger.Println(prefix, value) -> fmt.Sprint inserts no
+//     separator between two string operands, so the rendered prefix has no space.
+// The parser must accept both. https://github.com/launchdarkly/ld-relay/issues/670
+// shipped because the parser only matched the with-space shape.
+func TestParseLDLogPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantLevel   slog.Level
+		wantMessage string
+	}{
+		{"debug no space (Println shape)", "DEBUG:querying Big Segment store metadata", slog.LevelDebug, "querying Big Segment store metadata"},
+		{"debug with space (Printf shape)", "DEBUG: querying Big Segment store metadata", slog.LevelDebug, "querying Big Segment store metadata"},
+		{"info no space", "INFO:Starting client", slog.LevelInfo, "Starting client"},
+		{"info with space", "INFO: Starting client", slog.LevelInfo, "Starting client"},
+		{"warn no space", "WARN:slow consumer", slog.LevelWarn, "slow consumer"},
+		{"warn with space", "WARN: slow consumer", slog.LevelWarn, "slow consumer"},
+		{"error no space", "ERROR:stream failed", slog.LevelError, "stream failed"},
+		{"error with space", "ERROR: stream failed", slog.LevelError, "stream failed"},
+		{"no prefix defaults to info passthrough", "starting LaunchDarkly relay", slog.LevelInfo, "starting LaunchDarkly relay"},
+		{"empty defaults to info", "", slog.LevelInfo, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level, msg := parseLDLogPrefix(tt.input)
+			assert.Equal(t, tt.wantLevel, level)
+			assert.Equal(t, tt.wantMessage, msg)
+		})
+	}
+}
+
+// TestBridgeRoutesLDLogCallsThroughSlog drives an ldlog.Loggers built by
+// NewLDLogBridge with both Println-style (Debug/Info/Warn/Error) and
+// Printf-style (Debugf/Infof/Warnf/Errorf) calls. The captured slog records
+// must carry the right level and the LEVEL: prefix must be stripped from
+// the message.
+func TestBridgeRoutesLDLogCallsThroughSlog(t *testing.T) {
+	logger, h := logtest.NewMockLogger()
+	loggers := NewLDLogBridge(logger)
+
+	loggers.Debug("debug println")
+	loggers.Debugf("%s", "debug printf")
+	loggers.Info("info println")
+	loggers.Infof("%s", "info printf")
+	loggers.Warn("warn println")
+	loggers.Warnf("%s", "warn printf")
+	loggers.Error("error println")
+	loggers.Errorf("%s", "error printf")
+
+	entries := h.Entries()
+	require.Len(t, entries, 8)
+
+	expected := []struct {
+		level slog.Level
+		msg   string
+	}{
+		{slog.LevelDebug, "debug println"},
+		{slog.LevelDebug, "debug printf"},
+		{slog.LevelInfo, "info println"},
+		{slog.LevelInfo, "info printf"},
+		{slog.LevelWarn, "warn println"},
+		{slog.LevelWarn, "warn printf"},
+		{slog.LevelError, "error println"},
+		{slog.LevelError, "error printf"},
+	}
+	for i, want := range expected {
+		assert.Equal(t, want.level, entries[i].Level, "entry %d level", i)
+		assert.Equal(t, want.msg, entries[i].Message, "entry %d message", i)
+	}
+}
+
+// TestBridgeRespectsSlogLevelFilter is the regression guard for
+// https://github.com/launchdarkly/ld-relay/issues/670. With the slog handler
+// configured at Info, SDK Debug logs that come through the bridge must be
+// dropped -- not leak through as Info-level records with a "DEBUG:" prefix
+// still embedded in the message field.
+func TestBridgeRespectsSlogLevelFilter(t *testing.T) {
+	logger, h := logtest.NewMockLogger()
+	h.SetLevel(slog.LevelInfo)
+	loggers := NewLDLogBridge(logger)
+
+	loggers.Debug("querying Big Segment store metadata")
+	loggers.Info("starting LaunchDarkly client")
+
+	entries := h.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, slog.LevelInfo, entries[0].Level)
+	assert.Equal(t, "starting LaunchDarkly client", entries[0].Message)
+}


### PR DESCRIPTION
The ldlog -> slog bridge in internal/logging/bridge.go only matched level
prefixes with a trailing space ("DEBUG: ", "INFO: ", ...). That works for
ldlog's Printf path, which renders the format as `prefix + " " + format`,
but not for its Println path, which calls `baseLogger.Println(prefix, value)`
and lets fmt.Sprint join them -- fmt.Sprint inserts no separator between
two string operands, so the rendered message is e.g. "DEBUG:querying..."
with no space.

The result was that Println-routed SDK logs (e.g. the every-5-seconds
"querying Big Segment store metadata" trace from go-server-sdk) fell
through to the default branch: emitted at slog.LevelInfo with the
"DEBUG:" prefix still embedded in the message field, bypassing the
configured log-level filter.

Match the colon-terminated prefix and let TrimSpace handle whatever
follows. Add bridge_test.go covering both Println- and Printf-style
ldlog calls at each level, plus a regression guard that an Info-level
slog handler drops bridge-routed Debug records.

fixes #670

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to logging bridge parsing with targeted tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes the **ldlog → slog** bridge so SDK log lines routed through `Println` (no space after `LEVEL:`) are parsed to the correct `slog` level instead of defaulting to **Info** with a literal `DEBUG:` prefix still in the message.
> 
> `parseLDLogPrefix` now matches colon-terminated prefixes (`DEBUG:`, `INFO:`, …) and trims the remainder, covering both **Println** and **Printf** shapes. New tests in `bridge_test.go` exercise prefix parsing, end-to-end bridge routing, and the regression that an **Info**-level slog handler drops bridge-routed **Debug** records (fixes #670).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad67a17fd28457c959348bae951b6ce92e8119b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->