### PR TITLE
refactor(credential): rename sdkKey→anchor

### DIFF
--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -13,11 +13,11 @@ import (
 // expiry — plus the single environment ID and two primary designations:
 //
 //   - The anchor: the one SDK key that owns the environment's upstream connection. Set with
-//     WithPrimarySDKKey.
+//     WithAnchor.
 //   - The primary mobile key: the singular default mobile key (the wire's mobKey), used where one
 //     mobile key is required, e.g. event forwarding. Set with WithPrimaryMobileKey.
 //
-// WithPrimarySDKKey / WithPrimaryMobileKey both add the key to the set and designate it, so adding a
+// WithAnchor / WithPrimaryMobileKey both add the key to the set and designate it, so adding a
 // single key takes one call. Build requires that an anchor was designated. (Structural validation of
 // the wire payload — undefined credentials, an anchor absent from the array — happens upstream when
 // the payload is parsed into the set; see SDK-2547.)
@@ -30,9 +30,9 @@ type AcceptedSet struct {
 	// sdkKeys and mobileKeys store each accepted key once, keyed by value, so duplicates collapse
 	// without a containment scan. The map value is the key's expiry: a nil *time.Time means the key
 	// is permanent. A nil map is a valid empty set (reads return absent; only the builder writes).
-	sdkKeys          map[config.SDKKey]*time.Time
-	primarySdkKey    config.SDKKey
-	mobileKeys       map[config.MobileKey]*time.Time
+	sdkKeys    map[config.SDKKey]*time.Time
+	anchor     config.SDKKey
+	mobileKeys map[config.MobileKey]*time.Time
 	primaryMobileKey config.MobileKey
 	envID            config.EnvironmentID
 }

--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -30,9 +30,9 @@ type AcceptedSet struct {
 	// sdkKeys and mobileKeys store each accepted key once, keyed by value, so duplicates collapse
 	// without a containment scan. The map value is the key's expiry: a nil *time.Time means the key
 	// is permanent. A nil map is a valid empty set (reads return absent; only the builder writes).
-	sdkKeys    map[config.SDKKey]*time.Time
-	anchor     config.SDKKey
-	mobileKeys map[config.MobileKey]*time.Time
+	sdkKeys          map[config.SDKKey]*time.Time
+	anchor           config.SDKKey
+	mobileKeys       map[config.MobileKey]*time.Time
 	primaryMobileKey config.MobileKey
 	envID            config.EnvironmentID
 }

--- a/internal/credential/accepted_set_builder.go
+++ b/internal/credential/accepted_set_builder.go
@@ -36,12 +36,12 @@ func (b *AcceptedSetBuilder) WithExpiringSDKKey(key config.SDKKey, expiry time.T
 	return b
 }
 
-// WithPrimarySDKKey adds key (if not already present) and designates it as the anchor — the SDK key
+// WithAnchor adds key (if not already present) and designates it as the anchor — the SDK key
 // that owns the environment's upstream connection. It is a no-op if the key is undefined.
-func (b *AcceptedSetBuilder) WithPrimarySDKKey(key config.SDKKey) *AcceptedSetBuilder {
+func (b *AcceptedSetBuilder) WithAnchor(key config.SDKKey) *AcceptedSetBuilder {
 	if key.Defined() {
 		b.addSDKKey(key, nil)
-		b.set.primarySdkKey = key
+		b.set.anchor = key
 	}
 	return b
 }
@@ -99,13 +99,13 @@ func (b *AcceptedSetBuilder) WithEnvironmentID(id config.EnvironmentID) *Accepte
 
 // Build validates and returns the accumulated AcceptedSet. It returns errAcceptedSetMissingSDKKey if
 // no SDK key was added, or a *MalformedCredentialSetError if no anchor was designated (via
-// WithPrimarySDKKey). Because WithPrimarySDKKey also adds the key, a designated anchor is always
-// among the accepted SDK keys.
+// WithAnchor). Because WithAnchor also adds the key, a designated anchor is always among the
+// accepted SDK keys.
 func (b *AcceptedSetBuilder) Build() (AcceptedSet, error) {
 	if len(b.set.sdkKeys) == 0 {
 		return AcceptedSet{}, errAcceptedSetMissingSDKKey
 	}
-	if !b.set.primarySdkKey.Defined() {
+	if !b.set.anchor.Defined() {
 		return AcceptedSet{}, newMissingAnchorError()
 	}
 	return b.set, nil

--- a/internal/credential/accepted_set_builder_test.go
+++ b/internal/credential/accepted_set_builder_test.go
@@ -22,25 +22,25 @@ func TestAcceptedSetBuilderValidation(t *testing.T) {
 	_, err = NewAcceptedSetBuilder().WithSDKKey(config.SDKKey("sdk")).Build()
 	require.ErrorAs(t, err, &malformed)
 
-	// WithPrimarySDKKey adds the key and designates it as the anchor, so Build succeeds.
-	set, err := NewAcceptedSetBuilder().WithPrimarySDKKey(config.SDKKey("sdk")).Build()
+	// WithAnchor adds the key and designates it as the anchor, so Build succeeds.
+	set, err := NewAcceptedSetBuilder().WithAnchor(config.SDKKey("sdk")).Build()
 	require.NoError(t, err)
 	assert.True(t, set.hasSDKKey(config.SDKKey("sdk")))
-	assert.Equal(t, config.SDKKey("sdk"), set.primarySdkKey)
+	assert.Equal(t, config.SDKKey("sdk"), set.anchor)
 }
 
 func TestAcceptedSetBuilderDeduplicates(t *testing.T) {
 	// Adding the same key more than once (including via WithPrimary*) keeps a single entry.
 	set := mustBuild(t, NewAcceptedSetBuilder().
 		WithSDKKey(config.SDKKey("sdk")).
-		WithPrimarySDKKey(config.SDKKey("sdk")).
+		WithAnchor(config.SDKKey("sdk")).
 		WithSDKKey(config.SDKKey("sdk")).
 		WithMobileKey(config.MobileKey("mob")).
 		WithPrimaryMobileKey(config.MobileKey("mob")))
 
 	assert.Len(t, set.sdkKeys, 1)
 	assert.Len(t, set.mobileKeys, 1)
-	assert.Equal(t, config.SDKKey("sdk"), set.primarySdkKey)
+	assert.Equal(t, config.SDKKey("sdk"), set.anchor)
 	assert.Equal(t, config.MobileKey("mob"), set.primaryMobileKey)
 }
 

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -28,8 +28,8 @@ type Rotator struct {
 	// here to allow setting it in a deferred manner.
 	primaryEnvironmentID config.EnvironmentID
 
-	// There can be multiple SDK keys active at a given time, but only one is primary.
-	primarySdkKey config.SDKKey
+	// There can be multiple SDK keys active at a given time, but only one is the anchor.
+	anchorKey config.SDKKey
 
 	// Deprecated keys are stored in a map with a started timer for each key representing the deprecation period.
 	// Upon expiration, they are removed.
@@ -76,7 +76,7 @@ func (r *Rotator) Initialize(credentials []SDKCredential) {
 		}
 		switch cred := cred.(type) {
 		case config.SDKKey:
-			r.primarySdkKey = cred
+			r.anchorKey = cred
 			r.acceptedSDKKeys[cred] = &acceptedKeyInfo{}
 		case config.MobileKey:
 			r.primaryMobileKey = cred
@@ -94,11 +94,11 @@ func (r *Rotator) MobileKey() config.MobileKey {
 	return r.primaryMobileKey
 }
 
-// SDKKey returns the primary SDK key.
-func (r *Rotator) SDKKey() config.SDKKey {
+// AnchorKey returns the anchor SDK key — the key that owns the upstream connection.
+func (r *Rotator) AnchorKey() config.SDKKey {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.primarySdkKey
+	return r.anchorKey
 }
 
 // EnvironmentID returns the environment ID.
@@ -170,7 +170,7 @@ func (r *Rotator) DeprecatedCredentials() []SDKCredential {
 	out := r.deprecatedCredentials()
 
 	for key, info := range r.acceptedSDKKeys {
-		if info.expiry != nil && key != r.primarySdkKey {
+		if info.expiry != nil && key != r.anchorKey {
 			out = append(out, key)
 		}
 	}
@@ -285,22 +285,22 @@ func (r *Rotator) updateMobileKey(mobileKey config.MobileKey, grace *GracePeriod
 		previous.Masked(), grace.expiry, mobileKey.Masked())
 }
 
-func (r *Rotator) swapPrimaryKey(newKey config.SDKKey) config.SDKKey {
-	if newKey == r.primarySdkKey {
-		// There's no swap to be done, we already are using this as primary.
+func (r *Rotator) swapAnchor(newKey config.SDKKey) config.SDKKey {
+	if newKey == r.anchorKey {
+		// There's no swap to be done, we already are using this as the anchor.
 		return ""
 	}
-	previous := r.primarySdkKey
-	r.primarySdkKey = newKey
+	previous := r.anchorKey
+	r.anchorKey = newKey
 	// Keep the accepted-set map (the source of truth for PrimaryCredentials) consistent: the new
-	// primary is accepted and is no longer deprecated, even if it was being phased out before. Mirrors
+	// anchor is accepted and is no longer deprecated, even if it was being phased out before. Mirrors
 	// updateMobileKey for mobile keys.
 	if _, ok := r.acceptedSDKKeys[newKey]; !ok {
 		r.acceptedSDKKeys[newKey] = &acceptedKeyInfo{}
 	}
 	delete(r.deprecatedSdkKeys, newKey)
 	r.additions = append(r.additions, newKey)
-	r.loggers.Infof("New primary SDK key is %s", newKey.Masked())
+	r.loggers.Infof("New anchor SDK key is %s", newKey.Masked())
 
 	return previous
 }
@@ -317,8 +317,8 @@ func (r *Rotator) updateSDKKey(sdkKey config.SDKKey, grace *GracePeriod) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Previous will only be .Defined() if there was a previous primary key.
-	previous := r.swapPrimaryKey(sdkKey)
+	// Previous will only be .Defined() if there was a previous anchor key.
+	previous := r.swapAnchor(sdkKey)
 
 	// If there's no deprecation notice, then the previous key (if any) needs to be immediately revoked so it doesn't
 	// hang around forever. This case is also true when there is a grace period, but we need to inspect the grace period
@@ -427,13 +427,13 @@ func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expiration
 // rather than reconcile.
 //
 // The set is assumed well-formed: AcceptedSetBuilder.Build validates that an anchor was designated
-// (and, because WithPrimarySDKKey adds the key as it designates it, that the anchor is among the SDK
+// (and, because WithAnchor adds the key as it designates it, that the anchor is among the SDK
 // keys), so Reconcile trusts what it is handed rather than re-validating.
 func (r *Rotator) Reconcile(set AcceptedSet, now time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.reconcileSDKKeys(set, set.primarySdkKey, now)
+	r.reconcileSDKKeys(set, set.anchor, now)
 	r.reconcileMobileKeys(set, now)
 	r.reconcileEnvironmentID(set)
 }
@@ -500,7 +500,7 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 	}
 	desired[anchor] = nil
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, r.deprecatedSdkKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
-	r.primarySdkKey = anchor
+	r.anchorKey = anchor
 }
 
 // reconcileMobileKeys mirrors reconcileSDKKeys for mobile keys. The primary mobile key — the wire's

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -30,7 +30,7 @@ func TestImmediateKeyExpiration(t *testing.T) {
 		{
 			name:   "sdk keys",
 			keys:   []SDKCredential{config.SDKKey("key1"), config.SDKKey("key2"), config.SDKKey("key3")},
-			getKey: func(r *Rotator) SDKCredential { return r.SDKKey() },
+			getKey: func(r *Rotator) SDKCredential { return r.AnchorKey() },
 		},
 		{
 			name:   "mobile keys",
@@ -82,7 +82,7 @@ func TestManyImmediateKeyExpirations(t *testing.T) {
 		{
 			name:    "sdk keys",
 			makeKey: func(s string) SDKCredential { return config.SDKKey(s) },
-			getKey:  func(r *Rotator) SDKCredential { return r.SDKKey() },
+			getKey:  func(r *Rotator) SDKCredential { return r.AnchorKey() },
 		},
 		{
 			name:    "mobile keys",
@@ -208,7 +208,7 @@ func TestManyConcurrentSDKKeyDeprecation(t *testing.T) {
 	}
 
 	// The last key added should be the current primary key.
-	assert.Equal(t, keysAdded[len(keysAdded)-1], rotator.SDKKey())
+	assert.Equal(t, keysAdded[len(keysAdded)-1], rotator.AnchorKey())
 
 	// Until and including the exact expiry timestamp, there should be no expirations.
 	additions, expirations := rotator.StepTime(expiryTime)
@@ -254,7 +254,7 @@ func TestSDKKeyDeprecationWithAlreadyExpiredGraceRevokesPreviousPrimary(t *testi
 	// accepted-but-untracked key. (This mirrors the equivalent mobile-key behavior.)
 	rotator.RotateWithGrace(key2, NewGracePeriod(key1, expiry, now))
 
-	assert.Equal(t, key2, rotator.SDKKey())
+	assert.Equal(t, key2, rotator.AnchorKey())
 
 	additions, expirations := rotator.StepTime(now)
 	assert.ElementsMatch(t, []SDKCredential{key2}, additions)
@@ -282,7 +282,7 @@ func TestReAnchoringDeprecatedSDKKeyRemovesItFromDeprecatedSet(t *testing.T) {
 	// Re-anchor key2 -> key1 before key1's grace expires. key1 must be promoted out of the
 	// deprecated set; otherwise the cleanup ticker would later expire the active primary.
 	rotator.Rotate(key1)
-	assert.Equal(t, key1, rotator.SDKKey())
+	assert.Equal(t, key1, rotator.AnchorKey())
 	assert.Empty(t, rotator.DeprecatedCredentials())
 
 	additions, expirations := rotator.StepTime(start)
@@ -293,7 +293,7 @@ func TestReAnchoringDeprecatedSDKKeyRemovesItFromDeprecatedSet(t *testing.T) {
 	additions, expirations = rotator.StepTime(expiry.Add(1 * time.Hour))
 	assert.Empty(t, additions)
 	assert.Empty(t, expirations)
-	assert.Equal(t, key1, rotator.SDKKey())
+	assert.Equal(t, key1, rotator.AnchorKey())
 }
 
 func TestInitializePopulatesAcceptedSets(t *testing.T) {
@@ -319,7 +319,7 @@ func TestInitializePopulatesAcceptedSets(t *testing.T) {
 	}
 
 	// Existing public API is unchanged.
-	assert.Equal(t, sdkKey, rotator.SDKKey())
+	assert.Equal(t, sdkKey, rotator.AnchorKey())
 	assert.Equal(t, mobileKey, rotator.MobileKey())
 	assert.Equal(t, envID, rotator.EnvironmentID())
 }
@@ -446,7 +446,7 @@ func TestRotateSDKKeyRePromoteClearsDeprecation(t *testing.T) {
 	rotator.RotateWithGrace(key1, nil) // re-promote key1
 	rotator.StepTime(start)
 
-	assert.Equal(t, key1, rotator.SDKKey())
+	assert.Equal(t, key1, rotator.AnchorKey())
 	assert.Contains(t, rotator.PrimaryCredentials(), SDKCredential(key1))
 	assert.NotContains(t, rotator.DeprecatedCredentials(), SDKCredential(key1))
 }
@@ -463,7 +463,7 @@ func TestRotateSDKKeyWithExpiredGraceRevokesPrevious(t *testing.T) {
 	rotator.Initialize([]SDKCredential{key1})
 	rotator.RotateWithGrace(key2, NewGracePeriod(key1, expiry, now))
 
-	assert.Equal(t, key2, rotator.SDKKey())
+	assert.Equal(t, key2, rotator.AnchorKey())
 	additions, expirations := rotator.StepTime(now)
 	assert.ElementsMatch(t, []SDKCredential{key2}, additions)
 	assert.ElementsMatch(t, []SDKCredential{key1}, expirations)
@@ -475,12 +475,12 @@ func TestReconcileAnchorOnly(t *testing.T) {
 	anchor := config.SDKKey("anchor")
 	now := time.Now()
 
-	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor)), now)
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor)), now)
 	additions, expirations := r.StepTime(now)
 
 	assert.ElementsMatch(t, []SDKCredential{anchor}, additions)
 	assert.Empty(t, expirations)
-	assert.Equal(t, anchor, r.SDKKey())
+	assert.Equal(t, anchor, r.AnchorKey())
 	assert.ElementsMatch(t, []SDKCredential{anchor}, r.PrimaryCredentials())
 	assert.Empty(t, r.DeprecatedCredentials())
 }
@@ -492,13 +492,13 @@ func TestReconcileMultipleSDKKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor).WithSDKKey(other)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor).WithSDKKey(other)), now)
 	additions, expirations := r.StepTime(now)
 
 	// Both server keys are accepted; only the anchor is primary.
 	assert.ElementsMatch(t, []SDKCredential{anchor, other}, additions)
 	assert.Empty(t, expirations)
-	assert.Equal(t, anchor, r.SDKKey())
+	assert.Equal(t, anchor, r.AnchorKey())
 	assert.ElementsMatch(t, []SDKCredential{anchor, other}, r.PrimaryCredentials())
 	assert.Empty(t, r.DeprecatedCredentials())
 }
@@ -511,7 +511,7 @@ func TestReconcileMultipleMobileKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor).WithPrimaryMobileKey(mob1).WithMobileKey(mob2)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor).WithPrimaryMobileKey(mob1).WithMobileKey(mob2)), now)
 	additions, _ := r.StepTime(now)
 
 	// Every mobile key is accepted; the designated one is the primary.
