### PR TITLE
test(relay): fix flaky TestConcurrentKeysHarnessReference SSE race

### DIFF
--- a/relay/concurrent_keys_harness_ref_test.go
+++ b/relay/concurrent_keys_harness_ref_test.go
@@ -120,7 +120,17 @@ func TestConcurrentKeysHarnessReference(t *testing.T) {
 
 		// 3. Wait for the env to become available (confirms Relay processed the RAC put event).
 		h := relayTestHelper{t: t, relay: relay}
-		_ = h.awaitEnvironment(harnessEnvID)
+		env := h.awaitEnvironment(harnessEnvID)
+
+		// awaitEnvironment only waits until the env is discoverable by credential lookup. The SDK
+		// client is created in a background goroutine (go c.startSDKClient(...)), so GetClient() can
+		// still be nil at this point. Relay's stream middleware returns 503 (Service Unavailable)
+		// while GetClient() == nil, which would cause the SSE request below to fail intermittently.
+		// Wait for the client to be ready before connecting, mirroring the readiness poll in
+		// internal/relayenv/env_context_impl_test.go (TestChangeSDKKey).
+		require.Eventually(t, func() bool {
+			return env.GetClient() != nil
+		}, 5*time.Second, time.Millisecond*5, "timed out waiting for the SDK client to be ready")
 
 		// 4. Connect to Relay's SSE stream and verify it serves a put event.
 		req := sharedtest.BuildRequestWithAuth(http.MethodGet, "/all", harnessSDKKey, nil)


### PR DESCRIPTION
## Summary

Makes the `RAC mock + SDK stream` subcase of `TestConcurrentKeysHarnessReference` deterministic. No Jira ticket — pre-existing test race introduced by #705, unrelated to the credential-reconcile work in #712.

## Background

The subcase intermittently failed (most recently on the "Go 1.25.11, Valkey" CI matrix cell) with the SSE request returning HTTP 503 instead of 200, then `stream closed before receiving event of type 'put'`.

Root cause: the 503 comes from the relay stream middleware (`internal/middleware/middleware.go`), which returns Service Unavailable while `clientCtx.GetClient() == nil`. The test's `awaitEnvironment` helper only waits until the environment is discoverable via credential/key lookup — but the SDK client is created in a background goroutine (`go c.startSDKClient(...)` in `internal/relayenv/env_context_impl.go`), so `GetClient()` can still be nil when the test fires its SSE request.

## Changes

- After `awaitEnvironment`, poll `env.GetClient() != nil` with `require.Eventually` before connecting to the SSE stream. This mirrors the readiness poll already used in `internal/relayenv/env_context_impl_test.go` (`TestChangeSDKKey`) — no fixed `time.Sleep`.

Verified with `go test -race -count=20 -run TestConcurrentKeysHarnessReference ./relay/...` (consistently green), plus `go build ./...` and `go vet ./relay/...`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization change with no production code paths modified.
> 
> **Overview**
> Fixes intermittent failures in the **RAC mock + SDK stream** subtest of `TestConcurrentKeysHarnessReference`, where the SSE call could hit **503** before the background SDK client finished initializing.
> 
> After `awaitEnvironment`, the test now uses **`require.Eventually`** until `env.GetClient() != nil` (5s timeout, 5ms poll) before opening the stream—same readiness idea as `TestChangeSDKKey` in `env_context_impl_test.go`. Production relay behavior is unchanged; only test synchronization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77bb88f904b3fbd6bc89261b233685e3588a18e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->