### PR TITLE
feat(relayenv): gate startSDKClient on anchor key

### DIFF
--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -307,7 +307,25 @@ func (r *Rotator) updateSDKKey(sdkKey config.SDKKey, grace *GracePeriod) {
 func (r *Rotator) expireSDKKey(sdkKey config.SDKKey) {
 	r.loggers.Infof("Deprecated SDK key %s has expired and is no longer valid for authentication", sdkKey.Masked())
 	delete(r.deprecatedSdkKeys, sdkKey)
+	delete(r.acceptedSDKKeys, sdkKey)
 	r.expirations = append(r.expirations, sdkKey)
+}
+
+// AddNonAnchorSDKKey enqueues a non-primary SDK key for delivery via the next StepTime call.
+// The key will be routed through addCredential, which sets up envStreams, handler bundles, and
+// connection-mapper registration but skips startSDKClient (enforced in addCredential).
+// No-op if the key is already the primary (anchor) key or was already registered.
+func (r *Rotator) AddNonAnchorSDKKey(key config.SDKKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if key == r.primarySdkKey {
+		return
+	}
+	if _, exists := r.acceptedSDKKeys[key]; exists {
+		return
+	}
+	r.acceptedSDKKeys[key] = &acceptedKeyInfo{}
+	r.additions = append(r.additions, key)
 }
 
 // StepTime provides the current time to the Rotator, allowing it to compute the set of additions and expirations

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -437,11 +437,11 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 	}
 
 	// A new SDK key means:
-	//  1. we should start a new SDK client*, but only for the anchor (design §4.1: one upstream
-	//     connection per env, on the anchor). Non-anchor server keys get envStreams + handler bundles
-	//     above, but no upstream client — matching today's mobile-key behavior.
+	//  1. we should start a new SDK client*, but only for the anchor: there is a single upstream
+	//     connection per environment, owned by the anchor key. Non-anchor server keys get envStreams
+	//     + handler bundles above, but no upstream client — matching today's mobile-key behavior.
 	//  2. we should tell all event forwarding components that use an SDK key to use the new one,
-	//     again only when it is the anchor (events collapse to the anchor per kind — design §4.3).
+	//     again only when it is the anchor, since events collapse to the anchor per kind.
 	// A new mobile key does not require starting a new SDK client, but does requiring updating any event forwarding
 	// components that use a mobile key.
 	// *Note: we only start a new SDK client in online mode. This is somewhat of an architectural hack because EnvContextImpl

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -437,8 +437,11 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 	}
 
 	// A new SDK key means:
-	//  1. we should start a new SDK client*
-	//  2. we should tell all event forwarding components that use an SDK key to use the new one.
+	//  1. we should start a new SDK client*, but only for the anchor (design §4.1: one upstream
+	//     connection per env, on the anchor). Non-anchor server keys get envStreams + handler bundles
+	//     above, but no upstream client — matching today's mobile-key behavior.
+	//  2. we should tell all event forwarding components that use an SDK key to use the new one,
+	//     again only when it is the anchor (events collapse to the anchor per kind — design §4.3).
 	// A new mobile key does not require starting a new SDK client, but does requiring updating any event forwarding
 	// components that use a mobile key.
 	// *Note: we only start a new SDK client in online mode. This is somewhat of an architectural hack because EnvContextImpl
