### PR TITLE
test(relay): fix flaky TestAutoConfigRemovesCredentialForExpiredSDKKey

### DIFF
--- a/relay/testutils_test.go
+++ b/relay/testutils_test.go
@@ -133,10 +133,26 @@ func (h relayTestHelper) assertEndpointStatus(
 
 func (h relayTestHelper) awaitCredentialsUpdated(env relayenv.EnvContext, expected envfactory.EnvironmentParams) {
 	expectedCredentials := credentialsAsSet(expected.EnvID, expected.MobileKey, expected.SDKKey)
-	isChanged := func() bool {
-		return reflect.DeepEqual(credentialsAsSet(env.GetCredentials()...), expectedCredentials)
+	// Poll until both env.GetCredentials() and relay's connection mappings reflect the new credentials.
+	// The two updates are not atomic: AddCredential runs before AddConnectionMapping, so there is a
+	// window where GetCredentials() shows the new key but getEnvironment() still returns an error.
+	isReady := func() bool {
+		if !reflect.DeepEqual(credentialsAsSet(env.GetCredentials()...), expectedCredentials) {
+			return false
+		}
+		for _, cred := range []sdkauth.ScopedCredential{
+			sdkauth.New(expected.EnvID),
+			sdkauth.New(expected.MobileKey),
+			sdkauth.New(expected.SDKKey),
+		} {
+			found, err := h.relay.getEnvironment(cred)
+			if err != nil || found != env {
+				return false
+			}
+		}
+		return true
 	}
-	require.Eventually(h.t, isChanged, time.Second, time.Millisecond*5)
+	require.Eventually(h.t, isReady, time.Second, time.Millisecond*5)
 	h.assertEnvLookup(env, expected)
 }
 


### PR DESCRIPTION
## Summary
Fix an intermittent test failure in `TestAutoConfigRemovesCredentialForExpiredSDKKey` caused by a race between credential registration and relay connection mapping.
[Jira: SDK-2549](https://launchdarkly.atlassian.net/browse/SDK-2549)

## Background
`awaitCredentialsUpdated` polled `env.GetCredentials()` via `require.Eventually` until the credential set matched, then immediately called `assertEnvLookup`. Under CI load there is a window between `AddCredential` (which updates `GetCredentials`) and `AddConnectionMapping` (which makes `getEnvironment` return the new key) where the credential set looks correct but the relay lookup still fails with "no environment corresponds to given credentials".

## Changes
Merged both checks into the single `require.Eventually` condition: the loop now exits only once `env.GetCredentials()` matches the expected set AND all three `relay.getEnvironment` lookups (EnvID, MobileKey, SDKKey) succeed. This closes the race window without changing test semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to polling logic; no production relay behavior is modified.
> 
> **Overview**
> **`awaitCredentialsUpdated`** no longer treats a matching `env.GetCredentials()` set as sufficient before continuing. The `require.Eventually` predicate now also requires **EnvID**, **MobileKey**, and **SDKKey** lookups via `relay.getEnvironment` to succeed and return the same `env`, covering the gap where credentials update before connection mappings do.
> 
> Comments document that **AddCredential** and **AddConnectionMapping** are not atomic. The post-poll **`assertEnvLookup`** call is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93d040523bf6a94231772969b6f647f94ad874a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->