@@ -528,11 +528,11 @@ func TestReconcileRevokesOmittedKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor).WithSDKKey(other).WithPrimaryMobileKey(mob)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor).WithSDKKey(other).WithPrimaryMobileKey(mob)), now)
 	r.StepTime(now)
 
 	// Reconciling to just the anchor revokes the omitted server and mobile keys.
-	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor)), now)
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor)), now)
 	additions, expirations := r.StepTime(now)
 
 	assert.Empty(t, additions)
@@ -554,7 +554,7 @@ func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
 
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithPrimarySDKKey(anchor).
+			WithAnchor(anchor).
 			WithExpiringSDKKey(expiringSDK, now.Add(time.Hour)).
 			WithPrimaryMobileKey(mob).
 			WithExpiringMobileKey(expiringMobile, now.Add(time.Hour))),
@@ -580,7 +580,7 @@ func TestReconcilePrimaryMobileKeyIsAlwaysAccepted(t *testing.T) {
 	now := time.Unix(1000, 0)
 
 	set := mustBuild(t, NewAcceptedSetBuilder().
-		WithPrimarySDKKey(anchor).
+		WithAnchor(anchor).
 		WithExpiringMobileKey(mob, now.Add(-time.Hour)). // already expired in the payload...
 		WithPrimaryMobileKey(mob))                       // ...but designated as the primary
 	r.Reconcile(set, now)
@@ -607,7 +607,7 @@ func TestReconcileClearsStaleDeprecationForAcceptedKey(t *testing.T) {
 
 	// Reconcile to a set that fully accepts both keys.
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor).WithSDKKey(old)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor).WithSDKKey(old)), now)
 	r.StepTime(now)
 
 	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(old))