@@ -447,14 +450,16 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 	// So, the effect in offline mode when adding/removing credentials is just setting up the new credential mappings.
 	switch key := newCredential.(type) {
 	case config.SDKKey:
-		if !c.offline {
-			go c.startSDKClient(key, nil, false)
-		}
-		if c.metricsEventPub != nil { // metrics event publisher always uses SDK key
-			c.metricsEventPub.ReplaceCredential(key)
-		}
-		if c.eventDispatcher != nil {
-			c.eventDispatcher.ReplaceCredential(key)
+		if key == c.keyRotator.SDKKey() {
+			if !c.offline {
+				go c.startSDKClient(key, nil, false)
+			}
+			if c.metricsEventPub != nil { // metrics event publisher always uses SDK key
+				c.metricsEventPub.ReplaceCredential(key)
+			}
+			if c.eventDispatcher != nil {
+				c.eventDispatcher.ReplaceCredential(key)
+			}
 		}
 	case config.MobileKey:
 		if c.eventDispatcher != nil {
@@ -581,6 +586,15 @@ func (c *envContextImpl) reconcileCredentials(newSet AcceptedSet, anchor credent
 	}
 	if newSet.envID.Defined() {
 		c.keyRotator.Rotate(newSet.envID)
+	}
+
+	// Enqueue non-anchor SDK keys. These get envStreams + handler bundles + connection-mapper
+	// registration (via addCredential), but no upstream client — enforced in addCredential by the
+	// key == anchor check. The anchor itself is managed by the Rotate call above.
+	for _, k := range newSet.sdkKeys {
+		if k.key != anchorKey {
+			c.keyRotator.AddNonAnchorSDKKey(k.key)
+		}
 	}
 
 	// Apply the queued changes. triggerCredentialChanges drains the rotator's additions before its

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -357,6 +357,43 @@ func TestChangeSDKKey(t *testing.T) {
 
 }
 
+func TestNonAnchorSDKKeysDoNotOpenUpstreamClient(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	readyCh := make(chan EnvContext, 1)
+	// Buffer large enough to catch any unexpected extra clients.
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	clientFactory := testclient.FakeLDClientFactoryWithChannel(true, clientCh)
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	env := makeBasicEnv(t, envConfig, clientFactory, mockLog.Loggers, readyCh)
+	defer env.Close()
+
+	// One client is opened for the anchor key during construction.
+	assert.Equal(t, env, requireEnvReady(t, readyCh))
+	anchorClient := requireClientReady(t, clientCh)
+	assert.Equal(t, envConfig.SDKKey, anchorClient.Key)
+
+	nonAnchorKey1 := config.SDKKey("non-anchor-key-1")
+	nonAnchorKey2 := config.SDKKey("non-anchor-key-2")
+
+	// Reconcile to anchor + 2 non-anchor SDK keys. The anchor is unchanged, so no new anchor
+	// client is needed. Non-anchor keys must get envStreams + handlers + connection mapping but
+	// must NOT open an upstream client.
+	require.NoError(t, env.ReconcileCredentials(
+		NewAcceptedSet().
+			WithSDKKey(envConfig.SDKKey).
+			WithSDKKey(nonAnchorKey1).
+			WithSDKKey(nonAnchorKey2),
+		envConfig.SDKKey))
+
+	// Verify no additional clients were started.
+	if !helpers.AssertNoMoreValues(t, clientCh, 200*time.Millisecond) {
+		t.FailNow()
+	}
+}
+
 func TestSDKClientCreationFails(t *testing.T) {
 	envConfig := st.EnvWithAllCredentials.Config
 	envConfig.TTL = configtypes.NewOptDuration(time.Hour)

--- a/relay/autoconfig_actions_test.go
+++ b/relay/autoconfig_actions_test.go
@@ -137,7 +137,7 @@ func TestAutoConfigInitWithExpiringSDKKey(t *testing.T) {
 	initialEvent := makeAutoConfPutEvent(envWithKeys)
 	autoConfTest(t, testAutoConfDefaultConfig, &initialEvent, func(p autoConfTestParams) {
 		// Only the anchor (newKey) opens an upstream client; the expiring oldKey is accepted
-		// locally but shares the anchor's connection (T2.a: anchor-only upstream client).
+		// locally but shares the anchor's connection (anchor-only upstream client).
 		anchorClient := p.awaitClient()
 		assert.Equal(t, newKey, anchorClient.Key)
 		p.shouldNotCreateClient(200 * time.Millisecond)
@@ -219,7 +219,7 @@ func TestAutoConfigAddEnvironmentWithExpiringSDKKey(t *testing.T) {
 		p.stream.Enqueue(makeAutoConfPatchEvent(envWithKeys))
 
 		// Only the anchor (newKey) opens an upstream client; the expiring oldKey is accepted
-		// locally but shares the anchor's connection (T2.a: anchor-only upstream client).
+		// locally but shares the anchor's connection (anchor-only upstream client).
 		anchorClient := p.awaitClient()
 		assert.Equal(t, newKey, anchorClient.Key)
 		p.shouldNotCreateClient(200 * time.Millisecond)

--- a/relay/autoconfig_actions_test.go
+++ b/relay/autoconfig_actions_test.go
@@ -136,13 +136,11 @@ func TestAutoConfigInitWithExpiringSDKKey(t *testing.T) {
 	}
 	initialEvent := makeAutoConfPutEvent(envWithKeys)
 	autoConfTest(t, testAutoConfDefaultConfig, &initialEvent, func(p autoConfTestParams) {
-		client1 := p.awaitClient()
-		client2 := p.awaitClient()
-		if client1.Key == oldKey {
-			client1, client2 = client2, client1
-		}
-		assert.Equal(t, newKey, client1.Key)
-		assert.Equal(t, oldKey, client2.Key)
+		// Only the anchor (newKey) opens an upstream client; the expiring oldKey is accepted
+		// locally but shares the anchor's connection (T2.a: anchor-only upstream client).
+		anchorClient := p.awaitClient()
+		assert.Equal(t, newKey, anchorClient.Key)
+		p.shouldNotCreateClient(200 * time.Millisecond)
 
 		env := p.awaitEnvironment(envWithKeys.id)
 		assertEnvProps(t, envWithKeys.params(), env)
@@ -220,13 +218,11 @@ func TestAutoConfigAddEnvironmentWithExpiringSDKKey(t *testing.T) {
 	autoConfTest(t, testAutoConfDefaultConfig, &initialEvent, func(p autoConfTestParams) {
 		p.stream.Enqueue(makeAutoConfPatchEvent(envWithKeys))
 
-		client1 := p.awaitClient()
-		client2 := p.awaitClient()
-		if client1.Key == oldKey {
-			client1, client2 = client2, client1
-		}
-		assert.Equal(t, newKey, client1.Key)
-		assert.Equal(t, oldKey, client2.Key)
+		// Only the anchor (newKey) opens an upstream client; the expiring oldKey is accepted
+		// locally but shares the anchor's connection (T2.a: anchor-only upstream client).
+		anchorClient := p.awaitClient()
+		assert.Equal(t, newKey, anchorClient.Key)
+		p.shouldNotCreateClient(200 * time.Millisecond)
 
 		env := p.awaitEnvironment(envWithKeys.id)
 		assertEnvProps(t, envWithKeys.params(), env)
@@ -237,10 +233,6 @@ func TestAutoConfigAddEnvironmentWithExpiringSDKKey(t *testing.T) {
 		paramsWithOldKey := envWithKeys.params()
 		paramsWithOldKey.SDKKey = oldKey
 		p.assertEnvLookup(env, paramsWithOldKey)
-
-		if !helpers.AssertChannelNotClosed(t, client2.CloseCh, time.Millisecond*300, "should not have closed client for deprecated key yet") {
-			t.FailNow()
-		}
 	})
 }
 


### PR DESCRIPTION
## Summary
Non-anchor server SDK keys now flow through `addCredential` and receive `envStreams` registration, handler bundles, and connection-mapper mapping — but `startSDKClient` is only called when the added key is the current anchor. This is design §4.1 applied: one upstream connection per environment, on the anchor key; all other accepted server keys match locally.

The event dispatcher and metrics publisher are likewise only updated on anchor addition (design §4.3: events collapse to the anchor per kind).

[Jira: SDK-2540](https://launchdarkly.atlassian.net/browse/SDK-2540)

## Background
Previously `addCredential` called `startSDKClient` for every `config.SDKKey` it received. As long as every env had exactly one SDK key this was harmless — that key was always the anchor. Phase 1 (concurrent keys) breaks that assumption: a reconcile now delivers additional non-anchor SDK keys through `addCredential`, and each of them must not open its own upstream connection.

To route non-anchor keys through `addCredential`, `reconcileCredentials` now calls `Rotator.AddNonAnchorSDKKey` for each non-anchor entry in the accepted set. That method enqueues the key in the rotator's additions slice (with an idempotency guard via `acceptedSDKKeys`) so it is delivered by `triggerCredentialChanges` while preserving the add-before-remove ordering guarantee.

`expireSDKKey` is also updated to remove the expired key from `acceptedSDKKeys`, so a subsequent `AddNonAnchorSDKKey` call for a revoked-then-re-added key is treated as new rather than a no-op.

## Changes
- **`rotator.go`**: add `AddNonAnchorSDKKey`; clean up `acceptedSDKKeys` in `expireSDKKey`
- **`env_context_impl.go`**: gate `startSDKClient` + `ReplaceCredential` in `addCredential` on `key == c.keyRotator.SDKKey()`; call `AddNonAnchorSDKKey` for non-anchor entries in `reconcileCredentials`
- **`env_context_impl_test.go`**: `TestNonAnchorSDKKeysDoNotOpenUpstreamClient` — anchor + 2 non-anchor SDK keys, assert only one upstream client opened
