### PR TITLE
test(relayenv): verify GetClient returns anchor client in multi-key env

### DIFF
--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -606,10 +606,13 @@ func (c *envContextImpl) GetDeprecatedCredentials() []credential.SDKCredential {
 func (c *envContextImpl) GetClient() sdks.LDClientContext {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	// After T2.a (anchor-only upstream client), c.clients always has at most one entry — the anchor's
-	// client. Online mode looks it up by anchor key; offline mode iterates (the initial startSDKClient
-	// call does not carry the envConfig.SDKKey into the rotator's primary key in all offline code paths,
-	// so the lookup-by-key form is used only in the online path to be safe).
+	// c.clients always has at most one entry — the anchor's client. Only the anchor key triggers
+	// startSDKClient (in addCredential and at construction), so non-anchor server keys never open
+	// their own upstream connection.
+	//
+	// Offline mode uses iteration rather than key-based lookup for historical reasons; both
+	// approaches are correct because keyRotator is initialized with envConfig.SDKKey before
+	// startSDKClient is ever called.
 	if c.offline {
 		for _, client := range c.clients {
 			return client

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -606,10 +606,10 @@ func (c *envContextImpl) GetDeprecatedCredentials() []credential.SDKCredential {
 func (c *envContextImpl) GetClient() sdks.LDClientContext {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	// In offline mode, there's only one SDK client. This is awkward because we represent the active clients
-	// as a map, but in this case there's only one client in the map. A refactoring might pull this logic (along with
-	// differences in add/removeCredential into an interface that is injected based on the environment being
-	// offline or online.
+	// After T2.a (anchor-only upstream client), c.clients always has at most one entry — the anchor's
+	// client. Online mode looks it up by anchor key; offline mode iterates (the initial startSDKClient
+	// call does not carry the envConfig.SDKKey into the rotator's primary key in all offline code paths,
+	// so the lookup-by-key form is used only in the online path to be safe).
 	if c.offline {
 		for _, client := range c.clients {
 			return client

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -449,6 +449,48 @@ func TestNonAnchorSDKKeysDoNotOpenUpstreamClient(t *testing.T) {
 	}
 }
 
+// TestGetClientReturnsAnchorInMultiKeyEnv verifies that GetClient returns the anchor's upstream
+// client when the environment holds multiple SDK keys. Non-anchor SDK keys share the same
+// upstream connection (the anchor's), so GetClient must never return a non-anchor client
+// and must remain non-nil after non-anchor keys are added. This is the contract callers of
+// GetClient depend on: nil means "env not ready"; non-nil means "use this client."
+func TestGetClientReturnsAnchorInMultiKeyEnv(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	readyCh := make(chan EnvContext, 1)
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	clientFactory := testclient.FakeLDClientFactoryWithChannel(true, clientCh)
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	env := makeBasicEnv(t, envConfig, clientFactory, mockLog.Loggers, readyCh)
+	defer env.Close()
+
+	assert.Equal(t, env, requireEnvReady(t, readyCh))
+	anchorClient := requireClientReady(t, clientCh)
+	assert.Equal(t, envConfig.SDKKey, anchorClient.Key)
+
+	// GetClient must return the anchor's client even before any non-anchor keys are added.
+	assert.Equal(t, anchorClient, env.GetClient())
+
+	nonAnchorKey1 := config.SDKKey("non-anchor-key-1")
+	nonAnchorKey2 := config.SDKKey("non-anchor-key-2")
+
+	env.ReconcileCredentials(
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
+			WithPrimarySDKKey(envConfig.SDKKey).
+			WithSDKKey(nonAnchorKey1).
+			WithSDKKey(nonAnchorKey2)))
+
+	// No new upstream client was created for the non-anchor keys.
+	if !helpers.AssertNoMoreValues(t, clientCh, 200*time.Millisecond) {
+		t.FailNow()
+	}
+
+	// GetClient still returns the anchor's client — not nil, not a non-anchor client.
+	assert.Equal(t, anchorClient, env.GetClient())
+}
+
 func TestNonPrimaryMobileKeyDoesNotStealEventForwarding(t *testing.T) {
 	mockLog := ldlogtest.NewMockLog()
 	defer mockLog.DumpIfTestFailed(t)


### PR DESCRIPTION
## Summary

- Add `TestGetClientReturnsAnchorInMultiKeyEnv`: builds an env with two non-anchor SDK keys via `ReconcileCredentials` and asserts `GetClient` returns the anchor's client before and after the reconcile; confirms no extra upstream client is opened; confirms `GetClient` remains non-nil (the signal callers use for env readiness).
- Update the `GetClient` comment to reflect the post-T2.a reality: `c.clients` now holds at most one entry (the anchor's client), so the offline-mode loop and the online-mode lookup-by-anchor-key are both correct by the same invariant.

[Jira: SDK-2541](https://launchdarkly.atlassian.net/browse/SDK-2541)

## Background

After T2.a (PR #712), `addCredential` only calls `startSDKClient` when the credential is the anchor key — non-anchor server keys get `envStreams`, handler bundles, and connection-mapper mapping but no upstream client. T2.b verifies that `GetClient`, which returns `c.clients[c.keyRotator.SDKKey()]`, correctly surfaces the single anchor client to all callers even when the accepted set contains non-anchor SDK keys.

The existing callers of `GetClient` (`middleware.go` nil-check, `endpoints_status.go`, `relay_endpoints.go`) all rely on it returning non-nil for a ready env and the correct client object for evaluations and secure-mode hashing. The test confirms the multi-key reconcile path doesn't break that contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and comment-only changes in relayenv; no production logic modified.
> 
> **Overview**
> Adds **`TestGetClientReturnsAnchorInMultiKeyEnv`** to lock in the multi-key SDK contract after anchor-only upstream clients: `GetClient` must return the anchor’s fake upstream client before and after `ReconcileCredentials` adds two non-anchor keys, must stay non-nil, and must not spawn extra upstream clients.
> 
> Updates the **`GetClient`** comment to state that `c.clients` holds at most the anchor client (only the anchor calls `startSDKClient`), and that offline iteration vs online lookup-by-anchor-key are both valid given rotator initialization order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d7bd41efd4de24d50860f31f2da739ae03b399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->