@@ -629,7 +629,7 @@ func TestReconcileExpiringKeysAreEvictedByStepTime(t *testing.T) {
 
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithPrimarySDKKey(anchor).
+			WithAnchor(anchor).
 			WithExpiringSDKKey(expiringSDK, expiry).
 			WithPrimaryMobileKey(mob).
 			WithExpiringMobileKey(expiringMobile, expiry)),

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -28,12 +28,12 @@ import (
 func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.SDKKey, error) {
 	anchor := params.SDKKey
 
-	// WithPrimarySDKKey / WithPrimaryMobileKey each add the key and designate it (the anchor and the
+	// WithAnchor / WithPrimaryMobileKey each add the key and designate it (the anchor and the
 	// wire's mobKey, respectively). An undefined key makes the call a no-op, so an undefined anchor
 	// leaves the set with no designated anchor and Build returns a *MalformedCredentialSetError.
 	b := credential.NewAcceptedSetBuilder().
 		WithEnvironmentID(params.EnvID).
-		WithPrimarySDKKey(anchor).
+		WithAnchor(anchor).
 		WithPrimaryMobileKey(params.MobileKey)
 
 	// Validate and add the remaining accepted keys. The builder de-duplicates by value, so the
@@ -60,7 +60,7 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 
 	// The anchor must be one of the accepted SDK keys: the backend lists it in sdkKeys[] (and ToParams
 	// synthesizes it into the array for old-format payloads). A defined anchor absent from the array is
-	// a structurally malformed payload — reject it per §9 rather than letting WithPrimarySDKKey above
+	// a structurally malformed payload — reject it per §9 rather than letting WithAnchor above
 	// silently synthesize it into the set.
 	if anchor.Defined() && !anchorInArray {
 		return credential.AcceptedSet{}, anchor, credential.NewAnchorNotInSetError()

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -56,7 +56,7 @@ func TestBuildAcceptedSet_HappyPath(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
+		WithAnchor("sdk-anchor").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
 }
@@ -80,7 +80,7 @@ func TestBuildAcceptedSet_MultipleKeys(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
+		WithAnchor("sdk-anchor").
 		WithSDKKey("sdk-service-a").
 		WithExpiringSDKKey("sdk-old", expiry1).
 		WithPrimaryMobileKey("mob-primary"))
@@ -143,7 +143,7 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 	// The set built without expiry must include sdk-old as a permanent key.
 	expectedPermanent := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
+		WithAnchor("sdk-anchor").
 		WithSDKKey("sdk-old"). // permanent, no expiry
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expectedPermanent, setNoExpiry)
@@ -153,7 +153,7 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 }
 
 // TestBuildAcceptedSet_AnchorNotInArray verifies that an anchor absent from AcceptedSDKKeys is no
