### PR TITLE
test: add field names to KeyedItemDescriptor literals in benchmarks

### DIFF
--- a/internal/streams/stream_events_benchmark_test.go
+++ b/internal/streams/stream_events_benchmark_test.go
@@ -53,7 +53,7 @@ func makeLargePutDataSet() []ldstoretypes.Collection {
 			fb.AddTarget(t, userKeys...)
 		}
 		flag := fb.Build()
-		allData[0].Items = append(allData[0].Items, ldstoretypes.KeyedItemDescriptor{flag.Key, sharedtest.FlagDesc(flag)})
+		allData[0].Items = append(allData[0].Items, ldstoretypes.KeyedItemDescriptor{Key: flag.Key, Item: sharedtest.FlagDesc(flag)})
 	}
 
 	return allData

--- a/relay/relay_endpoints_benchmark_test.go
+++ b/relay/relay_endpoints_benchmark_test.go
@@ -36,7 +36,7 @@ func BenchmarkEvaluateAllFlags(b *testing.B) {
 			SingleVariation(ldvalue.String(fmt.Sprintf("value%d", i))).
 			ClientSideUsingEnvironmentID(true).
 			Build()
-		allData[0].Items = append(allData[0].Items, ldstoretypes.KeyedItemDescriptor{flag.Key, sharedtest.FlagDesc(flag)})
+		allData[0].Items = append(allData[0].Items, ldstoretypes.KeyedItemDescriptor{Key: flag.Key, Item: sharedtest.FlagDesc(flag)})
 	}
 
 	user := lduser.NewUserBuilder("user-key").Name("name").Email("email").Custom("a", ldvalue.String("b")).Build()


### PR DESCRIPTION
## Summary
Two benchmark test files used unkeyed struct literals for `ldstoretypes.KeyedItemDescriptor`, which triggered `go vet` warnings. Adds the `Key` and `Item` field names to the literals to silence the warnings.

## Background
The warnings are pre-existing — not introduced by any recent PR — but show up in `go vet ./...` on both v8 and v9 branches. Cleaning up keeps the vet output clean for future changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only benchmark fixture edits with no runtime or production code impact.
> 
> **Overview**
> Updates two benchmark helpers so `ldstoretypes.KeyedItemDescriptor` values use explicit **`Key`** and **`Item`** field names instead of positional struct literals.
> 
> The change is in `makeLargePutDataSet` (`stream_events_benchmark_test.go`) and the flag loop in `BenchmarkEvaluateAllFlags` (`relay_endpoints_benchmark_test.go`). Behavior is unchanged; this only satisfies `go vet` for composite literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8a9bdb71b20087b1e6db8b778a4301e59d3a17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->