### PR TITLE
feat: Support multiple keys per environment

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -260,19 +260,21 @@ type DynamoDBConfig struct {
 // variables, individual fields are not documented here; instead, see the `README.md` section on
 // configuration.
 type EnvConfig struct {
-	SDKKey        SDKKey           // set from env var LD_ENV_envname
-	MobileKey     MobileKey        `conf:"LD_MOBILE_KEY_"`
-	EnvID         EnvironmentID    `conf:"LD_CLIENT_SIDE_ID_"`
-	Prefix        string           `conf:"LD_PREFIX_"`     // used only if Redis, Consul, or DynamoDB is enabled
-	TableName     string           `conf:"LD_TABLE_NAME_"` // used only if DynamoDB is enabled
-	AllowedOrigin ct.OptStringList `conf:"LD_ALLOWED_ORIGIN_"`
-	AllowedHeader ct.OptStringList `conf:"LD_ALLOWED_HEADER_"`
-	SecureMode    bool             `conf:"LD_SECURE_MODE_"`
-	LogLevel      OptLogLevel      `conf:"LD_LOG_LEVEL_"`
-	TTL           ct.OptDuration   `conf:"LD_TTL_"`
-	ProjKey       string           `conf:"LD_PROJ_KEY_"`
-	FilterKey     FilterKey        // injected based on [filters] section
-	Offline       bool             // set to true if this environment was created in offline mode
+	SDKKey               SDKKey           // set from env var LD_ENV_envname
+	MobileKey            MobileKey        `conf:"LD_MOBILE_KEY_"`
+	EnvID                EnvironmentID    `conf:"LD_CLIENT_SIDE_ID_"`
+	Prefix               string           `conf:"LD_PREFIX_"`     // used only if Redis, Consul, or DynamoDB is enabled
+	TableName            string           `conf:"LD_TABLE_NAME_"` // used only if DynamoDB is enabled
+	AllowedOrigin        ct.OptStringList `conf:"LD_ALLOWED_ORIGIN_"`
+	AllowedHeader        ct.OptStringList `conf:"LD_ALLOWED_HEADER_"`
+	AdditionalSDKKeys    ct.OptStringList `conf:"LD_ADDITIONAL_SDK_KEYS_"`
+	AdditionalMobileKeys ct.OptStringList `conf:"LD_ADDITIONAL_MOBILE_KEYS_"`
+	SecureMode           bool             `conf:"LD_SECURE_MODE_"`
+	LogLevel             OptLogLevel      `conf:"LD_LOG_LEVEL_"`
+	TTL                  ct.OptDuration   `conf:"LD_TTL_"`
+	ProjKey              string           `conf:"LD_PROJ_KEY_"`
+	FilterKey            FilterKey        // injected based on [filters] section
+	Offline              bool             // set to true if this environment was created in offline mode
 }
 
 type FiltersConfig struct {

--- a/config/config_validation.go
+++ b/config/config_validation.go
@@ -34,6 +34,18 @@ func errEnvironmentWithNoSDKKey(envName string) error {
 	return fmt.Errorf("SDK key is required for environment %q", envName)
 }
 
+func errAdditionalKeyEmpty(envName, fieldName string) error {
+	return fmt.Errorf("%s for environment %q contains an empty entry", fieldName, envName)
+}
+
+func errAdditionalKeyDuplicatesPrimary(envName, fieldName string) error {
+	return fmt.Errorf("%s for environment %q must not duplicate the primary key", fieldName, envName)
+}
+
+func errAdditionalKeyDuplicate(envName, fieldName string) error {
+	return fmt.Errorf("%s for environment %q contains duplicate entries", fieldName, envName)
+}
+
 func errMultipleDatabases(databases []string) error {
 	return fmt.Errorf("multiple databases are enabled (%s); only one is allowed", strings.Join(databases, ", "))
 }
@@ -147,6 +159,29 @@ func validateConfigEnvironments(result *ct.ValidationResult, c *Config) {
 		if envConfig.SDKKey == "" {
 			result.AddError(nil, errEnvironmentWithNoSDKKey(envName))
 		}
+		validateAdditionalKeyList(result, envName, "additionalSdkKeys",
+			envConfig.AdditionalSDKKeys.Values(), string(envConfig.SDKKey))
+		validateAdditionalKeyList(result, envName, "additionalMobileKeys",
+			envConfig.AdditionalMobileKeys.Values(), string(envConfig.MobileKey))
+	}
+}
+
+func validateAdditionalKeyList(result *ct.ValidationResult, envName, fieldName string, keys []string, primary string) {
+	seen := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		if k == "" {
+			result.AddError(nil, errAdditionalKeyEmpty(envName, fieldName))
+			continue
+		}
+		if primary != "" && k == primary {
+			result.AddError(nil, errAdditionalKeyDuplicatesPrimary(envName, fieldName))
+			continue
+		}
+		if _, dup := seen[k]; dup {
+			result.AddError(nil, errAdditionalKeyDuplicate(envName, fieldName))
+			continue
+		}
+		seen[k] = struct{}{}
 	}
 }
 

--- a/config/config_validation.go
+++ b/config/config_validation.go
@@ -46,6 +46,10 @@ func errAdditionalKeyDuplicate(envName, fieldName string) error {
 	return fmt.Errorf("%s for environment %q contains duplicate entries", fieldName, envName)
 }
 
+func errAdditionalKeysWithoutPrimary(envName, additionalFieldName, primaryFieldName string) error {
+	return fmt.Errorf("%s for environment %q requires a primary %s to be defined", additionalFieldName, envName, primaryFieldName)
+}
+
 func errMultipleDatabases(databases []string) error {
 	return fmt.Errorf("multiple databases are enabled (%s); only one is allowed", strings.Join(databases, ", "))
 }
@@ -161,6 +165,12 @@ func validateConfigEnvironments(result *ct.ValidationResult, c *Config) {
 		}
 		envConfig.AdditionalSDKKeys = trimAdditionalKeyList(envConfig.AdditionalSDKKeys)
 		envConfig.AdditionalMobileKeys = trimAdditionalKeyList(envConfig.AdditionalMobileKeys)
+		if len(envConfig.AdditionalSDKKeys.Values()) > 0 && envConfig.SDKKey == "" {
+			result.AddError(nil, errAdditionalKeysWithoutPrimary(envName, "additionalSdkKeys", "sdkKey"))
+		}
+		if len(envConfig.AdditionalMobileKeys.Values()) > 0 && !envConfig.MobileKey.Defined() {
+			result.AddError(nil, errAdditionalKeysWithoutPrimary(envName, "additionalMobileKeys", "mobileKey"))
+		}
 		validateAdditionalKeyList(result, envName, "additionalSdkKeys",
 			envConfig.AdditionalSDKKeys.Values(), string(envConfig.SDKKey))
 		validateAdditionalKeyList(result, envName, "additionalMobileKeys",

--- a/config/config_validation.go
+++ b/config/config_validation.go
@@ -159,11 +159,29 @@ func validateConfigEnvironments(result *ct.ValidationResult, c *Config) {
 		if envConfig.SDKKey == "" {
 			result.AddError(nil, errEnvironmentWithNoSDKKey(envName))
 		}
+		envConfig.AdditionalSDKKeys = trimAdditionalKeyList(envConfig.AdditionalSDKKeys)
+		envConfig.AdditionalMobileKeys = trimAdditionalKeyList(envConfig.AdditionalMobileKeys)
 		validateAdditionalKeyList(result, envName, "additionalSdkKeys",
 			envConfig.AdditionalSDKKeys.Values(), string(envConfig.SDKKey))
 		validateAdditionalKeyList(result, envName, "additionalMobileKeys",
 			envConfig.AdditionalMobileKeys.Values(), string(envConfig.MobileKey))
+		c.Environment[envName] = envConfig
 	}
+}
+
+// trimAdditionalKeyList canonicalizes a comma- or list-form of additional keys by trimming
+// leading and trailing whitespace from each entry. Entries that are empty or whitespace-only
+// after trimming are preserved so the subsequent validator can report them.
+func trimAdditionalKeyList(list ct.OptStringList) ct.OptStringList {
+	if !list.IsDefined() {
+		return list
+	}
+	values := list.Values()
+	trimmed := make([]string, len(values))
+	for i, v := range values {
+		trimmed[i] = strings.TrimSpace(v)
+	}
+	return ct.NewOptStringList(trimmed)
 }
 
 func validateAdditionalKeyList(result *ct.ValidationResult, envName, fieldName string, keys []string, primary string) {

--- a/config/test_data_configs_invalid_test.go
+++ b/config/test_data_configs_invalid_test.go
@@ -47,7 +47,24 @@ func makeInvalidConfigs() []testDataInvalidConfig {
 		makeInvalidConfigAdditionalMobileKeyDuplicatesPrimary(),
 		makeInvalidConfigAdditionalSDKKeyDuplicates(),
 		makeInvalidConfigAdditionalMobileKeyDuplicates(),
+		makeInvalidConfigAdditionalMobileKeysWithoutPrimary(),
 	}
+}
+
+func makeInvalidConfigAdditionalMobileKeysWithoutPrimary() testDataInvalidConfig {
+	c := testDataInvalidConfig{name: "additional mobile keys without primary mobile key"}
+	c.envVarsError = errAdditionalKeysWithoutPrimary("envname", "additionalMobileKeys", "mobileKey").Error()
+	c.envVars = map[string]string{
+		"LD_ENV_envname":                    "sdk-primary",
+		"LD_ADDITIONAL_MOBILE_KEYS_envname": "mob-extra",
+	}
+	c.fileContent = `
+[Environment "envname"]
+SdkKey = sdk-primary
+AdditionalMobileKeys = mob-extra
+`
+	c.fileError = c.envVarsError
+	return c
 }
 
 func makeInvalidConfigAdditionalSDKKeyDuplicatesPrimary() testDataInvalidConfig {

--- a/config/test_data_configs_invalid_test.go
+++ b/config/test_data_configs_invalid_test.go
@@ -43,7 +43,82 @@ func makeInvalidConfigs() []testDataInvalidConfig {
 		makeInvalidConfigDynamoDBNoPrefixOrTableName(),
 		makeInvalidConfigDynamoDBAutoConfNoPrefixOrTableName(),
 		makeInvalidConfigMultipleDatabases(),
+		makeInvalidConfigAdditionalSDKKeyDuplicatesPrimary(),
+		makeInvalidConfigAdditionalMobileKeyDuplicatesPrimary(),
+		makeInvalidConfigAdditionalSDKKeyDuplicates(),
+		makeInvalidConfigAdditionalMobileKeyDuplicates(),
 	}
+}
+
+func makeInvalidConfigAdditionalSDKKeyDuplicatesPrimary() testDataInvalidConfig {
+	c := testDataInvalidConfig{name: "additional SDK key duplicates primary"}
+	c.envVarsError = errAdditionalKeyDuplicatesPrimary("envname", "additionalSdkKeys").Error()
+	c.envVars = map[string]string{
+		"LD_ENV_envname":                 "sdk-key",
+		"LD_ADDITIONAL_SDK_KEYS_envname": "sdk-key,other-key",
+	}
+	c.fileContent = `
+[Environment "envname"]
+SdkKey = sdk-key
+AdditionalSdkKeys = sdk-key
+AdditionalSdkKeys = other-key
+`
+	c.fileError = c.envVarsError
+	return c
+}
+
+func makeInvalidConfigAdditionalMobileKeyDuplicatesPrimary() testDataInvalidConfig {
+	c := testDataInvalidConfig{name: "additional mobile key duplicates primary"}
+	c.envVarsError = errAdditionalKeyDuplicatesPrimary("envname", "additionalMobileKeys").Error()
+	c.envVars = map[string]string{
+		"LD_ENV_envname":                    "sdk-key",
+		"LD_MOBILE_KEY_envname":             "mob-key",
+		"LD_ADDITIONAL_MOBILE_KEYS_envname": "mob-key",
+	}
+	c.fileContent = `
+[Environment "envname"]
+SdkKey = sdk-key
+MobileKey = mob-key
+AdditionalMobileKeys = mob-key
+`
+	c.fileError = c.envVarsError
+	return c
+}
+
+func makeInvalidConfigAdditionalSDKKeyDuplicates() testDataInvalidConfig {
+	c := testDataInvalidConfig{name: "additional SDK keys contain duplicate"}
+	c.envVarsError = errAdditionalKeyDuplicate("envname", "additionalSdkKeys").Error()
+	c.envVars = map[string]string{
+		"LD_ENV_envname":                 "sdk-primary",
+		"LD_ADDITIONAL_SDK_KEYS_envname": "sdk-extra,sdk-extra",
+	}
+	c.fileContent = `
+[Environment "envname"]
+SdkKey = sdk-primary
+AdditionalSdkKeys = sdk-extra
+AdditionalSdkKeys = sdk-extra
+`
+	c.fileError = c.envVarsError
+	return c
+}
+
+func makeInvalidConfigAdditionalMobileKeyDuplicates() testDataInvalidConfig {
+	c := testDataInvalidConfig{name: "additional mobile keys contain duplicate"}
+	c.envVarsError = errAdditionalKeyDuplicate("envname", "additionalMobileKeys").Error()
+	c.envVars = map[string]string{
+		"LD_ENV_envname":                    "sdk-primary",
+		"LD_MOBILE_KEY_envname":             "mob-primary",
+		"LD_ADDITIONAL_MOBILE_KEYS_envname": "mob-extra,mob-extra",
+	}
+	c.fileContent = `
+[Environment "envname"]
+SdkKey = sdk-primary
+MobileKey = mob-primary
+AdditionalMobileKeys = mob-extra
+AdditionalMobileKeys = mob-extra
+`
+	c.fileError = c.envVarsError
+	return c
 }
 
 func makeInvalidConfigMissingSDKKey() testDataInvalidConfig {

--- a/config/test_data_configs_valid_test.go
+++ b/config/test_data_configs_valid_test.go
@@ -94,7 +94,37 @@ func makeValidConfigs() []testDataValidConfig {
 		makeValidConfigPrometheusMinimal(),
 		makeValidConfigPrometheusAll(),
 		makeValidConfigProxy(),
+		makeValidConfigAdditionalKeys(),
 	}
+}
+
+func makeValidConfigAdditionalKeys() testDataValidConfig {
+	c := testDataValidConfig{name: "environment with additional SDK and mobile keys"}
+	c.makeConfig = func(c *Config) {
+		c.Environment = map[string]*EnvConfig{
+			"earth": {
+				SDKKey:               "earth-sdk",
+				MobileKey:            "earth-mob",
+				AdditionalSDKKeys:    ct.NewOptStringList([]string{"earth-sdk-2", "earth-sdk-3"}),
+				AdditionalMobileKeys: ct.NewOptStringList([]string{"earth-mob-2"}),
+			},
+		}
+	}
+	c.envVars = map[string]string{
+		"LD_ENV_earth":                    "earth-sdk",
+		"LD_MOBILE_KEY_earth":             "earth-mob",
+		"LD_ADDITIONAL_SDK_KEYS_earth":    "earth-sdk-2,earth-sdk-3",
+		"LD_ADDITIONAL_MOBILE_KEYS_earth": "earth-mob-2",
+	}
+	c.fileContent = `
+[Environment "earth"]
+SdkKey = "earth-sdk"
+MobileKey = "earth-mob"
+AdditionalSdkKeys = earth-sdk-2
+AdditionalSdkKeys = earth-sdk-3
+AdditionalMobileKeys = earth-mob-2
+`
+	return c
 }
 
 func makeValidConfigAllBaseProperties() testDataValidConfig {

--- a/config/test_data_configs_valid_test.go
+++ b/config/test_data_configs_valid_test.go
@@ -110,11 +110,13 @@ func makeValidConfigAdditionalKeys() testDataValidConfig {
 			},
 		}
 	}
+	// Include whitespace around the comma-separated entries to exercise the trim canonicalization
+	// performed by ValidateConfig. The expected config above has the trimmed values.
 	c.envVars = map[string]string{
 		"LD_ENV_earth":                    "earth-sdk",
 		"LD_MOBILE_KEY_earth":             "earth-mob",
-		"LD_ADDITIONAL_SDK_KEYS_earth":    "earth-sdk-2,earth-sdk-3",
-		"LD_ADDITIONAL_MOBILE_KEYS_earth": "earth-mob-2",
+		"LD_ADDITIONAL_SDK_KEYS_earth":    "earth-sdk-2, earth-sdk-3",
+		"LD_ADDITIONAL_MOBILE_KEYS_earth": " earth-mob-2 ",
 	}
 	c.fileContent = `
 [Environment "earth"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,8 +139,10 @@ The Relay Proxy allows you to proxy any number of LaunchDarkly environments; the
 
 | Property in file | Environment var               |   Type   | Description                                                                                                                                                                                                                                  |
 |------------------|-------------------------------|:--------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `sdkKey`         | `LD_ENV_MyEnvName`            |  String  | Server-side SDK key for the environment. Required.                                                                                                                                                                                           |
-| `mobileKey`      | `LD_MOBILE_KEY_MyEnvName`     |  String  | Mobile key for the environment. Required if you are proxying mobile SDK functionality.                                                                                                                                                       |
+| `sdkKey`               | `LD_ENV_MyEnvName`                     |  String  | Server-side SDK key for the environment. Required.                                                                                                                                                                                           |
+| `mobileKey`            | `LD_MOBILE_KEY_MyEnvName`              |  String  | Mobile key for the environment. Required if you are proxying mobile SDK functionality.                                                                                                                                                       |
+| `additionalSdkKeys`    | `LD_ADDITIONAL_SDK_KEYS_MyEnvName`     |  String  | Additional concurrent server-side SDK keys for this environment. Each key authenticates to the same environment as `sdkKey`. Can be repeated in the file or supplied as a comma-delimited list in the env var.                               |
+| `additionalMobileKeys` | `LD_ADDITIONAL_MOBILE_KEYS_MyEnvName`  |  String  | Additional concurrent mobile keys for this environment. Same semantics as `additionalSdkKeys`.                                                                                                                                               |
 | `envId`          | `LD_CLIENT_SIDE_ID_MyEnvName` |  String  | Client-side ID for the environment. Required if you are proxying client-side JavaScript-based SDK functionality.                                                                                                                             |
 | `secureMode`     | `LD_SECURE_MODE_MyEnvName`    | Boolean  | True if [secure mode](https://docs.launchdarkly.com/sdk/client-side/javascript#secure-mode) should be required for client-side JS SDK connections.                                                                                           |
 | `prefix`         | `LD_PREFIX_MyEnvName`         |  String  | If using a Redis, Consul, or DynamoDB feature store, this string will be added to all database keys to distinguish them from any other environments that are using the database.                                                             |
@@ -174,6 +176,30 @@ LD_MOBILE_KEY_Spree_Project_Production=SPREE_PROD_MOBILE_KEY
 LD_ENV_Spree_Project_Test=SPREE_TEST_SDK_KEY
 LD_MOBILE_KEY_Spree_Project_Test=SPREE_TEST_MOBILE_KEY
 ```
+
+To support concurrent SDK or mobile keys -- for example, while migrating SDK consumers off a leaked key without an outage -- list additional keys for an environment:
+
+```
+# Configuration file example
+
+[Environment "Spree Project Production"]
+    sdkKey = "SPREE_PROD_SDK_KEY"
+    mobileKey = "SPREE_PROD_MOBILE_KEY"
+    additionalSdkKeys = "SPREE_PROD_SDK_KEY_BACKUP_1"
+    additionalSdkKeys = "SPREE_PROD_SDK_KEY_BACKUP_2"
+    additionalMobileKeys = "SPREE_PROD_MOBILE_KEY_BACKUP"
+```
+
+```
+# Environment variables example
+
+LD_ENV_Spree_Project_Production=SPREE_PROD_SDK_KEY
+LD_MOBILE_KEY_Spree_Project_Production=SPREE_PROD_MOBILE_KEY
+LD_ADDITIONAL_SDK_KEYS_Spree_Project_Production=SPREE_PROD_SDK_KEY_BACKUP_1,SPREE_PROD_SDK_KEY_BACKUP_2
+LD_ADDITIONAL_MOBILE_KEYS_Spree_Project_Production=SPREE_PROD_MOBILE_KEY_BACKUP
+```
+
+Additional keys cannot duplicate the primary `sdkKey` / `mobileKey`, and the same key cannot appear twice within a list. Only the primary key opens an upstream connection to LaunchDarkly; the additional keys are accepted for inbound SDK authentication only.
 
 ### File section: `[Filters "PROJECT-KEY"]`
 

