### PR TITLE
feat(credential): generalize cleanup ticker for per-key expiry + mobile-key disconnects

### DIFF
--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -20,8 +20,8 @@ type Rotator struct {
 	primaryMobileKey config.MobileKey
 
 	// deprecatedMobileKeys stores mobile keys being phased out with a grace period, keyed
-	// by credential value with the associated expiry time. StepTime does not yet act on
-	// these entries; generalizing the cleanup ticker to drop them is handled separately.
+	// by credential value with the associated expiry time. StepTime walks this map and emits
+	// an expiration once a key's grace period passes, mirroring deprecatedSdkKeys.
 	deprecatedMobileKeys map[config.MobileKey]time.Time
 
 	// There is only one environment ID active at a given time, and it won't actually be rotated. The mechanism is
@@ -141,8 +141,11 @@ func (r *Rotator) primaryCredentials() []SDKCredential {
 }
 
 func (r *Rotator) deprecatedCredentials() []SDKCredential {
-	deprecated := make([]SDKCredential, 0, len(r.deprecatedSdkKeys))
+	deprecated := make([]SDKCredential, 0, len(r.deprecatedSdkKeys)+len(r.deprecatedMobileKeys))
 	for key := range r.deprecatedSdkKeys {
+		deprecated = append(deprecated, key)
+	}
+	for key := range r.deprecatedMobileKeys {
 		deprecated = append(deprecated, key)
 	}
 	return deprecated
@@ -225,8 +228,8 @@ func (r *Rotator) updateEnvironmentID(envID config.EnvironmentID) {
 }
 
 // updateMobileKey sets a new primary mobile key. When grace is nil the outgoing key is
-// immediately revoked; when non-nil its expiry is stored in deprecatedMobileKeys.
-// StepTime does not yet act on deprecatedMobileKeys; that cleanup is handled separately.
+// immediately revoked; when non-nil its expiry is stored in deprecatedMobileKeys for the
+// cleanup ticker (StepTime) to act on.
 func (r *Rotator) updateMobileKey(mobileKey config.MobileKey, grace *GracePeriod) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -341,29 +344,66 @@ func (r *Rotator) expireSDKKey(sdkKey config.SDKKey) {
 	r.expirations = append(r.expirations, sdkKey)
 }
 
+// expireMobileKey drops a mobile key from both the deprecated grace map and the accepted set, then
+// queues its expiration. Deleting from acceptedMobileKeys is load-bearing: PrimaryCredentials derives
+// from that map, so an expired key would otherwise linger as a primary credential. Mirrors expireSDKKey.
+func (r *Rotator) expireMobileKey(mobileKey config.MobileKey) {
+	r.loggers.Infof("Deprecated mobile key %s has expired and is no longer valid for authentication", mobileKey.Masked())
+	delete(r.deprecatedMobileKeys, mobileKey)
+	delete(r.acceptedMobileKeys, mobileKey)
+	r.expirations = append(r.expirations, mobileKey)
+}
+
 // StepTime provides the current time to the Rotator, allowing it to compute the set of additions and expirations
 // for the tracked credentials since the last time this method was called.
+//
+// It enforces expiry from both expiry mechanisms, for both SDK and mobile keys:
+//   - The legacy grace-period maps (deprecatedSdkKeys / deprecatedMobileKeys), populated by the
+//     RotateWithGrace path, where the expiry lives in the map value.
+//   - The reconcile path, where per-key expiry is stored as data on the accepted entry
+//     (acceptedKeyInfo.expiry); a nil expiry means the key is permanent and is never expired here.
+//
+// Expiry is strict (now strictly after the expiry timestamp), consistent across all four loops.
 func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expirations []SDKCredential) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Legacy grace-period deprecations (RotateWithGrace path).
 	for key, expiry := range r.deprecatedSdkKeys {
 		if now.After(expiry) {
 			r.expireSDKKey(key)
+		}
+	}
+	for key, expiry := range r.deprecatedMobileKeys {
+		if now.After(expiry) {
+			r.expireMobileKey(key)
+		}
+	}
+
+	// Reconcile-path per-key expiry, stored on the accepted entry. The anchor and primary mobile key
+	// carry a nil expiry, so this never drops them.
+	for key, info := range r.acceptedSDKKeys {
+		if info.expiry != nil && now.After(*info.expiry) {
+			r.expireSDKKey(key)
+		}
+	}
+	for key, info := range r.acceptedMobileKeys {
+		if info.expiry != nil && now.After(*info.expiry) {
+			r.expireMobileKey(key)
 		}
 	}
 
 	additions, expirations = r.additions, r.expirations
 	r.additions = nil
 	r.expirations = nil
-	return
+	return additions, expirations
 }
 
 // Reconcile updates the rotator to match set. The set names its own anchor (the primary SDK key) and
 // primary mobile key. It diffs the desired accepted set against the current one and queues additions
 // and expirations (drained by the next StepTime call); keys newly present are accepted, and keys no
