### PR TITLE
fix: Close orphaned and stale SDK clients during key rotation

### DIFF
--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -237,6 +237,65 @@ func TestSDKKeyExpiredInThePastIsNotAdded(t *testing.T) {
 	assert.Empty(t, expirations)
 }
 
+func TestSDKKeyDeprecationWithAlreadyExpiredGraceRevokesPreviousPrimary(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	key1 := config.SDKKey("key1")
+	key2 := config.SDKKey("key2")
+
+	expiry := time.Unix(10000, 0)
+	now := expiry.Add(1 * time.Hour) // now is after the grace period's expiry
+
+	rotator.Initialize([]SDKCredential{key1})
+
+	// Rotate key1 -> key2, but the deprecation grace for the outgoing key1 has already elapsed.
+	// key2 becomes primary; key1 must be revoked immediately rather than lingering forever as an
+	// accepted-but-untracked key. (This mirrors the equivalent mobile-key behavior.)
+	rotator.RotateWithGrace(key2, NewGracePeriod(key1, expiry, now))
+
+	assert.Equal(t, key2, rotator.SDKKey())
+
+	additions, expirations := rotator.StepTime(now)
+	assert.ElementsMatch(t, []SDKCredential{key2}, additions)
+	assert.ElementsMatch(t, []SDKCredential{key1}, expirations)
+	assert.Empty(t, rotator.DeprecatedCredentials())
+}
+
+func TestReAnchoringDeprecatedSDKKeyRemovesItFromDeprecatedSet(t *testing.T) {
+	mockLog := ldlogtest.NewMockLog()
+	rotator := NewRotator(mockLog.Loggers)
+
+	key1 := config.SDKKey("key1")
+	key2 := config.SDKKey("key2")
+
+	start := time.Unix(10000, 0)
+	expiry := start.Add(1 * time.Hour)
+
+	rotator.Initialize([]SDKCredential{key1})
+
+	// Rotate key1 -> key2 with grace; key1 enters the deprecated set.
+	rotator.RotateWithGrace(key2, NewGracePeriod(key1, expiry, start))
+	rotator.StepTime(start)
+	assert.ElementsMatch(t, []SDKCredential{key1}, rotator.DeprecatedCredentials())
+
+	// Re-anchor key2 -> key1 before key1's grace expires. key1 must be promoted out of the
+	// deprecated set; otherwise the cleanup ticker would later expire the active primary.
+	rotator.Rotate(key1)
+	assert.Equal(t, key1, rotator.SDKKey())
+	assert.Empty(t, rotator.DeprecatedCredentials())
+
+	additions, expirations := rotator.StepTime(start)
+	assert.ElementsMatch(t, []SDKCredential{key1}, additions)
+	assert.ElementsMatch(t, []SDKCredential{key2}, expirations)
+
+	// Well past the original grace expiry, key1 (the active primary) must NOT be expired.
+	additions, expirations = rotator.StepTime(expiry.Add(1 * time.Hour))
+	assert.Empty(t, additions)
+	assert.Empty(t, expirations)
+	assert.Equal(t, key1, rotator.SDKKey())
+}
+
 func TestInitializePopulatesAcceptedSets(t *testing.T) {
 	mockLog := ldlogtest.NewMockLog()
 	rotator := NewRotator(mockLog.Loggers)

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -576,12 +577,7 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 // to avoid installing (and thereby leaking) a client for a key that was revoked while the client was
 // being constructed.
 func (c *envContextImpl) sdkKeyIsActive(sdkKey config.SDKKey) bool {
-	for _, cred := range c.keyRotator.AllCredentials() {
-		if cred == sdkKey {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.keyRotator.AllCredentials(), credential.SDKCredential(sdkKey))
 }
 
 func (c *envContextImpl) GetPayloadFilter() config.FilterKey {

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -500,7 +500,29 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 	client, err := c.sdkClientFactory(sdkKey, c.sdkConfig, c.sdkInitTimeout)
 	c.mu.Lock()
 	name := c.identifiers.GetDisplayName()
+	droppedInactive := false
+	if client != nil && (c.closed || (sdkKey.Defined() && !c.sdkKeyIsActive(sdkKey))) {
+		// startSDKClient builds the client before taking c.mu, so by the time we hold the lock the key
+		// may already have been revoked (rotated away) or the environment may have been closed. In
+		// either case the freshly-built client must be closed here rather than installed, otherwise its
+		// upstream connection and goroutines leak until env.Close() (and, once closed, nothing ever
+		// closes it). removeCredential cannot close it because the client was never in c.clients.
+		//
+		// The revocation check applies only to a defined key: an undefined (empty) SDK key is never a
+		// tracked credential -- the rotator filters undefined credentials out of its accepted set -- so
+		// it can never be "revoked", and dropping its client would break environments that legitimately
+		// run without an SDK key (e.g. offline or not-yet-configured envs, and test fixtures).
+		_ = client.Close()
+		client = nil
+		droppedInactive = true
+	}
 	if client != nil {
+		// If a client already exists for this SDK key (e.g. the key was re-anchored back into the
+		// primary slot while a previous client for it was still alive in its grace period), close
+		// the stale one before replacing it so its upstream connection and goroutines are not leaked.
+		if existing := c.clients[sdkKey]; existing != nil && existing != client {
+			_ = existing.Close()
+		}
 		c.clients[sdkKey] = client
 
 		// The data store instance is created by the SDK when it creates the client. Now that
@@ -522,7 +544,8 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 	c.initErr = err
 	c.mu.Unlock()
 
-	if err != nil {
+	switch {
+	case err != nil:
 		if suppressErrors {
 			c.globalLoggers.Warnf("Ignoring error initializing LaunchDarkly client for %q: %+v",
 				name, err)
@@ -534,12 +557,31 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 			}
 			return
 		}
-	} else {
+	case droppedInactive:
+		// The client initialized successfully but the key was revoked (or the environment was closed)
+		// before it could be installed, so it was discarded above. The environment is still considered
+		// ready: it is in a consistent state with no client for this no-longer-tracked key.
+		c.globalLoggers.Infof("SDK key %s was revoked or the environment was closed before its client "+
+			"finished initializing; the client was discarded", sdkKey.Masked())
+	default:
 		c.globalLoggers.Infof("Initialized LaunchDarkly client for %q (SDK key %s)", name, sdkKey.Masked())
 	}
 	if readyCh != nil {
 		readyCh <- c
 	}
+}
+
+// sdkKeyIsActive reports whether the given SDK key is still a tracked credential -- either the primary
+// key or one within its deprecation grace period -- according to the rotator. startSDKClient uses this
+// to avoid installing (and thereby leaking) a client for a key that was revoked while the client was
+// being constructed.
+func (c *envContextImpl) sdkKeyIsActive(sdkKey config.SDKKey) bool {
+	for _, cred := range c.keyRotator.AllCredentials() {
+		if cred == sdkKey {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *envContextImpl) GetPayloadFilter() config.FilterKey {

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	ldevents "github.com/launchdarkly/go-sdk-events/v3"
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	ld "github.com/launchdarkly/go-server-sdk/v7"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
@@ -504,6 +505,174 @@ func TestNonPrimaryMobileKeyDoesNotStealEventForwarding(t *testing.T) {
 		eventPost := helpers.RequireValue(t, requestsCh, time.Second)
 		assert.Equal(t, string(primaryMobile), eventPost.Request.Header.Get("Authorization"))
 	})
+}
+
+// When an SDK key that is still alive in its grace period is re-anchored back into the primary slot,
+// a fresh SDK client is started for it. The previously-created client for that same key must be closed
+// rather than silently dropped from the clients map, otherwise its upstream connection leaks.
+func TestReAnchoringToKeyStillInGraceClosesStaleClient(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	keyA := envConfig.SDKKey
+	keyB := config.SDKKey("keyB")
+	readyCh := make(chan EnvContext, 1)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	clientFactory := testclient.FakeLDClientFactoryWithChannel(true, clientCh)
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	env := makeBasicEnv(t, envConfig, clientFactory, mockLog.Loggers, readyCh)
+	defer env.Close()
+
+	assert.Equal(t, env, requireEnvReady(t, readyCh))
+	clientA1 := requireClientReady(t, clientCh)
+	assert.Equal(t, env.GetClient(), clientA1)
+
+	start := time.Unix(1000, 0)
+
+	// Rotate keyA -> keyB, deprecating keyA with an hour-long grace. keyA's client (clientA1) stays
+	// alive because keyA is still accepted during the grace window.
+	env.UpdateCredential(
+		NewCredentialUpdate(keyB).
+			WithTime(start).
+			WithGracePeriod(keyA, start.Add(1*time.Hour)))
+
+	clientB := requireClientReady(t, clientCh)
+	assert.NotEqual(t, clientA1, clientB)
+	if !helpers.AssertChannelNotClosed(t, clientA1.CloseCh, time.Second, "clientA1 should still be alive during keyA's grace") {
+		t.FailNow()
+	}
+
+	// Re-anchor back to keyA while it is still within its grace period. This starts a new client for
+	// keyA; the stale clientA1 must be closed so its connection is not leaked.
+	env.UpdateCredential(NewCredentialUpdate(keyA).WithTime(start.Add(10 * time.Minute)))
+
+	clientA2 := requireClientReady(t, clientCh)
+	assert.NotEqual(t, clientA1, clientA2)
+
+	if !helpers.AssertChannelClosed(t, clientA1.CloseCh, time.Second, "the stale client for keyA should have been closed on re-anchor") {
+		t.FailNow()
+	}
+	// keyB was immediately revoked by the re-anchor, so its client should be closed too.
+	if !helpers.AssertChannelClosed(t, clientB.CloseCh, time.Second, "client for the revoked keyB should have been closed") {
+		t.FailNow()
+	}
+
+	require.Eventually(t, func() bool {
+		return env.GetClient() == clientA2
+	}, time.Second, 10*time.Millisecond, "env.GetClient() should return the new client for keyA after re-anchor")
+
+	creds := env.GetCredentials()
+	assert.Contains(t, creds, keyA)
+	assert.NotContains(t, creds, keyB)
+}
+
+// gatedClientFactory wraps the normal fake factory but blocks the factory call for gateKey until
+// `gate` is closed, signalling on `started` once that call is in flight. This lets a test interleave
+// a credential revocation with an in-flight startSDKClient that has not yet taken c.mu.
+func gatedClientFactory(
+	gate <-chan struct{},
+	started chan<- struct{},
+	createdCh chan<- *testclient.FakeLDClient,
+	gateKey config.SDKKey,
+) sdks.ClientFactoryFunc {
+	inner := testclient.FakeLDClientFactoryWithChannel(true, createdCh)
+	var once sync.Once
+	return func(sdkKey config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		if sdkKey == gateKey {
+			once.Do(func() { close(started) })
+			<-gate
+		}
+		return inner(sdkKey, cfg, timeout)
+	}
+}
+
+// When an SDK key is revoked while its client is still being constructed, startSDKClient builds the
+// client before taking c.mu, so it can finish and try to install a client for a key that is no longer
+// tracked. That client must be closed rather than installed -- otherwise it leaks its upstream
+// connection and goroutines, because removeCredential already ran and found nothing in c.clients to
+// close, and nothing else will ever close it until env.Close().
+func TestRevokingSDKKeyWhileClientIsStartingDoesNotLeakTheClient(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	keyA := envConfig.SDKKey
+	keyB := config.SDKKey("keyB")
+	readyCh := make(chan EnvContext, 1)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	gate := make(chan struct{})
+	started := make(chan struct{})
+	factory := gatedClientFactory(gate, started, clientCh, keyA)
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	env := makeBasicEnv(t, envConfig, factory, mockLog.Loggers, readyCh)
+	defer env.Close()
+
+	// Wait until the initial startSDKClient(keyA) is blocked inside the factory, before it takes c.mu.
+	<-started
+
+	// Revoke keyA by rotating to keyB with no grace. keyA is immediately revoked and removeCredential(keyA)
+	// runs now -- but c.clients[keyA] is still nil because the initial goroutine is blocked in the factory,
+	// so nothing is closed and the mapping is simply removed.
+	env.UpdateCredential(NewCredentialUpdate(keyB).WithTime(time.Unix(1000, 0)))
+
+	creds := env.GetCredentials()
+	require.NotContains(t, creds, keyA, "keyA should have been revoked")
+
+	// Release the gate; the now-unblocked startSDKClient(keyA) discovers keyA is no longer tracked and
+	// must close the client it just built rather than installing it.
+	close(gate)
+
+	// Collect the client that was created for keyA.
+	var clientA *testclient.FakeLDClient
+	require.Eventually(t, func() bool {
+		for {
+			select {
+			case c := <-clientCh:
+				if c.Key == keyA {
+					clientA = c
+				}
+			default:
+				return clientA != nil
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond, "expected a client to be created for keyA")
+	require.NotNil(t, clientA)
+
+	// The client built for the now-revoked keyA must be closed, not leaked.
+	if !helpers.AssertChannelClosed(t, clientA.CloseCh, time.Second,
+		"client built for the revoked keyA should have been closed rather than installed") {
+		t.FailNow()
+	}
+
+	// And it must not have been installed into the clients map.
+	impl := env.(*envContextImpl)
+	impl.mu.Lock()
+	_, present := impl.clients[keyA]
+	impl.mu.Unlock()
+	assert.False(t, present, "revoked keyA should not have a client in the clients map")
+}
+
+// An environment configured without an SDK key (e.g. offline or not-yet-configured envs, and test
+// fixtures) must still get its SDK client installed. An undefined key is never a tracked credential,
+// so the startup guard that discards clients for revoked keys must not fire for it.
+func TestEnvWithoutSDKKeyStillInstallsClient(t *testing.T) {
+	readyCh := make(chan EnvContext, 1)
+	clientCh := make(chan *testclient.FakeLDClient, 1)
+	clientFactory := testclient.FakeLDClientFactoryWithChannel(true, clientCh)
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	env := makeBasicEnv(t, config.EnvConfig{}, clientFactory, mockLog.Loggers, readyCh)
+	defer env.Close()
+
+	assert.Equal(t, env, requireEnvReady(t, readyCh))
+	client := requireClientReady(t, clientCh)
+	assert.NotNil(t, client)
+	assert.Equal(t, client, env.GetClient())
 }
 
 func TestSDKClientCreationFails(t *testing.T) {


### PR DESCRIPTION
## Summary

SDK key rotation in the Relay Proxy could leak credentials and SDK clients in three scenarios surfaced while building out concurrent-keys support:

- **Re-anchoring expired the active primary.** Rotating an SDK key back into the primary slot while it was still within its deprecation grace period left it in the rotator's deprecated set, so the cleanup ticker would later expire the now-active primary. `swapPrimaryKey` now removes a re-anchored key from the deprecated set.
- **Already-expired grace never revoked the previous primary.** A rotation arriving with a grace period that had already elapsed neither added nor revoked the previous primary, so it kept authenticating indefinitely. The already-expired-grace branch of `updateSDKKey` now revokes the previous primary.
- **Orphaned and stale SDK clients.** `startSDKClient` builds the client before taking the env lock and then installed it unconditionally. A key revoked (or the environment closed) while the client was still being constructed left a live client -- open upstream connection and goroutines -- that nothing closed until shutdown; re-anchoring a key whose previous client was still alive leaked that stale client too. `startSDKClient` now closes the stale same-key client before replacing it on re-anchor, and closes (rather than installs) a freshly-built client when, by the time it holds the lock, the key has been revoked or the environment has been closed (checked against the rotator's tracked credentials).

Regression tests cover each path, including a gated-factory test that deterministically reproduces the install-after-revoke race. Validated under the race detector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential rotation and SDK client lifecycle on a timing-sensitive path; mistakes could drop valid clients or leave connections open, but changes are narrowly scoped with race-detector-style tests.
> 
> **Overview**
> Fixes **SDK key rotation** leaks and incorrect credential lifetime behavior in the Relay Proxy.
> 
> **Credential rotator (regression tests)** documents and locks in two SDK-key fixes: rotations with an **already-expired grace** must **revoke the outgoing primary immediately**, and **re-anchoring** a key back to primary must **remove it from the deprecated set** so the cleanup ticker cannot expire the active anchor later.
> 
> **`startSDKClient`** no longer installs every successfully built client unconditionally. After the factory returns, it **drops and closes** clients when the environment is **closed** or the SDK key is **no longer tracked** (via new `sdkKeyIsActive`, with an exception for **undefined** keys so keyless envs still work). On install, it **closes any existing client** for the same key before replacing it (stale client on re-anchor). Successful-but-discarded inits still signal **ready** and log an info message instead of treating it as a hard failure.
> 
> **Tests** add rotator cases plus env tests for re-anchor stale close, a **gated factory** race (revoke while client is starting), and env-without-SDK-key behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f8243e0e18be36521000da87847a4653b2f0998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->