-// longer rejected here: WithPrimarySDKKey adds and designates the anchor regardless, so the
+// longer rejected here: WithAnchor adds and designates the anchor regardless, so the
 // resulting set contains both the anchor and the array entry. Structural validation of the wire
 // payload (anchor-absent-from-array) happens upstream when the payload is parsed into params.
 // TestBuildAcceptedSet_AnchorNotInArray verifies that a defined anchor absent from the sdkKeys[] array
@@ -192,7 +192,7 @@ func TestBuildAcceptedSet_NoMobileKey(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor"))
+		WithAnchor("sdk-anchor"))
 	assert.Equal(t, expected, set)
 }
 
@@ -252,7 +252,7 @@ func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-new-anchor").
+		WithAnchor("sdk-new-anchor").
 		WithSDKKey("sdk-b").
 		WithSDKKey("sdk-c").
 		WithPrimaryMobileKey("mob-primary"))
@@ -276,10 +276,10 @@ func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
 
-	// Anchor is permanent (WithPrimarySDKKey), not expiring — identical to a payload with no anchor expiry.
+	// Anchor is permanent (WithAnchor), not expiring — identical to a payload with no anchor expiry.
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
+		WithAnchor("sdk-anchor").
 		WithSDKKey("sdk-service-a").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
@@ -304,7 +304,7 @@ func TestBuildAcceptedSet_MultipleMobileKeys(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
+		WithAnchor("sdk-anchor").
 		WithMobileKey("mob-primary").
 		WithMobileKey("mob-secondary").
 		WithPrimaryMobileKey("mob-primary"))
