### PR TITLE
chore(v9): CI and toolchain updates

### DIFF
--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,2 +1,2 @@
-latest=1.26.3
-penultimate=1.25.10
+latest=1.26.4
+penultimate=1.25.11

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,12 +19,12 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       # Create any releases in release, then create tags, and then optionally create any new PRs.
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{secrets.GITHUB_TOKEN}}
-          skip-github-pull-request: true
           target-branch: ${{ github.ref_name }}
+          skip-github-pull-request: true
 
 
       # Need the repository content to be able to create and push a tag.
@@ -47,13 +47,13 @@ jobs:
             git push origin "${TAG_NAME}"
           fi
 
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         if: ${{ steps.release.outputs.release_created != 'true'}}
         id: release-prs
         with:
           token: ${{secrets.GITHUB_TOKEN}}
-          skip-github-release: true
           target-branch: ${{ github.ref_name }}
+          skip-github-release: true
 
   release-relay:
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # This is a standalone Dockerfile that does not depend on goreleaser building the binary
 # It is NOT the version that is pushed to dockerhub
-FROM golang:1.26.3-alpine3.23 as builder
+FROM golang:1.26.4-alpine3.23 as builder
 # See "Runtime platform versions" in CONTRIBUTING.md
 
 RUN apk --no-cache add \


### PR DESCRIPTION
## Summary

Applies recent v8 CI and toolchain changes to the v9 branch:

- Upgrade release-please-action from v4.4.0 to v5.0.0 (pinned SHA bump only; `target-branch` is retained on both invocations because the GitHub default branch is still v8, and omitting it would make release-please operate on v8's manifest instead of v9's)
- Grant pull-requests: read permission to lint-pr-title workflow so it can trigger
- Bump supported Go CI versions to 1.26.4 / 1.25.11 (matches the v8 cleanup commit by also updating the standalone Dockerfile builder image)

Corresponding v8 PRs: #659, #663, #681
