### PR TITLE
feat(envfactory): extend EnvironmentRep and EnvironmentParams for concurrent keys

### DIFF
--- a/internal/envfactory/env_params.go
+++ b/internal/envfactory/env_params.go
@@ -49,7 +49,7 @@ type EnvironmentParams struct {
 // AcceptedSDKKey is one entry in the accepted SDK key set for an environment.
 // Expiry is zero if the key is permanent.
 type AcceptedSDKKey struct {
-	Identifier string
+	Key string
 	Value      config.SDKKey
 	Expiry     time.Time
 }
@@ -57,7 +57,7 @@ type AcceptedSDKKey struct {
 // AcceptedMobileKey is one entry in the accepted mobile key set for an environment.
 // Expiry is zero if the key is permanent.
 type AcceptedMobileKey struct {
-	Identifier string
+	Key string
 	Value      config.MobileKey
 	Expiry     time.Time
 }

--- a/internal/envfactory/env_params.go
+++ b/internal/envfactory/env_params.go
@@ -49,17 +49,17 @@ type EnvironmentParams struct {
 // AcceptedSDKKey is one entry in the accepted SDK key set for an environment.
 // Expiry is zero if the key is permanent.
 type AcceptedSDKKey struct {
-	Key string
-	Value      config.SDKKey
-	Expiry     time.Time
+	Key    string
+	Value  config.SDKKey
+	Expiry time.Time
 }
 
 // AcceptedMobileKey is one entry in the accepted mobile key set for an environment.
 // Expiry is zero if the key is permanent.
 type AcceptedMobileKey struct {
-	Key string
-	Value      config.MobileKey
-	Expiry     time.Time
+	Key    string
+	Value  config.MobileKey
+	Expiry time.Time
 }
 
 type ExpiringSDKKey struct {

--- a/internal/envfactory/env_params.go
+++ b/internal/envfactory/env_params.go
@@ -31,13 +31,14 @@ type EnvironmentParams struct {
 	ExpiringSDKKey ExpiringSDKKey
 
 	// AcceptedSDKKeys is the full accepted set of SDK keys for this environment, including the
-	// anchor. Always non-nil after ToParams(): new-format payloads populate from the sdkKeys
-	// array; old-format payloads (no sdkKeys field) are synthesized from the singular sdkKey field.
+	// anchor. Always non-nil after ToParams(): non-empty sdkKeys arrays populate directly; absent
+	// or empty sdkKeys are synthesized from the singular sdkKey field so there is always at least
+	// the anchor entry.
 	AcceptedSDKKeys []AcceptedSDKKey
 
 	// AcceptedMobileKeys is the full accepted set of mobile keys for this environment. Always
-	// non-nil after ToParams(): new-format payloads populate from the mobileKeys array; old-format
-	// payloads are synthesized from the singular mobKey field.
+	// non-nil after ToParams(): non-empty mobileKeys arrays populate directly; absent or empty
+	// mobileKeys are synthesized from the singular mobKey field.
 	AcceptedMobileKeys []AcceptedMobileKey
 
 	// TTL is the cache TTL for PHP clients.

--- a/internal/envfactory/env_params.go
+++ b/internal/envfactory/env_params.go
@@ -31,12 +31,13 @@ type EnvironmentParams struct {
 	ExpiringSDKKey ExpiringSDKKey
 
 	// AcceptedSDKKeys is the full accepted set of SDK keys for this environment, including the
-	// anchor. Populated only when the source (RAC or offline archive) emits the sdkKeys array.
-	// Nil for old-format payloads that carry only the singular sdkKey field.
+	// anchor. Always non-nil after ToParams(): new-format payloads populate from the sdkKeys
+	// array; old-format payloads (no sdkKeys field) are synthesized from the singular sdkKey field.
 	AcceptedSDKKeys []AcceptedSDKKey
 
-	// AcceptedMobileKeys is the full accepted set of mobile keys for this environment. Populated
-	// only when the source emits the mobileKeys array; nil for old-format payloads.
+	// AcceptedMobileKeys is the full accepted set of mobile keys for this environment. Always
+	// non-nil after ToParams(): new-format payloads populate from the mobileKeys array; old-format
+	// payloads are synthesized from the singular mobKey field.
 	AcceptedMobileKeys []AcceptedMobileKey
 
 	// TTL is the cache TTL for PHP clients.

--- a/internal/envfactory/env_params.go
+++ b/internal/envfactory/env_params.go
@@ -30,11 +30,36 @@ type EnvironmentParams struct {
 	// the canonical one).
 	ExpiringSDKKey ExpiringSDKKey
 
+	// AcceptedSDKKeys is the full accepted set of SDK keys for this environment, including the
+	// anchor. Populated only when the source (RAC or offline archive) emits the sdkKeys array.
+	// Nil for old-format payloads that carry only the singular sdkKey field.
+	AcceptedSDKKeys []AcceptedSDKKey
+
+	// AcceptedMobileKeys is the full accepted set of mobile keys for this environment. Populated
+	// only when the source emits the mobileKeys array; nil for old-format payloads.
+	AcceptedMobileKeys []AcceptedMobileKey
+
 	// TTL is the cache TTL for PHP clients.
 	TTL time.Duration
 
 	// SecureMode is true if secure mode is required for this environment.
 	SecureMode bool
+}
+
+// AcceptedSDKKey is one entry in the accepted SDK key set for an environment.
+// Expiry is zero if the key is permanent.
+type AcceptedSDKKey struct {
+	Identifier string
+	Value      config.SDKKey
+	Expiry     time.Time
+}
+
+// AcceptedMobileKey is one entry in the accepted mobile key set for an environment.
+// Expiry is zero if the key is permanent.
+type AcceptedMobileKey struct {
+	Identifier string
+	Value      config.MobileKey
+	Expiry     time.Time
 }
 
 type ExpiringSDKKey struct {

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -35,19 +35,21 @@ import (
 //
 // TERMINOLOGY:
 //
-//	The wire "key" field is the human-readable IDENTIFIER (e.g. "default-sdk"),
-//	non-secret. The wire "value" field is the actual CREDENTIAL string (e.g.
-//	"sdk-xxxx-..."), which is the secret. Note that relay's own types
-//	(SDKKey, MobileKey, SDKCredential) refer to what the wire calls "value" —
-//	they are misnamed by today's standards but stable, so do not rename them.
+//	The wire "key" field is the human-readable identifier (e.g. "default-sdk"),
+//	non-secret — stored as AcceptedSDKKey.Key / AcceptedMobileKey.Key internally.
+//	The wire "value" field is the actual credential string (e.g. "sdk-xxxx-..."),
+//	which is the secret — stored as AcceptedSDKKey.Value / AcceptedMobileKey.Value.
+//	Note that relay's own types (SDKKey, MobileKey, SDKCredential) refer to what
+//	the wire calls "value" — they are misnamed by today's standards but stable,
+//	so do not rename them.
 //
 // Anchor selection: anchor = the sdkKeys entry whose `value` matches sdkKey.value.
-// No isDefault flag — value match is the signal. See phase1-design.md §4.2.
+// No isDefault flag — value match is the signal.
 //
 // Backwards compatibility: Go's default JSON decoder ignores unknown fields, so old
 // relays receiving payloads with sdkKeys/mobileKeys simply ignore them and continue
 // using sdkKey/mobKey. DisallowUnknownFields is intentionally not used anywhere in
-// this parse path — verified as T3.a pre-work. See phase1-design.md §10.
+// this parse path.
 type EnvironmentRep struct {
 	EnvID      config.EnvironmentID `json:"envID"`
 	EnvKey     string               `json:"envKey"`
@@ -100,10 +102,8 @@ type ExpiringKeyRep struct {
 // ConcurrentKeyRep is an entry in the sdkKeys or mobileKeys array on EnvironmentRep.
 // It represents one accepted credential in an environment's concurrent key set.
 //
-// TERMINOLOGY (mirrors EnvironmentRep comment):
-//
-//	Key   = identifier (non-secret, e.g. "default-sdk")
-//	Value = credential secret (e.g. "sdk-xxxx-..."), what relay types call SDKKey/MobileKey
+// Key is the human-readable identifier (non-secret, e.g. "default-sdk"); Value is
+// the credential secret (e.g. "sdk-xxxx-..."). See the EnvironmentRep TERMINOLOGY comment.
 type ConcurrentKeyRep struct {
 	Key    string `json:"key"`
 	Value  string `json:"value"`
@@ -149,7 +149,7 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		params.AcceptedSDKKeys = make([]AcceptedSDKKey, 0, len(r.SDKKeys))
 		for _, k := range r.SDKKeys {
 			entry := AcceptedSDKKey{
-				Identifier: k.Key,
+				Key: k.Key,
 				Value:      config.SDKKey(k.Value),
 			}
 			if k.Expiry != nil {
@@ -163,7 +163,7 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		params.AcceptedMobileKeys = make([]AcceptedMobileKey, 0, len(r.MobileKeys))
 		for _, k := range r.MobileKeys {
 			entry := AcceptedMobileKey{
-				Identifier: k.Key,
+				Key: k.Key,
 				Value:      config.MobileKey(k.Value),
 			}
 			if k.Expiry != nil {

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -159,7 +159,7 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		}
 	} else {
 		// Old-format payload: no sdkKeys array present. Synthesize AcceptedSDKKeys from the
-		// singular sdkKey fields so T3.b/c consumers always receive a consistent non-nil model
+		// singular sdkKey fields so consumers always receive a consistent non-nil model
 		// regardless of wire format version. Key (identifier) is empty — the old format had none.
 		params.AcceptedSDKKeys = make([]AcceptedSDKKey, 0, 2)
 		params.AcceptedSDKKeys = append(params.AcceptedSDKKeys, AcceptedSDKKey{Value: r.SDKKey.Value})

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -15,6 +15,39 @@ import (
 // or the other of those contexts should be in the appropriate package instead of here.
 
 // EnvironmentRep is a representation of an environment that is being added or updated.
+//
+// EnvironmentRep carries an environment's wire shape from RAC and the offline archive
+// (same struct serves both — keep them aligned).
+//
+// FIELD NAMING — read this before changing anything:
+//
+//	sdkKey  is the singular *default* SDK key for the environment. It's an
+//	        object ({"value": "sdk-..."}) so it can also carry the legacy
+//	        sdkKey.expiring{value, timestamp} slot during default rotation
+//	        (back-compat for relays predating concurrent keys).
+//
+//	mobKey  is the singular default mobile key. It's a *plain string*
+//	        because mobile keys never had a legacy expiring slot. The shape
+//	        asymmetry is historical, not a design choice.
+//
+//	sdkKeys/mobileKeys  are the authoritative full accepted set. Entries:
+//	                    { key: <identifier>, value: <credential>, expiry?: <ms> }
+//
+// TERMINOLOGY:
+//
+//	The wire "key" field is the human-readable IDENTIFIER (e.g. "default-sdk"),
+//	non-secret. The wire "value" field is the actual CREDENTIAL string (e.g.
+//	"sdk-xxxx-..."), which is the secret. Note that relay's own types
+//	(SDKKey, MobileKey, SDKCredential) refer to what the wire calls "value" —
+//	they are misnamed by today's standards but stable, so do not rename them.
+//
+// Anchor selection: anchor = the sdkKeys entry whose `value` matches sdkKey.value.
+// No isDefault flag — value match is the signal. See phase1-design.md §4.2.
+//
+// Backwards compatibility: Go's default JSON decoder ignores unknown fields, so old
+// relays receiving payloads with sdkKeys/mobileKeys simply ignore them and continue
+// using sdkKey/mobKey. DisallowUnknownFields is intentionally not used anywhere in
+// this parse path — verified as T3.a pre-work. See phase1-design.md §10.
 type EnvironmentRep struct {
 	EnvID      config.EnvironmentID `json:"envID"`
 	EnvKey     string               `json:"envKey"`
@@ -23,6 +56,8 @@ type EnvironmentRep struct {
 	ProjKey    string               `json:"projKey"`
 	ProjName   string               `json:"projName"`
 	SDKKey     SDKKeyRep            `json:"sdkKey"`
+	SDKKeys    []ConcurrentKeyRep   `json:"sdkKeys,omitempty"`
+	MobileKeys []ConcurrentKeyRep   `json:"mobileKeys,omitempty"`
 	DefaultTTL int                  `json:"defaultTtl"`
 	SecureMode bool                 `json:"secureMode"`
 	Version    int                  `json:"version"`
@@ -62,6 +97,19 @@ type ExpiringKeyRep struct {
 	Timestamp ldtime.UnixMillisecondTime `json:"timestamp"`
 }
 
+// ConcurrentKeyRep is an entry in the sdkKeys or mobileKeys array on EnvironmentRep.
+// It represents one accepted credential in an environment's concurrent key set.
+//
+// TERMINOLOGY (mirrors EnvironmentRep comment):
+//
+//	Key   = identifier (non-secret, e.g. "default-sdk")
+//	Value = credential secret (e.g. "sdk-xxxx-..."), what relay types call SDKKey/MobileKey
+type ConcurrentKeyRep struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Expiry *int64 `json:"expiry,omitempty"` // Unix-ms; nil = permanent
+}
+
 func (e ExpiringKeyRep) ToParams() ExpiringSDKKey {
 	if e.Value.Defined() {
 		return ExpiringSDKKey{
@@ -92,6 +140,34 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		MobileKey:      r.MobKey,
 		TTL:            time.Duration(r.DefaultTTL) * time.Minute,
 		SecureMode:     r.SecureMode,
+	}
+
+	if len(r.SDKKeys) > 0 {
+		params.AcceptedSDKKeys = make([]AcceptedSDKKey, 0, len(r.SDKKeys))
+		for _, k := range r.SDKKeys {
+			entry := AcceptedSDKKey{
+				Identifier: k.Key,
+				Value:      config.SDKKey(k.Value),
+			}
+			if k.Expiry != nil {
+				entry.Expiry = time.UnixMilli(*k.Expiry)
+			}
+			params.AcceptedSDKKeys = append(params.AcceptedSDKKeys, entry)
+		}
+	}
+
+	if len(r.MobileKeys) > 0 {
+		params.AcceptedMobileKeys = make([]AcceptedMobileKey, 0, len(r.MobileKeys))
+		for _, k := range r.MobileKeys {
+			entry := AcceptedMobileKey{
+				Identifier: k.Key,
+				Value:      config.MobileKey(k.Value),
+			}
+			if k.Expiry != nil {
+				entry.Expiry = time.UnixMilli(*k.Expiry)
+			}
+			params.AcceptedMobileKeys = append(params.AcceptedMobileKeys, entry)
+		}
 	}
 
 	return params

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -142,7 +142,10 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		SecureMode:     r.SecureMode,
 	}
 
-	if len(r.SDKKeys) > 0 {
+	// Use != nil (not len > 0) so that "sdkKeys": [] in new-format payloads produces a
+	// non-nil empty slice, preserving the nil/non-nil signal that distinguishes
+	// "old-format payload" (nil) from "new-format payload with no keys" ([]AcceptedSDKKey{}).
+	if r.SDKKeys != nil {
 		params.AcceptedSDKKeys = make([]AcceptedSDKKey, 0, len(r.SDKKeys))
 		for _, k := range r.SDKKeys {
 			entry := AcceptedSDKKey{
@@ -156,7 +159,7 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		}
 	}
 
-	if len(r.MobileKeys) > 0 {
+	if r.MobileKeys != nil {
 		params.AcceptedMobileKeys = make([]AcceptedMobileKey, 0, len(r.MobileKeys))
 		for _, k := range r.MobileKeys {
 			entry := AcceptedMobileKey{

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -142,10 +142,8 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		SecureMode:     r.SecureMode,
 	}
 
-	if r.SDKKeys != nil {
+	if len(r.SDKKeys) > 0 {
 		// New-format payload: populate directly from the array.
-		// Use != nil (not len > 0) so that "sdkKeys": [] produces a non-nil empty slice,
-		// distinct from the synthesized case below.
 		params.AcceptedSDKKeys = make([]AcceptedSDKKey, 0, len(r.SDKKeys))
 		for _, k := range r.SDKKeys {
 			entry := AcceptedSDKKey{
@@ -171,7 +169,7 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		}
 	}
 
-	if r.MobileKeys != nil {
+	if len(r.MobileKeys) > 0 {
 		// New-format payload: populate directly from the array.
 		params.AcceptedMobileKeys = make([]AcceptedMobileKey, 0, len(r.MobileKeys))
 		for _, k := range r.MobileKeys {

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -142,35 +142,51 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		SecureMode:     r.SecureMode,
 	}
 
-	// Use != nil (not len > 0) so that "sdkKeys": [] in new-format payloads produces a
-	// non-nil empty slice, preserving the nil/non-nil signal that distinguishes
-	// "old-format payload" (nil) from "new-format payload with no keys" ([]AcceptedSDKKey{}).
 	if r.SDKKeys != nil {
+		// New-format payload: populate directly from the array.
+		// Use != nil (not len > 0) so that "sdkKeys": [] produces a non-nil empty slice,
+		// distinct from the synthesized case below.
 		params.AcceptedSDKKeys = make([]AcceptedSDKKey, 0, len(r.SDKKeys))
 		for _, k := range r.SDKKeys {
 			entry := AcceptedSDKKey{
-				Key: k.Key,
-				Value:      config.SDKKey(k.Value),
+				Key:   k.Key,
+				Value: config.SDKKey(k.Value),
 			}
 			if k.Expiry != nil {
 				entry.Expiry = time.UnixMilli(*k.Expiry)
 			}
 			params.AcceptedSDKKeys = append(params.AcceptedSDKKeys, entry)
 		}
+	} else {
+		// Old-format payload: no sdkKeys array present. Synthesize AcceptedSDKKeys from the
+		// singular sdkKey fields so T3.b/c consumers always receive a consistent non-nil model
+		// regardless of wire format version. Key (identifier) is empty — the old format had none.
+		params.AcceptedSDKKeys = make([]AcceptedSDKKey, 0, 2)
+		params.AcceptedSDKKeys = append(params.AcceptedSDKKeys, AcceptedSDKKey{Value: r.SDKKey.Value})
+		if r.SDKKey.Expiring.Value.Defined() {
+			params.AcceptedSDKKeys = append(params.AcceptedSDKKeys, AcceptedSDKKey{
+				Value:  r.SDKKey.Expiring.Value,
+				Expiry: ToTime(r.SDKKey.Expiring.Timestamp),
+			})
+		}
 	}
 
 	if r.MobileKeys != nil {
+		// New-format payload: populate directly from the array.
 		params.AcceptedMobileKeys = make([]AcceptedMobileKey, 0, len(r.MobileKeys))
 		for _, k := range r.MobileKeys {
 			entry := AcceptedMobileKey{
-				Key: k.Key,
-				Value:      config.MobileKey(k.Value),
+				Key:   k.Key,
+				Value: config.MobileKey(k.Value),
 			}
 			if k.Expiry != nil {
 				entry.Expiry = time.UnixMilli(*k.Expiry)
 			}
 			params.AcceptedMobileKeys = append(params.AcceptedMobileKeys, entry)
 		}
+	} else {
+		// Old-format payload: synthesize from the singular mobKey field.
+		params.AcceptedMobileKeys = []AcceptedMobileKey{{Value: r.MobKey}}
 	}
 
 	return params

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -39,8 +39,8 @@ func TestEnvironmentRepToParams(t *testing.T) {
 		MobileKey:          env1.MobKey,
 		TTL:                2 * time.Minute,
 		SecureMode:         true,
-		AcceptedSDKKeys:    []AcceptedSDKKey{{Value: config.SDKKey("sdkkey1")}},
-		AcceptedMobileKeys: []AcceptedMobileKey{{Value: config.MobileKey("mobkey1")}},
+		AcceptedSDKKeys:    []AcceptedSDKKey{{Value: env1.SDKKey.Value}},
+		AcceptedMobileKeys: []AcceptedMobileKey{{Value: env1.MobKey}},
 	}, params1)
 
 	env2 := EnvironmentRep{
@@ -73,10 +73,10 @@ func TestEnvironmentRepToParams(t *testing.T) {
 		},
 		MobileKey: env2.MobKey,
 		AcceptedSDKKeys: []AcceptedSDKKey{
-			{Value: config.SDKKey("sdkkey2")},
-			{Value: config.SDKKey("oldkey"), Expiry: time.UnixMilli(10000)},
+			{Value: env2.SDKKey.Value},
+			{Value: env2.SDKKey.Expiring.Value, Expiry: time.UnixMilli(int64(env2.SDKKey.Expiring.Timestamp))},
 		},
-		AcceptedMobileKeys: []AcceptedMobileKey{{Value: config.MobileKey("mobkey2")}},
+		AcceptedMobileKeys: []AcceptedMobileKey{{Value: env2.MobKey}},
 	}, params2)
 }
 
@@ -166,7 +166,7 @@ func TestEnvironmentRepNewFormatWithArrays(t *testing.T) {
 // TestEnvironmentRepOldFormatNoArrays verifies that an old-format payload (singular sdkKey/mobKey
 // only, no sdkKeys/mobileKeys arrays) is normalized by ToParams() into a consistent accepted set.
 // The wire rep's SDKKeys/MobileKeys remain nil, but params.AcceptedSDKKeys/AcceptedMobileKeys are
-// synthesized from the singular fields so T3.b/c consumers never need to handle two code paths.
+// synthesized from the singular fields so consumers never need to handle two code paths.
 func TestEnvironmentRepOldFormatNoArrays(t *testing.T) {
 	jsonStr := `{
 		"envID": "envid1",
@@ -191,71 +191,4 @@ func TestEnvironmentRepOldFormatNoArrays(t *testing.T) {
 	assert.Equal(t, AcceptedSDKKey{Value: config.SDKKey("sdk-key1")}, params.AcceptedSDKKeys[0])
 	require.Len(t, params.AcceptedMobileKeys, 1)
 	assert.Equal(t, AcceptedMobileKey{Value: config.MobileKey("mob-default")}, params.AcceptedMobileKeys[0])
-}
-
-// TestEnvironmentRepEmptyArrays verifies that a new-format payload carrying explicitly empty
-// sdkKeys/mobileKeys arrays (present but []) produces non-nil empty AcceptedSDKKeys/
-// AcceptedMobileKeys — distinct from the old-format synthesis path which always produces at
-// least one entry (the anchor).
-func TestEnvironmentRepEmptyArrays(t *testing.T) {
-	jsonStr := `{
-		"envID": "envid1",
-		"sdkKey": { "value": "sdk-key1" },
-		"mobKey": "mob-key1",
-		"sdkKeys": [],
-		"mobileKeys": []
-	}`
-
-	var rep EnvironmentRep
-	require.NoError(t, json.Unmarshal([]byte(jsonStr), &rep))
-	assert.NotNil(t, rep.SDKKeys, "explicitly-empty sdkKeys array must unmarshal to non-nil slice")
-	assert.Len(t, rep.SDKKeys, 0)
-	assert.NotNil(t, rep.MobileKeys, "explicitly-empty mobileKeys array must unmarshal to non-nil slice")
-	assert.Len(t, rep.MobileKeys, 0)
-
-	params := rep.ToParams()
-	assert.NotNil(t, params.AcceptedSDKKeys, "non-nil empty sdkKeys must produce non-nil AcceptedSDKKeys")
-	assert.Len(t, params.AcceptedSDKKeys, 0)
-	assert.NotNil(t, params.AcceptedMobileKeys, "non-nil empty mobileKeys must produce non-nil AcceptedMobileKeys")
-	assert.Len(t, params.AcceptedMobileKeys, 0)
-}
-
-// TestEnvironmentRepBackCompatOldRelay verifies that a new-format payload (containing sdkKeys/
-// mobileKeys) is parsed cleanly by a relay that does not know about those fields. Go's JSON
-// decoder ignores unknown fields by default; this test makes that guarantee explicit and durable.
-// DisallowUnknownFields is intentionally not used in this parse path (see phase1-design.md §10).
-func TestEnvironmentRepBackCompatOldRelay(t *testing.T) {
-	// oldEnvironmentRep simulates a pre-concurrent-keys relay build — no SDKKeys/MobileKeys fields.
-	type oldEnvironmentRep struct {
-		EnvID   config.EnvironmentID `json:"envID"`
-		MobKey  config.MobileKey     `json:"mobKey"`
-		SDKKey  SDKKeyRep            `json:"sdkKey"`
-		Version int                  `json:"version"`
-	}
-
-	jsonStr := `{
-		"envID": "envid1",
-		"envKey": "envkey",
-		"envName": "envname",
-		"mobKey": "mob-default",
-		"projKey": "projkey",
-		"projName": "projname",
-		"sdkKey": { "value": "sdk-anchor" },
-		"sdkKeys": [
-			{ "key": "default-sdk", "value": "sdk-anchor" },
-			{ "key": "service-a",   "value": "sdk-service-a" }
-		],
-		"mobileKeys": [
-			{ "key": "mob-key-1", "value": "mob-default" }
-		],
-		"version": 5
-	}`
-
-	var rep oldEnvironmentRep
-	require.NoError(t, json.Unmarshal([]byte(jsonStr), &rep),
-		"new-format payload must parse cleanly into a pre-concurrent-keys relay struct")
-	assert.Equal(t, config.EnvironmentID("envid1"), rep.EnvID)
-	assert.Equal(t, config.SDKKey("sdk-anchor"), rep.SDKKey.Value)
-	assert.Equal(t, config.MobileKey("mob-default"), rep.MobKey)
-	assert.Equal(t, 5, rep.Version)
 }

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -35,14 +35,13 @@ func TestEnvironmentRepToParams(t *testing.T) {
 			ProjKey:  "projkey1",
 			ProjName: "projname1",
 		},
-		SDKKey:     env1.SDKKey.Value,
-		MobileKey:  env1.MobKey,
-		TTL:        2 * time.Minute,
-		SecureMode: true,
+		SDKKey:             env1.SDKKey.Value,
+		MobileKey:          env1.MobKey,
+		TTL:                2 * time.Minute,
+		SecureMode:         true,
+		AcceptedSDKKeys:    []AcceptedSDKKey{{Value: config.SDKKey("sdkkey1")}},
+		AcceptedMobileKeys: []AcceptedMobileKey{{Value: config.MobileKey("mobkey1")}},
 	}, params1)
-	// Old-format env (no SDKKeys/MobileKeys set) → accepted-set fields must be nil, not empty slice.
-	assert.Nil(t, params1.AcceptedSDKKeys)
-	assert.Nil(t, params1.AcceptedMobileKeys)
 
 	env2 := EnvironmentRep{
 		EnvID:    config.EnvironmentID("envid2"),
@@ -73,6 +72,11 @@ func TestEnvironmentRepToParams(t *testing.T) {
 			Expiration: time.UnixMilli(int64(env2.SDKKey.Expiring.Timestamp)),
 		},
 		MobileKey: env2.MobKey,
+		AcceptedSDKKeys: []AcceptedSDKKey{
+			{Value: config.SDKKey("sdkkey2")},
+			{Value: config.SDKKey("oldkey"), Expiry: time.UnixMilli(10000)},
+		},
+		AcceptedMobileKeys: []AcceptedMobileKey{{Value: config.MobileKey("mobkey2")}},
 	}, params2)
 }
 
@@ -148,19 +152,21 @@ func TestEnvironmentRepNewFormatWithArrays(t *testing.T) {
 	params := rep.ToParams()
 
 	require.Len(t, params.AcceptedSDKKeys, 2)
-	assert.Equal(t, AcceptedSDKKey{Key:"default-sdk", Value: config.SDKKey("sdk-anchor")}, params.AcceptedSDKKeys[0])
+	assert.Equal(t, AcceptedSDKKey{Key: "default-sdk", Value: config.SDKKey("sdk-anchor")}, params.AcceptedSDKKeys[0])
 	assert.Equal(t, AcceptedSDKKey{
-		Key:"service-a",
-		Value:      config.SDKKey("sdk-service-a"),
-		Expiry:     time.UnixMilli(expiryMs),
+		Key:    "service-a",
+		Value:  config.SDKKey("sdk-service-a"),
+		Expiry: time.UnixMilli(expiryMs),
 	}, params.AcceptedSDKKeys[1])
 
 	require.Len(t, params.AcceptedMobileKeys, 1)
-	assert.Equal(t, AcceptedMobileKey{Key:"mob-key-1", Value: config.MobileKey("mob-f41c")}, params.AcceptedMobileKeys[0])
+	assert.Equal(t, AcceptedMobileKey{Key: "mob-key-1", Value: config.MobileKey("mob-f41c")}, params.AcceptedMobileKeys[0])
 }
 
 // TestEnvironmentRepOldFormatNoArrays verifies that an old-format payload (singular sdkKey/mobKey
-// only, no sdkKeys/mobileKeys arrays) parses cleanly and leaves the accepted-set fields nil.
+// only, no sdkKeys/mobileKeys arrays) is normalized by ToParams() into a consistent accepted set.
+// The wire rep's SDKKeys/MobileKeys remain nil, but params.AcceptedSDKKeys/AcceptedMobileKeys are
+// synthesized from the singular fields so T3.b/c consumers never need to handle two code paths.
 func TestEnvironmentRepOldFormatNoArrays(t *testing.T) {
 	jsonStr := `{
 		"envID": "envid1",
@@ -179,16 +185,18 @@ func TestEnvironmentRepOldFormatNoArrays(t *testing.T) {
 	assert.Nil(t, rep.MobileKeys)
 
 	params := rep.ToParams()
-	assert.Nil(t, params.AcceptedSDKKeys)
-	assert.Nil(t, params.AcceptedMobileKeys)
 	assert.Equal(t, config.SDKKey("sdk-key1"), params.SDKKey)
 	assert.Equal(t, config.MobileKey("mob-default"), params.MobileKey)
+	require.Len(t, params.AcceptedSDKKeys, 1)
+	assert.Equal(t, AcceptedSDKKey{Value: config.SDKKey("sdk-key1")}, params.AcceptedSDKKeys[0])
+	require.Len(t, params.AcceptedMobileKeys, 1)
+	assert.Equal(t, AcceptedMobileKey{Value: config.MobileKey("mob-default")}, params.AcceptedMobileKeys[0])
 }
 
-// TestEnvironmentRepEmptyArrays verifies that a new-format payload carrying empty sdkKeys/mobileKeys
-// arrays (not absent, but explicitly []) produces non-nil empty slices in AcceptedSDKKeys/
-// AcceptedMobileKeys, preserving the nil/non-nil signal that distinguishes "old wire format" (nil)
-// from "new format with no keys yet" (non-nil empty slice).
+// TestEnvironmentRepEmptyArrays verifies that a new-format payload carrying explicitly empty
+// sdkKeys/mobileKeys arrays (present but []) produces non-nil empty AcceptedSDKKeys/
+// AcceptedMobileKeys — distinct from the old-format synthesis path which always produces at
+// least one entry (the anchor).
 func TestEnvironmentRepEmptyArrays(t *testing.T) {
 	jsonStr := `{
 		"envID": "envid1",

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -148,15 +148,15 @@ func TestEnvironmentRepNewFormatWithArrays(t *testing.T) {
 	params := rep.ToParams()
 
 	require.Len(t, params.AcceptedSDKKeys, 2)
-	assert.Equal(t, AcceptedSDKKey{Identifier: "default-sdk", Value: config.SDKKey("sdk-anchor")}, params.AcceptedSDKKeys[0])
+	assert.Equal(t, AcceptedSDKKey{Key:"default-sdk", Value: config.SDKKey("sdk-anchor")}, params.AcceptedSDKKeys[0])
 	assert.Equal(t, AcceptedSDKKey{
-		Identifier: "service-a",
+		Key:"service-a",
 		Value:      config.SDKKey("sdk-service-a"),
 		Expiry:     time.UnixMilli(expiryMs),
 	}, params.AcceptedSDKKeys[1])
 
 	require.Len(t, params.AcceptedMobileKeys, 1)
-	assert.Equal(t, AcceptedMobileKey{Identifier: "mob-key-1", Value: config.MobileKey("mob-f41c")}, params.AcceptedMobileKeys[0])
+	assert.Equal(t, AcceptedMobileKey{Key:"mob-key-1", Value: config.MobileKey("mob-f41c")}, params.AcceptedMobileKeys[0])
 }
 
 // TestEnvironmentRepOldFormatNoArrays verifies that an old-format payload (singular sdkKey/mobKey

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -40,6 +40,9 @@ func TestEnvironmentRepToParams(t *testing.T) {
 		TTL:        2 * time.Minute,
 		SecureMode: true,
 	}, params1)
+	// Old-format env (no SDKKeys/MobileKeys set) → accepted-set fields must be nil, not empty slice.
+	assert.Nil(t, params1.AcceptedSDKKeys)
+	assert.Nil(t, params1.AcceptedMobileKeys)
 
 	env2 := EnvironmentRep{
 		EnvID:    config.EnvironmentID("envid2"),
@@ -180,6 +183,33 @@ func TestEnvironmentRepOldFormatNoArrays(t *testing.T) {
 	assert.Nil(t, params.AcceptedMobileKeys)
 	assert.Equal(t, config.SDKKey("sdk-key1"), params.SDKKey)
 	assert.Equal(t, config.MobileKey("mob-default"), params.MobileKey)
+}
+
+// TestEnvironmentRepEmptyArrays verifies that a new-format payload carrying empty sdkKeys/mobileKeys
+// arrays (not absent, but explicitly []) produces non-nil empty slices in AcceptedSDKKeys/
+// AcceptedMobileKeys, preserving the nil/non-nil signal that distinguishes "old wire format" (nil)
+// from "new format with no keys yet" (non-nil empty slice).
+func TestEnvironmentRepEmptyArrays(t *testing.T) {
+	jsonStr := `{
+		"envID": "envid1",
+		"sdkKey": { "value": "sdk-key1" },
+		"mobKey": "mob-key1",
+		"sdkKeys": [],
+		"mobileKeys": []
+	}`
+
+	var rep EnvironmentRep
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &rep))
+	assert.NotNil(t, rep.SDKKeys, "explicitly-empty sdkKeys array must unmarshal to non-nil slice")
+	assert.Len(t, rep.SDKKeys, 0)
+	assert.NotNil(t, rep.MobileKeys, "explicitly-empty mobileKeys array must unmarshal to non-nil slice")
+	assert.Len(t, rep.MobileKeys, 0)
+
+	params := rep.ToParams()
+	assert.NotNil(t, params.AcceptedSDKKeys, "non-nil empty sdkKeys must produce non-nil AcceptedSDKKeys")
+	assert.Len(t, params.AcceptedSDKKeys, 0)
+	assert.NotNil(t, params.AcceptedMobileKeys, "non-nil empty mobileKeys must produce non-nil AcceptedMobileKeys")
+	assert.Len(t, params.AcceptedMobileKeys, 0)
 }
 
 // TestEnvironmentRepBackCompatOldRelay verifies that a new-format payload (containing sdkKeys/

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -105,3 +105,119 @@ func TestEnvironmentRepJSONFormat(t *testing.T) {
 		SecureMode: true,
 	}, rep)
 }
+
+// TestEnvironmentRepNewFormatWithArrays parses a realistic RAC put payload carrying the new
+// sdkKeys/mobileKeys arrays and verifies the struct fields are populated correctly.
+func TestEnvironmentRepNewFormatWithArrays(t *testing.T) {
+	expiryMs := int64(1700000000000)
+	jsonStr := `{
+		"envID": "68e5179e8307e4099c277e2a",
+		"envKey": "production",
+		"envName": "Production",
+		"mobKey": "mob-f41c",
+		"projKey": "my-project",
+		"projName": "My Project",
+		"sdkKey": { "value": "sdk-anchor" },
+		"sdkKeys": [
+			{ "key": "default-sdk", "value": "sdk-anchor" },
+			{ "key": "service-a",   "value": "sdk-service-a", "expiry": 1700000000000 }
+		],
+		"mobileKeys": [
+			{ "key": "mob-key-1", "value": "mob-f41c" }
+		],
+		"secureMode": false,
+		"version": 26
+	}`
+
+	var rep EnvironmentRep
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &rep))
+
+	assert.Equal(t, config.SDKKey("sdk-anchor"), rep.SDKKey.Value)
+	assert.Equal(t, config.MobileKey("mob-f41c"), rep.MobKey)
+
+	require.Len(t, rep.SDKKeys, 2)
+	assert.Equal(t, ConcurrentKeyRep{Key: "default-sdk", Value: "sdk-anchor"}, rep.SDKKeys[0])
+	assert.Equal(t, ConcurrentKeyRep{Key: "service-a", Value: "sdk-service-a", Expiry: &expiryMs}, rep.SDKKeys[1])
+
+	require.Len(t, rep.MobileKeys, 1)
+	assert.Equal(t, ConcurrentKeyRep{Key: "mob-key-1", Value: "mob-f41c"}, rep.MobileKeys[0])
+
+	params := rep.ToParams()
+
+	require.Len(t, params.AcceptedSDKKeys, 2)
+	assert.Equal(t, AcceptedSDKKey{Identifier: "default-sdk", Value: config.SDKKey("sdk-anchor")}, params.AcceptedSDKKeys[0])
+	assert.Equal(t, AcceptedSDKKey{
+		Identifier: "service-a",
+		Value:      config.SDKKey("sdk-service-a"),
+		Expiry:     time.UnixMilli(expiryMs),
+	}, params.AcceptedSDKKeys[1])
+
+	require.Len(t, params.AcceptedMobileKeys, 1)
+	assert.Equal(t, AcceptedMobileKey{Identifier: "mob-key-1", Value: config.MobileKey("mob-f41c")}, params.AcceptedMobileKeys[0])
+}
+
+// TestEnvironmentRepOldFormatNoArrays verifies that an old-format payload (singular sdkKey/mobKey
+// only, no sdkKeys/mobileKeys arrays) parses cleanly and leaves the accepted-set fields nil.
+func TestEnvironmentRepOldFormatNoArrays(t *testing.T) {
+	jsonStr := `{
+		"envID": "envid1",
+		"envKey": "envkey",
+		"envName": "envname",
+		"mobKey": "mob-default",
+		"projKey": "projkey",
+		"projName": "projname",
+		"sdkKey": { "value": "sdk-key1" },
+		"secureMode": false
+	}`
+
+	var rep EnvironmentRep
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &rep))
+	assert.Nil(t, rep.SDKKeys)
+	assert.Nil(t, rep.MobileKeys)
+
+	params := rep.ToParams()
+	assert.Nil(t, params.AcceptedSDKKeys)
+	assert.Nil(t, params.AcceptedMobileKeys)
+	assert.Equal(t, config.SDKKey("sdk-key1"), params.SDKKey)
+	assert.Equal(t, config.MobileKey("mob-default"), params.MobileKey)
+}
+
+// TestEnvironmentRepBackCompatOldRelay verifies that a new-format payload (containing sdkKeys/
+// mobileKeys) is parsed cleanly by a relay that does not know about those fields. Go's JSON
+// decoder ignores unknown fields by default; this test makes that guarantee explicit and durable.
+// DisallowUnknownFields is intentionally not used in this parse path (see phase1-design.md §10).
+func TestEnvironmentRepBackCompatOldRelay(t *testing.T) {
+	// oldEnvironmentRep simulates a pre-concurrent-keys relay build — no SDKKeys/MobileKeys fields.
+	type oldEnvironmentRep struct {
+		EnvID   config.EnvironmentID `json:"envID"`
+		MobKey  config.MobileKey     `json:"mobKey"`
+		SDKKey  SDKKeyRep            `json:"sdkKey"`
+		Version int                  `json:"version"`
+	}
+
+	jsonStr := `{
+		"envID": "envid1",
+		"envKey": "envkey",
+		"envName": "envname",
+		"mobKey": "mob-default",
+		"projKey": "projkey",
+		"projName": "projname",
+		"sdkKey": { "value": "sdk-anchor" },
+		"sdkKeys": [
+			{ "key": "default-sdk", "value": "sdk-anchor" },
+			{ "key": "service-a",   "value": "sdk-service-a" }
+		],
+		"mobileKeys": [
+			{ "key": "mob-key-1", "value": "mob-default" }
+		],
+		"version": 5
+	}`
+
+	var rep oldEnvironmentRep
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &rep),
+		"new-format payload must parse cleanly into a pre-concurrent-keys relay struct")
+	assert.Equal(t, config.EnvironmentID("envid1"), rep.EnvID)
+	assert.Equal(t, config.SDKKey("sdk-anchor"), rep.SDKKey.Value)
+	assert.Equal(t, config.MobileKey("mob-default"), rep.MobKey)
+	assert.Equal(t, 5, rep.Version)
+}


### PR DESCRIPTION
## Summary

Implements [SDK-2545](https://launchdarkly.atlassian.net/browse/SDK-2545) — the "data first" PR for the concurrent-keys wire-format side. No consumers yet (those land in T3.b/c).

- Adds `ConcurrentKeyRep` wire type for entries in the `sdkKeys`/`mobileKeys` arrays
- Adds `SDKKeys []ConcurrentKeyRep` and `MobileKeys []ConcurrentKeyRep` to `EnvironmentRep`
- Adds `AcceptedSDKKey`, `AcceptedMobileKey`, and corresponding slice fields to `EnvironmentParams`
- `EnvironmentRep.ToParams()` populates the new accepted-set fields from the arrays when present and non-empty; absent or empty arrays are synthesized from the singular `sdkKey`/`mobKey` fields so downstream consumers always receive a non-empty accepted set with at least the anchor
- Adds canonical TERMINOLOGY comment to `EnvironmentRep`

## Background

Part of the Phase 1 concurrent SDK keys feature ([SDK-2453](https://launchdarkly.atlassian.net/browse/SDK-2453)). Both RAC and the offline archive carry `EnvironmentRep`; one parsing change covers both sources.

Design reference: `docs/concurrent-keys/phase1-design.md` §5 (Wire format) and §10 (Backwards compatibility).

## Pre-work verifications (T3.a acceptance criteria)

- **`DisallowUnknownFields` absent**: confirmed by grep — not used anywhere in the env-parse path (`internal/envfactory/`, `internal/filedata/`, `relay/`). Documented in the new `EnvironmentRep` comment.
- **`archive_reader.go` uses `EnvironmentRep` directly**: confirmed — `archiveEnvironmentRep.Env` is `envfactory.EnvironmentRep` and calls `rep.Env.ToParams()`. No scope expansion needed.

## Changes

- `internal/envfactory/env_rep.go` — new `ConcurrentKeyRep` type; `SDKKeys`/`MobileKeys` fields on `EnvironmentRep`; canonical TERMINOLOGY comment; `ToParams()` with new-format (non-empty array) and old-format/empty synthesis branches
- `internal/envfactory/env_params.go` — new `AcceptedSDKKey`, `AcceptedMobileKey` types; `AcceptedSDKKeys`/`AcceptedMobileKeys` fields on `EnvironmentParams`
- `internal/envfactory/env_rep_test.go` — tests covering new-format parsing and old-format normalization

## Test coverage

| Test | What it verifies |
|---|---|
| `TestEnvironmentRepToParams` | `ToParams()` output matches expected params for single key and expiring key cases |
| `TestEnvironmentRepJSONFormat` | Legacy wire format (singular `sdkKey`) deserializes correctly |
| `TestEnvironmentRepNewFormatWithArrays` | Parse realistic RAC `put` payload with `sdkKeys`/`mobileKeys`; struct fields + `ToParams()` output |
| `TestEnvironmentRepOldFormatNoArrays` | Old-format payload (no arrays) → `ToParams()` synthesizes non-nil `AcceptedSDKKeys`/`AcceptedMobileKeys` from singular fields |

All existing tests pass unchanged.


[SDK-2545]: https://launchdarkly.atlassian.net/browse/SDK-2545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2453]: https://launchdarkly.atlassian.net/browse/SDK-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