@@ -331,7 +331,7 @@ func TestBuildAcceptedSet_ExpiringMobileKey(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
+		WithAnchor("sdk-anchor").
 		WithMobileKey("mob-primary").
 		WithExpiringMobileKey("mob-old", expiry1).
 		WithPrimaryMobileKey("mob-primary"))
@@ -361,7 +361,7 @@ func TestBuildAcceptedSet_TrustTheArray(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
+		WithAnchor("sdk-anchor").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set, "legacy sdkKey.expiring slot must not appear in AcceptedSet")
 }

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -40,12 +40,12 @@ type EnvContext interface {
 	// SetIdentifiers updates the environment and project names and keys.
 	SetIdentifiers(EnvIdentifiers)
 
-	// GetSDKKey returns the anchor SDK key — the primary key that owns the upstream connection.
+	// GetAnchorKey returns the anchor SDK key — the key that owns the upstream connection.
 	// Use this when you need exactly the anchor (e.g. the status endpoint's sdkKey field) rather
 	// than the full accepted set returned by GetCredentials.
-	GetSDKKey() config.SDKKey
+	GetAnchorKey() config.SDKKey
 
-	// GetMobileKey returns the primary (default) mobile key. Like GetSDKKey for the anchor, use this
+	// GetMobileKey returns the primary (default) mobile key. Like GetAnchorKey for the anchor, use this
 	// for the status endpoint's mobileKey field rather than iterating GetCredentials, which may return
 	// several accepted mobile keys (primary + expiring) in nondeterministic order.
 	GetMobileKey() config.MobileKey

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -451,7 +451,7 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 	// So, the effect in offline mode when adding/removing credentials is just setting up the new credential mappings.
 	switch key := newCredential.(type) {
 	case config.SDKKey:
-		if key == c.keyRotator.SDKKey() {
+		if key == c.keyRotator.AnchorKey() {
 			if !c.offline {
 				go c.startSDKClient(key, nil, false)
 			}
@@ -628,8 +628,8 @@ func (c *envContextImpl) GetCredentials() []credential.SDKCredential {
 	return c.keyRotator.PrimaryCredentials()
 }
 
-func (c *envContextImpl) GetSDKKey() config.SDKKey {
-	return c.keyRotator.SDKKey()
+func (c *envContextImpl) GetAnchorKey() config.SDKKey {
+	return c.keyRotator.AnchorKey()
 }
 
 func (c *envContextImpl) GetMobileKey() config.MobileKey {
@@ -656,7 +656,7 @@ func (c *envContextImpl) GetClient() sdks.LDClientContext {
 		}
 		return nil
 	}
-	return c.clients[c.keyRotator.SDKKey()]
+	return c.clients[c.keyRotator.AnchorKey()]
 }
 
 func (c *envContextImpl) GetStore() subsystems.DataStore {

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -203,7 +203,7 @@ func TestAddRemoveCredential(t *testing.T) {
 
 	// Reconcile to the full set: the SDK key (anchor) plus a mobile key and an environment ID.
 	env.ReconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(envConfig.SDKKey).WithPrimaryMobileKey(mobileKey).WithEnvironmentID(envID)))
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(envConfig.SDKKey).WithPrimaryMobileKey(mobileKey).WithEnvironmentID(envID)))
 
 	creds := env.GetCredentials()
 	assert.Len(t, creds, 3)
@@ -214,7 +214,7 @@ func TestAddRemoveCredential(t *testing.T) {
 	// Reconciling with a different mobile key evicts the previous one.
 	newMobileKey := config.MobileKey("evict-the-previous-key")
 	env.ReconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(envConfig.SDKKey).WithPrimaryMobileKey(newMobileKey).WithEnvironmentID(envID)))
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(envConfig.SDKKey).WithPrimaryMobileKey(newMobileKey).WithEnvironmentID(envID)))
 
 	creds = env.GetCredentials()
 	assert.Len(t, creds, 3)
