### PR TITLE
test(integrationtests): increase SDK key expiry margin and big-segment sync timeout

### DIFF
--- a/integrationtests/big_segments_test.go
+++ b/integrationtests/big_segments_test.go
@@ -110,7 +110,8 @@ func verifyEvaluationWithBigSegment(
 	// Poll the evaluation endpoint until we see the expected flag values. We're using a
 	// longer timeout here than we use in tests that don't involve big segments, because
 	// the user segment state caching inside the SDK makes it hard to say how soon we'll
-	// see the effect of an update.
+	// see the effect of an update. 60s gives enough headroom for streaming propagation
+	// of a second segment update to complete in staging CI environments.
 	success := assert.Eventually(t, func() bool {
 		ok := true
 		for i, env := range environments {
@@ -125,7 +126,7 @@ func verifyEvaluationWithBigSegment(
 			}
 		}
 		return ok
-	}, time.Second*20, time.Millisecond*100, "Did not see expected flag values from Relay")
+	}, time.Second*60, time.Millisecond*100, "Did not see expected flag values from Relay")
 
 	if !success {
 		manager.loggers.Infof("EXPLANATION OF TEST FAILURE FOLLOWS:")

--- a/integrationtests/offline_mode_test.go
+++ b/integrationtests/offline_mode_test.go
@@ -168,7 +168,11 @@ func testSDKKeyExpires(t *testing.T, manager *integrationTestManager) {
 			fileName := "archive.tar.gz"
 			filePath := filepath.Join(manager.relaySharedDir, fileName)
 
-			const keyGracePeriod = 5 * time.Second
+			// 30s gives plenty of margin for multiple sequential staging API calls to succeed
+			// even with round-trip latency and clock skew between the CI runner and staging.
+			// Previously 5s was too tight: the second rotateSDKKey call could arrive at staging
+			// with an expiry at-or-before "now", causing a 400 Bad Request.
+			const keyGracePeriod = 30 * time.Second
 			// Relay will check for expired keys at this interval.
 			const cleanupInterval = 100 * time.Millisecond
 


### PR DESCRIPTION
## Summary
Hardens two pre-existing flaky failures in the "Integration Tests - staging" CI job. Both are independent of any feature work — they surface on the base branch and on unrelated PRs.

[Jira: SDK-2567](https://launchdarkly.atlassian.net/browse/SDK-2567)

> **Note on the run that triggered this:** the CI run that originally surfaced these (and the failures on #704) overlapped [staging incident #182](https://launchdarkly.slack.com/archives/C0BB4KD84TZ) — staging Gonfalon 5xx errors from a Cognito OAuth quota issue (declared 09:46 PDT, resolved 11:32 PDT on 2026-06-18). That incident inflated the failure set. The two tests addressed here, however, are *independently* flaky for the reasons below — the incident was a red herring, not the root cause.

## Background

### Failure 1 — `TestEndToEnd/offline_mode/sdk_key_is_rotated_and_then_expires`
A latent timing race in the test, not the incident. `testSDKKeyExpires` computes an SDK key expiry of `time.Now() + 5s` **once**, then `rotateSDKKeys` makes **sequential** staging API calls (one per environment — this case uses 2) reusing that same absolute timestamp. If the second call lands more than 5s after the timestamp was computed (round-trip latency + clock skew), staging rejects it with a deterministic `400: expiry must be a Unix epoch time (ms) in the future`. A `400` validation rejection (not a `5xx`) confirms the request reached and was validated by staging — i.e. a genuine margin bug. Increased the grace period to **30s**.

### Failure 2 — `TestEndToEnd/big_segments/.../another_big_segment_is_created_after_synchronizer_has_started`
Proven-flaky on timing, with prior art:
- This exact timeout was already raised once for the same reason: [#274 "increase big segment integration test timeout"](https://github.com/launchdarkly/ld-relay/pull/274) bumped it 10s → 20s.
- It failed again **independently of any incident**: the scheduled daily run on 2026-06-09 ([run 27195971417](https://github.com/launchdarkly/ld-relay/actions/runs/27195971417)) failed this subtest at 27.98s against the **production** environment on base `v8` — no PR code, no incident.

Big-segment sync genuinely sometimes exceeds 20s in real LD environments. Raised the `assert.Eventually` timeout in `verifyEvaluationWithBigSegment` 20s → **60s**. The poll loop exits as soon as values match, so passing runs are not slowed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout and grace-period tweaks with no changes to Relay runtime code or security paths.
> 
> **Overview**
> Reduces flaky **Integration Tests - staging** failures by relaxing two timing constants only in tests—no production Relay behavior changes.
> 
> In **`testSDKKeyExpires`**, the deprecated-key grace period is increased from **5s to 30s** so sequential `rotateSDKKeys` calls (one per environment) still send a future expiry to staging after CI latency and clock skew; the test still sleeps only until keys expire before asserting cleanup.
> 
> In **`verifyEvaluationWithBigSegment`**, the `assert.Eventually` poll window is increased from **20s to 60s** so a second big-segment update can propagate via streaming in slow environments; passing runs still exit as soon as evaluations match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7043a46faf24e4f61adc54bec785dde7a14bc24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->