--- a/internal/api/status_reps.go
+++ b/internal/api/status_reps.go
@@ -19,18 +19,20 @@ type StatusRep struct {
 //
 // This is exported for use in integration test code.
 type EnvironmentStatusRep struct {
-	SDKKey           string               `json:"sdkKey"`
-	EnvID            string               `json:"envId,omitempty"`
-	EnvKey           string               `json:"envKey,omitempty"`
-	EnvName          string               `json:"envName,omitempty"`
-	ProjKey          string               `json:"projKey,omitempty"`
-	ProjName         string               `json:"projName,omitempty"`
-	MobileKey        string               `json:"mobileKey,omitempty"`
-	ExpiringSDKKey   string               `json:"expiringSdkKey,omitempty"`
-	Status           string               `json:"status"`
-	ConnectionStatus ConnectionStatusRep  `json:"connectionStatus"`
-	DataStoreStatus  DataStoreStatusRep   `json:"dataStoreStatus"`
-	BigSegmentStatus *BigSegmentStatusRep `json:"bigSegmentStatus,omitempty"`
+	SDKKey               string               `json:"sdkKey"`
+	EnvID                string               `json:"envId,omitempty"`
+	EnvKey               string               `json:"envKey,omitempty"`
+	EnvName              string               `json:"envName,omitempty"`
+	ProjKey              string               `json:"projKey,omitempty"`
+	ProjName             string               `json:"projName,omitempty"`
+	MobileKey            string               `json:"mobileKey,omitempty"`
+	ExpiringSDKKey       string               `json:"expiringSdkKey,omitempty"`
+	AdditionalSDKKeys    []string             `json:"additionalSdkKeys,omitempty"`
+	AdditionalMobileKeys []string             `json:"additionalMobileKeys,omitempty"`
+	Status               string               `json:"status"`
+	ConnectionStatus     ConnectionStatusRep  `json:"connectionStatus"`
+	DataStoreStatus      DataStoreStatusRep   `json:"dataStoreStatus"`
+	BigSegmentStatus     *BigSegmentStatusRep `json:"bigSegmentStatus,omitempty"`
 }
 
 // BigSegmentStatusRep is the big segment status representation returned by the status endpoint.

--- a/internal/api/status_reps.go
+++ b/internal/api/status_reps.go
@@ -27,6 +27,9 @@ type EnvironmentStatusRep struct {
 	ProjName             string               `json:"projName,omitempty"`
 	MobileKey            string               `json:"mobileKey,omitempty"`
 	ExpiringSDKKey       string               `json:"expiringSdkKey,omitempty"`
+	ExpiringMobileKey    string               `json:"expiringMobileKey,omitempty"`
+	ExpiringSDKKeys      []string             `json:"expiringSdkKeys,omitempty"`
+	ExpiringMobileKeys   []string             `json:"expiringMobileKeys,omitempty"`
 	AdditionalSDKKeys    []string             `json:"additionalSdkKeys,omitempty"`
 	AdditionalMobileKeys []string             `json:"additionalMobileKeys,omitempty"`
 	Status               string               `json:"status"`

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -467,6 +467,11 @@ func (r *Rotator) RotateMobileKeyWithGrace(primary config.MobileKey, grace *Mobi
 	}
 
 	r.loggers.Infof("Mobile key %s was marked for deprecation with an expiry at %v", grace.key.Masked(), grace.expiry)
+	// See the matching comment in updateSDKKey -- if the deprecated key was previously tracked as
+	// an additional mobile key, move it into the rotation-grace map so a later SetAdditional patch
+	// cannot revoke it and no phantom entry remains after expiry.
+	delete(r.additionalMobileKeys, grace.key)
+	delete(r.expiringAdditionalMobileKeys, grace.key)
 	r.deprecatedMobileKeys[grace.key] = grace.expiry
 
 	if grace.key != previous {
@@ -664,6 +669,13 @@ func (r *Rotator) updateSDKKey(sdkKey config.SDKKey, grace *GracePeriod) {
 	}
 
 	r.loggers.Infof("SDK key %s was marked for deprecation with an expiry at %v", grace.key.Masked(), grace.expiry)
+	// If the deprecated key was previously tracked as an additional key (active or expiring), move
+	// it into the rotation-grace map. Leaving the entry in the additional maps would (1) let a
+	// later SetAdditional patch's cleanup-loop revoke the key while the rotation grace still wants
+	// it alive, and (2) leave a phantom entry behind after the grace expires that ActiveSDKKeys
+	// would keep reporting forever.
+	delete(r.additionalSdkKeys, grace.key)
+	delete(r.expiringAdditionalSdkKeys, grace.key)
 	r.deprecatedSdkKeys[grace.key] = grace.expiry
 
 	if grace.key != previous {

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -211,14 +211,32 @@ func (r *Rotator) SetAdditionalSDKKeys(active []config.SDKKey, expiring map[conf
 
 	nextActive := make(map[config.SDKKey]struct{}, len(active))
 	for _, k := range active {
-		if !k.Defined() || k == r.primarySdkKey {
+		if !k.Defined() {
+			continue
+		}
+		if k == r.primarySdkKey {
+			r.loggers.Warnf("Primary SDK key %s appeared in additional-key list; ignoring", k.Masked())
+			continue
+		}
+		if _, ok := r.deprecatedSdkKeys[k]; ok {
+			// This key is already being managed as a rotation predecessor with its own grace
+			// timer. Leave that flow in charge of its lifecycle.
+			r.loggers.Warnf("SDK key %s is already in a rotation grace period; ignoring its appearance in additional-key list", k.Masked())
 			continue
 		}
 		nextActive[k] = struct{}{}
 	}
 	nextExpiring := make(map[config.SDKKey]time.Time, len(expiring))
 	for k, t := range expiring {
-		if !k.Defined() || k == r.primarySdkKey {
+		if !k.Defined() {
+			continue
+		}
+		if k == r.primarySdkKey {
+			r.loggers.Warnf("Primary SDK key %s appeared in additional-key list with an expiry; ignoring (primary-key expiry must be communicated via the Expiring slot in a rotation)", k.Masked())
+			continue
+		}
+		if _, ok := r.deprecatedSdkKeys[k]; ok {
+			r.loggers.Warnf("SDK key %s is already in a rotation grace period; ignoring its appearance in additional-key list", k.Masked())
 			continue
 		}
 		// If the same key shows up in both sets, treat the expiring entry as authoritative -- the
@@ -502,14 +520,30 @@ func (r *Rotator) SetAdditionalMobileKeys(active []config.MobileKey, expiring ma
 
 	nextActive := make(map[config.MobileKey]struct{}, len(active))
 	for _, k := range active {
-		if !k.Defined() || k == r.primaryMobileKey {
+		if !k.Defined() {
+			continue
+		}
+		if k == r.primaryMobileKey {
+			r.loggers.Warnf("Primary mobile key %s appeared in additional-key list; ignoring", k.Masked())
+			continue
+		}
+		if _, ok := r.deprecatedMobileKeys[k]; ok {
+			r.loggers.Warnf("Mobile key %s is already in a rotation grace period; ignoring its appearance in additional-key list", k.Masked())
 			continue
 		}
 		nextActive[k] = struct{}{}
 	}
 	nextExpiring := make(map[config.MobileKey]time.Time, len(expiring))
 	for k, t := range expiring {
-		if !k.Defined() || k == r.primaryMobileKey {
+		if !k.Defined() {
+			continue
+		}
+		if k == r.primaryMobileKey {
+			r.loggers.Warnf("Primary mobile key %s appeared in additional-key list with an expiry; ignoring (primary-key expiry must be communicated via the Expiring slot in a rotation)", k.Masked())
+			continue
+		}
+		if _, ok := r.deprecatedMobileKeys[k]; ok {
+			r.loggers.Warnf("Mobile key %s is already in a rotation grace period; ignoring its appearance in additional-key list", k.Masked())
 			continue
 		}
 		delete(nextActive, k)

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -112,6 +112,37 @@ func (r *Rotator) SeedAdditionalMobileKeys(keys []config.MobileKey) {
 	}
 }
 
+// SeedExpiringAdditionalSDKKeys populates the expiring additional SDK key map during initial
+// construction. Like SeedAdditionalSDKKeys, this does NOT queue additions; the caller is
+// responsible for the initial credential registration via the AllCredentials iteration in
+// NewEnvContext.
+func (r *Rotator) SeedExpiringAdditionalSDKKeys(expiring map[config.SDKKey]time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for k, t := range expiring {
+		if !k.Defined() || k == r.primarySdkKey {
+			continue
+		}
+		// Defensive: if the caller seeded the same key as active, the expiring entry wins (the
+		// platform attached an expiry to it).
+		delete(r.additionalSdkKeys, k)
+		r.expiringAdditionalSdkKeys[k] = t
+	}
+}
+
+// SeedExpiringAdditionalMobileKeys is the mobile-key analog of SeedExpiringAdditionalSDKKeys.
+func (r *Rotator) SeedExpiringAdditionalMobileKeys(expiring map[config.MobileKey]time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for k, t := range expiring {
+		if !k.Defined() || k == r.primaryMobileKey {
+			continue
+		}
+		delete(r.additionalMobileKeys, k)
+		r.expiringAdditionalMobileKeys[k] = t
+	}
+}
+
 // IsSDKKeyRotationPredecessor reports whether the given SDK key is the previous primary that is
 // currently in its rotation grace period. Used by callers (e.g. envContextImpl) that need to give
 // rotation-predecessor keys the same treatment as the primary -- specifically, keeping their

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -112,6 +112,26 @@ func (r *Rotator) SeedAdditionalMobileKeys(keys []config.MobileKey) {
 	}
 }
 
+// IsSDKKeyRotationPredecessor reports whether the given SDK key is the previous primary that is
+// currently in its rotation grace period. Used by callers (e.g. envContextImpl) that need to give
+// rotation-predecessor keys the same treatment as the primary -- specifically, keeping their
+// upstream SDK client alive during the grace window. Returns false for additional SDK keys (which
+// are auth-only and never had an upstream client).
+func (r *Rotator) IsSDKKeyRotationPredecessor(key config.SDKKey) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.deprecatedSdkKeys[key]
+	return ok
+}
+
+// IsMobileKeyRotationPredecessor is the mobile-key analog of IsSDKKeyRotationPredecessor.
+func (r *Rotator) IsMobileKeyRotationPredecessor(key config.MobileKey) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.deprecatedMobileKeys[key]
+	return ok
+}
+
 // MobileKey returns the primary mobile key.
 func (r *Rotator) MobileKey() config.MobileKey {
 	r.mu.RLock()

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -153,6 +153,53 @@ func (r *Rotator) EnvironmentID() config.EnvironmentID {
 	return r.primaryEnvironmentID
 }
 
+// CredentialSnapshot captures the full credential state of the rotator at a single point in time,
+// partitioned by kind. Callers that need an internally-consistent view (e.g., the /status
+// endpoint deciding which credentials are primary vs additional vs deprecated) should use
+// Snapshot rather than chaining multiple per-attribute accessors.
+type CredentialSnapshot struct {
+	PrimarySDKKey        config.SDKKey
+	PrimaryMobileKey     config.MobileKey
+	PrimaryEnvironmentID config.EnvironmentID
+	AdditionalSDKKeys    []config.SDKKey
+	AdditionalMobileKeys []config.MobileKey
+	DeprecatedSDKKeys    []config.SDKKey
+	DeprecatedMobileKeys []config.MobileKey
+}
+
+// Snapshot returns the rotator's full credential state under a single RLock so the returned
+// partitioning is internally consistent (no concurrent rotation can move a key between the
+// primary slot and an additional or deprecated slot mid-read).
+func (r *Rotator) Snapshot() CredentialSnapshot {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	snap := CredentialSnapshot{
+		PrimarySDKKey:        r.primarySdkKey,
+		PrimaryMobileKey:     r.primaryMobileKey,
+		PrimaryEnvironmentID: r.primaryEnvironmentID,
+	}
+	for k := range r.additionalSdkKeys {
+		snap.AdditionalSDKKeys = append(snap.AdditionalSDKKeys, k)
+	}
+	for k := range r.additionalMobileKeys {
+		snap.AdditionalMobileKeys = append(snap.AdditionalMobileKeys, k)
+	}
+	for k := range r.deprecatedSdkKeys {
+		snap.DeprecatedSDKKeys = append(snap.DeprecatedSDKKeys, k)
+	}
+	for k := range r.expiringAdditionalSdkKeys {
+		snap.DeprecatedSDKKeys = append(snap.DeprecatedSDKKeys, k)
+	}
+	for k := range r.deprecatedMobileKeys {
+		snap.DeprecatedMobileKeys = append(snap.DeprecatedMobileKeys, k)
+	}
+	for k := range r.expiringAdditionalMobileKeys {
+		snap.DeprecatedMobileKeys = append(snap.DeprecatedMobileKeys, k)
+	}
+	return snap
+}
+
 // PrimaryCredentials returns the primary (non-deprecated) credentials.
 func (r *Rotator) PrimaryCredentials() []SDKCredential {
 	r.mu.RLock()

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -87,6 +87,31 @@ func (r *Rotator) Initialize(credentials []SDKCredential) {
 	}
 }
 
+// SeedAdditionalSDKKeys populates the additional SDK key set during initial construction. Unlike
+// SetAdditionalSDKKeys, this does NOT queue additions; the caller is responsible for the initial
+// credential registration (e.g. via PrimaryCredentials feeding into the stream / lookup
+// initialization in NewEnvContext).
+func (r *Rotator) SeedAdditionalSDKKeys(keys []config.SDKKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, k := range keys {
+		if k.Defined() && k != r.primarySdkKey {
+			r.additionalSdkKeys[k] = struct{}{}
+		}
+	}
+}
+
+// SeedAdditionalMobileKeys is the mobile-key analog of SeedAdditionalSDKKeys.
+func (r *Rotator) SeedAdditionalMobileKeys(keys []config.MobileKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, k := range keys {
+		if k.Defined() && k != r.primaryMobileKey {
+			r.additionalMobileKeys[k] = struct{}{}
+		}
+	}
+}
+
 // MobileKey returns the primary mobile key.
 func (r *Rotator) MobileKey() config.MobileKey {
 	r.mu.RLock()

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -12,9 +12,6 @@ import (
 type Rotator struct {
 	loggers ldlog.Loggers
 
-	// There is only one mobile key active at a given time; it does not support a deprecation period.
-	primaryMobileKey config.MobileKey
-
 	// There is only one environment ID active at a given time, and it won't actually be rotated. The mechanism is
 	// here to allow setting it in a deferred manner.
 	primaryEnvironmentID config.EnvironmentID
@@ -36,6 +33,12 @@ type Rotator struct {
 	// expiration, entries are removed. This map is owned by the RotateWithGrace path.
 	deprecatedSdkKeys map[config.SDKKey]time.Time
 
+	// Mobile key state mirrors the SDK key state above.
+	primaryMobileKey             config.MobileKey
+	additionalMobileKeys         map[config.MobileKey]struct{}
+	expiringAdditionalMobileKeys map[config.MobileKey]time.Time
+	deprecatedMobileKeys         map[config.MobileKey]time.Time
+
 	expirations []SDKCredential
 	additions   []SDKCredential
 
@@ -52,10 +55,13 @@ type InitialCredentials struct {
 // contains no credentials and can optionally be initialized via Initialize.
 func NewRotator(loggers ldlog.Loggers) *Rotator {
 	r := &Rotator{
-		loggers:                   loggers,
-		additionalSdkKeys:         make(map[config.SDKKey]struct{}),
-		expiringAdditionalSdkKeys: make(map[config.SDKKey]time.Time),
-		deprecatedSdkKeys:         make(map[config.SDKKey]time.Time),
+		loggers:                      loggers,
+		additionalSdkKeys:            make(map[config.SDKKey]struct{}),
+		expiringAdditionalSdkKeys:    make(map[config.SDKKey]time.Time),
+		deprecatedSdkKeys:            make(map[config.SDKKey]time.Time),
+		additionalMobileKeys:         make(map[config.MobileKey]struct{}),
+		expiringAdditionalMobileKeys: make(map[config.MobileKey]time.Time),
+		deprecatedMobileKeys:         make(map[config.MobileKey]time.Time),
 	}
 	return r
 }
@@ -118,6 +124,9 @@ func (r *Rotator) primaryCredentials() []SDKCredential {
 		return !cred.Defined()
 	})
 	for key := range r.additionalSdkKeys {
+		creds = append(creds, key)
+	}
+	for key := range r.additionalMobileKeys {
 		creds = append(creds, key)
 	}
 	return creds
@@ -233,11 +242,19 @@ func (r *Rotator) SetAdditionalSDKKeys(active []config.SDKKey, expiring map[conf
 }
 
 func (r *Rotator) deprecatedCredentials() []SDKCredential {
-	deprecated := make([]SDKCredential, 0, len(r.deprecatedSdkKeys)+len(r.expiringAdditionalSdkKeys))
+	total := len(r.deprecatedSdkKeys) + len(r.expiringAdditionalSdkKeys) +
+		len(r.deprecatedMobileKeys) + len(r.expiringAdditionalMobileKeys)
+	deprecated := make([]SDKCredential, 0, total)
 	for key := range r.deprecatedSdkKeys {
 		deprecated = append(deprecated, key)
 	}
 	for key := range r.expiringAdditionalSdkKeys {
+		deprecated = append(deprecated, key)
+	}
+	for key := range r.deprecatedMobileKeys {
+		deprecated = append(deprecated, key)
+	}
+	for key := range r.expiringAdditionalMobileKeys {
 		deprecated = append(deprecated, key)
 	}
 	return deprecated
@@ -328,14 +345,179 @@ func (r *Rotator) updateMobileKey(mobileKey config.MobileKey) {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	previous := r.primaryMobileKey
-	r.primaryMobileKey = mobileKey
-	r.additions = append(r.additions, mobileKey)
+	previous := r.swapPrimaryMobileKey(mobileKey)
 	if previous.Defined() {
 		r.expirations = append(r.expirations, previous)
-		r.loggers.Infof("Mobile key %s was rotated, new primary mobile key is %s", previous.Masked(), mobileKey.Masked())
+		r.loggers.Infof("Mobile key %s has been immediately revoked", previous.Masked())
+	}
+}
+
+// MobileGracePeriod represents a grace period within which a particular mobile key is still valid,
+// pending revocation. Parallel to GracePeriod for SDK keys.
+type MobileGracePeriod struct {
+	key    config.MobileKey
+	expiry time.Time
+	now    time.Time
+}
+
+// Expired reports whether the key has already expired.
+func (g *MobileGracePeriod) Expired() bool {
+	return g.now.After(g.expiry)
+}
+
+// NewMobileGracePeriod constructs a new grace period for a mobile key being deprecated. The current
+// time must be provided in order to determine if the credential is already expired.
+func NewMobileGracePeriod(key config.MobileKey, expiry time.Time, now time.Time) *MobileGracePeriod {
+	return &MobileGracePeriod{key, expiry, now}
+}
+
+// RotateMobileKeyWithGrace sets a new primary mobile key, optionally deprecating the previous
+// primary with a grace period. Pass grace == nil for immediate revocation of the predecessor.
+func (r *Rotator) RotateMobileKeyWithGrace(primary config.MobileKey, grace *MobileGracePeriod) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	previous := r.swapPrimaryMobileKey(primary)
+
+	if grace == nil {
+		if previous.Defined() {
+			r.expirations = append(r.expirations, previous)
+			r.loggers.Infof("Mobile key %s has been immediately revoked", previous.Masked())
+		}
+		return
+	}
+
+	if previousExpiry, ok := r.deprecatedMobileKeys[grace.key]; ok {
+		if previousExpiry != grace.expiry {
+			r.loggers.Warnf("Mobile key %s was marked for deprecation with an expiry at %v, but it was previously deprecated with an expiry at %v. The previous expiry will be used.", grace.key.Masked(), grace.expiry, previousExpiry)
+		}
+		if previous.Defined() {
+			r.expirations = append(r.expirations, previous)
+			r.loggers.Infof("Mobile key %s has been immediately revoked", previous.Masked())
+		}
+		return
+	}
+
+	if grace.Expired() {
+		r.loggers.Infof("Deprecated mobile key %s already expired at %v; ignoring", grace.key.Masked(), grace.expiry)
+		return
+	}
+
+	r.loggers.Infof("Mobile key %s was marked for deprecation with an expiry at %v", grace.key.Masked(), grace.expiry)
+	r.deprecatedMobileKeys[grace.key] = grace.expiry
+
+	if grace.key != previous {
+		r.loggers.Infof("Deprecated mobile key %s was not previously managed by Relay", grace.key.Masked())
+		r.additions = append(r.additions, grace.key)
+	}
+}
+
+func (r *Rotator) swapPrimaryMobileKey(newKey config.MobileKey) config.MobileKey {
+	if newKey == r.primaryMobileKey {
+		return ""
+	}
+	previous := r.primaryMobileKey
+	r.primaryMobileKey = newKey
+	r.additions = append(r.additions, newKey)
+	if previous.Defined() {
+		r.loggers.Infof("Mobile key %s was rotated, new primary mobile key is %s", previous.Masked(), newKey.Masked())
 	} else {
-		r.loggers.Infof("New primary mobile key is %s", mobileKey.Masked())
+		r.loggers.Infof("New primary mobile key is %s", newKey.Masked())
+	}
+	return previous
+}
+
+// ActiveMobileKeys returns the primary mobile key plus all additional non-deprecated mobile keys.
+func (r *Rotator) ActiveMobileKeys() []config.MobileKey {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	keys := make([]config.MobileKey, 0, 1+len(r.additionalMobileKeys))
+	if r.primaryMobileKey.Defined() {
+		keys = append(keys, r.primaryMobileKey)
+	}
+	for k := range r.additionalMobileKeys {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// SetAdditionalMobileKeys synchronizes the set of concurrent mobile keys for this environment.
+// Semantics mirror SetAdditionalSDKKeys: keys new to active/expiring are queued as additions;
+// transitions between active and expiring leave the key mapped; updated ExpiresAt timestamps are
+// accepted as authoritative; omitted keys are revoked immediately without grace.
+//
+// The primary mobile key is filtered out of the additional set defensively. This method does not
+// touch deprecatedMobileKeys, which is owned by the RotateMobileKeyWithGrace path.
+func (r *Rotator) SetAdditionalMobileKeys(active []config.MobileKey, expiring map[config.MobileKey]time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	nextActive := make(map[config.MobileKey]struct{}, len(active))
+	for _, k := range active {
+		if !k.Defined() || k == r.primaryMobileKey {
+			continue
+		}
+		nextActive[k] = struct{}{}
+	}
+	nextExpiring := make(map[config.MobileKey]time.Time, len(expiring))
+	for k, t := range expiring {
+		if !k.Defined() || k == r.primaryMobileKey {
+			continue
+		}
+		delete(nextActive, k)
+		nextExpiring[k] = t
+	}
+
+	current := make(map[config.MobileKey]struct{})
+	for k := range r.additionalMobileKeys {
+		current[k] = struct{}{}
+	}
+	for k := range r.expiringAdditionalMobileKeys {
+		current[k] = struct{}{}
+	}
+
+	for k := range nextActive {
+		_, wasAdditional := r.additionalMobileKeys[k]
+		_, wasExpiring := r.expiringAdditionalMobileKeys[k]
+		switch {
+		case wasAdditional:
+		case wasExpiring:
+			delete(r.expiringAdditionalMobileKeys, k)
+			r.additionalMobileKeys[k] = struct{}{}
+		default:
+			r.additionalMobileKeys[k] = struct{}{}
+			r.additions = append(r.additions, k)
+			r.loggers.Infof("Additional mobile key %s is now active", k.Masked())
+		}
+		delete(current, k)
+	}
+
+	for k, t := range nextExpiring {
+		_, wasAdditional := r.additionalMobileKeys[k]
+		previousExpiry, wasExpiring := r.expiringAdditionalMobileKeys[k]
+		switch {
+		case wasAdditional:
+			delete(r.additionalMobileKeys, k)
+			r.expiringAdditionalMobileKeys[k] = t
+			r.loggers.Infof("Additional mobile key %s is now expiring at %v", k.Masked(), t)
+		case wasExpiring:
+			if previousExpiry != t {
+				r.loggers.Infof("Additional mobile key %s expiry updated from %v to %v", k.Masked(), previousExpiry, t)
+				r.expiringAdditionalMobileKeys[k] = t
+			}
+		default:
+			r.expiringAdditionalMobileKeys[k] = t
+			r.additions = append(r.additions, k)
+			r.loggers.Infof("Additional mobile key %s registered with expiry %v", k.Masked(), t)
+		}
+		delete(current, k)
+	}
+
+	for k := range current {
+		delete(r.additionalMobileKeys, k)
+		delete(r.expiringAdditionalMobileKeys, k)
+		r.expirations = append(r.expirations, k)
+		r.loggers.Infof("Additional mobile key %s has been revoked", k.Masked())
 	}
 }
 
@@ -422,6 +604,20 @@ func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expiration
 		if now.After(expiry) {
 			r.loggers.Infof("Additional SDK key %s has expired and is no longer valid for authentication", key.Masked())
 			delete(r.expiringAdditionalSdkKeys, key)
+			r.expirations = append(r.expirations, key)
+		}
+	}
+	for key, expiry := range r.deprecatedMobileKeys {
+		if now.After(expiry) {
+			r.loggers.Infof("Deprecated mobile key %s has expired and is no longer valid for authentication", key.Masked())
+			delete(r.deprecatedMobileKeys, key)
+			r.expirations = append(r.expirations, key)
+		}
+	}
+	for key, expiry := range r.expiringAdditionalMobileKeys {
+		if now.After(expiry) {
+			r.loggers.Infof("Additional mobile key %s has expired and is no longer valid for authentication", key.Masked())
+			delete(r.expiringAdditionalMobileKeys, key)
 			r.expirations = append(r.expirations, key)
 		}
 	}

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -464,11 +464,13 @@ func (r *Rotator) RotateWithGrace(primary SDKCredential, grace *GracePeriod) {
 }
 
 func (r *Rotator) updateEnvironmentID(envID config.EnvironmentID) {
-	if envID == r.EnvironmentID() {
-		return
-	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// Decide under the write lock so the no-op check sees the same state we'll then write. The
+	// previous RLock-then-Lock pattern was TOCTOU-prone -- consistent now with updateSDKKey.
+	if envID == r.primaryEnvironmentID {
+		return
+	}
 	previous := r.primaryEnvironmentID
 	r.primaryEnvironmentID = envID
 	r.additions = append(r.additions, envID)
@@ -481,9 +483,9 @@ func (r *Rotator) updateEnvironmentID(envID config.EnvironmentID) {
 }
 
 func (r *Rotator) updateMobileKey(mobileKey config.MobileKey) {
-	if mobileKey == r.MobileKey() {
-		return
-	}
+	// swapPrimaryMobileKey already short-circuits when the new key matches the current primary
+	// (it does so under the write lock so the check + write are atomic). Acquire the write lock
+	// directly and let swap decide -- no TOCTOU window.
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	previous := r.swapPrimaryMobileKey(mobileKey)

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -450,6 +450,16 @@ func (r *Rotator) RotateMobileKeyWithGrace(primary config.MobileKey, grace *Mobi
 		return
 	}
 
+	// Self-rotation defense (see updateSDKKey for the SDK analog): a rotation grace whose key
+	// matches the current primary is malformed input. Entering the deprecation flow would queue
+	// the primary through addCredential again with no upstream client to leak (mobile keys never
+	// open an upstream stream), but it would still clobber the dispatcher and leave a phantom
+	// entry in deprecatedMobileKeys that StepTime would eventually revoke.
+	if grace.key == r.primaryMobileKey {
+		r.loggers.Warnf("Ignoring rotation grace for mobile key %s: it matches the current primary key", grace.key.Masked())
+		return
+	}
+
 	if previousExpiry, ok := r.deprecatedMobileKeys[grace.key]; ok {
 		if previousExpiry != grace.expiry {
 			r.loggers.Warnf("Mobile key %s was marked for deprecation with an expiry at %v, but it was previously deprecated with an expiry at %v. The previous expiry will be used.", grace.key.Masked(), grace.expiry, previousExpiry)
@@ -647,6 +657,16 @@ func (r *Rotator) updateSDKKey(sdkKey config.SDKKey, grace *GracePeriod) {
 	// in order to find out if immediate revocation is necessary.
 	if grace == nil {
 		r.immediatelyRevoke(previous)
+		return
+	}
+
+	// Self-rotation defense: if the grace key is the current primary, do NOT enter the deprecation
+	// flow. Doing so would mark the primary as deprecated AND queue it through addCredential again,
+	// which would unconditionally overwrite c.clients[primary] and leak the running upstream SDK
+	// client. This case is malformed input (a rotation that grants a grace period to a key that is
+	// still the active primary); log a warning and ignore the grace.
+	if grace.key == r.primarySdkKey {
+		r.loggers.Warnf("Ignoring rotation grace for SDK key %s: it matches the current primary key", grace.key.Masked())
 		return
 	}
 

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -22,8 +22,18 @@ type Rotator struct {
 	// There can be multiple SDK keys active at a given time, but only one is primary.
 	primarySdkKey config.SDKKey
 
-	// Deprecated keys are stored in a map with a started timer for each key representing the deprecation period.
-	// Upon expiration, they are removed.
+	// additionalSdkKeys is the set of concurrent SDK keys that authenticate to the same environment
+	// as primarySdkKey but never open an upstream LD connection. Entries with a per-key expiry are
+	// tracked in expiringAdditionalSdkKeys instead.
+	additionalSdkKeys map[config.SDKKey]struct{}
+
+	// expiringAdditionalSdkKeys tracks concurrent SDK keys that have a per-key expiry. Separate
+	// from deprecatedSdkKeys so the SetAdditionalSDKKeys diff logic cannot accidentally remove the
+	// predecessor of primarySdkKey.
+	expiringAdditionalSdkKeys map[config.SDKKey]time.Time
+
+	// deprecatedSdkKeys holds the predecessor of primarySdkKey during a rotation grace period. Upon
+	// expiration, entries are removed. This map is owned by the RotateWithGrace path.
 	deprecatedSdkKeys map[config.SDKKey]time.Time
 
 	expirations []SDKCredential
@@ -42,8 +52,10 @@ type InitialCredentials struct {
 // contains no credentials and can optionally be initialized via Initialize.
 func NewRotator(loggers ldlog.Loggers) *Rotator {
 	r := &Rotator{
-		loggers:           loggers,
-		deprecatedSdkKeys: make(map[config.SDKKey]time.Time),
+		loggers:                   loggers,
+		additionalSdkKeys:         make(map[config.SDKKey]struct{}),
+		expiringAdditionalSdkKeys: make(map[config.SDKKey]time.Time),
+		deprecatedSdkKeys:         make(map[config.SDKKey]time.Time),
 	}
 	return r
 }
@@ -98,18 +110,134 @@ func (r *Rotator) PrimaryCredentials() []SDKCredential {
 }
 
 func (r *Rotator) primaryCredentials() []SDKCredential {
-	return slices.DeleteFunc([]SDKCredential{
+	creds := slices.DeleteFunc([]SDKCredential{
 		r.primarySdkKey,
 		r.primaryMobileKey,
 		r.primaryEnvironmentID,
 	}, func(cred SDKCredential) bool {
 		return !cred.Defined()
 	})
+	for key := range r.additionalSdkKeys {
+		creds = append(creds, key)
+	}
+	return creds
+}
+
+// ActiveSDKKeys returns the primary SDK key plus all additional non-deprecated SDK keys.
+func (r *Rotator) ActiveSDKKeys() []config.SDKKey {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	keys := make([]config.SDKKey, 0, 1+len(r.additionalSdkKeys))
+	if r.primarySdkKey.Defined() {
+		keys = append(keys, r.primarySdkKey)
+	}
+	for k := range r.additionalSdkKeys {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// SetAdditionalSDKKeys synchronizes the set of concurrent SDK keys for this environment.
+//
+// active contains keys that are present and have no per-key expiry. expiring maps each key with a
+// per-key expiry to its absolute expiration timestamp.
+//
+// Keys new to active or expiring are queued as additions. Keys previously tracked that are absent
+// from both sets are queued as expirations immediately, without a grace period -- omission from a
+// patch is treated as deletion. A key transitioning between active and expiring stays mapped; only
+// its grace state changes. An expiring key whose timestamp changes across calls accepts the new
+// value as authoritative.
+//
+// The primary SDK key is filtered out of the additional set defensively. This method does not
+// touch deprecatedSdkKeys, which is owned by the RotateWithGrace path for the predecessor of
+// primarySdkKey during a rotation.
+func (r *Rotator) SetAdditionalSDKKeys(active []config.SDKKey, expiring map[config.SDKKey]time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	nextActive := make(map[config.SDKKey]struct{}, len(active))
+	for _, k := range active {
+		if !k.Defined() || k == r.primarySdkKey {
+			continue
+		}
+		nextActive[k] = struct{}{}
+	}
+	nextExpiring := make(map[config.SDKKey]time.Time, len(expiring))
+	for k, t := range expiring {
+		if !k.Defined() || k == r.primarySdkKey {
+			continue
+		}
+		// If the same key shows up in both sets, treat the expiring entry as authoritative -- the
+		// platform explicitly attached an expiry to it.
+		delete(nextActive, k)
+		nextExpiring[k] = t
+	}
+
+	// Track all currently-tracked additional keys (active + expiring) so we can detect removals.
+	current := make(map[config.SDKKey]struct{})
+	for k := range r.additionalSdkKeys {
+		current[k] = struct{}{}
+	}
+	for k := range r.expiringAdditionalSdkKeys {
+		current[k] = struct{}{}
+	}
+
+	for k := range nextActive {
+		_, wasAdditional := r.additionalSdkKeys[k]
+		_, wasExpiring := r.expiringAdditionalSdkKeys[k]
+		switch {
+		case wasAdditional:
+			// Already active.
+		case wasExpiring:
+			// Was expiring, now active -- move state without re-queuing (still mapped).
+			delete(r.expiringAdditionalSdkKeys, k)
+			r.additionalSdkKeys[k] = struct{}{}
+		default:
+			r.additionalSdkKeys[k] = struct{}{}
+			r.additions = append(r.additions, k)
+			r.loggers.Infof("Additional SDK key %s is now active", k.Masked())
+		}
+		delete(current, k)
+	}
+
+	for k, t := range nextExpiring {
+		_, wasAdditional := r.additionalSdkKeys[k]
+		previousExpiry, wasExpiring := r.expiringAdditionalSdkKeys[k]
+		switch {
+		case wasAdditional:
+			// Was active, now has an expiry -- move into expiring, stay mapped.
+			delete(r.additionalSdkKeys, k)
+			r.expiringAdditionalSdkKeys[k] = t
+			r.loggers.Infof("Additional SDK key %s is now expiring at %v", k.Masked(), t)
+		case wasExpiring:
+			// Already expiring -- accept the new timestamp (platform is authoritative).
+			if previousExpiry != t {
+				r.loggers.Infof("Additional SDK key %s expiry updated from %v to %v", k.Masked(), previousExpiry, t)
+				r.expiringAdditionalSdkKeys[k] = t
+			}
+		default:
+			r.expiringAdditionalSdkKeys[k] = t
+			r.additions = append(r.additions, k)
+			r.loggers.Infof("Additional SDK key %s registered with expiry %v", k.Masked(), t)
+		}
+		delete(current, k)
+	}
+
+	// Anything still in current was previously tracked but absent from the new patch -- revoke now.
+	for k := range current {
+		delete(r.additionalSdkKeys, k)
+		delete(r.expiringAdditionalSdkKeys, k)
+		r.expirations = append(r.expirations, k)
+		r.loggers.Infof("Additional SDK key %s has been revoked", k.Masked())
+	}
 }
 
 func (r *Rotator) deprecatedCredentials() []SDKCredential {
-	deprecated := make([]SDKCredential, 0, len(r.deprecatedSdkKeys))
+	deprecated := make([]SDKCredential, 0, len(r.deprecatedSdkKeys)+len(r.expiringAdditionalSdkKeys))
 	for key := range r.deprecatedSdkKeys {
+		deprecated = append(deprecated, key)
+	}
+	for key := range r.expiringAdditionalSdkKeys {
 		deprecated = append(deprecated, key)
 	}
 	return deprecated
@@ -288,6 +416,13 @@ func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expiration
 	for key, expiry := range r.deprecatedSdkKeys {
 		if now.After(expiry) {
 			r.expireSDKKey(key)
+		}
+	}
+	for key, expiry := range r.expiringAdditionalSdkKeys {
+		if now.After(expiry) {
+			r.loggers.Infof("Additional SDK key %s has expired and is no longer valid for authentication", key.Masked())
+			delete(r.expiringAdditionalSdkKeys, key)
+			r.expirations = append(r.expirations, key)
 		}
 	}
 

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -463,6 +463,9 @@ func (r *Rotator) swapPrimaryMobileKey(newKey config.MobileKey) config.MobileKey
 	}
 	previous := r.primaryMobileKey
 	r.primaryMobileKey = newKey
+	// Mirror the SDK-key logic: a promoted additional mobile key drops out of the additional sets.
+	delete(r.additionalMobileKeys, newKey)
+	delete(r.expiringAdditionalMobileKeys, newKey)
 	r.additions = append(r.additions, newKey)
 	if previous.Defined() {
 		r.loggers.Infof("Mobile key %s was rotated, new primary mobile key is %s", previous.Masked(), newKey.Masked())
@@ -573,6 +576,13 @@ func (r *Rotator) swapPrimaryKey(newKey config.SDKKey) config.SDKKey {
 	}
 	previous := r.primarySdkKey
 	r.primarySdkKey = newKey
+	// If the new primary was previously tracked as an additional key (active or expiring), drop
+	// those entries -- it is the primary now. The additions-queue path below still re-fires
+	// addCredential for newKey so the env context can start its upstream SDK client; downstream
+	// operations (envStreams, lookup mapping, handlers) are idempotent for an already-registered
+	// credential.
+	delete(r.additionalSdkKeys, newKey)
+	delete(r.expiringAdditionalSdkKeys, newKey)
 	r.additions = append(r.additions, newKey)
 	r.loggers.Infof("New primary SDK key is %s", newKey.Masked())
 

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -216,6 +216,206 @@ func TestManyConcurrentSDKKeyDeprecation(t *testing.T) {
 	assert.ElementsMatch(t, keysDeprecated, expirations)
 }
 
+func TestSetAdditionalSDKKeysAddsActiveKeys(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+	_, _ = rotator.StepTime(time.Now())
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"extra1", "extra2"}, nil)
+	additions, expirations := rotator.StepTime(time.Now())
+
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("extra1"), config.SDKKey("extra2")}, additions)
+	assert.Empty(t, expirations)
+	assert.ElementsMatch(t, []config.SDKKey{"primary", "extra1", "extra2"}, rotator.ActiveSDKKeys())
+}
+
+func TestSetAdditionalSDKKeysAddsExpiringKeys(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+	_, _ = rotator.StepTime(time.Now())
+
+	expiry := time.Unix(2000, 0)
+	rotator.SetAdditionalSDKKeys(nil, map[config.SDKKey]time.Time{
+		"expiring1": expiry,
+	})
+	additions, expirations := rotator.StepTime(time.Unix(1000, 0))
+
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("expiring1")}, additions)
+	assert.Empty(t, expirations)
+	// Expiring keys are not "active" in the ActiveSDKKeys sense.
+	assert.ElementsMatch(t, []config.SDKKey{"primary"}, rotator.ActiveSDKKeys())
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("expiring1")}, rotator.DeprecatedCredentials())
+}
+
+func TestSetAdditionalSDKKeysOmissionRevokesImmediately(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"extra1", "extra2"}, nil)
+	_, _ = rotator.StepTime(time.Now())
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"extra1"}, nil)
+	additions, expirations := rotator.StepTime(time.Now())
+
+	assert.Empty(t, additions)
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("extra2")}, expirations)
+	assert.ElementsMatch(t, []config.SDKKey{"primary", "extra1"}, rotator.ActiveSDKKeys())
+}
+
+func TestSetAdditionalSDKKeysActiveToExpiringStaysMapped(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"k"}, nil)
+	additions, expirations := rotator.StepTime(time.Now())
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("k")}, additions)
+	assert.Empty(t, expirations)
+
+	// Now mark the same key as expiring; it should stay mapped (no churn in additions/expirations).
+	expiry := time.Unix(5000, 0)
+	rotator.SetAdditionalSDKKeys(nil, map[config.SDKKey]time.Time{"k": expiry})
+	additions, expirations = rotator.StepTime(time.Unix(1000, 0))
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+	assert.ElementsMatch(t, []config.SDKKey{"primary"}, rotator.ActiveSDKKeys())
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("k")}, rotator.DeprecatedCredentials())
+}
+
+func TestSetAdditionalSDKKeysExpiringToActiveStaysMapped(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	expiry := time.Unix(5000, 0)
+	rotator.SetAdditionalSDKKeys(nil, map[config.SDKKey]time.Time{"k": expiry})
+	additions, expirations := rotator.StepTime(time.Unix(1000, 0))
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("k")}, additions)
+	assert.Empty(t, expirations)
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"k"}, nil)
+	additions, expirations = rotator.StepTime(time.Unix(2000, 0))
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+	assert.ElementsMatch(t, []config.SDKKey{"primary", "k"}, rotator.ActiveSDKKeys())
+}
+
+func TestSetAdditionalSDKKeysAcceptsUpdatedExpiry(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	earlyExpiry := time.Unix(2000, 0)
+	rotator.SetAdditionalSDKKeys(nil, map[config.SDKKey]time.Time{"k": earlyExpiry})
+	additions, _ := rotator.StepTime(time.Unix(1000, 0))
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("k")}, additions)
+
+	// Extend the expiry.
+	lateExpiry := time.Unix(10000, 0)
+	rotator.SetAdditionalSDKKeys(nil, map[config.SDKKey]time.Time{"k": lateExpiry})
+
+	// At a time after the original expiry but before the new one, the key should still be alive.
+	additions, expirations := rotator.StepTime(time.Unix(5000, 0))
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+
+	// After the new expiry, the key should be revoked via StepTime.
+	additions, expirations = rotator.StepTime(time.Unix(11000, 0))
+	assert.Empty(t, additions)
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("k")}, expirations)
+}
+
+func TestSetAdditionalSDKKeysIdempotent(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"k1", "k2"}, nil)
+	_, _ = rotator.StepTime(time.Now())
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"k1", "k2"}, nil)
+	additions, expirations := rotator.StepTime(time.Now())
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+}
+
+func TestSetAdditionalSDKKeysFiltersPrimary(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	expiry := time.Unix(5000, 0)
+	rotator.SetAdditionalSDKKeys(
+		[]config.SDKKey{"primary", "extra"},
+		map[config.SDKKey]time.Time{"primary": expiry},
+	)
+	additions, expirations := rotator.StepTime(time.Unix(1000, 0))
+
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("extra")}, additions)
+	assert.Empty(t, expirations)
+	assert.ElementsMatch(t, []config.SDKKey{"primary", "extra"}, rotator.ActiveSDKKeys())
+}
+
+func TestSetAdditionalSDKKeysPrefersExpiringWhenKeyAppearsInBoth(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	expiry := time.Unix(5000, 0)
+	rotator.SetAdditionalSDKKeys(
+		[]config.SDKKey{"shared"},
+		map[config.SDKKey]time.Time{"shared": expiry},
+	)
+	additions, _ := rotator.StepTime(time.Unix(1000, 0))
+
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("shared")}, additions)
+	// Should be expiring, not active.
+	assert.ElementsMatch(t, []config.SDKKey{"primary"}, rotator.ActiveSDKKeys())
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("shared")}, rotator.DeprecatedCredentials())
+}
+
+func TestSetAdditionalSDKKeysSurvivesPrimaryRotation(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"k1", "k2"}, nil)
+	additions, _ := rotator.StepTime(time.Now())
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("k1"), config.SDKKey("k2")}, additions)
+
+	// Rotate the primary -- the additional set should stay intact.
+	start := time.Unix(10000, 0)
+	rotator.RotateWithGrace(config.SDKKey("primary-v2"), NewGracePeriod(config.SDKKey("primary"), start.Add(1*time.Hour), start))
+	additions, expirations := rotator.StepTime(start)
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("primary-v2")}, additions)
+	assert.Empty(t, expirations)
+	assert.ElementsMatch(t, []config.SDKKey{"primary-v2", "k1", "k2"}, rotator.ActiveSDKKeys())
+}
+
+func TestSetAdditionalSDKKeysDoesNotDisturbRotationPredecessor(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary-v1")})
+
+	// Rotate primary, putting primary-v1 into the rotation grace map.
+	start := time.Unix(10000, 0)
+	rotator.RotateWithGrace(
+		config.SDKKey("primary-v2"),
+		NewGracePeriod(config.SDKKey("primary-v1"), start.Add(1*time.Hour), start),
+	)
+	_, _ = rotator.StepTime(start)
+
+	// Now set an additional key. The rotation predecessor must NOT be revoked.
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"extra"}, nil)
+	additions, expirations := rotator.StepTime(start.Add(1 * time.Minute))
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("extra")}, additions)
+	assert.Empty(t, expirations)
+	assert.Contains(t, rotator.DeprecatedCredentials(), config.SDKKey("primary-v1"))
+}
+
 func TestSDKKeyExpiredInThePastIsNotAdded(t *testing.T) {
 	mockLog := ldlogtest.NewMockLog()
 	rotator := NewRotator(mockLog.Loggers)

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -569,6 +569,52 @@ func TestPromotingExpiringAdditionalSDKKeyToPrimaryRemovesFromExpiringSet(t *tes
 	assert.NotContains(t, deprecated, config.SDKKey("expiring1"))
 }
 
+// Regression test for the F4 finding: a self-rotation -- RotateWithGrace(P, grace{P, ...}) --
+// must NOT enter the deprecation flow. The unconditional addCredential -> startSDKClient that
+// would otherwise result overwrites c.clients[P] and leaks the running upstream client.
+func TestRotateWithGraceIgnoresSelfRotation(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+	_, _ = rotator.StepTime(time.Now())
+
+	// Rotate the primary to itself with a grace period for itself.
+	start := time.Unix(10000, 0)
+	rotator.RotateWithGrace(
+		config.SDKKey("primary"),
+		NewGracePeriod(config.SDKKey("primary"), start.Add(1*time.Hour), start),
+	)
+
+	// Nothing should be queued -- the rotation is a no-op.
+	additions, expirations := rotator.StepTime(start)
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+	// Primary remains the same and is NOT in the deprecated set.
+	assert.Equal(t, config.SDKKey("primary"), rotator.SDKKey())
+	assert.NotContains(t, rotator.DeprecatedCredentials(), config.SDKKey("primary"))
+	mockLog.AssertMessageMatch(t, true, ldlog.Warn, "matches the current primary key")
+}
+
+func TestRotateMobileKeyWithGraceIgnoresSelfRotation(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary")})
+	_, _ = rotator.StepTime(time.Now())
+
+	start := time.Unix(10000, 0)
+	rotator.RotateMobileKeyWithGrace(
+		config.MobileKey("primary"),
+		NewMobileGracePeriod(config.MobileKey("primary"), start.Add(1*time.Hour), start),
+	)
+
+	additions, expirations := rotator.StepTime(start)
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+	assert.Equal(t, config.MobileKey("primary"), rotator.MobileKey())
+	assert.NotContains(t, rotator.DeprecatedCredentials(), config.MobileKey("primary"))
+	mockLog.AssertMessageMatch(t, true, ldlog.Warn, "matches the current primary key")
+}
+
 // Regression test for the F2 finding from multi-agent review: a SetAdditional patch that omits a
 // key currently in rotation grace must NOT revoke that key. The rotation grace flow owns the
 // key's lifecycle; the diff loop must leave it alone.

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -432,6 +432,69 @@ func TestSDKKeyExpiredInThePastIsNotAdded(t *testing.T) {
 	assert.Empty(t, expirations)
 }
 
+func TestPromotingAdditionalSDKKeyToPrimaryRemovesFromAdditionalSet(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"extra1", "extra2"}, nil)
+	_, _ = rotator.StepTime(time.Now())
+
+	// Promote "extra1" to primary. The old primary deprecates with a grace period.
+	start := time.Unix(10000, 0)
+	rotator.RotateWithGrace(
+		config.SDKKey("extra1"),
+		NewGracePeriod(config.SDKKey("primary"), start.Add(1*time.Hour), start),
+	)
+
+	// The new primary must report as the primary.
+	assert.Equal(t, config.SDKKey("extra1"), rotator.SDKKey())
+
+	// The promoted key is no longer in the additional set; extra2 still is.
+	active := rotator.ActiveSDKKeys()
+	assert.Contains(t, active, config.SDKKey("extra1"))
+	assert.Contains(t, active, config.SDKKey("extra2"))
+	assert.NotContains(t, active, config.SDKKey("primary"))
+
+	// The old primary is in the deprecation map.
+	assert.Contains(t, rotator.DeprecatedCredentials(), config.SDKKey("primary"))
+
+	// Drain the additions queued by the rotation. The new primary (extra1) is queued so the env
+	// context can start its upstream SDK client; downstream operations on it are idempotent.
+	additions, _ := rotator.StepTime(start)
+	assert.Contains(t, additions, config.SDKKey("extra1"))
+
+	// After the grace expiry, the old primary should be revoked.
+	additions, expirations := rotator.StepTime(start.Add(1*time.Hour + time.Millisecond))
+	assert.Empty(t, additions)
+	assert.Contains(t, expirations, config.SDKKey("primary"))
+}
+
+func TestPromotingExpiringAdditionalSDKKeyToPrimaryRemovesFromExpiringSet(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	expiry := time.Unix(100000, 0)
+	rotator.SetAdditionalSDKKeys(nil, map[config.SDKKey]time.Time{"expiring1": expiry})
+	_, _ = rotator.StepTime(time.Unix(1000, 0))
+
+	// Now the platform decides to promote the expiring additional key to primary -- it stops
+	// being deprecated and becomes the new primary.
+	start := time.Unix(10000, 0)
+	rotator.RotateWithGrace(
+		config.SDKKey("expiring1"),
+		NewGracePeriod(config.SDKKey("primary"), start.Add(1*time.Hour), start),
+	)
+
+	assert.Equal(t, config.SDKKey("expiring1"), rotator.SDKKey())
+	// The previously-expiring entry should no longer appear in the deprecated list as an additional;
+	// only the old primary should be there now.
+	deprecated := rotator.DeprecatedCredentials()
+	assert.Contains(t, deprecated, config.SDKKey("primary"))
+	assert.NotContains(t, deprecated, config.SDKKey("expiring1"))
+}
+
 // --- Mobile-key additional-set tests (parallel to the SDK suite above) ---
 
 func TestSetAdditionalMobileKeysAddsActiveKeys(t *testing.T) {

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -569,6 +569,99 @@ func TestPromotingExpiringAdditionalSDKKeyToPrimaryRemovesFromExpiringSet(t *tes
 	assert.NotContains(t, deprecated, config.SDKKey("expiring1"))
 }
 
+// Regression test for the F2 finding from multi-agent review: a SetAdditional patch that omits a
+// key currently in rotation grace must NOT revoke that key. The rotation grace flow owns the
+// key's lifecycle; the diff loop must leave it alone.
+func TestSetAdditionalOmissionDoesNotRevokeRotationPredecessor(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary-v1")})
+
+	// Patch 1: register "A" as an additional key.
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"A"}, nil)
+	_, _ = rotator.StepTime(time.Now())
+
+	// Patch 2: rotation arrives where "A" is now the expiring predecessor (grace.key = A) and a
+	// new primary is "primary-v2". The autoconfig path runs UpdateCredential first, then
+	// SetAdditional with an empty additional list.
+	start := time.Unix(10000, 0)
+	rotator.RotateWithGrace(
+		config.SDKKey("primary-v2"),
+		NewGracePeriod(config.SDKKey("A"), start.Add(1*time.Hour), start),
+	)
+	rotator.SetAdditionalSDKKeys(nil, nil)
+
+	additions, expirations := rotator.StepTime(start)
+	// "primary-v2" is queued as the new primary. "A" should NOT be expired -- it just transitioned
+	// from additional to rotation-predecessor and still has its full grace window.
+	assert.Contains(t, additions, config.SDKKey("primary-v2"))
+	assert.NotContains(t, expirations, config.SDKKey("A"))
+	assert.Contains(t, rotator.DeprecatedCredentials(), config.SDKKey("A"))
+}
+
+// Regression test for the F3 finding: after a rotation grace expires for a key that was previously
+// an additional, the additional set must not retain a phantom entry.
+func TestRotationPredecessorClearedFromAdditionalSet(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary-v1")})
+
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"A"}, nil)
+	_, _ = rotator.StepTime(time.Now())
+
+	start := time.Unix(10000, 0)
+	rotator.RotateWithGrace(
+		config.SDKKey("primary-v2"),
+		NewGracePeriod(config.SDKKey("A"), start.Add(1*time.Hour), start),
+	)
+	_, _ = rotator.StepTime(start)
+
+	// After the grace expires, the rotator should not still report "A" as an active additional.
+	_, _ = rotator.StepTime(start.Add(1*time.Hour + time.Millisecond))
+	assert.NotContains(t, rotator.ActiveSDKKeys(), config.SDKKey("A"))
+}
+
+// Same scenarios for mobile keys.
+func TestSetAdditionalOmissionDoesNotRevokeMobileRotationPredecessor(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary-v1")})
+
+	rotator.SetAdditionalMobileKeys([]config.MobileKey{"A"}, nil)
+	_, _ = rotator.StepTime(time.Now())
+
+	start := time.Unix(10000, 0)
+	rotator.RotateMobileKeyWithGrace(
+		config.MobileKey("primary-v2"),
+		NewMobileGracePeriod(config.MobileKey("A"), start.Add(1*time.Hour), start),
+	)
+	rotator.SetAdditionalMobileKeys(nil, nil)
+
+	additions, expirations := rotator.StepTime(start)
+	assert.Contains(t, additions, config.MobileKey("primary-v2"))
+	assert.NotContains(t, expirations, config.MobileKey("A"))
+	assert.Contains(t, rotator.DeprecatedCredentials(), config.MobileKey("A"))
+}
+
+func TestMobileRotationPredecessorClearedFromAdditionalSet(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary-v1")})
+
+	rotator.SetAdditionalMobileKeys([]config.MobileKey{"A"}, nil)
+	_, _ = rotator.StepTime(time.Now())
+
+	start := time.Unix(10000, 0)
+	rotator.RotateMobileKeyWithGrace(
+		config.MobileKey("primary-v2"),
+		NewMobileGracePeriod(config.MobileKey("A"), start.Add(1*time.Hour), start),
+	)
+	_, _ = rotator.StepTime(start)
+	_, _ = rotator.StepTime(start.Add(1*time.Hour + time.Millisecond))
+
+	assert.NotContains(t, rotator.ActiveMobileKeys(), config.MobileKey("A"))
+}
+
 // --- Mobile-key additional-set tests (parallel to the SDK suite above) ---
 
 func TestSetAdditionalMobileKeysAddsActiveKeys(t *testing.T) {

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/stretchr/testify/assert"
@@ -357,6 +358,79 @@ func TestSetAdditionalSDKKeysFiltersPrimary(t *testing.T) {
 	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("extra")}, additions)
 	assert.Empty(t, expirations)
 	assert.ElementsMatch(t, []config.SDKKey{"primary", "extra"}, rotator.ActiveSDKKeys())