@@ -236,7 +236,7 @@ func TestAddExistingCredentialDoesNothing(t *testing.T) {
 	assert.Equal(t, []credential.SDKCredential{envConfig.SDKKey}, env.GetCredentials())
 
 	mobileKey := st.EnvWithAllCredentials.Config.MobileKey
-	set := mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(envConfig.SDKKey).WithPrimaryMobileKey(mobileKey))
+	set := mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(envConfig.SDKKey).WithPrimaryMobileKey(mobileKey))
 
 	env.ReconcileCredentials(set)
 
@@ -286,7 +286,7 @@ func TestChangeSDKKey(t *testing.T) {
 
 	// Upon rotating to key2, the original key should still be valid for an hour.
 	rotationSet, err := credential.NewAcceptedSetBuilder().
-		WithPrimarySDKKey(key2).
+		WithAnchor(key2).
 		WithExpiringSDKKey(envConfig.SDKKey, start.Add(1*time.Hour)).
 		Build()
 	require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestMobileKeyReconcileExpiry(t *testing.T) {
 	// carries a per-key expiry.
 	envImpl.reconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(envConfig.SDKKey).
+			WithAnchor(envConfig.SDKKey).
 			WithPrimaryMobileKey(primaryMobile).
 			WithExpiringMobileKey(expiringMobile, expiry)),
 		start)