-// longer present are revoked. Per-key expiry is stored as data on the accepted entry — grace-period
-// deprecation and the cleanup ticker that drops expiring keys are handled separately. An undefined
+// longer present are revoked. Per-key expiry is stored as data on the accepted entry; the cleanup
+// ticker (StepTime) is what later acts on it, dropping a key once its expiry passes. An undefined
 // environment ID leaves the current one unchanged, since environments are removed via teardown
 // rather than reconcile.
 //

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -287,10 +287,18 @@ func TestRotateWithGraceMobileKey(t *testing.T) {
 		assert.Equal(t, mob2, rotator.MobileKey())
 
 		// mob2 is a new addition; mob1 is in the deprecated set (not yet expired),
-		// so it should not appear as an expiration here. Cleanup is deferred to T1.c.
+		// so it should not appear as an expiration here.
 		additions, expirations := rotator.StepTime(start)
 		assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
 		assert.Empty(t, expirations)
+
+		// One moment past the grace period, the cleanup ticker expires mob1 and evicts it from the
+		// accepted set entirely.
+		additions, expirations = rotator.StepTime(expiry.Add(1 * time.Millisecond))
+		assert.Empty(t, additions)
+		assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
+		assert.NotContains(t, rotator.PrimaryCredentials(), SDKCredential(mob1))
+		assert.NotContains(t, rotator.DeprecatedCredentials(), SDKCredential(mob1))
 	})
 
 	t.Run("immediately revokes outgoing key when grace period is already expired", func(t *testing.T) {
@@ -474,8 +482,9 @@ func TestReconcileRevokesOmittedKeys(t *testing.T) {
 }
 
 func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
-	// The foundation stores per-key expiry but does not yet act on it (no grace-period deprecation,
-	// no cleanup ticker — those are handled separately). An expiring key is simply accepted.
+	// Reconcile stores per-key expiry as data on the accepted entry; before that expiry passes, an
+	// expiring key is simply accepted and non-deprecated. The cleanup ticker (StepTime) only acts on
+	// the expiry once it elapses — see TestReconcileExpiringKeysAreEvictedByStepTime.
 	r := newTestRotator()
 	anchor := config.SDKKey("anchor")
 	expiringSDK := config.SDKKey("expiring-sdk")
@@ -540,4 +549,160 @@ func TestReconcileClearsStaleDeprecationForAcceptedKey(t *testing.T) {
 
 	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(old))
 	assert.Empty(t, r.DeprecatedCredentials())
+}
+
+func TestReconcileExpiringKeysAreEvictedByStepTime(t *testing.T) {
+	// End-to-end on the reconcile path: a reconcile records per-key expiry as data on the accepted
+	// entry, and the cleanup ticker (StepTime) later drops both the expiring SDK key and the expiring
+	// mobile key once their expiry elapses — without ever passing through the legacy deprecated maps.
+	// The anchor and primary mobile key carry no expiry and survive.
+	r := newTestRotator()
+	anchor := config.SDKKey("anchor")
+	expiringSDK := config.SDKKey("expiring-sdk")
+	mob := config.MobileKey("mob")
+	expiringMobile := config.MobileKey("expiring-mob")
+	now := time.Unix(1000, 0)
+	expiry := now.Add(time.Hour)
+
+	r.Reconcile(
+		mustBuild(t, NewAcceptedSetBuilder().
+			WithPrimarySDKKey(anchor).
+			WithExpiringSDKKey(expiringSDK, expiry).
+			WithPrimaryMobileKey(mob).
+			WithExpiringMobileKey(expiringMobile, expiry)),
+		now)
+	additions, expirations := r.StepTime(now)
+	require.ElementsMatch(t, []SDKCredential{anchor, expiringSDK, mob, expiringMobile}, additions)
+	require.Empty(t, expirations)
+
+	// At the exact expiry, expiry is strict (now must be strictly after), so nothing is dropped yet.
+	additions, expirations = r.StepTime(expiry)
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+
+	// One moment past the expiry: both expiring keys are evicted; anchor and primary mobile survive.
+	additions, expirations = r.StepTime(expiry.Add(1 * time.Millisecond))
+	assert.Empty(t, additions)
+	assert.ElementsMatch(t, []SDKCredential{expiringSDK, expiringMobile}, expirations)
+	assert.ElementsMatch(t, []SDKCredential{anchor, mob}, r.PrimaryCredentials())
+	assert.NotContains(t, r.PrimaryCredentials(), SDKCredential(expiringSDK))
+	assert.NotContains(t, r.PrimaryCredentials(), SDKCredential(expiringMobile))
+}
+
+func TestMobileKeyDeprecation(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	const (
+		mob1 = config.MobileKey("mob1")
+		mob2 = config.MobileKey("mob2")
+	)
+
+	start := time.Unix(10000, 0)
+	halfTime := start.Add(30 * time.Second)
+	deprecationTime := start.Add(1 * time.Minute)
+
+	rotator.Initialize([]SDKCredential{mob1})
+
+	rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), deprecationTime, halfTime))
+	additions, expirations := rotator.StepTime(halfTime)
+	assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
+	assert.Empty(t, expirations)
+
+	// At the exact expiry, not yet expired.
+	additions, expirations = rotator.StepTime(deprecationTime)
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+
+	// One moment past the expiry: mob1 is expired.
+	additions, expirations = rotator.StepTime(deprecationTime.Add(1 * time.Millisecond))
+	assert.Empty(t, additions)
+	assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
+}
+
+func TestManyConcurrentMobileKeyDeprecation(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	makeKey := func(i int) config.MobileKey {
+		return config.MobileKey(fmt.Sprintf("mob%v", i))
+	}
+
+	rotator.Initialize([]SDKCredential{makeKey(0)})
+
+	const numKeys = 50
+	now := time.Unix(10000, 0)
+	expiryTime := now.Add(1 * time.Hour)
+
+	var keysDeprecated []SDKCredential
+	var keysAdded []SDKCredential
+
+	for i := 0; i < numKeys; i++ {
+		nextKey := makeKey(i + 1)
+		keysDeprecated = append(keysDeprecated, makeKey(i))
+		keysAdded = append(keysAdded, nextKey)
+		rotator.RotateWithGrace(nextKey, NewGracePeriod(config.SDKKey(""), expiryTime, now))
+	}
+
+	assert.Equal(t, keysAdded[len(keysAdded)-1], rotator.MobileKey())
+
+	// Until and including the exact expiry timestamp, no expirations.
+	additions, expirations := rotator.StepTime(expiryTime)
+	assert.ElementsMatch(t, keysAdded, additions)
+	assert.Empty(t, expirations)
+
+	// One moment after the expiry time: batch of expirations.
+	additions, expirations = rotator.StepTime(expiryTime.Add(1 * time.Millisecond))
+	assert.Empty(t, additions)
+	assert.ElementsMatch(t, keysDeprecated, expirations)
+}
+
+func TestMixedSDKAndMobileKeyExpiry(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	sdk1 := config.SDKKey("sdk1")
+	sdk2 := config.SDKKey("sdk2")
+	mob1 := config.MobileKey("mob1")
+	mob2 := config.MobileKey("mob2")
+
+	now := time.Unix(10000, 0)
+	expiry := now.Add(1 * time.Hour)
+
+	rotator.Initialize([]SDKCredential{sdk1, mob1})
+
+	rotator.RotateWithGrace(sdk2, NewGracePeriod(sdk1, expiry, now))
+	rotator.StepTime(now)
+
+	rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, now))
+	rotator.StepTime(now)
+
+	// Both sdk1 and mob1 should expire at the same tick.
+	additions, expirations := rotator.StepTime(expiry.Add(1 * time.Millisecond))
+	assert.Empty(t, additions)
+	assert.ElementsMatch(t, []SDKCredential{sdk1, mob1}, expirations)
+}
+
+func TestDeprecatedCredentialsIncludesMobileKeys(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	sdk1 := config.SDKKey("sdk1")
+	sdk2 := config.SDKKey("sdk2")
+	mob1 := config.MobileKey("mob1")
+	mob2 := config.MobileKey("mob2")
+
+	now := time.Unix(10000, 0)
+	expiry := now.Add(1 * time.Hour)
+
+	rotator.Initialize([]SDKCredential{sdk1, mob1})
+
+	rotator.RotateWithGrace(sdk2, NewGracePeriod(sdk1, expiry, now))
+	rotator.StepTime(now)
+
+	rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, now))
+	rotator.StepTime(now)
+
+	deprecated := rotator.DeprecatedCredentials()
+	assert.ElementsMatch(t, []SDKCredential{sdk1, mob1}, deprecated)
 }

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -323,6 +323,90 @@ func TestChangeSDKKey(t *testing.T) {
 
 }
 
