### PR TITLE
feat(credential): remove RotateWithGrace mobile-key panic

### DIFF
--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -12,8 +12,13 @@ import (
 type Rotator struct {
 	loggers ldlog.Loggers
 
-	// There is only one mobile key active at a given time; it does not support a deprecation period.
+	// There is only one mobile key active at a given time.
 	primaryMobileKey config.MobileKey
+
+	// deprecatedMobileKeys stores mobile keys being phased out with a grace period, keyed
+	// by credential value with the associated expiry time. StepTime does not yet act on
+	// these entries — that is deferred to T1.c (generalize cleanup ticker).
+	deprecatedMobileKeys map[config.MobileKey]time.Time
 
 	// There is only one environment ID active at a given time, and it won't actually be rotated. The mechanism is
 	// here to allow setting it in a deferred manner.
@@ -42,8 +47,9 @@ type InitialCredentials struct {
 // contains no credentials and can optionally be initialized via Initialize.
 func NewRotator(loggers ldlog.Loggers) *Rotator {
 	r := &Rotator{
-		loggers:           loggers,
-		deprecatedSdkKeys: make(map[config.SDKKey]time.Time),
+		loggers:              loggers,
+		deprecatedSdkKeys:    make(map[config.SDKKey]time.Time),
+		deprecatedMobileKeys: make(map[config.MobileKey]time.Time),
 	}
 	return r
 }
@@ -158,17 +164,19 @@ func NewGracePeriod(key config.SDKKey, expiry time.Time, now time.Time) *GracePe
 
 // RotateWithGrace sets a new primary credential while deprecating a previous credential. The grace
 // parameter may be nil to immediately revoke the previous credential.
-// It is invalid to specify a grace period when the credential being rotate is a mobile key or
-// environment ID.
+// It is invalid to specify a grace period when the credential being rotated is an environment ID.
+// For mobile keys, a non-nil grace period stores the expiry for the outgoing key; the cleanup
+// ticker (T1.c) is responsible for acting on it.
 func (r *Rotator) RotateWithGrace(primary SDKCredential, grace *GracePeriod) {
 	switch primary := primary.(type) {
 	case config.SDKKey:
 		r.updateSDKKey(primary, grace)
 	case config.MobileKey:
 		if grace != nil {
-			panic("programmer error: mobile keys do not support deprecation")
+			r.updateMobileKeyWithGrace(primary, grace)
+		} else {
+			r.updateMobileKey(primary)
 		}
-		r.updateMobileKey(primary)
 	case config.EnvironmentID:
 		if grace != nil {
 			panic("programmer error: environment IDs do not support deprecation")
@@ -209,6 +217,29 @@ func (r *Rotator) updateMobileKey(mobileKey config.MobileKey) {
 	} else {
 		r.loggers.Infof("New primary mobile key is %s", mobileKey.Masked())
 	}
+}
+
+func (r *Rotator) updateMobileKeyWithGrace(mobileKey config.MobileKey, grace *GracePeriod) {
+	if mobileKey == r.MobileKey() {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	previous := r.primaryMobileKey
+	r.primaryMobileKey = mobileKey
+	r.additions = append(r.additions, mobileKey)
+	if !previous.Defined() {
+		r.loggers.Infof("New primary mobile key is %s", mobileKey.Masked())
+		return
+	}
+	if grace.Expired() {
+		r.loggers.Infof("Deprecated mobile key %s already expired at %v; revoking immediately", previous.Masked(), grace.expiry)
+		r.expirations = append(r.expirations, previous)
+		return
+	}
+	r.deprecatedMobileKeys[previous] = grace.expiry
+	r.loggers.Infof("Mobile key %s was marked for deprecation with an expiry at %v, new primary mobile key is %s",
+		previous.Masked(), grace.expiry, mobileKey.Masked())
 }
 
 func (r *Rotator) swapPrimaryKey(newKey config.SDKKey) config.SDKKey {

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -162,21 +162,16 @@ func NewGracePeriod(key config.SDKKey, expiry time.Time, now time.Time) *GracePe
 	return &GracePeriod{key, expiry, now}
 }
 
-// RotateWithGrace sets a new primary credential while deprecating a previous credential. The grace
-// parameter may be nil to immediately revoke the previous credential.
-// It is invalid to specify a grace period when the credential being rotated is an environment ID.
-// For mobile keys, a non-nil grace period stores the expiry for the outgoing key; the cleanup
-// ticker (T1.c) is responsible for acting on it.
+// RotateWithGrace sets a new primary credential while deprecating the previous one. When grace is nil
+// the outgoing credential is immediately revoked. It is invalid to specify a grace period for an
+// environment ID. For mobile keys, a non-nil grace period stores the expiry for the outgoing key;
+// the cleanup ticker (T1.c) is responsible for acting on it.
 func (r *Rotator) RotateWithGrace(primary SDKCredential, grace *GracePeriod) {
 	switch primary := primary.(type) {
 	case config.SDKKey:
 		r.updateSDKKey(primary, grace)
 	case config.MobileKey:
-		if grace != nil {
-			r.updateMobileKeyWithGrace(primary, grace)
-		} else {
-			r.updateMobileKey(primary)
-		}
+		r.updateMobileKey(primary, grace)
 	case config.EnvironmentID:
 		if grace != nil {
 			panic("programmer error: environment IDs do not support deprecation")
@@ -202,34 +197,25 @@ func (r *Rotator) updateEnvironmentID(envID config.EnvironmentID) {
 	}
 }
 
-func (r *Rotator) updateMobileKey(mobileKey config.MobileKey) {
-	if mobileKey == r.MobileKey() {
-		return
-	}
+// updateMobileKey sets a new primary mobile key. When grace is nil the outgoing key is
+// immediately revoked; when non-nil its expiry is stored in deprecatedMobileKeys.
+// StepTime does not yet act on deprecatedMobileKeys — that is deferred to T1.c.
+func (r *Rotator) updateMobileKey(mobileKey config.MobileKey, grace *GracePeriod) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	previous := r.primaryMobileKey
-	r.primaryMobileKey = mobileKey
-	r.additions = append(r.additions, mobileKey)
-	if previous.Defined() {
-		r.expirations = append(r.expirations, previous)
-		r.loggers.Infof("Mobile key %s was rotated, new primary mobile key is %s", previous.Masked(), mobileKey.Masked())
-	} else {
-		r.loggers.Infof("New primary mobile key is %s", mobileKey.Masked())
-	}
-}
-
-func (r *Rotator) updateMobileKeyWithGrace(mobileKey config.MobileKey, grace *GracePeriod) {
-	if mobileKey == r.MobileKey() {
+	if mobileKey == r.primaryMobileKey {
 		return
 	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
 	previous := r.primaryMobileKey
 	r.primaryMobileKey = mobileKey
 	r.additions = append(r.additions, mobileKey)
 	if !previous.Defined() {
 		r.loggers.Infof("New primary mobile key is %s", mobileKey.Masked())
+		return
+	}
+	if grace == nil {
+		r.expirations = append(r.expirations, previous)
+		r.loggers.Infof("Mobile key %s was rotated, new primary mobile key is %s", previous.Masked(), mobileKey.Masked())
 		return
 	}
 	if grace.Expired() {

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -165,7 +165,7 @@ func NewGracePeriod(key config.SDKKey, expiry time.Time, now time.Time) *GracePe
 // RotateWithGrace sets a new primary credential while deprecating the previous one. When grace is nil
 // the outgoing credential is immediately revoked. It is invalid to specify a grace period for an
 // environment ID. For mobile keys, a non-nil grace period stores the expiry for the outgoing key;
-// the cleanup ticker (T1.c) is responsible for acting on it.
+// the cleanup ticker is responsible for acting on it.
 func (r *Rotator) RotateWithGrace(primary SDKCredential, grace *GracePeriod) {
 	switch primary := primary.(type) {
 	case config.SDKKey:
@@ -208,6 +208,7 @@ func (r *Rotator) updateMobileKey(mobileKey config.MobileKey, grace *GracePeriod
 	}
 	previous := r.primaryMobileKey
 	r.primaryMobileKey = mobileKey
+	delete(r.deprecatedMobileKeys, mobileKey)
 	r.additions = append(r.additions, mobileKey)
 	if !previous.Defined() {
 		r.loggers.Infof("New primary mobile key is %s", mobileKey.Masked())

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -297,4 +297,31 @@ func TestRotateWithGraceMobileKey(t *testing.T) {
 		assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
 		assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
 	})
+
+	t.Run("re-promoting a deprecated key removes it from the deprecated set", func(t *testing.T) {
+		mockLog := ldlogtest.NewMockLog()
+		rotator := NewRotator(mockLog.Loggers)
+
+		mob1 := config.MobileKey("mob1")
+		mob2 := config.MobileKey("mob2")
+
+		start := time.Unix(10000, 0)
+		expiry := start.Add(1 * time.Hour)
+
+		rotator.Initialize([]SDKCredential{mob1})
+
+		// Rotate mob1 → mob2 with grace; mob1 enters deprecatedMobileKeys.
+		rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, start))
+		rotator.StepTime(start)
+
+		// Rotate back mob2 → mob1; mob1 should be promoted out of the deprecated set.
+		rotator.RotateWithGrace(mob1, nil)
+
+		assert.Equal(t, mob1, rotator.MobileKey())
+
+		// mob1 should appear only as an addition, not also as an expiration.
+		additions, expirations := rotator.StepTime(start)
+		assert.ElementsMatch(t, []SDKCredential{mob1}, additions)
+		assert.ElementsMatch(t, []SDKCredential{mob2}, expirations)
+	})
 }

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -231,3 +231,53 @@ func TestSDKKeyExpiredInThePastIsNotAdded(t *testing.T) {
 	assert.ElementsMatch(t, []SDKCredential{primaryKey}, additions)
 	assert.Empty(t, expirations)
 }
+
+func TestRotateWithGraceMobileKey(t *testing.T) {
+	t.Run("does not panic with non-nil grace period", func(t *testing.T) {
+		mockLog := ldlogtest.NewMockLog()
+		rotator := NewRotator(mockLog.Loggers)
+
+		mob1 := config.MobileKey("mob1")
+		mob2 := config.MobileKey("mob2")
+
+		start := time.Unix(10000, 0)
+		expiry := start.Add(1 * time.Hour)
+
+		rotator.Initialize([]SDKCredential{mob1})
+
+		// GracePeriod.key is SDK-key typed; pass a zero value since mobile-key rotation
+		// does not use that identifier field.
+		assert.NotPanics(t, func() {
+			rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, start))
+		})
+
+		assert.Equal(t, mob2, rotator.MobileKey())
+
+		// mob2 is a new addition; mob1 is in the deprecated set (not yet expired),
+		// so it should not appear as an expiration here. Cleanup is deferred to T1.c.
+		additions, expirations := rotator.StepTime(start)
+		assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
+		assert.Empty(t, expirations)
+	})
+
+	t.Run("immediately revokes outgoing key when grace period is already expired", func(t *testing.T) {
+		mockLog := ldlogtest.NewMockLog()
+		rotator := NewRotator(mockLog.Loggers)
+
+		mob1 := config.MobileKey("mob1")
+		mob2 := config.MobileKey("mob2")
+
+		expiry := time.Unix(10000, 0)
+		now := expiry.Add(1 * time.Hour) // now is after expiry
+
+		rotator.Initialize([]SDKCredential{mob1})
+
+		rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, now))
+
+		assert.Equal(t, mob2, rotator.MobileKey())
+
+		additions, expirations := rotator.StepTime(now)
+		assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
+		assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
+	})
+}

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -280,4 +280,21 @@ func TestRotateWithGraceMobileKey(t *testing.T) {
 		assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
 		assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
 	})
+
+	t.Run("immediately revokes outgoing key when grace is nil", func(t *testing.T) {
+		mockLog := ldlogtest.NewMockLog()
+		rotator := NewRotator(mockLog.Loggers)
+
+		mob1 := config.MobileKey("mob1")
+		mob2 := config.MobileKey("mob2")
+
+		rotator.Initialize([]SDKCredential{mob1})
+		rotator.RotateWithGrace(mob2, nil)
+
+		assert.Equal(t, mob2, rotator.MobileKey())
+
+		additions, expirations := rotator.StepTime(time.Now())
+		assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
+		assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
+	})
 }


### PR DESCRIPTION
## Summary
Removes the panic guard at the `MobileKey` branch of `Rotator.RotateWithGrace` and adds a `deprecatedMobileKeys` map to store the outgoing key's expiry when a grace period is provided.

[Jira: SDK-2536](https://launchdarkly.atlassian.net/browse/SDK-2536)

## Background
The panic existed because the Rotator had no data-model slot for an expiring mobile key — failing loud was preferable to silently storing junk. T1.a (next) will add the full accepted-set data structures; this PR removes the now-incorrect guard ahead of that, and adds the minimal storage needed to hold the expiry time. `StepTime` does not yet act on `deprecatedMobileKeys` — that is deferred to T1.c (generalize cleanup ticker).

Behavior for all existing callers (grace == nil) is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential rotation for mobile keys (auth-related), but existing nil-grace call paths are unchanged and grace-period keys are not yet enforced by `StepTime` or exposed via `DeprecatedCredentials`.
> 
> **Overview**
> **Mobile key rotation** no longer panics when `RotateWithGrace` is called with a non-nil grace period. The outgoing key can be recorded in a new `deprecatedMobileKeys` map (key → expiry), mirroring the SDK-key deprecation model at a minimal level.
> 
> `updateMobileKey` now takes `grace *GracePeriod`: **nil** or **already-expired** grace still revokes the previous key immediately (same as before for existing callers). A valid grace period only stores the old key’s expiry; **`StepTime` does not expire deprecated mobile keys yet** (planned in T1.c). Re-promoting a key clears it from `deprecatedMobileKeys`.
> 
> Tests cover the non-panic grace path, immediate revoke cases, and re-promotion out of the deprecated set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f8e4999877bd9364f810b114282b3cfad116d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->