### PR TITLE
feat(credential): add Rotator accepted-set data structures

### DIFF
--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -36,7 +36,7 @@ type Rotator struct {
 	// Upon expiration, they are removed.
 	deprecatedSdkKeys map[config.SDKKey]time.Time
 
-	// Consumed by T1.b (ReconcileCredentials API). See docs/concurrent-keys/phase1-design.md §6.2.
+	// Consumed by ReconcileCredentials API
 	acceptedSDKKeys    map[config.SDKKey]*acceptedKeyInfo
 	acceptedMobileKeys map[config.MobileKey]*acceptedKeyInfo
 

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -11,7 +11,7 @@ import (
 
 // acceptedKeyInfo holds per-key metadata for the accepted-set maps.
 type acceptedKeyInfo struct {
-	expiry *time.Time // nil means the key does not expire
+	expiry *time.Time //nolint:unused // nil = permanent; read by T1.b (ReconcileCredentials)
 }
 
 type Rotator struct {

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -9,6 +9,11 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/config"
 )
 
+// acceptedKeyInfo holds per-key metadata for the accepted-set maps.
+type acceptedKeyInfo struct {
+	expiry *time.Time // nil means the key does not expire
+}
+
 type Rotator struct {
 	loggers ldlog.Loggers
 
@@ -31,6 +36,10 @@ type Rotator struct {
 	// Upon expiration, they are removed.
 	deprecatedSdkKeys map[config.SDKKey]time.Time
 
+	// Consumed by T1.b (ReconcileCredentials API). See docs/concurrent-keys/phase1-design.md §6.2.
+	acceptedSDKKeys    map[config.SDKKey]*acceptedKeyInfo
+	acceptedMobileKeys map[config.MobileKey]*acceptedKeyInfo
+
 	expirations []SDKCredential
 	additions   []SDKCredential
 
@@ -50,6 +59,8 @@ func NewRotator(loggers ldlog.Loggers) *Rotator {
 		loggers:              loggers,
 		deprecatedSdkKeys:    make(map[config.SDKKey]time.Time),
 		deprecatedMobileKeys: make(map[config.MobileKey]time.Time),
+		acceptedSDKKeys:      make(map[config.SDKKey]*acceptedKeyInfo),
+		acceptedMobileKeys:   make(map[config.MobileKey]*acceptedKeyInfo),
 	}
 	return r
 }
@@ -67,8 +78,10 @@ func (r *Rotator) Initialize(credentials []SDKCredential) {
 		switch cred := cred.(type) {
 		case config.SDKKey:
 			r.primarySdkKey = cred
+			r.acceptedSDKKeys[cred] = &acceptedKeyInfo{}
 		case config.MobileKey:
 			r.primaryMobileKey = cred
+			r.acceptedMobileKeys[cred] = &acceptedKeyInfo{}
 		case config.EnvironmentID:
 			r.primaryEnvironmentID = cred
 		}

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -232,6 +232,34 @@ func TestSDKKeyExpiredInThePastIsNotAdded(t *testing.T) {
 	assert.Empty(t, expirations)
 }
 
+func TestInitializePopulatesAcceptedSets(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	sdkKey := config.SDKKey("sdk-test-key")
+	mobileKey := config.MobileKey("mob-test-key")
+	envID := config.EnvironmentID("env-test-id")
+
+	rotator.Initialize([]SDKCredential{sdkKey, mobileKey, envID})
+
+	// Verify accepted SDK key set: one entry, no expiry.
+	assert.Len(t, rotator.acceptedSDKKeys, 1)
+	if info, ok := rotator.acceptedSDKKeys[sdkKey]; assert.True(t, ok, "acceptedSDKKeys should contain the initialized SDK key") {
+		assert.Nil(t, info.expiry, "a key initialized without expiry should have nil expiry in acceptedKeyInfo")
+	}
+
+	// Verify accepted mobile key set: one entry, no expiry.
+	assert.Len(t, rotator.acceptedMobileKeys, 1)
+	if info, ok := rotator.acceptedMobileKeys[mobileKey]; assert.True(t, ok, "acceptedMobileKeys should contain the initialized mobile key") {
+		assert.Nil(t, info.expiry, "a key initialized without expiry should have nil expiry in acceptedKeyInfo")
+	}
+
+	// Existing public API is unchanged.
+	assert.Equal(t, sdkKey, rotator.SDKKey())
+	assert.Equal(t, mobileKey, rotator.MobileKey())
+	assert.Equal(t, envID, rotator.EnvironmentID())
+}
+
 func TestRotateWithGraceMobileKey(t *testing.T) {
 	t.Run("does not panic with non-nil grace period", func(t *testing.T) {
 		mockLog := ldlogtest.NewMockLog()


### PR DESCRIPTION
## Summary
Adds internal accepted-set maps (`acceptedSDKKeys`, `acceptedMobileKeys`) to `Rotator`, each entry holding an optional expiry timestamp (`*time.Time`, nil = permanent). Populates the maps from `Initialize()` so a single-key environment immediately reflects the accepted set correctly.

This is the "data first" step — no consumer of the new fields exists yet. Consumers land in T1.b (`ReconcileCredentials` API).

[Jira: SDK-2537](https://launchdarkly.atlassian.net/browse/SDK-2537)

## Background
Phase 1 concurrent keys requires `Rotator` to track a full *set* of accepted credentials per key type (server + mobile) with optional per-key expiry, rather than the current primary + single-deprecated-slot model. This PR introduces the data structures (§6.2 of `docs/concurrent-keys/phase1-design.md`) without touching any external API surface, so all existing tests pass unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal-only fields with no runtime consumers; `Initialize` only adds map entries alongside existing primary-key assignment.
> 
> **Overview**
> Introduces **accepted-set** tracking on `Rotator` for concurrent-keys Phase 1: new `acceptedSDKKeys` and `acceptedMobileKeys` maps, each value an `acceptedKeyInfo` with optional `expiry` (`nil` = permanent).
> 
> `NewRotator` allocates the maps; **`Initialize`** now registers defined SDK and mobile keys into those sets (environment ID is unchanged). Primary/deprecated rotation paths are **not** wired to the accepted sets yet—nothing reads them outside tests.
> 
> Adds **`TestInitializePopulatesAcceptedSets`** to assert one accepted entry per initialized key with nil expiry and unchanged `SDKKey()` / `MobileKey()` / `EnvironmentID()` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0433a9779c0df26b0865dee563c3bf34b1f136ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->