+}
+
+func TestSetAdditionalSDKKeysFiltersRotationPredecessor(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	// Rotate to put "old" in the deprecatedSdkKeys map.
+	rotator.Initialize([]SDKCredential{config.SDKKey("old")})
+	start := time.Unix(10000, 0)
+	rotator.RotateWithGrace(
+		config.SDKKey("new"),
+		NewGracePeriod(config.SDKKey("old"), start.Add(1*time.Hour), start),
+	)
+	_, _ = rotator.StepTime(start)
+
+	// Now the platform mistakenly includes "old" in the additional list. The rotator should
+	// ignore it -- the rotation flow is in charge of old's lifecycle.
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"old", "extra"}, nil)
+
+	// Only "extra" should have been queued; "old" stays in the deprecated map only.
+	additions, expirations := rotator.StepTime(start)
+	assert.ElementsMatch(t, []SDKCredential{config.SDKKey("extra")}, additions)
+	assert.Empty(t, expirations)
+	assert.NotContains(t, rotator.ActiveSDKKeys(), config.SDKKey("old"))
+	assert.Contains(t, rotator.DeprecatedCredentials(), config.SDKKey("old"))
+
+	// And the next patch omitting "old" from the additional list must NOT revoke it -- the
+	// rotation grace timer still owns it.
+	rotator.SetAdditionalSDKKeys([]config.SDKKey{"extra"}, nil)
+	additions, expirations = rotator.StepTime(start.Add(1 * time.Minute))
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+	assert.Contains(t, rotator.DeprecatedCredentials(), config.SDKKey("old"))
+
+	// Confirm a warning was logged.
+	mockLog.AssertMessageMatch(t, true, ldlog.Warn, "already in a rotation grace period")
+}
+
+func TestSetAdditionalSDKKeysWarnsOnPrimaryInList(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.SDKKey("primary")})
+
+	rotator.SetAdditionalSDKKeys(
+		[]config.SDKKey{"primary", "extra"},
+		map[config.SDKKey]time.Time{"primary": time.Unix(5000, 0)},
+	)
+
+	mockLog.AssertMessageMatch(t, true, ldlog.Warn, "Primary SDK key .* appeared in additional-key list")
+	mockLog.AssertMessageMatch(t, true, ldlog.Warn, "Primary SDK key .* appeared in additional-key list with an expiry")
+}
+
+func TestSetAdditionalMobileKeysFiltersRotationPredecessor(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	rotator.Initialize([]SDKCredential{config.MobileKey("old")})
+	start := time.Unix(10000, 0)
+	rotator.RotateMobileKeyWithGrace(
+		config.MobileKey("new"),
+		NewMobileGracePeriod(config.MobileKey("old"), start.Add(1*time.Hour), start),
+	)
+	_, _ = rotator.StepTime(start)
+
+	rotator.SetAdditionalMobileKeys([]config.MobileKey{"old", "extra"}, nil)
+
+	additions, expirations := rotator.StepTime(start)
+	assert.ElementsMatch(t, []SDKCredential{config.MobileKey("extra")}, additions)
+	assert.Empty(t, expirations)
+	assert.NotContains(t, rotator.ActiveMobileKeys(), config.MobileKey("old"))
+	assert.Contains(t, rotator.DeprecatedCredentials(), config.MobileKey("old"))
+
+	mockLog.AssertMessageMatch(t, true, ldlog.Warn, "already in a rotation grace period")
 }
 
 func TestSetAdditionalSDKKeysPrefersExpiringWhenKeyAppearsInBoth(t *testing.T) {

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -431,3 +431,179 @@ func TestSDKKeyExpiredInThePastIsNotAdded(t *testing.T) {
 	assert.ElementsMatch(t, []SDKCredential{primaryKey}, additions)
 	assert.Empty(t, expirations)
 }
+
+// --- Mobile-key additional-set tests (parallel to the SDK suite above) ---
+
+func TestSetAdditionalMobileKeysAddsActiveKeys(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary")})
+	_, _ = rotator.StepTime(time.Now())
+
+	rotator.SetAdditionalMobileKeys([]config.MobileKey{"extra1", "extra2"}, nil)
+	additions, expirations := rotator.StepTime(time.Now())
+
+	assert.ElementsMatch(t, []SDKCredential{config.MobileKey("extra1"), config.MobileKey("extra2")}, additions)
+	assert.Empty(t, expirations)
+	assert.ElementsMatch(t, []config.MobileKey{"primary", "extra1", "extra2"}, rotator.ActiveMobileKeys())
+}
+
+func TestSetAdditionalMobileKeysAddsExpiringKeys(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary")})
+	_, _ = rotator.StepTime(time.Now())
+
+	expiry := time.Unix(2000, 0)
+	rotator.SetAdditionalMobileKeys(nil, map[config.MobileKey]time.Time{"expiring1": expiry})
+	additions, expirations := rotator.StepTime(time.Unix(1000, 0))
+
+	assert.ElementsMatch(t, []SDKCredential{config.MobileKey("expiring1")}, additions)
+	assert.Empty(t, expirations)
+	assert.ElementsMatch(t, []config.MobileKey{"primary"}, rotator.ActiveMobileKeys())
+	assert.ElementsMatch(t, []SDKCredential{config.MobileKey("expiring1")}, rotator.DeprecatedCredentials())
+}
+
+func TestSetAdditionalMobileKeysOmissionRevokesImmediately(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary")})
+
+	rotator.SetAdditionalMobileKeys([]config.MobileKey{"extra1", "extra2"}, nil)
+	_, _ = rotator.StepTime(time.Now())
+
+	rotator.SetAdditionalMobileKeys([]config.MobileKey{"extra1"}, nil)
+	additions, expirations := rotator.StepTime(time.Now())
+
+	assert.Empty(t, additions)
+	assert.ElementsMatch(t, []SDKCredential{config.MobileKey("extra2")}, expirations)
+}
+
+func TestSetAdditionalMobileKeysActiveToExpiringStaysMapped(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary")})
+
+	rotator.SetAdditionalMobileKeys([]config.MobileKey{"k"}, nil)
+	_, _ = rotator.StepTime(time.Now())
+
+	expiry := time.Unix(5000, 0)
+	rotator.SetAdditionalMobileKeys(nil, map[config.MobileKey]time.Time{"k": expiry})
+	additions, expirations := rotator.StepTime(time.Unix(1000, 0))
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+}
+
+func TestSetAdditionalMobileKeysAcceptsUpdatedExpiry(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary")})
+
+	earlyExpiry := time.Unix(2000, 0)
+	rotator.SetAdditionalMobileKeys(nil, map[config.MobileKey]time.Time{"k": earlyExpiry})
+	_, _ = rotator.StepTime(time.Unix(1000, 0))
+
+	lateExpiry := time.Unix(10000, 0)
+	rotator.SetAdditionalMobileKeys(nil, map[config.MobileKey]time.Time{"k": lateExpiry})
+
+	additions, expirations := rotator.StepTime(time.Unix(5000, 0))
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+
+	additions, expirations = rotator.StepTime(time.Unix(11000, 0))
+	assert.Empty(t, additions)
+	assert.ElementsMatch(t, []SDKCredential{config.MobileKey("k")}, expirations)
+}
+
+func TestSetAdditionalMobileKeysFiltersPrimary(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary")})
+
+	rotator.SetAdditionalMobileKeys([]config.MobileKey{"primary", "extra"}, nil)
+	additions, _ := rotator.StepTime(time.Now())
+
+	assert.ElementsMatch(t, []SDKCredential{config.MobileKey("extra")}, additions)
+	assert.ElementsMatch(t, []config.MobileKey{"primary", "extra"}, rotator.ActiveMobileKeys())
+}
+
+// --- RotateMobileKeyWithGrace tests ---
+
+func TestRotateMobileKeyWithGraceDeprecatesPrevious(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	key1 := config.MobileKey("mob-v1")
+	key2 := config.MobileKey("mob-v2")
+
+	start := time.Unix(10000, 0)
+	halftime := start.Add(30 * time.Minute)
+	deprecationTime := start.Add(1 * time.Hour)
+
+	rotator.Initialize([]SDKCredential{key1})
+	rotator.RotateMobileKeyWithGrace(key2, NewMobileGracePeriod(key1, deprecationTime, start))
+
+	additions, expirations := rotator.StepTime(halftime)
+	assert.ElementsMatch(t, []SDKCredential{key2}, additions)
+	assert.Empty(t, expirations)
+
+	// Before expiry: still valid.
+	additions, expirations = rotator.StepTime(deprecationTime)
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+
+	// After expiry: predecessor gets revoked.
+	additions, expirations = rotator.StepTime(deprecationTime.Add(1 * time.Millisecond))
+	assert.Empty(t, additions)
+	assert.ElementsMatch(t, []SDKCredential{key1}, expirations)
+}
+
+func TestRotateMobileKeyWithGraceNilImmediatelyRevokes(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	key1 := config.MobileKey("mob-v1")
+	key2 := config.MobileKey("mob-v2")
+
+	rotator.Initialize([]SDKCredential{key1})
+	rotator.RotateMobileKeyWithGrace(key2, nil)
+
+	additions, expirations := rotator.StepTime(time.Now())
+	assert.ElementsMatch(t, []SDKCredential{key2}, additions)
+	assert.ElementsMatch(t, []SDKCredential{key1}, expirations)
+}
+
+func TestRotateMobileKeyWithGraceExpiredInThePastIsNotAdded(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	primary := config.MobileKey("primary")
+	obsolete := config.MobileKey("obsolete")
+	obsoleteExpiry := time.Unix(1000000, 0)
+	now := obsoleteExpiry.Add(1 * time.Hour)
+
+	rotator.RotateMobileKeyWithGrace(primary, NewMobileGracePeriod(obsolete, obsoleteExpiry, now))
+
+	additions, expirations := rotator.StepTime(now)
+	assert.ElementsMatch(t, []SDKCredential{primary}, additions)
+	assert.Empty(t, expirations)
+}
+
+func TestSetAdditionalMobileKeysDoesNotDisturbRotationPredecessor(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+	rotator.Initialize([]SDKCredential{config.MobileKey("primary-v1")})
+
+	start := time.Unix(10000, 0)
+	rotator.RotateMobileKeyWithGrace(
+		config.MobileKey("primary-v2"),
+		NewMobileGracePeriod(config.MobileKey("primary-v1"), start.Add(1*time.Hour), start),
+	)
+	_, _ = rotator.StepTime(start)
+
+	rotator.SetAdditionalMobileKeys([]config.MobileKey{"extra"}, nil)
+	additions, expirations := rotator.StepTime(start.Add(1 * time.Minute))
+	assert.ElementsMatch(t, []SDKCredential{config.MobileKey("extra")}, additions)
+	assert.Empty(t, expirations)
+	assert.Contains(t, rotator.DeprecatedCredentials(), config.MobileKey("primary-v1"))
+}

--- a/internal/envfactory/env_config_factory.go
+++ b/internal/envfactory/env_config_factory.go
@@ -46,24 +46,51 @@ func NewEnvConfigFactoryForOfflineMode(c config.OfflineModeConfig) EnvConfigFact
 
 // MakeEnvironmentConfig creates an EnvConfig based on both the individual EnvironmentParams and the
 // properties of the EnvConfigFactory.
+//
+// EnvConfig only carries the active (non-expiring) additional keys. Expiring additional keys flow
+// directly from EnvironmentParams to the rotator, the same way ExpiringSDKKey does today.
 func (f EnvConfigFactory) MakeEnvironmentConfig(params EnvironmentParams) config.EnvConfig {
 	ret := config.EnvConfig{
-		SDKKey:        params.SDKKey,
-		MobileKey:     params.MobileKey,
-		EnvID:         params.EnvID,
-		Prefix:        maybeSubstituteEnvironmentID(f.DataStorePrefix, params.EnvID, params.Identifiers.FilterKey),
-		TableName:     maybeSubstituteEnvironmentID(f.TableName, params.EnvID, params.Identifiers.FilterKey),
-		AllowedOrigin: f.AllowedOrigin,
-		AllowedHeader: f.AllowedHeader,
-		SecureMode:    params.SecureMode,
-		FilterKey:     params.Identifiers.FilterKey,
-		Offline:       f.Offline,
+		SDKKey:               params.SDKKey,
+		MobileKey:            params.MobileKey,
+		EnvID:                params.EnvID,
+		Prefix:               maybeSubstituteEnvironmentID(f.DataStorePrefix, params.EnvID, params.Identifiers.FilterKey),
+		TableName:            maybeSubstituteEnvironmentID(f.TableName, params.EnvID, params.Identifiers.FilterKey),
+		AllowedOrigin:        f.AllowedOrigin,
+		AllowedHeader:        f.AllowedHeader,
+		AdditionalSDKKeys:    sdkKeysToOptStringList(params.AdditionalSDKKeys),
+		AdditionalMobileKeys: mobileKeysToOptStringList(params.AdditionalMobileKeys),
+		SecureMode:           params.SecureMode,
+		FilterKey:            params.Identifiers.FilterKey,
+		Offline:              f.Offline,
 	}
 	if params.TTL != 0 {
 		ret.TTL = ct.NewOptDuration(params.TTL)
 	}
 
 	return ret
+}
+
+func sdkKeysToOptStringList(keys []config.SDKKey) ct.OptStringList {
+	if len(keys) == 0 {
+		return ct.OptStringList{}
+	}
+	vals := make([]string, len(keys))
+	for i, k := range keys {
+		vals[i] = string(k)
+	}
+	return ct.NewOptStringList(vals)
+}
+
+func mobileKeysToOptStringList(keys []config.MobileKey) ct.OptStringList {
+	if len(keys) == 0 {
+		return ct.OptStringList{}
+	}
+	vals := make([]string, len(keys))
+	for i, k := range keys {
+		vals[i] = string(k)
+	}
+	return ct.NewOptStringList(vals)
 }
 
 func maybeSubstituteEnvironmentID(s string, envID config.EnvironmentID, filterKey config.FilterKey) string {

--- a/internal/envfactory/env_params.go
+++ b/internal/envfactory/env_params.go
@@ -20,15 +20,31 @@ type EnvironmentParams struct {
 	// Identifiers contains the project and environment names and keys.
 	Identifiers relayenv.EnvIdentifiers
 
-	// SDKKey is the environment's SDK key; if there is more than one active key, it is the latest.
+	// SDKKey is the environment's primary SDK key. Additional concurrent SDK keys are carried in
+	// AdditionalSDKKeys and ExpiringAdditionalSDKKeys.
 	SDKKey config.SDKKey
 
-	// MobileKey is the environment's mobile key.
+	// MobileKey is the environment's primary mobile key. Additional concurrent mobile keys are
+	// carried in AdditionalMobileKeys and ExpiringAdditionalMobileKeys.
 	MobileKey config.MobileKey
 
-	// ExpiringSDKKey is an additional SDK key that should also be allowed (but not surfaced as
-	// the canonical one).
+	// ExpiringSDKKey is the predecessor of SDKKey during a rotation grace period, if any.
 	ExpiringSDKKey ExpiringSDKKey
+
+	// ExpiringMobileKey is the predecessor of MobileKey during a rotation grace period, if any.
+	ExpiringMobileKey ExpiringMobileKey
+
+	// AdditionalSDKKeys is the set of concurrent SDK keys with no per-key expiry.
+	AdditionalSDKKeys []config.SDKKey
+
+	// ExpiringAdditionalSDKKeys is the subset of concurrent SDK keys that carry a per-key expiry.
+	ExpiringAdditionalSDKKeys map[config.SDKKey]time.Time
+
+	// AdditionalMobileKeys is the set of concurrent mobile keys with no per-key expiry.
+	AdditionalMobileKeys []config.MobileKey
+
+	// ExpiringAdditionalMobileKeys is the subset of concurrent mobile keys that carry a per-key expiry.
+	ExpiringAdditionalMobileKeys map[config.MobileKey]time.Time
 
 	// TTL is the cache TTL for PHP clients.
 	TTL time.Duration
@@ -43,6 +59,15 @@ type ExpiringSDKKey struct {
 }
 
 func (e ExpiringSDKKey) Defined() bool {
+	return e.Key.Defined()
+}
+
+type ExpiringMobileKey struct {
+	Key        config.MobileKey
+	Expiration time.Time
+}
+
+func (e ExpiringMobileKey) Defined() bool {
 	return e.Key.Defined()
 }
 

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -163,6 +163,21 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 }
 
 func splitAdditionalSDKKeys(additional []AdditionalSDKKeyRep) (active []config.SDKKey, expiring map[config.SDKKey]time.Time) {
+	// Defense-in-depth dedupe of duplicate entries in the wire-format Additional list. The
+	// platform shouldn't send duplicates, but if it does we want deterministic results: expiring
+	// wins over active (it carries a stronger signal), and within a kind the first occurrence
+	// wins.
+	var hasExpiring map[config.SDKKey]struct{}
+	for _, a := range additional {
+		if a.Value.Defined() && a.ExpiresAt != nil {
+			if hasExpiring == nil {
+				hasExpiring = make(map[config.SDKKey]struct{})
+			}
+			hasExpiring[a.Value] = struct{}{}
+		}
+	}
+
+	seenActive := make(map[config.SDKKey]struct{})
 	for _, a := range additional {
 		if !a.Value.Defined() {
 			continue
@@ -171,15 +186,36 @@ func splitAdditionalSDKKeys(additional []AdditionalSDKKeyRep) (active []config.S
 			if expiring == nil {
 				expiring = make(map[config.SDKKey]time.Time)
 			}
-			expiring[a.Value] = ToTime(*a.ExpiresAt)
-		} else {
-			active = append(active, a.Value)
+			if _, dup := expiring[a.Value]; !dup {
+				expiring[a.Value] = ToTime(*a.ExpiresAt)
+			}
+			continue
 		}
+		if _, isExp := hasExpiring[a.Value]; isExp {
+			continue
+		}
+		if _, dup := seenActive[a.Value]; dup {
+			continue
+		}
+		seenActive[a.Value] = struct{}{}
+		active = append(active, a.Value)
 	}
 	return active, expiring
 }
 
 func splitAdditionalMobileKeys(additional []AdditionalMobileKeyRep) (active []config.MobileKey, expiring map[config.MobileKey]time.Time) {
+	// Same dedupe semantics as splitAdditionalSDKKeys; see the comment there.
+	var hasExpiring map[config.MobileKey]struct{}
+	for _, a := range additional {
+		if a.Value.Defined() && a.ExpiresAt != nil {
+			if hasExpiring == nil {
+				hasExpiring = make(map[config.MobileKey]struct{})
+			}
+			hasExpiring[a.Value] = struct{}{}
+		}
+	}
+
+	seenActive := make(map[config.MobileKey]struct{})
 	for _, a := range additional {
 		if !a.Value.Defined() {
 			continue
@@ -188,10 +224,19 @@ func splitAdditionalMobileKeys(additional []AdditionalMobileKeyRep) (active []co
 			if expiring == nil {
 				expiring = make(map[config.MobileKey]time.Time)
 			}
-			expiring[a.Value] = ToTime(*a.ExpiresAt)
-		} else {
-			active = append(active, a.Value)
+			if _, dup := expiring[a.Value]; !dup {
+				expiring[a.Value] = ToTime(*a.ExpiresAt)
+			}
+			continue
 		}
+		if _, isExp := hasExpiring[a.Value]; isExp {
+			continue
+		}
+		if _, dup := seenActive[a.Value]; dup {
+			continue
+		}
+		seenActive[a.Value] = struct{}{}
+		active = append(active, a.Value)
 	}
 	return active, expiring
 }

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -132,7 +132,11 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 	var activeMobile []config.MobileKey
 	var expiringAdditionalMobile map[config.MobileKey]time.Time
 	if r.MobileKey != nil {
-		mobileKey = r.MobileKey.Value
+		// Defensive: a partially-populated MobileKey struct with an empty Value should not clobber
+		// the legacy MobKey field that an older platform serializer might have populated.
+		if r.MobileKey.Value.Defined() {
+			mobileKey = r.MobileKey.Value
+		}
 		expiringMobile = r.MobileKey.Expiring.ToParams()
 		activeMobile, expiringAdditionalMobile = splitAdditionalMobileKeys(r.MobileKey.Additional)
 	}

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -15,11 +15,15 @@ import (
 // or the other of those contexts should be in the appropriate package instead of here.
 
 // EnvironmentRep is a representation of an environment that is being added or updated.
+//
+// MobKey is the legacy single-mobile-key field. When MobileKey is non-nil it takes precedence;
+// MobKey is retained so older relays reading newer payloads continue to function.
 type EnvironmentRep struct {
 	EnvID      config.EnvironmentID `json:"envID"`
 	EnvKey     string               `json:"envKey"`
 	EnvName    string               `json:"envName"`
-	MobKey     config.MobileKey     `json:"mobKey"`
+	MobKey     config.MobileKey     `json:"mobKey,omitempty"`
+	MobileKey  *MobileKeyRep        `json:"mobileKey,omitempty"`
 	ProjKey    string               `json:"projKey"`
 	ProjName   string               `json:"projName"`
 	SDKKey     SDKKeyRep            `json:"sdkKey"`
@@ -50,16 +54,48 @@ func (f FilterRep) ToTestParams() FilterParams {
 	return f.ToParams(config.FilterID(fmt.Sprintf("%s.%s", f.ProjKey, f.FilterKey)))
 }
 
-// SDKKeyRep describes an SDK key optionally accompanied by an old expiring key.
+// SDKKeyRep describes an SDK key, an optional predecessor that is rotating out with a grace period,
+// and an optional list of additional concurrent SDK keys.
+//
+// Each additional key may carry its own ExpiresAt. Entries without ExpiresAt are active; entries
+// with ExpiresAt are in a per-key grace period and stop being honored after the timestamp.
+// Omission of a previously-listed additional key indicates immediate revocation.
 type SDKKeyRep struct {
-	Value    config.SDKKey  `json:"value"`
-	Expiring ExpiringKeyRep `json:"expiring"`
+	Value      config.SDKKey         `json:"value"`
+	Expiring   ExpiringKeyRep        `json:"expiring"`
+	Additional []AdditionalSDKKeyRep `json:"additional,omitempty"`
 }
 
 // ExpiringKeyRep describes an old key that will expire at the specified date/time.
 type ExpiringKeyRep struct {
 	Value     config.SDKKey              `json:"value"`
 	Timestamp ldtime.UnixMillisecondTime `json:"timestamp"`
+}
+
+// AdditionalSDKKeyRep describes a concurrent SDK key with an optional per-key expiry.
+type AdditionalSDKKeyRep struct {
+	Value     config.SDKKey               `json:"value"`
+	ExpiresAt *ldtime.UnixMillisecondTime `json:"expiresAt,omitempty"`
+}
+
+// MobileKeyRep describes a mobile key, an optional predecessor that is rotating out with a grace
+// period, and an optional list of additional concurrent mobile keys. Semantics mirror SDKKeyRep.
+type MobileKeyRep struct {
+	Value      config.MobileKey         `json:"value"`
+	Expiring   ExpiringMobileKeyRep     `json:"expiring"`
+	Additional []AdditionalMobileKeyRep `json:"additional,omitempty"`
+}
+
+// ExpiringMobileKeyRep describes an old mobile key that will expire at the specified date/time.
+type ExpiringMobileKeyRep struct {
+	Value     config.MobileKey           `json:"value"`
+	Timestamp ldtime.UnixMillisecondTime `json:"timestamp"`
+}
+
+// AdditionalMobileKeyRep describes a concurrent mobile key with an optional per-key expiry.
+type AdditionalMobileKeyRep struct {
+	Value     config.MobileKey            `json:"value"`
+	ExpiresAt *ldtime.UnixMillisecondTime `json:"expiresAt,omitempty"`
 }
 
 func (e ExpiringKeyRep) ToParams() ExpiringSDKKey {
@@ -73,13 +109,35 @@ func (e ExpiringKeyRep) ToParams() ExpiringSDKKey {
 	}
 }
 
+func (e ExpiringMobileKeyRep) ToParams() ExpiringMobileKey {
+	if e.Value.Defined() {
+		return ExpiringMobileKey{
+			Key:        e.Value,
+			Expiration: ToTime(e.Timestamp),
+		}
+	}
+	return ExpiringMobileKey{}
+}
+
 func ToTime(millisecondTime ldtime.UnixMillisecondTime) time.Time {
 	return time.UnixMilli(int64(millisecondTime)) //nolint: gosec
 }
 
 // ToParams converts the JSON properties for an environment into our internal parameter type.
 func (r EnvironmentRep) ToParams() EnvironmentParams {
-	params := EnvironmentParams{
+	activeSDK, expiringAdditionalSDK := splitAdditionalSDKKeys(r.SDKKey.Additional)
+
+	mobileKey := r.MobKey
+	var expiringMobile ExpiringMobileKey
+	var activeMobile []config.MobileKey
+	var expiringAdditionalMobile map[config.MobileKey]time.Time
+	if r.MobileKey != nil {
+		mobileKey = r.MobileKey.Value
+		expiringMobile = r.MobileKey.Expiring.ToParams()
+		activeMobile, expiringAdditionalMobile = splitAdditionalMobileKeys(r.MobileKey.Additional)
+	}
+
+	return EnvironmentParams{
 		EnvID: r.EnvID,
 		Identifiers: relayenv.EnvIdentifiers{
 			EnvKey:   r.EnvKey,
@@ -87,14 +145,51 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 			ProjKey:  r.ProjKey,
 			ProjName: r.ProjName,
 		},
-		SDKKey:         r.SDKKey.Value,
-		ExpiringSDKKey: r.SDKKey.Expiring.ToParams(),
-		MobileKey:      r.MobKey,
-		TTL:            time.Duration(r.DefaultTTL) * time.Minute,
-		SecureMode:     r.SecureMode,
+		SDKKey:                       r.SDKKey.Value,
+		ExpiringSDKKey:               r.SDKKey.Expiring.ToParams(),
+		AdditionalSDKKeys:            activeSDK,
+		ExpiringAdditionalSDKKeys:    expiringAdditionalSDK,
+		MobileKey:                    mobileKey,
+		ExpiringMobileKey:            expiringMobile,
+		AdditionalMobileKeys:         activeMobile,
+		ExpiringAdditionalMobileKeys: expiringAdditionalMobile,
+		TTL:                          time.Duration(r.DefaultTTL) * time.Minute,
+		SecureMode:                   r.SecureMode,
 	}
+}
 
-	return params
+func splitAdditionalSDKKeys(additional []AdditionalSDKKeyRep) (active []config.SDKKey, expiring map[config.SDKKey]time.Time) {
+	for _, a := range additional {
+		if !a.Value.Defined() {
+			continue
+		}
+		if a.ExpiresAt != nil {
+			if expiring == nil {
+				expiring = make(map[config.SDKKey]time.Time)
+			}
+			expiring[a.Value] = ToTime(*a.ExpiresAt)
+		} else {
+			active = append(active, a.Value)
+		}
+	}
+	return active, expiring
+}
+
+func splitAdditionalMobileKeys(additional []AdditionalMobileKeyRep) (active []config.MobileKey, expiring map[config.MobileKey]time.Time) {
+	for _, a := range additional {
+		if !a.Value.Defined() {
+			continue
+		}
+		if a.ExpiresAt != nil {
+			if expiring == nil {
+				expiring = make(map[config.MobileKey]time.Time)
+			}
+			expiring[a.Value] = ToTime(*a.ExpiresAt)
+		} else {
+			active = append(active, a.Value)
+		}
+	}
+	return active, expiring
 }
 
 func (r EnvironmentRep) Describe() string {

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -96,6 +96,56 @@ func TestEnvironmentRepToParamsAdditionalSDKKeys(t *testing.T) {
 	}, params.ExpiringAdditionalSDKKeys)
 }
 
+func TestEnvironmentRepToParamsAdditionalSDKKeysDedupesDuplicates(t *testing.T) {
+	// Defense in depth against malformed platform payloads: duplicate entries dedupe with
+	// expiring winning over active and the first occurrence within a kind winning.
+	expiresEarly := ldtime.UnixMillisecondTime(10000)
+	expiresLate := ldtime.UnixMillisecondTime(20000)
+	env := EnvironmentRep{
+		SDKKey: SDKKeyRep{
+			Value: config.SDKKey("primary"),
+			Additional: []AdditionalSDKKeyRep{
+				{Value: config.SDKKey("dup-active")},
+				{Value: config.SDKKey("dup-active")}, // identical to previous
+				{Value: config.SDKKey("dup-expiring"), ExpiresAt: &expiresEarly},
+				{Value: config.SDKKey("dup-expiring"), ExpiresAt: &expiresLate}, // ignored, first wins
+				{Value: config.SDKKey("mixed")},                                 // listed as active first
+				{Value: config.SDKKey("mixed"), ExpiresAt: &expiresEarly},       // promoted to expiring
+			},
+		},
+	}
+
+	params := env.ToParams()
+
+	assert.Equal(t, []config.SDKKey{"dup-active"}, params.AdditionalSDKKeys)
+	assert.Equal(t, map[config.SDKKey]time.Time{
+		"dup-expiring": time.UnixMilli(int64(expiresEarly)),
+		"mixed":        time.UnixMilli(int64(expiresEarly)),
+	}, params.ExpiringAdditionalSDKKeys)
+}
+
+func TestEnvironmentRepToParamsAdditionalMobileKeysDedupesDuplicates(t *testing.T) {
+	expiresEarly := ldtime.UnixMillisecondTime(10000)
+	env := EnvironmentRep{
+		MobileKey: &MobileKeyRep{
+			Value: config.MobileKey("primary"),
+			Additional: []AdditionalMobileKeyRep{
+				{Value: config.MobileKey("dup-active")},
+				{Value: config.MobileKey("dup-active")},
+				{Value: config.MobileKey("mixed")},
+				{Value: config.MobileKey("mixed"), ExpiresAt: &expiresEarly},
+			},
+		},
+	}
+
+	params := env.ToParams()
+
+	assert.Equal(t, []config.MobileKey{"dup-active"}, params.AdditionalMobileKeys)
+	assert.Equal(t, map[config.MobileKey]time.Time{
+		"mixed": time.UnixMilli(int64(expiresEarly)),
+	}, params.ExpiringAdditionalMobileKeys)
+}
+
 func TestEnvironmentRepToParamsAdditionalSDKKeysSkipsUndefinedEntries(t *testing.T) {
 	env := EnvironmentRep{
 		SDKKey: SDKKeyRep{

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -76,8 +76,8 @@ func TestEnvironmentRepToParams(t *testing.T) {
 func TestEnvironmentRepToParamsAdditionalSDKKeys(t *testing.T) {
 	expiresAt := ldtime.UnixMillisecondTime(20000)
 	env := EnvironmentRep{
-		EnvID:   config.EnvironmentID("envid"),
-		MobKey:  config.MobileKey("mob"),
+		EnvID:  config.EnvironmentID("envid"),
+		MobKey: config.MobileKey("mob"),
 		SDKKey: SDKKeyRep{
 			Value: config.SDKKey("primary"),
 			Additional: []AdditionalSDKKeyRep{
@@ -125,6 +125,21 @@ func TestEnvironmentRepToParamsMobileKeyPrefersNewField(t *testing.T) {
 	params := env.ToParams()
 
 	assert.Equal(t, config.MobileKey("primary"), params.MobileKey)
+}
+
+func TestEnvironmentRepToParamsMobileKeyEmptyValueFallsBackToLegacy(t *testing.T) {
+	// Regression test for the F11 finding: a partially-populated MobileKey struct (e.g., during a
+	// platform rollout where the new field exists but the value isn't filled in) must not clobber
+	// the legacy MobKey field.
+	env := EnvironmentRep{
+		MobKey: config.MobileKey("legacy"),
+		MobileKey: &MobileKeyRep{
+			Value: config.MobileKey(""), // not defined
+		},
+	}
+
+	params := env.ToParams()
+	assert.Equal(t, config.MobileKey("legacy"), params.MobileKey)
 }
 
 func TestEnvironmentRepToParamsMobileKeyFallsBackToLegacyField(t *testing.T) {

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -73,6 +73,113 @@ func TestEnvironmentRepToParams(t *testing.T) {
 	}, params2)
 }
 
+func TestEnvironmentRepToParamsAdditionalSDKKeys(t *testing.T) {
+	expiresAt := ldtime.UnixMillisecondTime(20000)
+	env := EnvironmentRep{
+		EnvID:   config.EnvironmentID("envid"),
+		MobKey:  config.MobileKey("mob"),
+		SDKKey: SDKKeyRep{
+			Value: config.SDKKey("primary"),
+			Additional: []AdditionalSDKKeyRep{
+				{Value: config.SDKKey("active1")},
+				{Value: config.SDKKey("active2")},
+				{Value: config.SDKKey("expiring1"), ExpiresAt: &expiresAt},
+			},
+		},
+	}
+
+	params := env.ToParams()
+
+	assert.Equal(t, []config.SDKKey{"active1", "active2"}, params.AdditionalSDKKeys)
+	assert.Equal(t, map[config.SDKKey]time.Time{
+		"expiring1": time.UnixMilli(int64(expiresAt)),
+	}, params.ExpiringAdditionalSDKKeys)
+}
+
+func TestEnvironmentRepToParamsAdditionalSDKKeysSkipsUndefinedEntries(t *testing.T) {
+	env := EnvironmentRep{
+		SDKKey: SDKKeyRep{
+			Value: config.SDKKey("primary"),
+			Additional: []AdditionalSDKKeyRep{
+				{Value: config.SDKKey("")},
+				{Value: config.SDKKey("active")},
+			},
+		},
+	}
+
+	params := env.ToParams()
+
+	assert.Equal(t, []config.SDKKey{"active"}, params.AdditionalSDKKeys)
+	assert.Nil(t, params.ExpiringAdditionalSDKKeys)
+}
+
+func TestEnvironmentRepToParamsMobileKeyPrefersNewField(t *testing.T) {
+	env := EnvironmentRep{
+		EnvID:  config.EnvironmentID("envid"),
+		MobKey: config.MobileKey("legacy"),
+		MobileKey: &MobileKeyRep{
+			Value: config.MobileKey("primary"),
+		},
+	}
+
+	params := env.ToParams()
+
+	assert.Equal(t, config.MobileKey("primary"), params.MobileKey)
+}
+
+func TestEnvironmentRepToParamsMobileKeyFallsBackToLegacyField(t *testing.T) {
+	env := EnvironmentRep{
+		EnvID:  config.EnvironmentID("envid"),
+		MobKey: config.MobileKey("legacy"),
+	}
+
+	params := env.ToParams()
+
+	assert.Equal(t, config.MobileKey("legacy"), params.MobileKey)
+	assert.False(t, params.ExpiringMobileKey.Defined())
+	assert.Nil(t, params.AdditionalMobileKeys)
+	assert.Nil(t, params.ExpiringAdditionalMobileKeys)
+}
+
+func TestEnvironmentRepToParamsExpiringMobileKey(t *testing.T) {
+	env := EnvironmentRep{
+		MobileKey: &MobileKeyRep{
+			Value: config.MobileKey("primary"),
+			Expiring: ExpiringMobileKeyRep{
+				Value:     config.MobileKey("oldprimary"),
+				Timestamp: ldtime.UnixMillisecondTime(30000),
+			},
+		},
+	}
+
+	params := env.ToParams()
+
+	assert.Equal(t, ExpiringMobileKey{
+		Key:        config.MobileKey("oldprimary"),
+		Expiration: time.UnixMilli(30000),
+	}, params.ExpiringMobileKey)
+}
+
+func TestEnvironmentRepToParamsAdditionalMobileKeys(t *testing.T) {
+	expiresAt := ldtime.UnixMillisecondTime(40000)
+	env := EnvironmentRep{
+		MobileKey: &MobileKeyRep{
+			Value: config.MobileKey("primary"),
+			Additional: []AdditionalMobileKeyRep{
+				{Value: config.MobileKey("active1")},
+				{Value: config.MobileKey("expiring1"), ExpiresAt: &expiresAt},
+			},
+		},
+	}
+
+	params := env.ToParams()
+
+	assert.Equal(t, []config.MobileKey{"active1"}, params.AdditionalMobileKeys)
+	assert.Equal(t, map[config.MobileKey]time.Time{
+		"expiring1": time.UnixMilli(int64(expiresAt)),
+	}, params.ExpiringAdditionalMobileKeys)
+}
+
 func TestEnvironmentRepJSONFormat(t *testing.T) {
 	jsonStr := `{
 		"envID": "envid1",
@@ -103,5 +210,67 @@ func TestEnvironmentRepJSONFormat(t *testing.T) {
 		},
 		DefaultTTL: 2,
 		SecureMode: true,
+	}, rep)
+}
+
+func TestEnvironmentRepJSONFormatWithAdditionalKeys(t *testing.T) {
+	jsonStr := `{
+		"envID": "envid",
+		"envKey": "envkey",
+		"envName": "envname",
+		"mobKey": "mob-legacy",
+		"mobileKey": {
+			"value": "mob-primary",
+			"expiring": { "value": "mob-old", "timestamp": 5000 },
+			"additional": [
+				{ "value": "mob-extra-1" },
+				{ "value": "mob-extra-2", "expiresAt": 9000 }
+			]
+		},
+		"projKey": "projkey",
+		"projName": "projname",
+		"sdkKey": {
+			"value": "sdk-primary",
+			"expiring": { "value": "sdk-old", "timestamp": 6000 },
+			"additional": [
+				{ "value": "sdk-extra-1" },
+				{ "value": "sdk-extra-2", "expiresAt": 8000 }
+			]
+		}
+	  }`
+	var rep EnvironmentRep
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &rep))
+
+	expiresMob := ldtime.UnixMillisecondTime(9000)
+	expiresSDK := ldtime.UnixMillisecondTime(8000)
+	assert.Equal(t, EnvironmentRep{
+		EnvID:    config.EnvironmentID("envid"),
+		EnvKey:   "envkey",
+		EnvName:  "envname",
+		MobKey:   config.MobileKey("mob-legacy"),
+		ProjKey:  "projkey",
+		ProjName: "projname",
+		MobileKey: &MobileKeyRep{
+			Value: config.MobileKey("mob-primary"),
+			Expiring: ExpiringMobileKeyRep{
+				Value:     config.MobileKey("mob-old"),
+				Timestamp: ldtime.UnixMillisecondTime(5000),
+			},
+			Additional: []AdditionalMobileKeyRep{
+				{Value: config.MobileKey("mob-extra-1")},
+				{Value: config.MobileKey("mob-extra-2"), ExpiresAt: &expiresMob},
+			},
+		},
+		SDKKey: SDKKeyRep{
+			Value: config.SDKKey("sdk-primary"),
+			Expiring: ExpiringKeyRep{
+				Value:     config.SDKKey("sdk-old"),
+				Timestamp: ldtime.UnixMillisecondTime(6000),
+			},
+			Additional: []AdditionalSDKKeyRep{
+				{Value: config.SDKKey("sdk-extra-1")},
+				{Value: config.SDKKey("sdk-extra-2"), ExpiresAt: &expiresSDK},
+			},
+		},
 	}, rep)
 }

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -98,6 +98,12 @@ type EnvContext interface {
 	// mobile key has been set.
 	PrimaryMobileKey() config.MobileKey
 
+	// CredentialSnapshot returns the environment's full credential state under a single lock
+	// acquisition so the returned partitioning (primary, additional, deprecated) is internally
+	// consistent. Callers that need a coherent view across multiple credential roles -- the
+	// /status endpoint, for one -- should use this instead of chaining per-attribute accessors.
+	CredentialSnapshot() credential.CredentialSnapshot
+
 	// GetCredentials returns all currently enabled and non-deprecated credentials for the environment.
 	GetCredentials() []credential.SDKCredential
 

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -81,6 +81,14 @@ type EnvContext interface {
 	// with a grace period.
 	UpdateCredential(update *CredentialUpdate)
 
+	// SetAdditionalSDKKeys synchronizes the set of concurrent SDK keys for this environment. Keys
+	// not previously seen are mapped in for auth; keys absent from active and expiring are revoked
+	// immediately. Keys with a per-key expiry stay mapped until the timestamp passes.
+	SetAdditionalSDKKeys(active []config.SDKKey, expiring map[config.SDKKey]time.Time)
+
+	// SetAdditionalMobileKeys is the mobile-key analog of SetAdditionalSDKKeys.
+	SetAdditionalMobileKeys(active []config.MobileKey, expiring map[config.MobileKey]time.Time)
+
 	// GetCredentials returns all currently enabled and non-deprecated credentials for the environment.
 	GetCredentials() []credential.SDKCredential
 

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -25,13 +25,13 @@ import (
 // For example, an environment may have a primary SDK key and a primary mobile key at the same time; each would
 // be specified in individual CredentialUpdate objects.
 type CredentialUpdate struct {
-	// The new primary credential
+	// The new primary credential.
 	primary credential.SDKCredential
-	// An optional deprecated credential (only SDK keys are supported currently)
-	deprecated config.SDKKey
-	// When the deprecated credential expires
+	// An optional deprecated credential. Must be of the same kind as primary (SDK key or mobile key).
+	deprecated credential.SDKCredential
+	// When the deprecated credential expires.
 	expiry time.Time
-	// The current time
+	// The current time.
 	now time.Time
 }
 
@@ -42,8 +42,9 @@ func NewCredentialUpdate(primary credential.SDKCredential) *CredentialUpdate {
 }
 
 // WithGracePeriod modifies the default behavior from immediate revocation to a delayed revocation of the previous
-// credential. During the grace period, the previous credential continues to function.
-func (c *CredentialUpdate) WithGracePeriod(deprecated config.SDKKey, expiry time.Time) *CredentialUpdate {
+// credential. During the grace period, the previous credential continues to function. The deprecated credential
+// must be of the same kind as the primary credential of this update (SDK key or mobile key).
+func (c *CredentialUpdate) WithGracePeriod(deprecated credential.SDKCredential, expiry time.Time) *CredentialUpdate {
 	c.deprecated = deprecated
 	c.expiry = expiry
 	return c

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -90,6 +90,14 @@ type EnvContext interface {
 	// SetAdditionalMobileKeys is the mobile-key analog of SetAdditionalSDKKeys.
 	SetAdditionalMobileKeys(active []config.MobileKey, expiring map[config.MobileKey]time.Time)
 
+	// PrimarySDKKey returns the environment's primary (upstream) SDK key. Returns the empty key if
+	// no SDK key has been set.
+	PrimarySDKKey() config.SDKKey
+
+	// PrimaryMobileKey returns the environment's primary mobile key. Returns the empty key if no
+	// mobile key has been set.
+	PrimaryMobileKey() config.MobileKey
+
 	// GetCredentials returns all currently enabled and non-deprecated credentials for the environment.
 	GetCredentials() []credential.SDKCredential
 

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -86,6 +86,12 @@ type EnvContextImplParams struct {
 	Loggers                          ldlog.Loggers
 	ConnectionMapper                 ConnectionMapper
 	ExpiredCredentialCleanupInterval time.Duration
+	// InitialExpiringAdditionalSDKKeys / InitialExpiringAdditionalMobileKeys seed the rotator's
+	// expiring-additional maps before the env is registered with the lookup. Without these, the
+	// expiring entries arrive only after construction via env.SetAdditional*, leaving a brief
+	// window where requests authenticated with an expiring additional key would 401.
+	InitialExpiringAdditionalSDKKeys    map[config.SDKKey]time.Time
+	InitialExpiringAdditionalMobileKeys map[config.MobileKey]time.Time
 }
 
 type envContextImpl struct {
@@ -203,6 +209,8 @@ func NewEnvContext(
 	})
 	envContext.keyRotator.SeedAdditionalSDKKeys(toSDKKeys(envConfig.AdditionalSDKKeys.Values()))
 	envContext.keyRotator.SeedAdditionalMobileKeys(toMobileKeys(envConfig.AdditionalMobileKeys.Values()))
+	envContext.keyRotator.SeedExpiringAdditionalSDKKeys(params.InitialExpiringAdditionalSDKKeys)
+	envContext.keyRotator.SeedExpiringAdditionalMobileKeys(params.InitialExpiringAdditionalMobileKeys)
 
 	bigSegmentStoreFactory := params.BigSegmentStoreFactory
 	if bigSegmentStoreFactory == nil {

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -95,8 +95,14 @@ type EnvContextImplParams struct {
 }
 
 type envContextImpl struct {
-	mu                        sync.RWMutex
-	clients                   map[config.SDKKey]sdks.LDClientContext
+	mu      sync.RWMutex
+	clients map[config.SDKKey]sdks.LDClientContext
+	// pendingClientRemoval tracks SDK keys that removeCredential saw in flight (no entry in
+	// clients yet, but a startSDKClient goroutine may still be running). When the goroutine
+	// finally writes the client, it checks this set and closes the client immediately rather
+	// than leaving an orphan whose Close() nothing will ever call. addCredential clears the flag
+	// before launching a new spawn so a key re-added after removal still gets its client.
+	pendingClientRemoval      map[config.SDKKey]struct{}
 	storeAdapter              *store.SSERelayDataStoreAdapter
 	loggers                   ldlog.Loggers
 	identifiers               EnvIdentifiers
@@ -182,6 +188,7 @@ func NewEnvContext(
 	envContext := &envContextImpl{
 		identifiers:               params.Identifiers,
 		clients:                   make(map[config.SDKKey]sdks.LDClientContext),
+		pendingClientRemoval:      make(map[config.SDKKey]struct{}),
 		loggers:                   envLoggers,
 		secureMode:                envConfig.SecureMode,
 		streamProviders:           params.StreamProviders,
@@ -465,6 +472,10 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 		isPrimary := key == c.keyRotator.SDKKey()
 		needsUpstreamClient := isPrimary || c.keyRotator.IsSDKKeyRotationPredecessor(key)
 		if needsUpstreamClient && !c.offline {
+			// Clear any stale pending-removal flag for this key. If the key was previously
+			// removed-while-in-flight and a startSDKClient was still cleaning up, we want the new
+			// spawn's client to land normally rather than be auto-closed.
+			delete(c.pendingClientRemoval, key)
 			go c.startSDKClient(key, nil, false)
 		}
 		if isPrimary {
@@ -505,6 +516,12 @@ func (c *envContextImpl) removeCredential(oldCredential credential.SDKCredential
 			if client := c.clients[sdkKey]; client != nil {
 				delete(c.clients, sdkKey)
 				_ = client.Close()
+			} else {
+				// addCredential may have launched a startSDKClient goroutine that hasn't yet
+				// written the client into c.clients. Mark the key so that goroutine closes the
+				// client immediately when it finishes -- otherwise it would land orphaned with
+				// nothing to clean it up until env shutdown.
+				c.pendingClientRemoval[sdkKey] = struct{}{}
 			}
 		}
 	}
@@ -513,6 +530,16 @@ func (c *envContextImpl) removeCredential(oldCredential credential.SDKCredential
 func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- EnvContext, suppressErrors bool) {
 	client, err := c.sdkClientFactory(sdkKey, c.sdkConfig, c.sdkInitTimeout)
 	c.mu.Lock()
+	if _, removed := c.pendingClientRemoval[sdkKey]; removed {
+		// removeCredential ran before this goroutine finished. The new client (if any) has no
+		// home; close it and drop the pending-removal flag.
+		delete(c.pendingClientRemoval, sdkKey)
+		c.mu.Unlock()
+		if client != nil {
+			_ = client.Close()
+		}
+		return
+	}
 	name := c.identifiers.GetDisplayName()
 	if client != nil {
 		c.clients[sdkKey] = client

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -560,10 +560,26 @@ func (c *envContextImpl) SetIdentifiers(ei EnvIdentifiers) {
 }
 
 func (c *envContextImpl) UpdateCredential(update *CredentialUpdate) {
-	if !update.deprecated.Defined() {
-		c.keyRotator.Rotate(update.primary)
-	} else {
-		c.keyRotator.RotateWithGrace(update.primary, credential.NewGracePeriod(update.deprecated, update.expiry, update.now))
+	hasGrace := update.deprecated != nil && update.deprecated.Defined()
+	switch primary := update.primary.(type) {
+	case config.SDKKey:
+		if hasGrace {
+			if deprecated, ok := update.deprecated.(config.SDKKey); ok {
+				c.keyRotator.RotateWithGrace(primary, credential.NewGracePeriod(deprecated, update.expiry, update.now))
+				break
+			}
+		}
+		c.keyRotator.Rotate(primary)
+	case config.MobileKey:
+		if hasGrace {
+			if deprecated, ok := update.deprecated.(config.MobileKey); ok {
+				c.keyRotator.RotateMobileKeyWithGrace(primary, credential.NewMobileGracePeriod(deprecated, update.expiry, update.now))
+				break
+			}
+		}
+		c.keyRotator.Rotate(primary)
+	default:
+		c.keyRotator.Rotate(primary)
 	}
 	c.triggerCredentialChanges(update.now)
 }

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -468,11 +468,12 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 			}
 		}
 	case config.MobileKey:
-		// Only the primary mobile key (and its rotation predecessor) drive the event-forwarder
-		// lifecycle. Additional mobile keys are auth-only.
-		isPrimary := key == c.keyRotator.MobileKey()
-		needsDispatcher := isPrimary || c.keyRotator.IsMobileKeyRotationPredecessor(key)
-		if needsDispatcher && c.eventDispatcher != nil {
+		// Only the primary mobile key drives the event dispatcher's authKey. The rotation
+		// predecessor must be registered for inbound auth (streams, handlers, lookup mapping) but
+		// must NOT clobber the dispatcher -- ReplaceCredential is replace-semantics, and the
+		// predecessor would otherwise overwrite the new primary's outbound forwarding credential.
+		// Additional mobile keys are auth-only and also do not touch the dispatcher.
+		if key == c.keyRotator.MobileKey() && c.eventDispatcher != nil {
 			c.eventDispatcher.ReplaceCredential(key)
 		}
 	}

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -200,6 +200,8 @@ func NewEnvContext(
 		envConfig.MobileKey,
 		envConfig.EnvID,
 	})
+	envContext.keyRotator.SeedAdditionalSDKKeys(toSDKKeys(envConfig.AdditionalSDKKeys.Values()))
+	envContext.keyRotator.SeedAdditionalMobileKeys(toMobileKeys(envConfig.AdditionalMobileKeys.Values()))
 
 	bigSegmentStoreFactory := params.BigSegmentStoreFactory
 	if bigSegmentStoreFactory == nil {
@@ -447,17 +449,24 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 	// So, the effect in offline mode when adding/removing credentials is just setting up the new credential mappings.
 	switch key := newCredential.(type) {
 	case config.SDKKey:
-		if !c.offline {
-			go c.startSDKClient(key, nil, false)
-		}
-		if c.metricsEventPub != nil { // metrics event publisher always uses SDK key
-			c.metricsEventPub.ReplaceCredential(key)
-		}
-		if c.eventDispatcher != nil {
-			c.eventDispatcher.ReplaceCredential(key)
+		// Only the primary/upstream SDK key drives the SDK client and event-forwarder lifecycle.
+		// Additional SDK keys are auth-only -- they get mapped in for incoming requests but never
+		// open an upstream stream to LaunchDarkly.
+		if key == c.keyRotator.SDKKey() {
+			if !c.offline {
+				go c.startSDKClient(key, nil, false)
+			}
+			if c.metricsEventPub != nil { // metrics event publisher always uses SDK key
+				c.metricsEventPub.ReplaceCredential(key)
+			}
+			if c.eventDispatcher != nil {
+				c.eventDispatcher.ReplaceCredential(key)
+			}
 		}
 	case config.MobileKey:
-		if c.eventDispatcher != nil {
+		// Only the primary mobile key drives the event-forwarder lifecycle. Additional mobile keys
+		// are auth-only.
+		if key == c.keyRotator.MobileKey() && c.eventDispatcher != nil {
 			c.eventDispatcher.ReplaceCredential(key)
 		}
 	}
@@ -557,6 +566,16 @@ func (c *envContextImpl) UpdateCredential(update *CredentialUpdate) {
 		c.keyRotator.RotateWithGrace(update.primary, credential.NewGracePeriod(update.deprecated, update.expiry, update.now))
 	}
 	c.triggerCredentialChanges(update.now)
+}
+
+func (c *envContextImpl) SetAdditionalSDKKeys(active []config.SDKKey, expiring map[config.SDKKey]time.Time) {
+	c.keyRotator.SetAdditionalSDKKeys(active, expiring)
+	c.triggerCredentialChanges(time.Now())
+}
+
+func (c *envContextImpl) SetAdditionalMobileKeys(active []config.MobileKey, expiring map[config.MobileKey]time.Time) {
+	c.keyRotator.SetAdditionalMobileKeys(active, expiring)
+	c.triggerCredentialChanges(time.Now())
 }
 
 func (c *envContextImpl) triggerCredentialChanges(now time.Time) {
@@ -820,6 +839,32 @@ func (u *envContextStreamUpdates) SendSingleItemUpdate(kind ldstoretypes.DataKin
 
 func (u *envContextStreamUpdates) InvalidateClientSideState() {
 	u.context.envStreams.InvalidateClientSideState()
+}
+
+func toSDKKeys(values []string) []config.SDKKey {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]config.SDKKey, 0, len(values))
+	for _, v := range values {
+		if v != "" {
+			keys = append(keys, config.SDKKey(v))
+		}
+	}
+	return keys
+}
+
+func toMobileKeys(values []string) []config.MobileKey {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]config.MobileKey, 0, len(values))
+	for _, v := range values {
+		if v != "" {
+			keys = append(keys, config.MobileKey(v))
+		}
+	}
+	return keys
 }
 
 func makeLogPrefix(logNameMode LogNameMode, sdkKey config.SDKKey, envID config.EnvironmentID) string {

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -609,6 +609,10 @@ func (c *envContextImpl) PrimaryMobileKey() config.MobileKey {
 	return c.keyRotator.MobileKey()
 }
 
+func (c *envContextImpl) CredentialSnapshot() credential.CredentialSnapshot {
+	return c.keyRotator.Snapshot()
+}
+
 func (c *envContextImpl) triggerCredentialChanges(now time.Time) {
 	additions, expirations := c.keyRotator.StepTime(now)
 	for _, cred := range additions {

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -876,6 +877,7 @@ func toSDKKeys(values []string) []config.SDKKey {
 	}
 	keys := make([]config.SDKKey, 0, len(values))
 	for _, v := range values {
+		v = strings.TrimSpace(v)
 		if v != "" {
 			keys = append(keys, config.SDKKey(v))
 		}
@@ -889,6 +891,7 @@ func toMobileKeys(values []string) []config.MobileKey {
 	}
 	keys := make([]config.MobileKey, 0, len(values))
 	for _, v := range values {
+		v = strings.TrimSpace(v)
 		if v != "" {
 			keys = append(keys, config.MobileKey(v))
 		}

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -449,13 +449,16 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 	// So, the effect in offline mode when adding/removing credentials is just setting up the new credential mappings.
 	switch key := newCredential.(type) {
 	case config.SDKKey:
-		// Only the primary/upstream SDK key drives the SDK client and event-forwarder lifecycle.
-		// Additional SDK keys are auth-only -- they get mapped in for incoming requests but never
-		// open an upstream stream to LaunchDarkly.
-		if key == c.keyRotator.SDKKey() {
-			if !c.offline {
-				go c.startSDKClient(key, nil, false)
-			}
+		// The primary SDK key and the predecessor primary during a rotation grace both need a
+		// running upstream SDK client (the predecessor stays connected until its expiry to bridge
+		// the rotation cleanly). Additional SDK keys are auth-only -- they get mapped in for
+		// incoming requests but never open an upstream stream.
+		isPrimary := key == c.keyRotator.SDKKey()
+		needsUpstreamClient := isPrimary || c.keyRotator.IsSDKKeyRotationPredecessor(key)
+		if needsUpstreamClient && !c.offline {
+			go c.startSDKClient(key, nil, false)
+		}
+		if isPrimary {
 			if c.metricsEventPub != nil { // metrics event publisher always uses SDK key
 				c.metricsEventPub.ReplaceCredential(key)
 			}
@@ -464,9 +467,11 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 			}
 		}
 	case config.MobileKey:
-		// Only the primary mobile key drives the event-forwarder lifecycle. Additional mobile keys
-		// are auth-only.
-		if key == c.keyRotator.MobileKey() && c.eventDispatcher != nil {
+		// Only the primary mobile key (and its rotation predecessor) drive the event-forwarder
+		// lifecycle. Additional mobile keys are auth-only.
+		isPrimary := key == c.keyRotator.MobileKey()
+		needsDispatcher := isPrimary || c.keyRotator.IsMobileKeyRotationPredecessor(key)
+		if needsDispatcher && c.eventDispatcher != nil {
 			c.eventDispatcher.ReplaceCredential(key)
 		}
 	}

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -599,6 +599,14 @@ func (c *envContextImpl) SetAdditionalMobileKeys(active []config.MobileKey, expi
 	c.triggerCredentialChanges(time.Now())
 }
 
+func (c *envContextImpl) PrimarySDKKey() config.SDKKey {
+	return c.keyRotator.SDKKey()
+}
+
+func (c *envContextImpl) PrimaryMobileKey() config.MobileKey {
+	return c.keyRotator.MobileKey()
+}
+
 func (c *envContextImpl) triggerCredentialChanges(now time.Time) {
 	additions, expirations := c.keyRotator.StepTime(now)
 	for _, cred := range additions {

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -609,6 +609,69 @@ func TestEventDispatcherIsNotCreatedIfSendEventsIsTrueAndNotInOfflineMode(t *tes
 	})
 }
 
+// Regression test for the F1 finding from multi-agent review: when a mobile-key rotation arrives
+// with grace.key != previous primary (the "stale deprecation message" case), the event
+// dispatcher's outbound authKey must remain the new primary -- it must not be clobbered by the
+// rotation predecessor flowing through addCredential.
+func TestEventDispatcherMobileAuthIsPrimaryAfterRotationGrace(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	envConfig := st.EnvMobile.Config
+	primaryMobileKey := envConfig.MobileKey
+	require.NotEmpty(t, primaryMobileKey)
+	staleDeprecatedKey := config.MobileKey("stale-deprecated-mobile-key")
+
+	eventRecorderHandler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(202))
+	httphelpers.WithServer(eventRecorderHandler, func(server *httptest.Server) {
+		var allConfig config.Config
+		allConfig.Events.SendEvents = true
+		allConfig.Events.EventsURI, _ = configtypes.NewOptURLAbsoluteFromString(server.URL)
+		allConfig.Events.FlushInterval = configtypes.NewOptDuration(time.Millisecond * 10)
+		env, err := NewEnvContext(EnvContextImplParams{
+			Identifiers:      EnvIdentifiers{ConfiguredName: envName},
+			EnvConfig:        envConfig,
+			AllConfig:        allConfig,
+			ClientFactory:    testclient.FakeLDClientFactory(true),
+			ConnectionMapper: mockConnectionMapper{},
+			Loggers:          mockLog.Loggers,
+		}, nil)
+		require.NoError(t, err)
+		defer env.Close()
+
+		// Mimic the autoconfig applyExpiringPrimaries call: a rotation arrives with the current
+		// mobile key as the new primary and an unrelated key as the deprecated predecessor.
+		// In the rotator, swapPrimaryMobileKey returns "" (newKey already matches primary), but
+		// the predecessor still gets enqueued into additions. Without F1's fix, the addCredential
+		// path for the predecessor would call dispatcher.ReplaceCredential(staleDeprecatedKey),
+		// silently overwriting the primary's outbound auth.
+		expiry := time.Now().Add(time.Hour)
+		env.UpdateCredential(
+			NewCredentialUpdate(primaryMobileKey).WithGracePeriod(staleDeprecatedKey, expiry),
+		)
+
+		envImpl := env.(*envContextImpl)
+		ed := envImpl.GetEventDispatcher()
+		require.NotNil(t, ed)
+		eventDispatchHandler := ed.GetHandler(basictypes.MobileSDK, ldevents.AnalyticsEventDataKind)
+		require.NotNil(t, eventDispatchHandler)
+
+		rr := httptest.NewRecorder()
+		headers := make(http.Header)
+		headers.Set("Content-Type", "application/json")
+		headers.Set("Authorization", string(primaryMobileKey))
+		headers.Set("X-LaunchDarkly-Event-Schema", strconv.Itoa(events.SummaryEventsSchemaVersion))
+		body := `[{"kind":"identify","creationDate":1000,"key":"userkey","user":{"key":"userkey"}}]`
+		req := st.BuildRequest("POST", server.URL+"/mobile", []byte(body), headers)
+		eventDispatchHandler(rr, req)
+		require.Equal(t, 202, rr.Result().StatusCode)
+
+		eventPost := helpers.RequireValue(t, requestsCh, time.Second)
+		// The outbound auth must be the primary mobile key, NOT the stale deprecated one.
+		assert.Equal(t, string(primaryMobileKey), eventPost.Request.Header.Get("Authorization"))
+	})
+}
+
 func TestBigSegmentsSynchronizerIsCreatedIfBigSegmentStoreExists(t *testing.T) {
 	envConfig := st.EnvMain.Config
 	allConfig := config.Config{}

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -207,6 +207,121 @@ func TestAddRemoveCredential(t *testing.T) {
 	assert.Contains(t, creds, st.EnvWithAllCredentials.Config.EnvID)
 }
 
+// recordingConnectionMapper tracks Add/Remove calls so tests can assert mapping changes.
+type recordingConnectionMapper struct {
+	mu       sync.Mutex
+	mappings map[sdkauth.ScopedCredential]struct{}
+}
+
+func newRecordingConnectionMapper() *recordingConnectionMapper {
+	return &recordingConnectionMapper{mappings: make(map[sdkauth.ScopedCredential]struct{})}
+}
+
+func (m *recordingConnectionMapper) AddConnectionMapping(sc sdkauth.ScopedCredential, env EnvContext) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mappings[sc] = struct{}{}
+}
+
+func (m *recordingConnectionMapper) RemoveConnectionMapping(sc sdkauth.ScopedCredential) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.mappings, sc)
+}
+
+func (m *recordingConnectionMapper) hasMapping(cred credential.SDKCredential) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.mappings[sdkauth.NewScoped("", cred)]
+	return ok
+}
+
+func TestEnvContextSeedsAdditionalKeysFromConfig(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	envConfig.AdditionalSDKKeys = configtypes.NewOptStringList([]string{"sdk-extra-1", "sdk-extra-2"})
+	envConfig.AdditionalMobileKeys = configtypes.NewOptStringList([]string{"mob-extra-1"})
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	env := makeBasicEnv(t, envConfig, testclient.FakeLDClientFactory(true), mockLog.Loggers, nil)
+	defer env.Close()
+
+	creds := env.GetCredentials()
+	assert.Contains(t, creds, envConfig.SDKKey)
+	assert.Contains(t, creds, config.SDKKey("sdk-extra-1"))
+	assert.Contains(t, creds, config.SDKKey("sdk-extra-2"))
+	assert.Contains(t, creds, config.MobileKey("mob-extra-1"))
+}
+
+func TestEnvContextAdditionalSDKKeysDoNotSpawnExtraClients(t *testing.T) {
+	envConfig := st.EnvMain.Config
+
+	clientCh := make(chan *testclient.FakeLDClient, 8)
+	clientFactory := testclient.FakeLDClientFactoryWithChannel(true, clientCh)
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, envConfig, clientFactory, mockLog.Loggers, readyCh)
+	defer env.Close()
+
+	// One client is created for the primary SDK key.
+	requireEnvReady(t, readyCh)
+	_ = requireClientReady(t, clientCh)
+
+	env.SetAdditionalSDKKeys([]config.SDKKey{"extra-1", "extra-2", "extra-3"}, nil)
+	env.SetAdditionalMobileKeys([]config.MobileKey{"mob-extra-1"}, nil)
+
+	// No additional clients should have been spawned for the extra keys.
+	if !helpers.AssertChannelNotClosed(t, clientCh, 100*time.Millisecond, "expected no additional SDK clients") {
+		// AssertChannelNotClosed only complains on close; check there's no extra value either.
+	}
+	select {
+	case extra := <-clientCh:
+		t.Fatalf("expected no additional SDK client, but got one: %v", extra)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The active credential set should include the additionals.
+	creds := env.GetCredentials()
+	assert.Contains(t, creds, config.SDKKey("extra-1"))
+	assert.Contains(t, creds, config.SDKKey("extra-2"))
+	assert.Contains(t, creds, config.SDKKey("extra-3"))
+	assert.Contains(t, creds, config.MobileKey("mob-extra-1"))
+}
+
+func TestEnvContextSetAdditionalKeysPropagatesToLookup(t *testing.T) {
+	envConfig := st.EnvMain.Config
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+	mapper := newRecordingConnectionMapper()
+
+	env, err := NewEnvContext(EnvContextImplParams{
+		Identifiers:      EnvIdentifiers{ConfiguredName: envName},
+		EnvConfig:        envConfig,
+		ClientFactory:    testclient.FakeLDClientFactory(true),
+		Loggers:          mockLog.Loggers,
+		ConnectionMapper: mapper,
+	}, nil)
+	require.NoError(t, err)
+	defer env.Close()
+
+	env.SetAdditionalSDKKeys([]config.SDKKey{"sdk-extra"}, nil)
+	env.SetAdditionalMobileKeys([]config.MobileKey{"mob-extra"}, nil)
+
+	assert.True(t, mapper.hasMapping(config.SDKKey("sdk-extra")))
+	assert.True(t, mapper.hasMapping(config.MobileKey("mob-extra")))
+
+	// Omit them in the next patch; the mappings should be removed.
+	env.SetAdditionalSDKKeys(nil, nil)
+	env.SetAdditionalMobileKeys(nil, nil)
+
+	assert.False(t, mapper.hasMapping(config.SDKKey("sdk-extra")))
+	assert.False(t, mapper.hasMapping(config.MobileKey("mob-extra")))
+}
+
 func TestAddExistingCredentialDoesNothing(t *testing.T) {
 	envConfig := st.EnvMain.Config
 

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	ldevents "github.com/launchdarkly/go-sdk-events/v3"
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	ld "github.com/launchdarkly/go-server-sdk/v7"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
@@ -607,6 +608,86 @@ func TestEventDispatcherIsNotCreatedIfSendEventsIsTrueAndNotInOfflineMode(t *tes
 		ed := envImpl.GetEventDispatcher()
 		require.Nil(t, ed)
 	})
+}
+
+// Regression test for the F7 finding: addCredential spawns startSDKClient in a goroutine and
+// releases c.mu before c.clients[sdkKey] is populated. If removeCredential runs in the gap, the
+// eventually-created client used to be orphaned (no Close() ever called) because c.clients[sdkKey]
+// looked nil at removeCredential time. The fix tracks pending removals so the spawned goroutine
+// auto-closes its client if removeCredential ran before it finished.
+func TestRemoveCredentialClosesInFlightSDKClient(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	// Gated factory: production of each FakeLDClient blocks until we release the gate. This lets
+	// us deterministically interleave removeCredential between addCredential's spawn and the
+	// client landing in c.clients.
+	gate := make(chan struct{})
+	createdCh := make(chan *testclient.FakeLDClient, 4)
+	gatedFactory := sdks.ClientFactoryFunc(func(sdkKey config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		<-gate
+		client := &testclient.FakeLDClient{Key: sdkKey, CloseCh: make(chan struct{})}
+		createdCh <- client
+		return client, nil
+	})
+
+	env, err := NewEnvContext(EnvContextImplParams{
+		Identifiers:      EnvIdentifiers{ConfiguredName: envName},
+		EnvConfig:        envConfig,
+		ClientFactory:    gatedFactory,
+		ConnectionMapper: mockConnectionMapper{},
+		Loggers:          mockLog.Loggers,
+	}, nil)
+	require.NoError(t, err)
+	defer env.Close()
+	impl := env.(*envContextImpl)
+
+	// Promote an additional SDK key to a rotation predecessor by simulating the autoconfig path:
+	// register the key as additional, then rotate to a new primary with the original as grace.key.
+	// addCredential for the predecessor will fire startSDKClient (which blocks on the gate).
+	extra := config.SDKKey("extra-sdk")
+	env.SetAdditionalSDKKeys([]config.SDKKey{extra}, nil)
+	env.UpdateCredential(
+		NewCredentialUpdate(config.SDKKey("new-primary")).
+			WithGracePeriod(extra, time.Now().Add(time.Hour)),
+	)
+
+	// At this point the new-primary spawn and the rotation-predecessor spawn are both blocked on
+	// the gate. Remove the original primary's SDK key (the one EnvMain was constructed with)
+	// before the gate opens, then unblock everything.
+	env.UpdateCredential(NewCredentialUpdate(config.SDKKey("new-primary")))
+	// Now `extra` is the rotation predecessor of new-primary's previous rotation; its
+	// startSDKClient goroutine is still waiting on the gate. removeCredential for `extra` runs
+	// as soon as its grace expires -- but for this test we trigger it directly:
+	impl.removeCredential(extra)
+
+	// Release the factory. Every spawned client should be immediately closed because
+	// pendingClientRemoval was set for at least the predecessor.
+	close(gate)
+
+	// Drain createdCh and verify at least one of the clients got Close()d. (We don't assert all
+	// clients close because the new primary should keep running.)
+	deadline := time.Now().Add(time.Second)
+	sawClose := false
+	for time.Now().Before(deadline) {
+		select {
+		case client := <-createdCh:
+			if client.Key == extra {
+				select {
+				case <-client.CloseCh:
+					sawClose = true
+				case <-time.After(500 * time.Millisecond):
+					t.Fatalf("client for revoked key %q was created but never closed", client.Key)
+				}
+			}
+		case <-time.After(50 * time.Millisecond):
+		}
+		if sawClose {
+			break
+		}
+	}
+	assert.True(t, sawClose, "expected the in-flight client for the removed key to be closed")
 }
 
 // Regression test for the F1 finding from multi-agent review: when a mobile-key rotation arrives

--- a/internal/streams/env_streams.go
+++ b/internal/streams/env_streams.go
@@ -106,12 +106,21 @@ func NewEnvStreams(
 }
 
 // AddCredential adds an environment keyed off the combination of credential and payload filter,
-// and creates a corresponding EnvStreamProvider.
+// and creates a corresponding EnvStreamProvider. Calling AddCredential a second time with the same
+// credential is a no-op -- the registration is already in place.
 func (es *EnvStreams) AddCredential(credential credential.SDKCredential) {
 	if credential == nil {
 		return
 	}
 	scopedCred := sdkauth.NewScoped(es.filterKey, credential)
+	es.lock.Lock()
+	for _, s := range es.activeStreams {
+		if s.credential == scopedCred {
+			es.lock.Unlock()
+			return
+		}
+	}
+	es.lock.Unlock()
 	for _, sp := range es.streamProviders {
 		if esp := sp.Register(scopedCred, es.storeQueries, es.loggers); esp != nil {
 			es.lock.Lock()

--- a/internal/streams/env_streams.go
+++ b/internal/streams/env_streams.go
@@ -108,24 +108,26 @@ func NewEnvStreams(
 // AddCredential adds an environment keyed off the combination of credential and payload filter,
 // and creates a corresponding EnvStreamProvider. Calling AddCredential a second time with the same
 // credential is a no-op -- the registration is already in place.
+//
+// The lock is held across the duplicate check and the Register-then-append loop so two concurrent
+// callers can never both pass the duplicate check and double-register. In-tree callers serialize
+// via envContextImpl.mu, but the public docstring advertises idempotency against concurrent
+// callers as well.
 func (es *EnvStreams) AddCredential(credential credential.SDKCredential) {
 	if credential == nil {
 		return
 	}
 	scopedCred := sdkauth.NewScoped(es.filterKey, credential)
 	es.lock.Lock()
+	defer es.lock.Unlock()
 	for _, s := range es.activeStreams {
 		if s.credential == scopedCred {
-			es.lock.Unlock()
 			return
 		}
 	}
-	es.lock.Unlock()
 	for _, sp := range es.streamProviders {
 		if esp := sp.Register(scopedCred, es.storeQueries, es.loggers); esp != nil {
-			es.lock.Lock()
 			es.activeStreams = append(es.activeStreams, streamInfo{scopedCred, esp})
-			es.lock.Unlock()
 		}
 	}
 }

--- a/internal/streams/env_streams_test.go
+++ b/internal/streams/env_streams_test.go
@@ -122,6 +122,30 @@ func TestAddCredential(t *testing.T) {
 	assert.Equal(t, store, esp3.store)
 }
 
+// Regression test for the F6 finding: AddCredential must be idempotent against concurrent callers.
+// The original check-then-act released the lock between the duplicate check and the Register+append
+// loop, so two goroutines hitting the same credential could both pass the check and double-register.
+func TestAddCredentialConcurrent(t *testing.T) {
+	sp := &mockStreamProvider{credentialOfDesiredType: config.SDKKey("")}
+	store := makeMockStore(nil, nil)
+	es := NewEnvStreams([]StreamProvider{sp}, store, 0, config.DefaultFilter, ldlog.NewDisabledLoggers())
+	defer es.Close()
+
+	sdkKey := config.SDKKey("contested-key")
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			es.AddCredential(sdkKey)
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, sp.createdStreams, 1, "expected exactly one stream registration despite concurrent AddCredential calls")
+}
+
 func TestRemoveCredential(t *testing.T) {
 	sp := &mockStreamProvider{credentialOfDesiredType: config.SDKKey("")}
 

--- a/internal/streams/env_streams_test.go
+++ b/internal/streams/env_streams_test.go
@@ -95,9 +95,11 @@ func TestAddCredential(t *testing.T) {
 	es := NewEnvStreams([]StreamProvider{sp1, sp2}, store, 0, config.DefaultFilter, ldlog.NewDisabledLoggers())
 	defer es.Close()
 
-	sdkKey1, sdkKey2 := config.SDKKey("sdk-key1"), config.SDKKey("sdk-key1")
+	sdkKey1, sdkKey2 := config.SDKKey("sdk-key1"), config.SDKKey("sdk-key2")
 	es.AddCredential(sdkKey1)
 	es.AddCredential(sdkKey2)
+	// Re-adding sdkKey1 should be a no-op; AddCredential is idempotent.
+	es.AddCredential(sdkKey1)
 
 	mobileKey := config.MobileKey("mobile-key")
 	es.AddCredential(mobileKey)

--- a/relay/autoconfig_actions.go
+++ b/relay/autoconfig_actions.go
@@ -31,12 +31,12 @@ func (a *relayAutoConfigActions) AddEnvironment(params envfactory.EnvironmentPar
 	env, _, err := a.r.addEnvironment(params.Identifiers, envConfig, nil)
 	if err != nil {
 		a.r.loggers.Errorf(logMsgAutoConfEnvInitError, params.Identifiers.GetDisplayName(), err)
+		return
 	}
 
-	if params.ExpiringSDKKey.Defined() {
-		update := relayenv.NewCredentialUpdate(params.SDKKey)
-		env.UpdateCredential(update.WithGracePeriod(params.ExpiringSDKKey.Key, params.ExpiringSDKKey.Expiration))
-	}
+	applyExpiringPrimaries(env, params)
+	env.SetAdditionalSDKKeys(params.AdditionalSDKKeys, params.ExpiringAdditionalSDKKeys)
+	env.SetAdditionalMobileKeys(params.AdditionalMobileKeys, params.ExpiringAdditionalMobileKeys)
 }
 
 func (a *relayAutoConfigActions) UpdateEnvironment(params envfactory.EnvironmentParams) {
@@ -50,15 +50,35 @@ func (a *relayAutoConfigActions) UpdateEnvironment(params envfactory.Environment
 	env.SetTTL(params.TTL)
 	env.SetSecureMode(params.SecureMode)
 
-	if params.MobileKey.Defined() {
-		env.UpdateCredential(relayenv.NewCredentialUpdate(params.MobileKey))
-	}
 	if params.SDKKey.Defined() {
 		update := relayenv.NewCredentialUpdate(params.SDKKey)
 		if params.ExpiringSDKKey.Defined() {
 			update = update.WithGracePeriod(params.ExpiringSDKKey.Key, params.ExpiringSDKKey.Expiration)
 		}
 		env.UpdateCredential(update)
+	}
+	if params.MobileKey.Defined() {
+		update := relayenv.NewCredentialUpdate(params.MobileKey)
+		if params.ExpiringMobileKey.Defined() {
+			update = update.WithGracePeriod(params.ExpiringMobileKey.Key, params.ExpiringMobileKey.Expiration)
+		}
+		env.UpdateCredential(update)
+	}
+	env.SetAdditionalSDKKeys(params.AdditionalSDKKeys, params.ExpiringAdditionalSDKKeys)
+	env.SetAdditionalMobileKeys(params.AdditionalMobileKeys, params.ExpiringAdditionalMobileKeys)
+}
+
+// applyExpiringPrimaries handles the optional grace periods on the primary SDK and mobile keys when
+// a freshly-added environment already arrives mid-rotation. The primary keys themselves are set via
+// the EnvConfig during construction; this function only applies the deprecated predecessors.
+func applyExpiringPrimaries(env relayenv.EnvContext, params envfactory.EnvironmentParams) {
+	if params.ExpiringSDKKey.Defined() {
+		update := relayenv.NewCredentialUpdate(params.SDKKey)
+		env.UpdateCredential(update.WithGracePeriod(params.ExpiringSDKKey.Key, params.ExpiringSDKKey.Expiration))
+	}
+	if params.ExpiringMobileKey.Defined() {
+		update := relayenv.NewCredentialUpdate(params.MobileKey)
+		env.UpdateCredential(update.WithGracePeriod(params.ExpiringMobileKey.Key, params.ExpiringMobileKey.Expiration))
 	}
 }
 

--- a/relay/autoconfig_actions.go
+++ b/relay/autoconfig_actions.go
@@ -28,7 +28,14 @@ func (a *relayAutoConfigActions) AddEnvironment(params envfactory.EnvironmentPar
 	// But in reality, this method is only going to be called from a single goroutine in the auto-config
 	// stream handler.
 	envConfig := envfactory.NewEnvConfigFactoryForAutoConfig(a.r.config.AutoConfig).MakeEnvironmentConfig(params)
-	env, _, err := a.r.addEnvironment(params.Identifiers, envConfig, nil)
+	// Seed expiring additional keys at construction so the rotator's maps are populated before
+	// InsertEnvironment runs. Without this, the env would be mapped into the lookup with only the
+	// active additionals; a request authenticated with an expiring additional key would 401 until
+	// the follow-up SetAdditional call lands.
+	env, _, err := a.r.addEnvironment(params.Identifiers, envConfig, nil, addEnvironmentOptions{
+		initialExpiringAdditionalSDKKeys:    params.ExpiringAdditionalSDKKeys,
+		initialExpiringAdditionalMobileKeys: params.ExpiringAdditionalMobileKeys,
+	})
 	if err != nil {
 		a.r.loggers.Errorf(logMsgAutoConfEnvInitError, params.Identifiers.GetDisplayName(), err)
 		return

--- a/relay/autoconfig_actions_test.go
+++ b/relay/autoconfig_actions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"
 
 	c "github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
 
 	"github.com/launchdarkly/go-configtypes"
@@ -151,6 +152,83 @@ func TestAutoConfigInitWithExpiringSDKKey(t *testing.T) {
 		paramsWithOldKey := envWithKeys.params()
 		paramsWithOldKey.SDKKey = oldKey
 		p.assertEnvLookup(env, paramsWithOldKey)
+	})
+}
+
+func TestAutoConfigInitWithAdditionalSDKKeys(t *testing.T) {
+	primaryKey := c.SDKKey("primary-sdk")
+	extra1 := c.SDKKey("extra-sdk-1")
+	extra2 := c.SDKKey("extra-sdk-2")
+
+	env := testAutoConfEnv1
+	env.sdkKey = envfactory.SDKKeyRep{
+		Value: primaryKey,
+		Additional: []envfactory.AdditionalSDKKeyRep{
+			{Value: extra1},
+			{Value: extra2},
+		},
+	}
+
+	initialEvent := makeAutoConfPutEvent(env)
+	autoConfTest(t, testAutoConfDefaultConfig, &initialEvent, func(p autoConfTestParams) {
+		client := p.awaitClient()
+		assert.Equal(t, primaryKey, client.Key)
+
+		envCtx := p.awaitEnvironment(env.id)
+
+		// All three SDK keys should authenticate to the same environment.
+		paramsPrimary := env.params()
+		paramsPrimary.SDKKey = primaryKey
+		p.assertEnvLookup(envCtx, paramsPrimary)
+
+		paramsExtra1 := env.params()
+		paramsExtra1.SDKKey = extra1
+		p.assertEnvLookup(envCtx, paramsExtra1)
+
+		paramsExtra2 := env.params()
+		paramsExtra2.SDKKey = extra2
+		p.assertEnvLookup(envCtx, paramsExtra2)
+
+		// But only one SDK client should have been spawned (the primary).
+		p.shouldNotCreateClient(100 * time.Millisecond)
+	})
+}
+
+func TestAutoConfigPatchRemovingAdditionalSDKKeyRevokesIt(t *testing.T) {
+	primaryKey := c.SDKKey("primary-sdk")
+	extra := c.SDKKey("extra-sdk")
+
+	env := testAutoConfEnv1
+	env.sdkKey = envfactory.SDKKeyRep{
+		Value:      primaryKey,
+		Additional: []envfactory.AdditionalSDKKeyRep{{Value: extra}},
+	}
+
+	initialEvent := makeAutoConfPutEvent(env)
+	autoConfTest(t, testAutoConfDefaultConfig, &initialEvent, func(p autoConfTestParams) {
+		_ = p.awaitClient()
+		envCtx := p.awaitEnvironment(env.id)
+
+		paramsExtra := env.params()
+		paramsExtra.SDKKey = extra
+		p.assertEnvLookup(envCtx, paramsExtra)
+
+		// Patch with the additional key omitted -- should be revoked immediately.
+		envWithoutExtra := env
+		envWithoutExtra.sdkKey = envfactory.SDKKeyRep{Value: primaryKey}
+		envWithoutExtra.version = env.version + 1
+		p.stream.Enqueue(makeAutoConfPatchEvent(envWithoutExtra))
+
+		// Wait for the revoke to propagate; the env lookup for `extra` should start failing.
+		require.Eventually(t, func() bool {
+			_, err := p.relay.getEnvironment(sdkauth.New(extra))
+			return err != nil
+		}, time.Second, 5*time.Millisecond, "extra key should no longer authenticate")
+
+		// Primary still works.
+		paramsPrimary := env.params()
+		paramsPrimary.SDKKey = primaryKey
+		p.assertEnvLookup(envCtx, paramsPrimary)
 	})
 }
 

--- a/relay/autoconfig_actions_test.go
+++ b/relay/autoconfig_actions_test.go
@@ -194,6 +194,36 @@ func TestAutoConfigInitWithAdditionalSDKKeys(t *testing.T) {
 	})
 }
 
+// Regression test for the F9 finding: an env that arrives mid-rotation with expiring additional
+// SDK keys must have those keys mapped in the lookup BEFORE InsertEnvironment completes, not via
+// a follow-up SetAdditional call. Otherwise the env briefly returns 401 for requests using the
+// expiring key.
+func TestAutoConfigInitWithExpiringAdditionalSDKKey(t *testing.T) {
+	primaryKey := c.SDKKey("primary-sdk")
+	expiringExtra := c.SDKKey("expiring-extra-sdk")
+	expiresAt := ldtime.UnixMillisecondTime(ldtime.UnixMillisFromTime(time.Now().Add(time.Hour)))
+
+	env := testAutoConfEnv1
+	env.sdkKey = envfactory.SDKKeyRep{
+		Value: primaryKey,
+		Additional: []envfactory.AdditionalSDKKeyRep{
+			{Value: expiringExtra, ExpiresAt: &expiresAt},
+		},
+	}
+
+	initialEvent := makeAutoConfPutEvent(env)
+	autoConfTest(t, testAutoConfDefaultConfig, &initialEvent, func(p autoConfTestParams) {
+		_ = p.awaitClient()
+		envCtx := p.awaitEnvironment(env.id)
+
+		// The expiring extra key must already be mapped in the lookup immediately after env
+		// construction -- not after a subsequent SetAdditional call.
+		paramsExpiring := env.params()
+		paramsExpiring.SDKKey = expiringExtra
+		p.assertEnvLookup(envCtx, paramsExpiring)
+	})
+}
+
 func TestAutoConfigPatchRemovingAdditionalSDKKeyRevokesIt(t *testing.T) {
 	primaryKey := c.SDKKey("primary-sdk")
 	extra := c.SDKKey("extra-sdk")

--- a/relay/autoconfig_testdata_test.go
+++ b/relay/autoconfig_testdata_test.go
@@ -17,14 +17,15 @@ var testAutoConfDefaultConfig = c.Config{
 }
 
 type testAutoConfEnv struct {
-	id       c.EnvironmentID
-	envKey   string
-	envName  string
-	mobKey   c.MobileKey
-	projKey  string
-	projName string
-	sdkKey   envfactory.SDKKeyRep
-	version  int
+	id        c.EnvironmentID
+	envKey    string
+	envName   string
+	mobKey    c.MobileKey
+	mobileKey *envfactory.MobileKeyRep
+	projKey   string
+	projName  string
+	sdkKey    envfactory.SDKKeyRep
+	version   int
 }
 
 func (e testAutoConfEnv) SDKKey() c.SDKKey {
@@ -57,14 +58,15 @@ var (
 
 func (e testAutoConfEnv) toEnvironmentRep() envfactory.EnvironmentRep {
 	rep := envfactory.EnvironmentRep{
-		EnvID:    e.id,
-		EnvKey:   e.envKey,
-		EnvName:  e.envName,
-		MobKey:   e.mobKey,
-		ProjKey:  e.projKey,
-		ProjName: e.projName,
-		SDKKey:   e.sdkKey,
-		Version:  e.version,
+		EnvID:     e.id,
+		EnvKey:    e.envKey,
+		EnvName:   e.envName,
+		MobKey:    e.mobKey,
+		MobileKey: e.mobileKey,
+		ProjKey:   e.projKey,
+		ProjName:  e.projName,
+		SDKKey:    e.sdkKey,
+		Version:   e.version,
 	}
 	return rep
 }

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -46,49 +46,43 @@ func statusHandler(relay *Relay) http.Handler {
 				ProjName: identifiers.ProjName,
 			}
 
-			primarySDKKey := clientCtx.PrimarySDKKey()
-			primaryMobileKey := clientCtx.PrimaryMobileKey()
-			for _, c := range clientCtx.GetCredentials() {
-				switch c := c.(type) {
-				case config.SDKKey:
-					obscured := sdks.ObscureKey(string(c))
-					if c == primarySDKKey {
-						status.SDKKey = obscured
-					} else {
-						status.AdditionalSDKKeys = append(status.AdditionalSDKKeys, obscured)
-					}
-				case config.MobileKey:
-					obscured := sdks.ObscureKey(string(c))
-					if c == primaryMobileKey {
-						status.MobileKey = obscured
-					} else {
-						status.AdditionalMobileKeys = append(status.AdditionalMobileKeys, obscured)
-					}
-				case config.EnvironmentID:
-					status.EnvID = string(c)
-				}
+			// Take an atomic snapshot of all credentials so the primary / additional / deprecated
+			// partitioning is internally consistent. Chaining separate accessors would let a
+			// concurrent rotation slip between calls and mis-classify keys.
+			snap := clientCtx.CredentialSnapshot()
+			if snap.PrimarySDKKey.Defined() {
+				status.SDKKey = sdks.ObscureKey(string(snap.PrimarySDKKey))
 			}
-
+			if snap.PrimaryMobileKey.Defined() {
+				status.MobileKey = sdks.ObscureKey(string(snap.PrimaryMobileKey))
+			}
+			if snap.PrimaryEnvironmentID.Defined() {
+				status.EnvID = string(snap.PrimaryEnvironmentID)
+			}
+			for _, k := range snap.AdditionalSDKKeys {
+				status.AdditionalSDKKeys = append(status.AdditionalSDKKeys, sdks.ObscureKey(string(k)))
+			}
+			for _, k := range snap.AdditionalMobileKeys {
+				status.AdditionalMobileKeys = append(status.AdditionalMobileKeys, sdks.ObscureKey(string(k)))
+			}
 			// Surface every deprecated credential the rotator knows about, partitioned by kind.
 			// The scalar ExpiringSDKKey / ExpiringMobileKey fields are retained for back-compat
 			// with existing dashboards and carry the first key of each kind seen; the array
 			// fields carry the full set so callers can inspect every grace-period entry (which is
 			// possible now that additional keys can each carry their own ExpiresAt).
-			for _, c := range clientCtx.GetDeprecatedCredentials() {
-				switch key := c.(type) {
-				case config.SDKKey:
-					obscured := sdks.ObscureKey(string(key))
-					if status.ExpiringSDKKey == "" {
-						status.ExpiringSDKKey = obscured
-					}
-					status.ExpiringSDKKeys = append(status.ExpiringSDKKeys, obscured)
-				case config.MobileKey:
-					obscured := sdks.ObscureKey(string(key))
-					if status.ExpiringMobileKey == "" {
-						status.ExpiringMobileKey = obscured
-					}
-					status.ExpiringMobileKeys = append(status.ExpiringMobileKeys, obscured)
+			for _, k := range snap.DeprecatedSDKKeys {
+				obscured := sdks.ObscureKey(string(k))
+				if status.ExpiringSDKKey == "" {
+					status.ExpiringSDKKey = obscured
 				}
+				status.ExpiringSDKKeys = append(status.ExpiringSDKKeys, obscured)
+			}
+			for _, k := range snap.DeprecatedMobileKeys {
+				obscured := sdks.ObscureKey(string(k))
+				if status.ExpiringMobileKey == "" {
+					status.ExpiringMobileKey = obscured
+				}
+				status.ExpiringMobileKeys = append(status.ExpiringMobileKeys, obscured)
 			}
 
 			client := clientCtx.GetClient()

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -46,12 +46,24 @@ func statusHandler(relay *Relay) http.Handler {
 				ProjName: identifiers.ProjName,
 			}
 
+			primarySDKKey := clientCtx.PrimarySDKKey()
+			primaryMobileKey := clientCtx.PrimaryMobileKey()
 			for _, c := range clientCtx.GetCredentials() {
 				switch c := c.(type) {
 				case config.SDKKey:
-					status.SDKKey = sdks.ObscureKey(string(c))
+					obscured := sdks.ObscureKey(string(c))
+					if c == primarySDKKey {
+						status.SDKKey = obscured
+					} else {
+						status.AdditionalSDKKeys = append(status.AdditionalSDKKeys, obscured)
+					}
 				case config.MobileKey:
-					status.MobileKey = sdks.ObscureKey(string(c))
+					obscured := sdks.ObscureKey(string(c))
+					if c == primaryMobileKey {
+						status.MobileKey = obscured
+					} else {
+						status.AdditionalMobileKeys = append(status.AdditionalMobileKeys, obscured)
+					}
 				case config.EnvironmentID:
 					status.EnvID = string(c)
 				}

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -69,9 +69,25 @@ func statusHandler(relay *Relay) http.Handler {
 				}
 			}
 
+			// Surface every deprecated credential the rotator knows about, partitioned by kind.
+			// The scalar ExpiringSDKKey / ExpiringMobileKey fields are retained for back-compat
+			// with existing dashboards and carry the first key of each kind seen; the array
+			// fields carry the full set so callers can inspect every grace-period entry (which is
+			// possible now that additional keys can each carry their own ExpiresAt).
 			for _, c := range clientCtx.GetDeprecatedCredentials() {
-				if key, ok := c.(config.SDKKey); ok {
-					status.ExpiringSDKKey = sdks.ObscureKey(string(key))
+				switch key := c.(type) {
+				case config.SDKKey:
+					obscured := sdks.ObscureKey(string(key))
+					if status.ExpiringSDKKey == "" {
+						status.ExpiringSDKKey = obscured
+					}
+					status.ExpiringSDKKeys = append(status.ExpiringSDKKeys, obscured)
+				case config.MobileKey:
+					obscured := sdks.ObscureKey(string(key))
+					if status.ExpiringMobileKey == "" {
+						status.ExpiringMobileKey = obscured
+					}
+					status.ExpiringMobileKeys = append(status.ExpiringMobileKeys, obscured)
 				}
 			}
 

--- a/relay/endpoints_status_test.go
+++ b/relay/endpoints_status_test.go
@@ -58,6 +58,44 @@ func TestEndpointsStatus(t *testing.T) {
 		})
 	})
 
+	t.Run("additional SDK and mobile keys are surfaced", func(t *testing.T) {
+		envConfig := st.EnvMobile.Config
+		envConfig.AdditionalSDKKeys = ct.NewOptStringList([]string{"sdk-extra-1", "sdk-extra-2"})
+		envConfig.AdditionalMobileKeys = ct.NewOptStringList([]string{"mob-extra-1"})
+		envMobileWithExtras := st.EnvMobile
+		envMobileWithExtras.Config = envConfig
+
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(envMobileWithExtras)
+
+		withStartedRelay(t, config, func(p relayTestParams) {
+			r, _ := http.NewRequest("GET", "http://localhost/status", nil)
+			result, body := st.DoRequest(r, p.relay)
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+			status := ldvalue.Parse(body)
+
+			st.AssertJSONPathMatch(t, sdks.ObscureKey(string(envConfig.SDKKey)),
+				status, "environments", envMobileWithExtras.Name, "sdkKey")
+			st.AssertJSONPathMatch(t, sdks.ObscureKey(string(envConfig.MobileKey)),
+				status, "environments", envMobileWithExtras.Name, "mobileKey")
+
+			additionalSDKKeys := status.GetByKey("environments").GetByKey(envMobileWithExtras.Name).GetByKey("additionalSdkKeys")
+			require.Equal(t, 2, additionalSDKKeys.Count())
+			masked1 := sdks.ObscureKey("sdk-extra-1")
+			masked2 := sdks.ObscureKey("sdk-extra-2")
+			seen := map[string]bool{}
+			for i := 0; i < additionalSDKKeys.Count(); i++ {
+				seen[additionalSDKKeys.GetByIndex(i).StringValue()] = true
+			}
+			assert.True(t, seen[masked1])
+			assert.True(t, seen[masked2])
+
+			additionalMobileKeys := status.GetByKey("environments").GetByKey(envMobileWithExtras.Name).GetByKey("additionalMobileKeys")
+			require.Equal(t, 1, additionalMobileKeys.Count())
+			assert.Equal(t, sdks.ObscureKey("mob-extra-1"), additionalMobileKeys.GetByIndex(0).StringValue())
+		})
+	})
+
 	t.Run("connection interruption - less than DisconnectedStatusTime", func(t *testing.T) {
 		var config c.Config
 		config.Environment = st.MakeEnvConfigs(st.EnvMain, st.EnvMobile)

--- a/relay/endpoints_status_test.go
+++ b/relay/endpoints_status_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
 
 	c "github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
@@ -93,6 +94,39 @@ func TestEndpointsStatus(t *testing.T) {
 			additionalMobileKeys := status.GetByKey("environments").GetByKey(envMobileWithExtras.Name).GetByKey("additionalMobileKeys")
 			require.Equal(t, 1, additionalMobileKeys.Count())
 			assert.Equal(t, sdks.ObscureKey("mob-extra-1"), additionalMobileKeys.GetByIndex(0).StringValue())
+		})
+	})
+
+	t.Run("expiring mobile key is surfaced", func(t *testing.T) {
+		envConfig := st.EnvMobile.Config
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(st.EnvMobile)
+
+		withStartedRelay(t, config, func(p relayTestParams) {
+			envMobile, err := p.relay.getEnvironment(sdkauth.New(envConfig.SDKKey))
+			require.NotNil(t, envMobile)
+			require.NoError(t, err)
+
+			// Rotate the mobile key with grace; the deprecated mobile key should surface in the
+			// status endpoint -- it was silently dropped before the F5 fix.
+			oldMobileKey := envConfig.MobileKey
+			newMobileKey := c.MobileKey("new-mobile-key")
+			envMobile.UpdateCredential(
+				relayenv.NewCredentialUpdate(newMobileKey).
+					WithGracePeriod(oldMobileKey, time.Now().Add(time.Hour)),
+			)
+
+			r, _ := http.NewRequest("GET", "http://localhost/status", nil)
+			result, body := st.DoRequest(r, p.relay)
+			assert.Equal(t, http.StatusOK, result.StatusCode)
+			status := ldvalue.Parse(body)
+
+			expiring := status.GetByKey("environments").GetByKey(st.EnvMobile.Name).GetByKey("expiringMobileKey")
+			assert.Equal(t, sdks.ObscureKey(string(oldMobileKey)), expiring.StringValue())
+
+			arr := status.GetByKey("environments").GetByKey(st.EnvMobile.Name).GetByKey("expiringMobileKeys")
+			require.Equal(t, 1, arr.Count())
+			assert.Equal(t, sdks.ObscureKey(string(oldMobileKey)), arr.GetByIndex(0).StringValue())
 		})
 	})
 

--- a/relay/environment_lookup.go
+++ b/relay/environment_lookup.go
@@ -74,13 +74,23 @@ func NewEnvironmentLookup() *EnvironmentLookup {
 // InsertEnvironment creates a mapping from the given environment's credentials (and optional filter key)
 // to that environment, which can later be looked up using Lookup.
 // Only credentials that are defined are mapped (credential.Defined() must return true for each).
+//
+// The deprecated set is included so that an env which arrives mid-rotation -- whether the primary
+// is rotating with grace or an additional key was already expiring at construction time -- has
+// every credential it expects to honor mapped in the lookup before the first incoming request.
 func (e *EnvironmentLookup) InsertEnvironment(env relayenv.EnvContext) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	filterKey := env.GetPayloadFilter()
 	for _, cred := range env.GetCredentials() {
 		if cred.Defined() {
-			e.mapParams(sdkauth.NewScoped(env.GetPayloadFilter(), cred), env)
+			e.mapParams(sdkauth.NewScoped(filterKey, cred), env)
+		}
+	}
+	for _, cred := range env.GetDeprecatedCredentials() {
+		if cred.Defined() {
+			e.mapParams(sdkauth.NewScoped(filterKey, cred), env)
 		}
 	}
 

--- a/relay/filedata_actions.go
+++ b/relay/filedata_actions.go
@@ -51,7 +51,10 @@ func (a *relayFileDataActions) AddEnvironment(ae filedata.ArchiveEnvironment) {
 		return config
 	}
 	envConfig := envfactory.NewEnvConfigFactoryForOfflineMode(a.r.config.OfflineMode).MakeEnvironmentConfig(ae.Params)
-	env, _, err := a.r.addEnvironment(ae.Params.Identifiers, envConfig, transformConfig)
+	env, _, err := a.r.addEnvironment(ae.Params.Identifiers, envConfig, transformConfig, addEnvironmentOptions{
+		initialExpiringAdditionalSDKKeys:    ae.Params.ExpiringAdditionalSDKKeys,
+		initialExpiringAdditionalMobileKeys: ae.Params.ExpiringAdditionalMobileKeys,
+	})
 	if err != nil {
 		a.r.loggers.Errorf(logMsgAutoConfEnvInitError, ae.Params.Identifiers.GetDisplayName(), err)
 		return

--- a/relay/filedata_actions.go
+++ b/relay/filedata_actions.go
@@ -56,10 +56,9 @@ func (a *relayFileDataActions) AddEnvironment(ae filedata.ArchiveEnvironment) {
 		a.r.loggers.Errorf(logMsgAutoConfEnvInitError, ae.Params.Identifiers.GetDisplayName(), err)
 		return
 	}
-	if ae.Params.ExpiringSDKKey.Defined() {
-		update := relayenv.NewCredentialUpdate(ae.Params.SDKKey)
-		env.UpdateCredential(update.WithGracePeriod(ae.Params.ExpiringSDKKey.Key, ae.Params.ExpiringSDKKey.Expiration))
-	}
+	applyExpiringPrimaries(env, ae.Params)
+	env.SetAdditionalSDKKeys(ae.Params.AdditionalSDKKeys, ae.Params.ExpiringAdditionalSDKKeys)
+	env.SetAdditionalMobileKeys(ae.Params.AdditionalMobileKeys, ae.Params.ExpiringAdditionalMobileKeys)
 	select {
 	case updates := <-updatesCh:
 		if a.envUpdates == nil {
@@ -89,9 +88,6 @@ func (a *relayFileDataActions) UpdateEnvironment(ae filedata.ArchiveEnvironment)
 	env.SetTTL(ae.Params.TTL)
 	env.SetSecureMode(ae.Params.SecureMode)
 
-	if ae.Params.MobileKey.Defined() {
-		env.UpdateCredential(relayenv.NewCredentialUpdate(ae.Params.MobileKey))
-	}
 	if ae.Params.SDKKey.Defined() {
 		update := relayenv.NewCredentialUpdate(ae.Params.SDKKey)
 		if ae.Params.ExpiringSDKKey.Defined() {
@@ -99,6 +95,15 @@ func (a *relayFileDataActions) UpdateEnvironment(ae filedata.ArchiveEnvironment)
 		}
 		env.UpdateCredential(update)
 	}
+	if ae.Params.MobileKey.Defined() {
+		update := relayenv.NewCredentialUpdate(ae.Params.MobileKey)
+		if ae.Params.ExpiringMobileKey.Defined() {
+			update = update.WithGracePeriod(ae.Params.ExpiringMobileKey.Key, ae.Params.ExpiringMobileKey.Expiration)
+		}
+		env.UpdateCredential(update)
+	}
+	env.SetAdditionalSDKKeys(ae.Params.AdditionalSDKKeys, ae.Params.ExpiringAdditionalSDKKeys)
+	env.SetAdditionalMobileKeys(ae.Params.AdditionalMobileKeys, ae.Params.ExpiringAdditionalMobileKeys)
 
 	// SDKData will be non-nil only if the flag/segment data for the environment has actually changed.
 	if ae.SDKData != nil {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -172,7 +172,7 @@ func newRelayInternal(c config.Config, options relayInternalOptions) (*Relay, er
 	r.clientSideSDKBaseURL = *c.Main.ClientSideBaseURI.Get() // config.ValidateConfig has ensured that this has a value
 
 	for envName, envConfig := range makeFilteredEnvironments(&c) {
-		env, resultCh, err := r.addEnvironment(relayenv.EnvIdentifiers{ConfiguredName: envName}, *envConfig, nil)
+		env, resultCh, err := r.addEnvironment(relayenv.EnvIdentifiers{ConfiguredName: envName}, *envConfig, nil, addEnvironmentOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -402,12 +402,21 @@ func (r *Relay) getAllEnvironments() []relayenv.EnvContext {
 	return r.envsByCredential.Environments()
 }
 
+// addEnvironmentOptions carries optional inputs to addEnvironment that don't fit naturally in
+// EnvConfig (which is shared with the public configuration surface). For now this is just the
+// expiring additional-key maps that arrive only from the autoconfig / filedata sources.
+type addEnvironmentOptions struct {
+	initialExpiringAdditionalSDKKeys    map[config.SDKKey]time.Time
+	initialExpiringAdditionalMobileKeys map[config.MobileKey]time.Time
+}
+
 // addEnvironment attempts to add a new environment. It returns an error only if the configuration
 // is invalid; it does not wait to see whether the connection to LaunchDarkly succeeded.
 func (r *Relay) addEnvironment(
 	identifiers relayenv.EnvIdentifiers,
 	envConfig config.EnvConfig,
 	transformClientConfig func(ld.Config) ld.Config,
+	opts addEnvironmentOptions,
 ) (relayenv.EnvContext, <-chan relayenv.EnvContext, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -455,20 +464,22 @@ func (r *Relay) addEnvironment(
 		return r.clientFactory(sdkKey, config, timeout)
 	}
 	clientContext, err := relayenv.NewEnvContext(relayenv.EnvContextImplParams{
-		Identifiers:                      identifiers,
-		EnvConfig:                        envConfig,
-		AllConfig:                        r.config,
-		ClientFactory:                    wrappedClientFactory,
-		DataStoreFactory:                 dataStoreFactory,
-		DataStoreInfo:                    dataStoreInfo,
-		StreamProviders:                  r.allStreamProviders(),
-		JSClientContext:                  jsClientContext,
-		MetricsManager:                   r.metricsManager,
-		UserAgent:                        r.userAgent,
-		LogNameMode:                      r.envLogNameMode,
-		Loggers:                          r.loggers,
-		ConnectionMapper:                 r,
-		ExpiredCredentialCleanupInterval: r.config.Main.ExpiredCredentialCleanupInterval.GetOrElse(0),
+		Identifiers:                         identifiers,
+		EnvConfig:                           envConfig,
+		AllConfig:                           r.config,
+		ClientFactory:                       wrappedClientFactory,
+		DataStoreFactory:                    dataStoreFactory,
+		DataStoreInfo:                       dataStoreInfo,
+		StreamProviders:                     r.allStreamProviders(),
+		JSClientContext:                     jsClientContext,
+		MetricsManager:                      r.metricsManager,
+		UserAgent:                           r.userAgent,
+		LogNameMode:                         r.envLogNameMode,
+		Loggers:                             r.loggers,
+		ConnectionMapper:                    r,
+		ExpiredCredentialCleanupInterval:    r.config.Main.ExpiredCredentialCleanupInterval.GetOrElse(0),
+		InitialExpiringAdditionalSDKKeys:    opts.initialExpiringAdditionalSDKKeys,
+		InitialExpiringAdditionalMobileKeys: opts.initialExpiringAdditionalMobileKeys,
 	}, resultCh)
 	if err != nil {
 		return nil, nil, errNewClientContextFailed(identifiers.GetDisplayName(), err)

--- a/relay/relay_environments_test.go
+++ b/relay/relay_environments_test.go
@@ -113,7 +113,7 @@ func TestRelayAddEnvironment(t *testing.T) {
 	require.NoError(t, err)
 	defer relay.Close()
 
-	env, resultCh, err := relay.addEnvironment(relayenv.EnvIdentifiers{ConfiguredName: st.EnvMobile.Name}, st.EnvMobile.Config, nil)
+	env, resultCh, err := relay.addEnvironment(relayenv.EnvIdentifiers{ConfiguredName: st.EnvMobile.Name}, st.EnvMobile.Config, nil, addEnvironmentOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, env)
 	require.NotNil(t, resultCh)
@@ -134,7 +134,7 @@ func TestRelayAddEnvironmentAfterClosed(t *testing.T) {
 	require.NoError(t, err)
 	_ = relay.Close()
 
-	env, resultCh, err := relay.addEnvironment(relayenv.EnvIdentifiers{ConfiguredName: st.EnvMobile.Name}, st.EnvMobile.Config, nil)
+	env, resultCh, err := relay.addEnvironment(relayenv.EnvIdentifiers{ConfiguredName: st.EnvMobile.Name}, st.EnvMobile.Config, nil, addEnvironmentOptions{})
 	assert.Error(t, err)
 	assert.Nil(t, env)
 	assert.Nil(t, resultCh)


### PR DESCRIPTION
- **feat: Add wire format types for concurrent SDK and mobile keys**
- **feat: Add manual config for additional SDK and mobile keys**
- **feat: Add concurrent SDK key support to credential rotator**
- **feat: Add concurrent mobile key support to credential rotator**
- **feat: Wire env context to additional SDK and mobile keys**
- **feat: Wire autoconfig and filedata to additional and mobile-grace keys**
- **fix: Keep upstream client alive for rotation-predecessor SDK keys**
- **feat: Surface additional SDK and mobile keys on the status endpoint**
- **test: Cover autoconfig flow for additional SDK keys**
- **docs: Document additional SDK and mobile keys in configuration**
- **fix: Handle promoting an additional key to primary**
- **fix: Trim whitespace around additional keys in manual config**
- **feat: Validate that additional keys require a primary key**