@@ -442,7 +442,7 @@ func TestNonAnchorSDKKeysDoNotOpenUpstreamClient(t *testing.T) {
 	// open an upstream client.
 	env.ReconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(envConfig.SDKKey).
+			WithAnchor(envConfig.SDKKey).
 			WithSDKKey(nonAnchorKey1).
 			WithSDKKey(nonAnchorKey2)))
 
@@ -487,7 +487,7 @@ func TestGetClientReturnsAnchorInMultiKeyEnv(t *testing.T) {
 
 	env.ReconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(envConfig.SDKKey).
+			WithAnchor(envConfig.SDKKey).
 			WithSDKKey(nonAnchorKey1).
 			WithSDKKey(nonAnchorKey2)))
 
@@ -530,7 +530,7 @@ func TestNonPrimaryMobileKeyDoesNotStealEventForwarding(t *testing.T) {
 		// non-primary mobile key. Accepting the non-primary key must NOT repoint event forwarding —
 		// events collapse to the primary mobile key, mirroring the SDK anchor.
 		env.ReconcileCredentials(mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(envConfig.SDKKey).
+			WithAnchor(envConfig.SDKKey).
 			WithPrimaryMobileKey(primaryMobile).
 			WithMobileKey(nonPrimaryMobile).
 			WithEnvironmentID(envConfig.EnvID)))
@@ -590,7 +590,7 @@ func TestReAnchoringToKeyStillInGraceReusesItsClient(t *testing.T) {
 	// alive because keyA is still accepted during the grace window.
 	env.(*envContextImpl).reconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(keyB).
+			WithAnchor(keyB).
 			WithExpiringSDKKey(keyA, start.Add(1*time.Hour))),
 		start)
 
@@ -605,7 +605,7 @@ func TestReAnchoringToKeyStillInGraceReusesItsClient(t *testing.T) {
 	// being started -- so there is no stale client to orphan. keyB is omitted from the set (no expiry),
 	// so it is revoked immediately and its client is closed.
 	env.(*envContextImpl).reconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(keyA)),
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(keyA)),
 		start.Add(10*time.Minute))
 
 	// keyB was revoked by the re-anchor, so its client is closed.
@@ -680,7 +680,7 @@ func TestRevokingSDKKeyWhileClientIsStartingDoesNotLeakTheClient(t *testing.T) {
 	// runs now -- but c.clients[keyA] is still nil because the initial goroutine is blocked in the factory,
 	// so nothing is closed and the mapping is simply removed.
 	env.(*envContextImpl).reconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(keyB)),
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(keyB)),
 		time.Unix(1000, 0))
 
 	creds := env.GetCredentials()

