### PR TITLE
feat(envfactory): shared BuildAcceptedSet helper for ReconcileCredentials

### DIFF
--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -2,7 +2,7 @@ package envfactory
 
 import (
 	"github.com/launchdarkly/ld-relay/v8/config"
-	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 )
 
 // BuildAcceptedSet converts an EnvironmentParams into the AcceptedSet and anchor
@@ -15,50 +15,54 @@ import (
 // Expiry comes from AcceptedSDKKey.Expiry / AcceptedMobileKey.Expiry (the arrays). The legacy
 // sdkKey.expiring wire slot is never consulted here — relay trusts the array.
 //
-// If the anchor is malformed, no set is built and a *relayenv.MalformedCredentialSetError is
-// returned with an empty AcceptedSet. The anchor is malformed when params.SDKKey is undefined
-// or is not found in AcceptedSDKKeys by value. The caller must preserve the previous accepted
-// state and, for RAC handlers, reconnect the stream with jitter to force a fresh put.
-func BuildAcceptedSet(params EnvironmentParams) (relayenv.AcceptedSet, config.SDKKey, error) {
+// The anchor (params.SDKKey) is added and designated as the primary SDK key, and the primary
+// mobile key (params.MobileKey) is added and designated, in addition to the full accepted arrays.
+// The builder de-duplicates by value, so an anchor or primary mobile key that also appears in its
+// array is added only once.
+//
+// If no anchor is designated — params.SDKKey is undefined — no set is built and a
+// *credential.MalformedCredentialSetError is returned with an empty AcceptedSet. The caller must
+// preserve the previous accepted state and, for RAC handlers, reconnect the stream with jitter to
+// force a fresh put. Structural validation of the wire payload (undefined credentials, an anchor
+// absent from the array) happens upstream when the payload is parsed into params.
+func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.SDKKey, error) {
 	anchor := params.SDKKey
-	if !anchor.Defined() {
-		// Pass an untyped nil rather than the empty config.SDKKey: a concrete zero value boxed
-		// into the credential.SDKCredential interface is non-nil, which would route Error() down
-		// the "not present" branch instead of the accurate "anchor SDK key is missing" branch.
-		return relayenv.NewAcceptedSet(), anchor, &relayenv.MalformedCredentialSetError{Anchor: nil}
-	}
-	if !anchorInSDKKeys(anchor, params.AcceptedSDKKeys) {
-		return relayenv.NewAcceptedSet(), anchor, &relayenv.MalformedCredentialSetError{Anchor: anchor}
-	}
 
-	set := relayenv.NewAcceptedSet().WithEnvironmentID(params.EnvID)
+	// WithPrimarySDKKey both adds the anchor and designates it. If anchor is undefined it is a
+	// no-op, leaving the set with no designated anchor; Build then returns a
+	// *MalformedCredentialSetError. The builder de-duplicates, so re-adding the anchor in the loop
+	// below is safe.
+	b := credential.NewAcceptedSetBuilder().
+		WithEnvironmentID(params.EnvID).
+		WithPrimarySDKKey(anchor)
 
 	for _, k := range params.AcceptedSDKKeys {
-		// The anchor is always permanent: the singular sdkKey always names a non-expiring key.
-		// Defend the invariant here: even if a payload carries an expiry on the anchor entry,
-		// add it as a permanent key so it can never be treated as a deprecated/expiring key.
-		if k.Value == anchor || k.Expiry.IsZero() {
-			set = set.WithSDKKey(k.Value)
-		} else {
-			set = set.WithExpiringSDKKey(k.Value, k.Expiry)
-		}
-	}
-
-	// AcceptedSet.mobileKeys is a flat slice with no per-key expiry; expiring mobile key
-	// cleanup is handled by the StepTime ticker. Add all mobile keys unconditionally.
-	for _, k := range params.AcceptedMobileKeys {
-		set = set.WithMobileKey(k.Value)
-	}
-
-	return set, anchor, nil
-}
-
-// anchorInSDKKeys reports whether anchor appears in keys by value.
-func anchorInSDKKeys(anchor config.SDKKey, keys []AcceptedSDKKey) bool {
-	for _, k := range keys {
+		// The anchor is added permanently above; skip it so a payload that (wrongly) carries an
+		// expiry on the anchor's own entry can never demote it to an expiring key.
 		if k.Value == anchor {
-			return true
+			continue
+		}
+		if k.Expiry.IsZero() {
+			b.WithSDKKey(k.Value)
+		} else {
+			b.WithExpiringSDKKey(k.Value, k.Expiry)
 		}
 	}
-	return false
+
+	for _, k := range params.AcceptedMobileKeys {
+		if k.Expiry.IsZero() {
+			b.WithMobileKey(k.Value)
+		} else {
+			b.WithExpiringMobileKey(k.Value, k.Expiry)
+		}
+	}
+
+	// Designate the primary mobile key (the wire's mobKey). De-duplicated against the array above.
+	b.WithPrimaryMobileKey(params.MobileKey)
+
+	set, err := b.Build()
+	if err != nil {
+		return credential.AcceptedSet{}, anchor, err
+	}
+	return set, anchor, nil
 }

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -13,12 +13,12 @@ import (
 // AcceptedSet as if nothing changed.
 //
 // Expiry comes from AcceptedSDKKey.Expiry / AcceptedMobileKey.Expiry (the arrays). The legacy
-// sdkKey.expiring wire slot is never consulted here ("trust the array", design §6.3).
+// sdkKey.expiring wire slot is never consulted here — relay trusts the array.
 //
 // If the anchor is malformed, no set is built and a *relayenv.MalformedCredentialSetError is
 // returned with an empty AcceptedSet. The anchor is malformed when params.SDKKey is undefined
 // or is not found in AcceptedSDKKeys by value. The caller must preserve the previous accepted
-// state and, for RAC handlers, reconnect the stream with jitter to force a fresh put (design §9).
+// state and, for RAC handlers, reconnect the stream with jitter to force a fresh put.
 func BuildAcceptedSet(params EnvironmentParams) (relayenv.AcceptedSet, config.SDKKey, error) {
 	anchor := params.SDKKey
 	if !anchor.Defined() {
@@ -34,7 +34,7 @@ func BuildAcceptedSet(params EnvironmentParams) (relayenv.AcceptedSet, config.SD
 	set := relayenv.NewAcceptedSet().WithEnvironmentID(params.EnvID)
 
 	for _, k := range params.AcceptedSDKKeys {
-		// The anchor is always permanent (design §4.2: sdkKey always names a non-expiring key).
+		// The anchor is always permanent: the singular sdkKey always names a non-expiring key.
 		// Defend the invariant here: even if a payload carries an expiry on the anchor entry,
 		// add it as a permanent key so it can never be treated as a deprecated/expiring key.
 		if k.Value == anchor || k.Expiry.IsZero() {
@@ -45,7 +45,7 @@ func BuildAcceptedSet(params EnvironmentParams) (relayenv.AcceptedSet, config.SD
 	}
 
 	// AcceptedSet.mobileKeys is a flat slice with no per-key expiry; expiring mobile key
-	// cleanup is handled by the StepTime ticker (T1.c). Add all mobile keys unconditionally.
+	// cleanup is handled by the StepTime ticker. Add all mobile keys unconditionally.
 	for _, k := range params.AcceptedMobileKeys {
 		set = set.WithMobileKey(k.Value)
 	}

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -15,12 +15,18 @@ import (
 // Expiry comes from AcceptedSDKKey.Expiry / AcceptedMobileKey.Expiry (the arrays). The legacy
 // sdkKey.expiring wire slot is never consulted here ("trust the array", design §6.3).
 //
-// If params.SDKKey (the anchor) is not found in AcceptedSDKKeys by value, no set is built
-// and a *relayenv.MalformedCredentialSetError is returned with an empty AcceptedSet. The
-// caller must preserve the previous accepted state and, for RAC handlers, reconnect the
-// stream with jitter to force a fresh put (design §9).
+// If the anchor is malformed, no set is built and a *relayenv.MalformedCredentialSetError is
+// returned with an empty AcceptedSet. The anchor is malformed when params.SDKKey is undefined
+// or is not found in AcceptedSDKKeys by value. The caller must preserve the previous accepted
+// state and, for RAC handlers, reconnect the stream with jitter to force a fresh put (design §9).
 func BuildAcceptedSet(params EnvironmentParams) (relayenv.AcceptedSet, config.SDKKey, error) {
 	anchor := params.SDKKey
+	if !anchor.Defined() {
+		// Pass an untyped nil rather than the empty config.SDKKey: a concrete zero value boxed
+		// into the credential.SDKCredential interface is non-nil, which would route Error() down
+		// the "not present" branch instead of the accurate "anchor SDK key is missing" branch.
+		return relayenv.NewAcceptedSet(), anchor, &relayenv.MalformedCredentialSetError{Anchor: nil}
+	}
 	if !anchorInSDKKeys(anchor, params.AcceptedSDKKeys) {
 		return relayenv.NewAcceptedSet(), anchor, &relayenv.MalformedCredentialSetError{Anchor: anchor}
 	}
@@ -28,7 +34,10 @@ func BuildAcceptedSet(params EnvironmentParams) (relayenv.AcceptedSet, config.SD
 	set := relayenv.NewAcceptedSet().WithEnvironmentID(params.EnvID)
 
 	for _, k := range params.AcceptedSDKKeys {
-		if k.Expiry.IsZero() {
+		// The anchor is always permanent (design §4.2: sdkKey always names a non-expiring key).
+		// Defend the invariant here: even if a payload carries an expiry on the anchor entry,
+		// add it as a permanent key so it can never be treated as a deprecated/expiring key.
+		if k.Value == anchor || k.Expiry.IsZero() {
 			set = set.WithSDKKey(k.Value)
 		} else {
 			set = set.WithExpiringSDKKey(k.Value, k.Expiry)
@@ -44,12 +53,8 @@ func BuildAcceptedSet(params EnvironmentParams) (relayenv.AcceptedSet, config.SD
 	return set, anchor, nil
 }
 
-// anchorInSDKKeys reports whether anchor appears in keys by value. Returns false for an
-// undefined anchor regardless of what keys contains.
+// anchorInSDKKeys reports whether anchor appears in keys by value.
 func anchorInSDKKeys(anchor config.SDKKey, keys []AcceptedSDKKey) bool {
-	if !anchor.Defined() {
-		return false
-	}
 	for _, k := range keys {
 		if k.Value == anchor {
 			return true

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -1,0 +1,59 @@
+package envfactory
+
+import (
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
+)
+
+// BuildAcceptedSet converts an EnvironmentParams into the AcceptedSet and anchor
+// credential needed by EnvContext.ReconcileCredentials.
+//
+// Credential identity is keyed by value (the secret string), not by key (the human-readable
+// identifier). A rename — same value, different identifier — therefore produces the same
+// AcceptedSet as if nothing changed.
+//
+// Expiry comes from AcceptedSDKKey.Expiry / AcceptedMobileKey.Expiry (the arrays). The legacy
+// sdkKey.expiring wire slot is never consulted here ("trust the array", design §6.3).
+//
+// If params.SDKKey (the anchor) is not found in AcceptedSDKKeys by value, no set is built
+// and a *relayenv.MalformedCredentialSetError is returned with an empty AcceptedSet. The
+// caller must preserve the previous accepted state and, for RAC handlers, reconnect the
+// stream with jitter to force a fresh put (design §9).
+func BuildAcceptedSet(params EnvironmentParams) (relayenv.AcceptedSet, config.SDKKey, error) {
+	anchor := params.SDKKey
+	if !anchorInSDKKeys(anchor, params.AcceptedSDKKeys) {
+		return relayenv.NewAcceptedSet(), anchor, &relayenv.MalformedCredentialSetError{Anchor: anchor}
+	}
+
+	set := relayenv.NewAcceptedSet().WithEnvironmentID(params.EnvID)
+
+	for _, k := range params.AcceptedSDKKeys {
+		if k.Expiry.IsZero() {
+			set = set.WithSDKKey(k.Value)
+		} else {
+			set = set.WithExpiringSDKKey(k.Value, k.Expiry)
+		}
+	}
+
+	// AcceptedSet.mobileKeys is a flat slice with no per-key expiry; expiring mobile key
+	// cleanup is handled by the StepTime ticker (T1.c). Add all mobile keys unconditionally.
+	for _, k := range params.AcceptedMobileKeys {
+		set = set.WithMobileKey(k.Value)
+	}
+
+	return set, anchor, nil
+}
+
+// anchorInSDKKeys reports whether anchor appears in keys by value. Returns false for an
+// undefined anchor regardless of what keys contains.
+func anchorInSDKKeys(anchor config.SDKKey, keys []AcceptedSDKKey) bool {
+	if !anchor.Defined() {
+		return false
+	}
+	for _, k := range keys {
+		if k.Value == anchor {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -28,20 +28,20 @@ import (
 func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.SDKKey, error) {
 	anchor := params.SDKKey
 
-	// WithPrimarySDKKey both adds the anchor and designates it. If anchor is undefined it is a
-	// no-op, leaving the set with no designated anchor; Build then returns a
-	// *MalformedCredentialSetError. The builder de-duplicates, so re-adding the anchor in the loop
-	// below is safe.
+	// WithPrimarySDKKey / WithPrimaryMobileKey each add the key and designate it (the anchor and the
+	// wire's mobKey, respectively). An undefined key makes the call a no-op, so an undefined anchor
+	// leaves the set with no designated anchor and Build returns a *MalformedCredentialSetError.
 	b := credential.NewAcceptedSetBuilder().
 		WithEnvironmentID(params.EnvID).
-		WithPrimarySDKKey(anchor)
+		WithPrimarySDKKey(anchor).
+		WithPrimaryMobileKey(params.MobileKey)
 
+	// Add the remaining accepted keys. The builder de-duplicates by value, so the anchor and the
+	// primary mobile key — already added permanently above — are ignored when they reappear in
+	// their arrays. That also defends the anchor-never-expiring invariant: a payload that (wrongly)
+	// carries an expiry on the anchor's own entry cannot demote it, because the permanent anchor is
+	// already present.
 	for _, k := range params.AcceptedSDKKeys {
-		// The anchor is added permanently above; skip it so a payload that (wrongly) carries an
-		// expiry on the anchor's own entry can never demote it to an expiring key.
-		if k.Value == anchor {
-			continue
-		}
 		if k.Expiry.IsZero() {
 			b.WithSDKKey(k.Value)
 		} else {
@@ -56,9 +56,6 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 			b.WithExpiringMobileKey(k.Value, k.Expiry)
 		}
 	}
-
-	// Designate the primary mobile key (the wire's mobKey). De-duplicated against the array above.
-	b.WithPrimaryMobileKey(params.MobileKey)
 
 	set, err := b.Build()
 	if err != nil {

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -124,9 +124,10 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 		"mob-primary",
 	)
 
-	setWithExpiry, _, _ := BuildAcceptedSet(paramsWithExpiry)
+	setWithExpiry, _, errWithExpiry := BuildAcceptedSet(paramsWithExpiry)
 	setNoExpiry, _, errNoExpiry := BuildAcceptedSet(paramsNoExpiry)
 
+	require.NoError(t, errWithExpiry)
 	require.NoError(t, errNoExpiry)
 
 	// The set built without expiry must include sdk-old as a permanent key.
@@ -159,6 +160,9 @@ func TestBuildAcceptedSet_MalformedPayload(t *testing.T) {
 	require.True(t, errors.As(err, &malformed), "error should be *relayenv.MalformedCredentialSetError")
 	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
 	assert.Equal(t, relayenv.NewAcceptedSet(), set, "AcceptedSet must be empty on malformed payload")
+	// The error must carry the offending anchor so the caller/log identifies it (masked).
+	assert.Equal(t, config.SDKKey("sdk-anchor"), malformed.Anchor)
+	assert.Contains(t, malformed.Error(), "not present in the accepted set")
 }
 
 // TestBuildAcceptedSet_MalformedPayload_AnchorUndefined verifies that an undefined anchor
@@ -175,7 +179,12 @@ func TestBuildAcceptedSet_MalformedPayload_AnchorUndefined(t *testing.T) {
 
 	require.Error(t, err)
 	var malformed *relayenv.MalformedCredentialSetError
-	assert.True(t, errors.As(err, &malformed))
+	require.True(t, errors.As(err, &malformed))
+	// An undefined anchor must produce the "missing" message, not the "not present" one. This
+	// only holds if Anchor is an untyped nil — a boxed zero-value config.SDKKey would be non-nil
+	// and route Error() down the wrong branch.
+	assert.Nil(t, malformed.Anchor)
+	assert.Contains(t, malformed.Error(), "anchor SDK key is missing")
 }
 
 // TestBuildAcceptedSet_MixedUpdate verifies add + re-anchor + remove in a single params update
@@ -208,6 +217,55 @@ func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
 		WithSDKKey("sdk-b").
 		WithSDKKey("sdk-c").
 		WithMobileKey("mob-primary")
+	assert.Equal(t, expected, set)
+}
+
+// TestBuildAcceptedSet_AnchorNeverExpiring verifies the §4.2 invariant defense: even if a
+// payload carries an expiry on the anchor's own entry, the anchor is added as a permanent key,
+// never as an expiring one.
+func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
+	params := makeParams(
+		"sdk-anchor",
+		[]AcceptedSDKKey{
+			{Key: "default", Value: "sdk-anchor", Expiry: expiry1}, // anchor with a bogus expiry
+			{Key: "service-a", Value: "sdk-service-a"},
+		},
+		"mob-primary",
+	)
+	set, anchor, err := BuildAcceptedSet(params)
+
+	require.NoError(t, err)
+	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
+
+	// Anchor is permanent (WithSDKKey), not expiring — identical to a payload with no anchor expiry.
+	expected := relayenv.NewAcceptedSet().
+		WithEnvironmentID("env-abc").
+		WithSDKKey("sdk-anchor").
+		WithSDKKey("sdk-service-a").
+		WithMobileKey("mob-primary")
+	assert.Equal(t, expected, set)
+}
+
+// TestBuildAcceptedSet_MultipleMobileKeys verifies that all accepted mobile keys are included,
+// exercising the len(AcceptedMobileKeys) > 1 path.
+func TestBuildAcceptedSet_MultipleMobileKeys(t *testing.T) {
+	params := EnvironmentParams{
+		EnvID:           "env-abc",
+		SDKKey:          "sdk-anchor",
+		AcceptedSDKKeys: []AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
+		AcceptedMobileKeys: []AcceptedMobileKey{
+			{Key: "mob-1", Value: "mob-primary"},
+			{Key: "mob-2", Value: "mob-secondary"},
+		},
+	}
+	set, _, err := BuildAcceptedSet(params)
+
+	require.NoError(t, err)
+	expected := relayenv.NewAcceptedSet().
+		WithEnvironmentID("env-abc").
+		WithSDKKey("sdk-anchor").
+		WithMobileKey("mob-primary").
+		WithMobileKey("mob-secondary")
 	assert.Equal(t, expected, set)
 }
 

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
-	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,9 +15,18 @@ import (
 // expiry1 is a fixed future timestamp used in tests to represent an expiring key.
 var expiry1 = time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
 
+// mustBuild builds the AcceptedSet from b, failing the test if Build returns an error. It is used to
+// construct the expected set for comparison.
+func mustBuild(t *testing.T, b *credential.AcceptedSetBuilder) credential.AcceptedSet {
+	t.Helper()
+	set, err := b.Build()
+	require.NoError(t, err)
+	return set
+}
+
 // makeParams is a convenience builder for EnvironmentParams test fixtures.
 // sdkKey is the anchor, sdkKeys are the full accepted set (must include the anchor),
-// mobileKey is the single mobile key to include.
+// mobileKey is the single (primary) mobile key to include.
 func makeParams(sdkKey config.SDKKey, sdkKeys []AcceptedSDKKey, mobileKey config.MobileKey) EnvironmentParams {
 	mob := []AcceptedMobileKey{}
 	if mobileKey.Defined() {
@@ -26,6 +35,7 @@ func makeParams(sdkKey config.SDKKey, sdkKeys []AcceptedSDKKey, mobileKey config
 	return EnvironmentParams{
 		EnvID:              config.EnvironmentID("env-abc"),
 		SDKKey:             sdkKey,
+		MobileKey:          mobileKey,
 		AcceptedSDKKeys:    sdkKeys,
 		AcceptedMobileKeys: mob,
 	}
@@ -44,10 +54,10 @@ func TestBuildAcceptedSet_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
 
-	expected := relayenv.NewAcceptedSet().
+	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithSDKKey("sdk-anchor").
-		WithMobileKey("mob-primary")
+		WithPrimarySDKKey("sdk-anchor").
+		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
 }
 
@@ -58,8 +68,8 @@ func TestBuildAcceptedSet_MultipleKeys(t *testing.T) {
 		"sdk-anchor",
 		[]AcceptedSDKKey{
 			{Key: "default", Value: "sdk-anchor"},
-			{Key: "service-a", Value: "sdk-service-a"},                    // permanent, non-anchor
-			{Key: "old-key", Value: "sdk-old", Expiry: expiry1},          // expiring, non-anchor
+			{Key: "service-a", Value: "sdk-service-a"},          // permanent, non-anchor
+			{Key: "old-key", Value: "sdk-old", Expiry: expiry1}, // expiring, non-anchor
 		},
 		"mob-primary",
 	)
@@ -68,12 +78,12 @@ func TestBuildAcceptedSet_MultipleKeys(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
 
-	expected := relayenv.NewAcceptedSet().
+	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithSDKKey("sdk-anchor").
+		WithPrimarySDKKey("sdk-anchor").
 		WithSDKKey("sdk-service-a").
 		WithExpiringSDKKey("sdk-old", expiry1).
-		WithMobileKey("mob-primary")
+		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
 }
 
@@ -131,43 +141,45 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 	require.NoError(t, errNoExpiry)
 
 	// The set built without expiry must include sdk-old as a permanent key.
-	expectedPermanent := relayenv.NewAcceptedSet().
+	expectedPermanent := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithSDKKey("sdk-anchor").
+		WithPrimarySDKKey("sdk-anchor").
 		WithSDKKey("sdk-old"). // permanent, no expiry
-		WithMobileKey("mob-primary")
+		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expectedPermanent, setNoExpiry)
 
 	// Sanity: the expiring and non-expiring versions are different.
 	assert.NotEqual(t, setWithExpiry, setNoExpiry)
 }
 
-// TestBuildAcceptedSet_MalformedPayload verifies that when the anchor (params.SDKKey) is not
-// present in AcceptedSDKKeys, BuildAcceptedSet returns a *relayenv.MalformedCredentialSetError
-// and an empty AcceptedSet.
-func TestBuildAcceptedSet_MalformedPayload(t *testing.T) {
+// TestBuildAcceptedSet_AnchorNotInArray verifies that an anchor absent from AcceptedSDKKeys is no
+// longer rejected here: WithPrimarySDKKey adds and designates the anchor regardless, so the
+// resulting set contains both the anchor and the array entry. Structural validation of the wire
+// payload (anchor-absent-from-array) happens upstream when the payload is parsed into params.
+func TestBuildAcceptedSet_AnchorNotInArray(t *testing.T) {
 	params := makeParams(
 		"sdk-anchor",
 		[]AcceptedSDKKey{
-			{Key: "other-key", Value: "sdk-other"}, // anchor NOT here
+			{Key: "other-key", Value: "sdk-other"}, // anchor NOT in the array
 		},
 		"mob-primary",
 	)
 	set, anchor, err := BuildAcceptedSet(params)
 
-	require.Error(t, err)
-	var malformed *relayenv.MalformedCredentialSetError
-	require.True(t, errors.As(err, &malformed), "error should be *relayenv.MalformedCredentialSetError")
+	require.NoError(t, err)
 	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
-	assert.Equal(t, relayenv.NewAcceptedSet(), set, "AcceptedSet must be empty on malformed payload")
-	// The error must carry the offending anchor so the caller/log identifies it (masked).
-	assert.Equal(t, config.SDKKey("sdk-anchor"), malformed.Anchor)
-	assert.Contains(t, malformed.Error(), "not present in the accepted set")
+
+	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
+		WithEnvironmentID("env-abc").
+		WithPrimarySDKKey("sdk-anchor"). // added + designated even though absent from the array
+		WithSDKKey("sdk-other").
+		WithPrimaryMobileKey("mob-primary"))
+	assert.Equal(t, expected, set)
 }
 
-// TestBuildAcceptedSet_MalformedPayload_AnchorUndefined verifies that an undefined anchor
-// (empty SDKKey) is treated as a malformed payload.
-func TestBuildAcceptedSet_MalformedPayload_AnchorUndefined(t *testing.T) {
+// TestBuildAcceptedSet_AnchorUndefined verifies that an undefined anchor (empty SDKKey) yields a
+// *credential.MalformedCredentialSetError: no anchor was designated, so Build rejects the set.
+func TestBuildAcceptedSet_AnchorUndefined(t *testing.T) {
 	params := makeParams(
 		"", // undefined anchor
 		[]AcceptedSDKKey{
@@ -178,13 +190,25 @@ func TestBuildAcceptedSet_MalformedPayload_AnchorUndefined(t *testing.T) {
 	_, _, err := BuildAcceptedSet(params)
 
 	require.Error(t, err)
-	var malformed *relayenv.MalformedCredentialSetError
+	var malformed *credential.MalformedCredentialSetError
 	require.True(t, errors.As(err, &malformed))
 	// An undefined anchor must produce the "missing" message, not the "not present" one. This
 	// only holds if Anchor is an untyped nil — a boxed zero-value config.SDKKey would be non-nil
 	// and route Error() down the wrong branch.
 	assert.Nil(t, malformed.Anchor)
 	assert.Contains(t, malformed.Error(), "anchor SDK key is missing")
+}
+
+// TestBuildAcceptedSet_NoSDKKeys verifies that when neither an anchor nor any array SDK keys are
+// present, Build returns an error (the set has no SDK key at all).
+func TestBuildAcceptedSet_NoSDKKeys(t *testing.T) {
+	params := EnvironmentParams{
+		SDKKey:             "", // undefined anchor
+		AcceptedSDKKeys:    []AcceptedSDKKey{},
+		AcceptedMobileKeys: []AcceptedMobileKey{},
+	}
+	_, _, err := BuildAcceptedSet(params)
+	require.Error(t, err, "a set with no SDK key at all must be rejected")
 }
 
 // TestBuildAcceptedSet_MixedUpdate verifies add + re-anchor + remove in a single params update
@@ -211,12 +235,12 @@ func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config.SDKKey("sdk-new-anchor"), anchor)
 
-	expected := relayenv.NewAcceptedSet().
+	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithSDKKey("sdk-new-anchor").
+		WithPrimarySDKKey("sdk-new-anchor").
 		WithSDKKey("sdk-b").
 		WithSDKKey("sdk-c").
-		WithMobileKey("mob-primary")
+		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
 }
 
@@ -237,21 +261,23 @@ func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
 
-	// Anchor is permanent (WithSDKKey), not expiring — identical to a payload with no anchor expiry.
-	expected := relayenv.NewAcceptedSet().
+	// Anchor is permanent (WithPrimarySDKKey), not expiring — identical to a payload with no anchor expiry.
+	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithSDKKey("sdk-anchor").
+		WithPrimarySDKKey("sdk-anchor").
 		WithSDKKey("sdk-service-a").
-		WithMobileKey("mob-primary")
+		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
 }
 
 // TestBuildAcceptedSet_MultipleMobileKeys verifies that all accepted mobile keys are included,
-// exercising the len(AcceptedMobileKeys) > 1 path.
+// exercising the len(AcceptedMobileKeys) > 1 path, and that the wire's mobKey is designated as the
+// primary mobile key.
 func TestBuildAcceptedSet_MultipleMobileKeys(t *testing.T) {
 	params := EnvironmentParams{
 		EnvID:           "env-abc",
 		SDKKey:          "sdk-anchor",
+		MobileKey:       "mob-primary",
 		AcceptedSDKKeys: []AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
 		AcceptedMobileKeys: []AcceptedMobileKey{
 			{Key: "mob-1", Value: "mob-primary"},
@@ -261,12 +287,40 @@ func TestBuildAcceptedSet_MultipleMobileKeys(t *testing.T) {
 	set, _, err := BuildAcceptedSet(params)
 
 	require.NoError(t, err)
-	expected := relayenv.NewAcceptedSet().
+	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithSDKKey("sdk-anchor").
+		WithPrimarySDKKey("sdk-anchor").
 		WithMobileKey("mob-primary").
-		WithMobileKey("mob-secondary")
+		WithMobileKey("mob-secondary").
+		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
+}
+
+// TestBuildAcceptedSet_ExpiringMobileKey verifies that a mobile key carrying a non-zero Expiry is
+// plumbed through as an expiring key (parallel to the expiring-SDK-key path), while the permanent
+// primary mobile key is designated. This is what makes per-key mobile expiry work end-to-end:
+// params carry it → BuildAcceptedSet plumbs it into the AcceptedSet → Reconcile acts on it.
+func TestBuildAcceptedSet_ExpiringMobileKey(t *testing.T) {
+	params := EnvironmentParams{
+		EnvID:           "env-abc",
+		SDKKey:          "sdk-anchor",
+		MobileKey:       "mob-primary",
+		AcceptedSDKKeys: []AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
+		AcceptedMobileKeys: []AcceptedMobileKey{
+			{Key: "mob-1", Value: "mob-primary"},                // permanent primary
+			{Key: "mob-old", Value: "mob-old", Expiry: expiry1}, // expiring
+		},
+	}
+	set, _, err := BuildAcceptedSet(params)
+
+	require.NoError(t, err)
+	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
+		WithEnvironmentID("env-abc").
+		WithPrimarySDKKey("sdk-anchor").
+		WithMobileKey("mob-primary").
+		WithExpiringMobileKey("mob-old", expiry1).
+		WithPrimaryMobileKey("mob-primary"))
+	assert.Equal(t, expected, set, "expiring mobile key must land as an expiring key in the set")
 }
 
 // TestBuildAcceptedSet_TrustTheArray verifies that the legacy sdkKey.expiring slot is not
@@ -276,8 +330,9 @@ func TestBuildAcceptedSet_TrustTheArray(t *testing.T) {
 	// Simulate an old-relay payload where ExpiringSDKKey is populated from sdkKey.expiring,
 	// but AcceptedSDKKeys only has the anchor (no expiring key in the array).
 	params := EnvironmentParams{
-		EnvID:  "env-abc",
-		SDKKey: "sdk-anchor",
+		EnvID:     "env-abc",
+		SDKKey:    "sdk-anchor",
+		MobileKey: "mob-primary",
 		ExpiringSDKKey: ExpiringSDKKey{ // legacy field — must NOT be consulted
 			Key:        "sdk-legacy-expiring",
 			Expiration: expiry1,
@@ -289,22 +344,9 @@ func TestBuildAcceptedSet_TrustTheArray(t *testing.T) {
 	set, _, err := BuildAcceptedSet(params)
 
 	require.NoError(t, err)
-	expected := relayenv.NewAcceptedSet().
+	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithSDKKey("sdk-anchor").
-		WithMobileKey("mob-primary")
+		WithPrimarySDKKey("sdk-anchor").
+		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set, "legacy sdkKey.expiring slot must not appear in AcceptedSet")
-}
-
-// TestBuildAcceptedSet_EmptyArrays verifies the edge case where AcceptedSDKKeys is empty:
-// the anchor cannot be found, so a malformed-payload error is returned.
-func TestBuildAcceptedSet_EmptyArrays(t *testing.T) {
-	// Edge case: AcceptedSDKKeys is empty (which means malformed, since anchor can't be found).
-	params := EnvironmentParams{
-		SDKKey:             "sdk-anchor",
-		AcceptedSDKKeys:    []AcceptedSDKKey{},
-		AcceptedMobileKeys: []AcceptedMobileKey{},
-	}
-	_, _, err := BuildAcceptedSet(params)
-	require.Error(t, err, "empty AcceptedSDKKeys should be malformed since anchor is not present")
 }

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -220,9 +220,9 @@ func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
 	assert.Equal(t, expected, set)
 }
 
-// TestBuildAcceptedSet_AnchorNeverExpiring verifies the §4.2 invariant defense: even if a
-// payload carries an expiry on the anchor's own entry, the anchor is added as a permanent key,
-// never as an expiring one.
+// TestBuildAcceptedSet_AnchorNeverExpiring verifies the invariant defense: even if a payload
+// carries an expiry on the anchor's own entry, the anchor is added as a permanent key, never
+// as an expiring one.
 func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
 	params := makeParams(
 		"sdk-anchor",

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -1,0 +1,252 @@
+package envfactory
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// expiry1 is a fixed future timestamp used in tests to represent an expiring key.
+var expiry1 = time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// makeParams is a convenience builder for EnvironmentParams test fixtures.
+// sdkKey is the anchor, sdkKeys are the full accepted set (must include the anchor),
+// mobileKey is the single mobile key to include.
+func makeParams(sdkKey config.SDKKey, sdkKeys []AcceptedSDKKey, mobileKey config.MobileKey) EnvironmentParams {
+	mob := []AcceptedMobileKey{}
+	if mobileKey.Defined() {
+		mob = []AcceptedMobileKey{{Value: mobileKey}}
+	}
+	return EnvironmentParams{
+		EnvID:              config.EnvironmentID("env-abc"),
+		SDKKey:             sdkKey,
+		AcceptedSDKKeys:    sdkKeys,
+		AcceptedMobileKeys: mob,
+	}
+}
+
+// TestBuildAcceptedSet_HappyPath verifies the basic case: a single permanent SDK key that is the
+// anchor, plus a mobile key and env ID.
+func TestBuildAcceptedSet_HappyPath(t *testing.T) {
+	params := makeParams(
+		"sdk-anchor",
+		[]AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
+		"mob-primary",
+	)
+	set, anchor, err := BuildAcceptedSet(params)
+
+	require.NoError(t, err)
+	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
+
+	expected := relayenv.NewAcceptedSet().
+		WithEnvironmentID("env-abc").
+		WithSDKKey("sdk-anchor").
+		WithMobileKey("mob-primary")
+	assert.Equal(t, expected, set)
+}
+
+// TestBuildAcceptedSet_MultipleKeys verifies that multiple accepted SDK keys (anchor + non-anchor
+// permanent + expiring non-anchor) are all included in the returned AcceptedSet.
+func TestBuildAcceptedSet_MultipleKeys(t *testing.T) {
+	params := makeParams(
+		"sdk-anchor",
+		[]AcceptedSDKKey{
+			{Key: "default", Value: "sdk-anchor"},
+			{Key: "service-a", Value: "sdk-service-a"},                    // permanent, non-anchor
+			{Key: "old-key", Value: "sdk-old", Expiry: expiry1},          // expiring, non-anchor
+		},
+		"mob-primary",
+	)
+	set, anchor, err := BuildAcceptedSet(params)
+
+	require.NoError(t, err)
+	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
+
+	expected := relayenv.NewAcceptedSet().
+		WithEnvironmentID("env-abc").
+		WithSDKKey("sdk-anchor").
+		WithSDKKey("sdk-service-a").
+		WithExpiringSDKKey("sdk-old", expiry1).
+		WithMobileKey("mob-primary")
+	assert.Equal(t, expected, set)
+}
+
+// TestBuildAcceptedSet_Rename verifies that a rename — same credential value, different key
+// identifier — is a no-op: the returned AcceptedSet is identical regardless of the identifier.
+func TestBuildAcceptedSet_Rename(t *testing.T) {
+	// Build AcceptedSet for the "before" and "after" of a rename.
+	paramsOldName := makeParams(
+		"sdk-anchor",
+		[]AcceptedSDKKey{{Key: "old-name", Value: "sdk-anchor"}},
+		"mob-primary",
+	)
+	paramsNewName := makeParams(
+		"sdk-anchor",
+		[]AcceptedSDKKey{{Key: "new-name", Value: "sdk-anchor"}},
+		"mob-primary",
+	)
+
+	setOld, _, errOld := BuildAcceptedSet(paramsOldName)
+	setNew, _, errNew := BuildAcceptedSet(paramsNewName)
+
+	require.NoError(t, errOld)
+	require.NoError(t, errNew)
+	assert.Equal(t, setOld, setNew, "rename (same value, different key identifier) should produce the same AcceptedSet")
+}
+
+// TestBuildAcceptedSet_Deexpiry verifies that removing the expiry from an existing key (a
+// previously expiring key that is now permanent) results in the key being permanent in the
+// returned AcceptedSet. The "cancel scheduled drop" effect is realized when ReconcileCredentials
+// applies this set to the Rotator.
+func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
+	// "Before" state: sdk-old has an expiry.
+	paramsWithExpiry := makeParams(
+		"sdk-anchor",
+		[]AcceptedSDKKey{
+			{Key: "default", Value: "sdk-anchor"},
+			{Key: "old-key", Value: "sdk-old", Expiry: expiry1},
+		},
+		"mob-primary",
+	)
+	// "After" state: sdk-old's expiry is removed — it is now permanent.
+	paramsNoExpiry := makeParams(
+		"sdk-anchor",
+		[]AcceptedSDKKey{
+			{Key: "default", Value: "sdk-anchor"},
+			{Key: "old-key", Value: "sdk-old"}, // Expiry zero = permanent
+		},
+		"mob-primary",
+	)
+
+	setWithExpiry, _, _ := BuildAcceptedSet(paramsWithExpiry)
+	setNoExpiry, _, errNoExpiry := BuildAcceptedSet(paramsNoExpiry)
+
+	require.NoError(t, errNoExpiry)
+
+	// The set built without expiry must include sdk-old as a permanent key.
+	expectedPermanent := relayenv.NewAcceptedSet().
+		WithEnvironmentID("env-abc").
+		WithSDKKey("sdk-anchor").
+		WithSDKKey("sdk-old"). // permanent, no expiry
+		WithMobileKey("mob-primary")
+	assert.Equal(t, expectedPermanent, setNoExpiry)
+
+	// Sanity: the expiring and non-expiring versions are different.
+	assert.NotEqual(t, setWithExpiry, setNoExpiry)
+}
+
+// TestBuildAcceptedSet_MalformedPayload verifies that when the anchor (params.SDKKey) is not
+// present in AcceptedSDKKeys, BuildAcceptedSet returns a *relayenv.MalformedCredentialSetError
+// and an empty AcceptedSet.
+func TestBuildAcceptedSet_MalformedPayload(t *testing.T) {
+	params := makeParams(
+		"sdk-anchor",
+		[]AcceptedSDKKey{
+			{Key: "other-key", Value: "sdk-other"}, // anchor NOT here
+		},
+		"mob-primary",
+	)
+	set, anchor, err := BuildAcceptedSet(params)
+
+	require.Error(t, err)
+	var malformed *relayenv.MalformedCredentialSetError
+	require.True(t, errors.As(err, &malformed), "error should be *relayenv.MalformedCredentialSetError")
+	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
+	assert.Equal(t, relayenv.NewAcceptedSet(), set, "AcceptedSet must be empty on malformed payload")
+}
+
+// TestBuildAcceptedSet_MalformedPayload_AnchorUndefined verifies that an undefined anchor
+// (empty SDKKey) is treated as a malformed payload.
+func TestBuildAcceptedSet_MalformedPayload_AnchorUndefined(t *testing.T) {
+	params := makeParams(
+		"", // undefined anchor
+		[]AcceptedSDKKey{
+			{Key: "key-a", Value: "sdk-a"},
+		},
+		"mob-primary",
+	)
+	_, _, err := BuildAcceptedSet(params)
+
+	require.Error(t, err)
+	var malformed *relayenv.MalformedCredentialSetError
+	assert.True(t, errors.As(err, &malformed))
+}
+
+// TestBuildAcceptedSet_MixedUpdate verifies add + re-anchor + remove in a single params update
+// produces an AcceptedSet that contains the right keys in the right state. The ordering
+// (add → re-anchor → remove) is enforced by ReconcileCredentials when it consumes this set;
+// this test only asserts the AcceptedSet content.
+func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
+	// New state after the patch:
+	//   - sdk-new-anchor is the new anchor (re-anchor)
+	//   - sdk-b carries over unchanged
+	//   - sdk-c is newly added
+	//   - sdk-old-anchor is gone (remove)
+	params := makeParams(
+		"sdk-new-anchor",
+		[]AcceptedSDKKey{
+			{Key: "new-default", Value: "sdk-new-anchor"}, // re-anchor
+			{Key: "service-b", Value: "sdk-b"},            // unchanged
+			{Key: "service-c", Value: "sdk-c"},            // added
+		},
+		"mob-primary",
+	)
+	set, anchor, err := BuildAcceptedSet(params)
+
+	require.NoError(t, err)
+	assert.Equal(t, config.SDKKey("sdk-new-anchor"), anchor)
+
+	expected := relayenv.NewAcceptedSet().
+		WithEnvironmentID("env-abc").
+		WithSDKKey("sdk-new-anchor").
+		WithSDKKey("sdk-b").
+		WithSDKKey("sdk-c").
+		WithMobileKey("mob-primary")
+	assert.Equal(t, expected, set)
+}
+
+// TestBuildAcceptedSet_TrustTheArray verifies that the legacy sdkKey.expiring slot is not
+// consulted: when EnvironmentParams.ExpiringSDKKey is populated (from the legacy field) but
+// AcceptedSDKKeys does NOT contain that key, the key is absent from the returned AcceptedSet.
+func TestBuildAcceptedSet_TrustTheArray(t *testing.T) {
+	// Simulate an old-relay payload where ExpiringSDKKey is populated from sdkKey.expiring,
+	// but AcceptedSDKKeys only has the anchor (no expiring key in the array).
+	params := EnvironmentParams{
+		EnvID:  "env-abc",
+		SDKKey: "sdk-anchor",
+		ExpiringSDKKey: ExpiringSDKKey{ // legacy field — must NOT be consulted
+			Key:        "sdk-legacy-expiring",
+			Expiration: expiry1,
+		},
+		AcceptedSDKKeys:    []AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
+		AcceptedMobileKeys: []AcceptedMobileKey{{Value: "mob-primary"}},
+	}
+
+	set, _, err := BuildAcceptedSet(params)
+
+	require.NoError(t, err)
+	expected := relayenv.NewAcceptedSet().
+		WithEnvironmentID("env-abc").
+		WithSDKKey("sdk-anchor").
+		WithMobileKey("mob-primary")
+	assert.Equal(t, expected, set, "legacy sdkKey.expiring slot must not appear in AcceptedSet")
+}
+
+// TestBuildAcceptedSet_EmptyArrays verifies the edge case where AcceptedSDKKeys is empty:
+// the anchor cannot be found, so a malformed-payload error is returned.
+func TestBuildAcceptedSet_EmptyArrays(t *testing.T) {
+	// Edge case: AcceptedSDKKeys is empty (which means malformed, since anchor can't be found).
+	params := EnvironmentParams{
+		SDKKey:             "sdk-anchor",
+		AcceptedSDKKeys:    []AcceptedSDKKey{},
+		AcceptedMobileKeys: []AcceptedMobileKey{},
+	}
+	_, _, err := BuildAcceptedSet(params)
+	require.Error(t, err, "empty AcceptedSDKKeys should be malformed since anchor is not present")
+}


### PR DESCRIPTION
## Summary

- Adds `BuildAcceptedSet` in `internal/envfactory/reconcile_helper.go` — a pure, shared helper that both `autoconfig_actions.go` and `filedata_actions.go` will use to prepare inputs for `EnvContext.ReconcileCredentials`
- Closes [SDK-2546](https://launchdarkly.atlassian.net/browse/SDK-2546)

## Background

A follow-up will update both action handlers to call `BuildAcceptedSet(params)` and pass the result to `env.ReconcileCredentials(set)`. This PR delivers the helper itself, keeping it as a separate reviewable unit from the handler wiring.

The helper's contract:
- Builds `credential.AcceptedSet` from `params.AcceptedSDKKeys` / `params.AcceptedMobileKeys` (the arrays), keyed by credential value — not by the human-readable `key` identifier. A rename (same value, different identifier) is therefore a no-op.
- Adds and designates the anchor (`params.SDKKey`) via `WithPrimarySDKKey` and the primary mobile key (`params.MobileKey`) via `WithPrimaryMobileKey`. The builder de-duplicates by value, so an anchor/primary that also appears in its array is added once.
- If the anchor is undefined, no set is built and a `*credential.MalformedCredentialSetError` is returned with an empty `AcceptedSet`, signalling the caller to preserve the previous accepted state and (for RAC handlers) reconnect with jitter. There is no "anchor present in the array" check — add-and-designate guarantees the anchor is present, and structural validation of the wire payload happens upstream.
- Implements the "trust the array" expiry policy: the legacy `sdkKey.expiring` wire slot is never consulted; expiry comes only from `AcceptedSDKKey.Expiry` / `AcceptedMobileKey.Expiry`.
- Plumbs per-key mobile expiry through `WithExpiringMobileKey`, mirroring the SDK side, so an expiring mobile key lands as an expiring entry in the set.

## Changes

- **`internal/envfactory/reconcile_helper.go`** — `BuildAcceptedSet`, built on the `internal/credential` pointer builder (`NewAcceptedSetBuilder().…Build()`)
- **`internal/envfactory/reconcile_helper_test.go`** — unit tests covering the edge cases: happy path, multiple concurrent keys, rename no-op, de-expiry to permanent, anchor-absent-from-array (now accepted via add-and-designate), undefined-anchor error, no-SDK-key error, mixed add+re-anchor+remove, anchor-never-expiring invariant, multiple mobile keys, expiring mobile key, and trust-the-array policy

### Base branch

Stacked on `aaronz/SDK-2538/reconcile-credentials-api`; merge that first. Targets `feat/concurrent-keys` transitively.


[SDK-2546]: https://launchdarkly.atlassian.net/browse/SDK-2546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential acceptance and anchor/expiry rules that will feed reconciliation, but the change is a new pure helper with tests and is not yet wired into live handlers.
> 
> **Overview**
> Introduces **`BuildAcceptedSet`**, a shared `envfactory` helper that turns **`EnvironmentParams`** into a **`credential.AcceptedSet`** (plus anchor SDK key) for upcoming **`EnvContext.ReconcileCredentials`** use in autoconfig and filedata handlers. Handler wiring is intentionally deferred.
> 
> The builder treats credentials by **secret value** (renames are no-ops), designates anchor and primary mobile keys via **`WithPrimarySDKKey` / `WithPrimaryMobileKey`**, merges **`AcceptedSDKKeys` / `AcceptedMobileKeys`** with per-entry expiry, ignores the legacy **`sdkKey.expiring`** slot, and returns **`MalformedCredentialSetError`** when the anchor is missing so callers can keep prior state.
> 
> Adds broad unit tests for happy paths, concurrent keys, de-expiry, anchor invariants, mobile expiry, and malformed inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558b2e62d85c91aca82137fb69093558d727ed7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->