### PR TITLE
chore: auto-increment rc prerelease versions via release-please [SDK-2477]

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,9 @@
     ".": {
       "release-type": "go",
       "bump-minor-pre-major": true,
-      "versioning": "default",
+      "versioning": "prerelease",
+      "prerelease": true,
+      "prerelease-type": "rc",
       "bootstrap-sha": "21866d02812c93457097540ee49f098bc405fdec",
       "draft": true,
       "include-component-in-tag" : false,


### PR DESCRIPTION
## Summary

Switches the `v9` release-please config from the `default` versioning strategy to `prerelease` so release-please **auto-increments the `-rc.N` suffix** instead of requiring a manual version bump for each release candidate.

```diff
-      "versioning": "default",
+      "versioning": "prerelease",
+      "prerelease": true,
+      "prerelease-type": "rc",
```

## Why

The `default` versioning strategy's updaters carry `version.preRelease` through **unchanged**, so the `-rc.N` number never bumps on its own — it has been bumped by hand each time. The `prerelease` strategy (`PrereleaseVersioningStrategy`) increments the trailing prerelease number instead.

- `prerelease: true` is required for the strategy to actually emit `-rc.N` versions (otherwise it collapses to the plain base version); it also marks the GitHub Release as a prerelease.
- `prerelease-type: "rc"` sets the label.

`.release-please-manifest.json` is left at `9.0.0-rc.4`, so the next release auto-bumps to `9.0.0-rc.5`, then `.6`, etc. All commit types (feat/fix/breaking) bump the rc suffix while the base stays `9.0.0` (minor and patch are both 0).

## Testing

- Validated the config JSON parses.
- Traced feat/fix/breaking commits through `PrereleaseVersioningStrategy.bump()` against `9.0.0-rc.4`; every path increments the rc suffix.

Jira: SDK-2477

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation config only; no runtime or application logic changes.
> 
> **Overview**
> Updates **`release-please-config.json`** so the root Go package uses **`prerelease`** versioning instead of **`default`**, with **`prerelease: true`** and **`prerelease-type: "rc"`**.
> 
> Release-please will **auto-increment the `-rc.N` suffix** on each release (e.g. `9.0.0-rc.4` → `9.0.0-rc.5`) without manual manifest bumps, and GitHub releases from this config should be marked as prereleases. **`relay/version/version.go`** remains in **`extra-files`**, so version bumps still flow through that file as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913b382a4ef8d655fb98694cdc457e60d662a270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->