--- a/internal/relayenv/env_context_reanchor_test.go
+++ b/internal/relayenv/env_context_reanchor_test.go
@@ -103,7 +103,7 @@ func (f *sharedStoreFactory) Build(_ subsystems.ClientContext) (subsystems.DataS
 func reanchor(t *testing.T, env EnvContext, newKey, oldKey config.SDKKey, now time.Time) {
 	t.Helper()
 	set, err := credential.NewAcceptedSetBuilder().
-		WithPrimarySDKKey(newKey).
+		WithAnchor(newKey).
 		WithExpiringSDKKey(oldKey, now.Add(time.Hour)).
 		Build()
 	require.NoError(t, err)
@@ -562,8 +562,8 @@ func TestReanchorPoC_H6_AnchorPointerFlipsBeforeNewClientIsRegistered(t *testing
 	reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, start)
 
 	// FINDING: there is a window where the anchor pointer already names the new key but no client exists
-	// for it yet, so GetClient() returns nil. GetClient() == clients[rotator.SDKKey()], and the rotator's
-	// primary flipped to the new key before startSDKClient registered the client. A request arriving in
+	// for it yet, so GetClient() returns nil. GetClient() == clients[rotator.AnchorKey()], and the rotator's
+	// anchor flipped to the new key before startSDKClient registered the client. A request arriving in
 	// this window gets a nil client. T2.c must not advance the anchor pointer until the new client is
 	// registered (and ideally Initialized()).
 	assert.Nil(t, env.GetClient(), "GetClient() is nil during the swap window")

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -49,7 +49,7 @@ func statusHandler(relay *Relay) http.Handler {
 			// Use the anchor SDK key and primary mobile key specifically — GetCredentials() may return
 			// multiple SDK and mobile keys (primary + expiring), so iterating it for these singular
 			// status fields would give a non-deterministic result.
-			if key := clientCtx.GetSDKKey(); key.Defined() {
+			if key := clientCtx.GetAnchorKey(); key.Defined() {
 				status.SDKKey = sdks.ObscureKey(string(key))
 			}
 			if key := clientCtx.GetMobileKey(); key.Defined() {


### PR DESCRIPTION
## Summary
Makes "anchor" a first-class name in the code. In the multi-key model, an environment accepts many SDK keys but exactly one is the anchor — the key that owns the upstream connection and that events and the status endpoint attribute to the environment. Several identifiers previously called that key the "primary SDK key", which is ambiguous now that multiple SDK keys can be accepted at once.

[Jira: SDK-2604](https://launchdarkly.atlassian.net/browse/SDK-2604)

## Background
Pure mechanical refactor with no behavior change, kept separate from behavior PRs so those diffs remain reviewable.

The dividing line: identifiers that represent the anchor *role* are renamed; wire-format, type, and full-collection names stay as "SDK key". Concretely, the rename boundary is `anchor := params.SDKKey` in `BuildAcceptedSet` — wire-derived SDK key in, anchor out.

## Changes
| From | To | Layer |
|---|---|---|
| `Rotator.SDKKey()` | `AnchorKey()` | credential |
| `Rotator.primarySdkKey` (field) | `anchorKey` | credential |
| `Rotator.swapPrimaryKey()` | `swapAnchor()` | credential |
| `AcceptedSet.primarySdkKey` (field) | `anchor` | credential |
| `AcceptedSetBuilder.WithPrimarySDKKey()` | `WithAnchor()` | credential |
| `EnvContext.GetSDKKey()` | `GetAnchorKey()` | relayenv |

Unchanged: `config.SDKKey`, `EnvironmentRep.SDKKey`, `AcceptedSDKKeys`, `AcceptedSet.sdkKeys`, `WithSDKKey`/`WithExpiringSDKKey`, `Rotator.acceptedSDKKeys`/`deprecatedSdkKeys`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public `EnvContext` interface and credential rotator APIs (compile-breaking renames), but logic is unchanged and call sites in this repo are updated.
> 
> **Overview**
> Renames the **anchor** role (the single SDK key that owns the upstream connection) so it is not confused with “primary” when many SDK keys can be accepted at once. Behavior is unchanged; wire types and collections (`config.SDKKey`, `AcceptedSDKKeys`, `WithSDKKey`, etc.) stay as-is.
> 
> **Credential layer:** `AcceptedSet.primarySdkKey` → `anchor`, `WithPrimarySDKKey` → `WithAnchor`, `Rotator.primarySdkKey` → `anchorKey`, `SDKKey()` → `AnchorKey()`, and `swapPrimaryKey` → `swapAnchor`, with reconcile/deprecation logic updated to use the new names.
> 
> **Relay integration:** `EnvContext.GetSDKKey` → `GetAnchorKey` (impl, tests, and status endpoint now call `GetAnchorKey` for the singular `sdkKey` field). `BuildAcceptedSet` designates the anchor via `WithAnchor` instead of `WithPrimarySDKKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b96fc9eb962c58f895f0567fcdc3891811a3d1c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->