### PR TITLE
fix(server): eliminate send-on-closed-channel race in StartHTTPServer

### DIFF
--- a/internal/application/server.go
+++ b/internal/application/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -39,13 +40,15 @@ func StartHTTPServer(
 		}
 	}
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 
 	// Create a channel to listen for signals
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM)
 
-	go func() {
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
 		var err error
 		loggers.Infof("Starting server listening on port %d\n", port)
 		if tlsEnabled {
@@ -61,7 +64,7 @@ func StartHTTPServer(
 		if err != nil && err != http.ErrServerClosed {
 			errCh <- err
 		}
-	}()
+	})
 
 	// Handle graceful shutdown in a separate goroutine
 	go func() {
@@ -83,7 +86,8 @@ func StartHTTPServer(
 		} else {
 			loggers.Info("Server gracefully stopped")
 		}
-		close(errCh) // Close the error channel after shutdown
+		wg.Wait()
+		close(errCh)
 	}()
 
 	return srv, errCh


### PR DESCRIPTION
## Summary
Fix a data race in `StartHTTPServer` where the shutdown goroutine calls `close(errCh)` concurrently with the listener goroutine sending to `errCh`, producing a "send on closed channel" panic.

## Background
The Go race detector on Go 1.26.4 flagged a `closechan` / `chansend` write-write race in `StartHTTPServer`. The scenario: `srv.Shutdown()` closes the HTTP listener, which causes `ListenAndServe` to return. If that return produces a non-`ErrServerClosed` error (possible under unusual shutdown timing), the listener goroutine attempts `errCh <- err` at the same moment the shutdown goroutine executes `close(errCh)`. Because there was no synchronization between these two operations, the runtime could panic. The race is schedule-sensitive and did not reproduce on Go 1.25.

## Changes
- Track the listener goroutine with `sync.WaitGroup` (using `wg.Go`, available since Go 1.25, the project's minimum version).
- Replace `close(errCh)` with `wg.Wait(); close(errCh)` in the shutdown goroutine — the channel is only closed after the listener goroutine has fully exited and can no longer send.
- Buffer `errCh` with capacity 1 so the listener's error send is non-blocking; this ensures `wg.Done` fires promptly rather than waiting for the caller to drain the channel first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow concurrency fix in HTTP server startup/shutdown with no auth or data-path changes; behavior should match except avoiding the rare panic.
> 
> **Overview**
> Fixes a **schedule-sensitive race** in `StartHTTPServer` where SIGTERM shutdown could **`close(errCh)`** while the listener goroutine still tried to send a startup/listen error, causing a **send-on-closed-channel panic** (flagged by the Go 1.26 race detector).
> 
> The listener is now tracked with **`sync.WaitGroup`** (`wg.Go`), **`errCh` is buffered (capacity 1)**, and shutdown does **`wg.Wait()` before `close(errCh)`** so the channel is only closed after the listener goroutine has exited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d67e067514ec040840d7e8386faac0629e51ec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->