+// TestMobileKeyGraceExpiry drives a deprecated mobile key (legacy RotateWithGrace path) to expiry
+// through the cleanup ticker (triggerCredentialChanges → StepTime), mirroring the SDK-key flow in
+// TestChangeSDKKey.
+func TestMobileKeyGraceExpiry(t *testing.T) {
+	envConfig := st.EnvMobile.Config
+	readyCh := make(chan EnvContext, 1)
+
+	mob1 := envConfig.MobileKey
+	mob2 := config.MobileKey("mob2-new-key")
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	env := makeBasicEnv(t, envConfig, testclient.FakeLDClientFactory(true), mockLog.Loggers, readyCh)
+	defer env.Close()
+	envImpl := env.(*envContextImpl)
+
+	assert.Equal(t, env, requireEnvReady(t, readyCh))
+
+	start := time.Unix(2000, 0)
+	graceDuration := 1 * time.Hour
+
+	// Rotate mob1 → mob2 with a grace period; mob1 is deprecated but still valid.
+	envImpl.keyRotator.RotateWithGrace(mob2, credential.NewGracePeriod(config.SDKKey(""), start.Add(graceDuration), start))
+	envImpl.triggerCredentialChanges(start)
+
+	assert.Contains(t, env.GetDeprecatedCredentials(), mob1)
+
+	// Before the grace period ends, mob1 is still deprecated (not yet expired).
+	envImpl.triggerCredentialChanges(start.Add(30 * time.Minute))
+	assert.Contains(t, env.GetDeprecatedCredentials(), mob1)
+
+	// One moment past the grace period: the cleanup ticker evicts mob1 entirely.
+	envImpl.triggerCredentialChanges(start.Add(graceDuration + 1*time.Millisecond))
+
+	assert.NotContains(t, env.GetCredentials(), mob1)
+	assert.NotContains(t, env.GetDeprecatedCredentials(), mob1)
+}
+
+// TestMobileKeyReconcileExpiry drives a mobile key carrying a per-key expiry end-to-end through the
+// reconcile path: ReconcileCredentials records the expiry as data on the accepted entry, and the
+// cleanup ticker (triggerCredentialChanges → StepTime) later evicts the key once its expiry elapses.
+func TestMobileKeyReconcileExpiry(t *testing.T) {
+	envConfig := st.EnvMobile.Config
+	readyCh := make(chan EnvContext, 1)
+
+	primaryMobile := envConfig.MobileKey
+	expiringMobile := config.MobileKey("mob-expiring")
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	env := makeBasicEnv(t, envConfig, testclient.FakeLDClientFactory(true), mockLog.Loggers, readyCh)
+	defer env.Close()
+	envImpl := env.(*envContextImpl)
+
+	assert.Equal(t, env, requireEnvReady(t, readyCh))
+
+	start := time.Unix(2000, 0)
+	expiry := start.Add(1 * time.Hour)
+
+	// Reconcile to a set that accepts the primary mobile key (permanent) plus a second mobile key that
+	// carries a per-key expiry.
+	envImpl.reconcileCredentials(
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
+			WithPrimarySDKKey(envConfig.SDKKey).
+			WithPrimaryMobileKey(primaryMobile).
+			WithExpiringMobileKey(expiringMobile, expiry)),
+		start)
+
+	// Reconcile stores the expiry as data, so before it elapses the key is accepted (not deprecated).
+	assert.Contains(t, env.GetCredentials(), expiringMobile)
+	assert.NotContains(t, env.GetDeprecatedCredentials(), expiringMobile)
+
+	// Halfway through, still accepted.
+	envImpl.triggerCredentialChanges(start.Add(30 * time.Minute))
+	assert.Contains(t, env.GetCredentials(), expiringMobile)
+
+	// One moment past expiry: the cleanup ticker evicts the expiring mobile key; the primary survives.
+	envImpl.triggerCredentialChanges(expiry.Add(1 * time.Millisecond))
+	assert.NotContains(t, env.GetCredentials(), expiringMobile)
+	assert.Contains(t, env.GetCredentials(), primaryMobile)
+}
+
 func TestNonAnchorSDKKeysDoNotOpenUpstreamClient(t *testing.T) {
 	envConfig := st.EnvMain.Config
 	readyCh := make(chan EnvContext, 1)


### PR DESCRIPTION
## Summary

Generalizes `Rotator.StepTime` to enforce per-key expiry for **mobile keys** and for the **reconcile path**, symmetric with the existing SDK/legacy grace path. Completes T1.c of the concurrent-keys plan. `DeprecatedCredentials` now surfaces deprecated mobile keys alongside deprecated SDK keys. The downstream-disconnect path (`triggerCredentialChanges` → `removeCredential` → `envStreams.RemoveCredential`) already handles any credential kind, so no production changes to `env_context_impl` are required beyond new tests.

[Jira: SDK-2539](https://launchdarkly.atlassian.net/browse/SDK-2539)

## Background

The `Rotator` foundation (SDK-2538, #712) stores per-key expiry as data on each accepted-set entry (`acceptedKeyInfo.expiry`) and populates `deprecatedMobileKeys` via the legacy `RotateWithGrace` path — but nothing acted on either: `StepTime` only walked `deprecatedSdkKeys`, there was no `expireMobileKey`, and `deprecatedCredentials()` was SDK-only. This PR closes that gap so the cleanup ticker enforces expiry uniformly across both key kinds and both expiry mechanisms.

## StepTime design decision

There were two ways to make `StepTime` act on reconcile-path expiry: (a) read `acceptedKeyInfo.expiry` directly off the accepted-set entry, or (b) first migrate expiring reconcile-path keys into the deprecated maps and let the existing deprecated-map walk drop them.

This PR takes **(a)**. `StepTime` expires reconcile-path keys in place by reading the expiry stored on the accepted entry, and the deprecated maps remain exclusively the legacy `RotateWithGrace` grace mechanism (which `StepTime` continues to drain for both SDK and mobile keys). This keeps #712's "per-key expiry is data on the accepted entry" model intact and is symmetric for both key kinds.

Consequence (consistent with #712): a reconcile-path key with a future expiry appears in `PrimaryCredentials` (accepted, non-deprecated) until its expiry elapses, whereas a legacy grace-period key appears in `DeprecatedCredentials` during its grace window. Expiry is strict (`now` must be strictly after the expiry timestamp) across all four `StepTime` loops, preserving the established SDK-key semantics.

The re-anchor swap and mobile-primary-switch re-queue are intentionally **out of scope** here (T2.c / SDK-2542).

## Changes

- `StepTime` now enforces expiry across four loops: the legacy `deprecatedSdkKeys` / `deprecatedMobileKeys` grace maps, and the reconcile-path `acceptedSDKKeys` / `acceptedMobileKeys` maps keyed by `acceptedKeyInfo.expiry` (a `nil` expiry is permanent and never dropped).
- `expireMobileKey` helper added, mirroring `expireSDKKey` — deletes from both `deprecatedMobileKeys` **and** `acceptedMobileKeys` (the latter is load-bearing: `PrimaryCredentials` derives from `acceptedMobileKeys`, so an expired key would otherwise linger).
- `deprecatedCredentials()` now includes entries from `deprecatedMobileKeys`.
- Comments on `deprecatedMobileKeys`, `updateMobileKey`, and `Reconcile` updated to reflect that the cleanup ticker now acts on the stored expiry.
- New rotator tests: `TestReconcileExpiringKeysAreEvictedByStepTime` (reconcile path, SDK + mobile, end-to-end), `TestMobileKeyDeprecation`, `TestManyConcurrentMobileKeyDeprecation`, `TestMixedSDKAndMobileKeyExpiry`, `TestDeprecatedCredentialsIncludesMobileKeys`. `TestRotateWithGraceMobileKey/does-not-panic` extended with a post-expiry assertion; `TestReconcileAcceptsExpiringKeysAsData` comment corrected.
- New env-level tests: `TestMobileKeyGraceExpiry` (legacy path) and `TestMobileKeyReconcileExpiry` (reconcile path), both driving a mobile key to expiry through `triggerCredentialChanges`.
