### PR TITLE
refactor(credential): remove legacy single-key rotation path from Rotator

### DIFF
--- a/internal/credential/accepted_set_test.go
+++ b/internal/credential/accepted_set_test.go
@@ -3,8 +3,6 @@ package credential
 import (
 	"testing"
 
-	"github.com/launchdarkly/ld-relay/v8/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +13,4 @@ func TestMalformedCredentialSetErrorMessage(t *testing.T) {
 
 	// Empty credential value.
 	assert.Contains(t, NewEmptyCredentialError("sdkKeys", "my-key").Error(), "empty value")
-
-	// The config.SDKKey import is exercised; confirm it still compiles.
-	_ = config.SDKKey("sdk-abcd1234")
 }

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -23,7 +23,7 @@ type Rotator struct {
 	// here to allow setting it in a deferred manner.
 	primaryEnvironmentID config.EnvironmentID
 
-	// There can be multiple SDK keys active at a given time, but only one is primary (the anchor).
+	// There can be multiple SDK keys active at a given time, but only one is primary.
 	primarySdkKey config.SDKKey
 
 	// acceptedSDKKeys is the full set of accepted SDK keys with optional per-key expiry.
@@ -101,18 +101,9 @@ func (r *Rotator) EnvironmentID() config.EnvironmentID {
 	return r.primaryEnvironmentID
 }
 
-// PrimaryCredentials returns all currently accepted credentials: every accepted SDK key, every
-// accepted mobile key (including those with a future expiry — they still authenticate until then),
-// and the environment ID.
-func (r *Rotator) PrimaryCredentials() []SDKCredential {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.primaryCredentials()
-}
-
-// primaryCredentials returns every accepted credential. Expiring keys are included until the
+// allCredentials returns every accepted credential. Expiring keys are included until the
 // cleanup ticker drops them (StepTime). The caller must hold at least a read lock.
-func (r *Rotator) primaryCredentials() []SDKCredential {
+func (r *Rotator) allCredentials() []SDKCredential {
 	creds := make([]SDKCredential, 0, len(r.acceptedSDKKeys)+len(r.acceptedMobileKeys)+1)
 	for key := range r.acceptedSDKKeys {
 		creds = append(creds, key)
@@ -147,13 +138,13 @@ func (r *Rotator) DeprecatedCredentials() []SDKCredential {
 	return out
 }
 
-// AllCredentials returns all accepted credentials. It is equivalent to PrimaryCredentials; both
-// methods return the full accepted set (accepted keys, including those carrying a future expiry,
-// together with the environment ID).
+// AllCredentials returns every accepted credential: every accepted SDK key, every accepted mobile
+// key (including those carrying a future expiry — they still authenticate until the cleanup ticker
+// drops them), and the environment ID.
 func (r *Rotator) AllCredentials() []SDKCredential {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.primaryCredentials()
+	return r.allCredentials()
 }
 
 func (r *Rotator) expireSDKKey(sdkKey config.SDKKey) {
@@ -163,7 +154,7 @@ func (r *Rotator) expireSDKKey(sdkKey config.SDKKey) {
 }
 
 // expireMobileKey drops a mobile key from the accepted set and queues its expiration.
-// Deleting from acceptedMobileKeys is load-bearing: PrimaryCredentials derives from that map,
+// Deleting from acceptedMobileKeys is load-bearing: AllCredentials derives from that map,
 // so an expired key would otherwise linger as an accepted credential. Mirrors expireSDKKey.
 func (r *Rotator) expireMobileKey(mobileKey config.MobileKey) {
 	r.loggers.Infof("Deprecated mobile key %s has expired and is no longer valid for authentication", mobileKey.Masked())
@@ -177,7 +168,7 @@ func (r *Rotator) expireMobileKey(mobileKey config.MobileKey) {
 // It enforces per-key expiry for both SDK and mobile keys: expiry is stored as data on the accepted
 // entry (acceptedKeyInfo.expiry); a nil expiry means the key is permanent and is never expired here.
 //
-// Expiry is strict (now strictly after the expiry timestamp).
+// Expiry happens strictly after a key's expiry timestamp.
 func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expirations []SDKCredential) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -19,24 +19,19 @@ type Rotator struct {
 	// There is only one mobile key active at a given time.
 	primaryMobileKey config.MobileKey
 
-	// deprecatedMobileKeys stores mobile keys being phased out with a grace period, keyed
-	// by credential value with the associated expiry time. StepTime walks this map and emits
-	// an expiration once a key's grace period passes, mirroring deprecatedSdkKeys.
-	deprecatedMobileKeys map[config.MobileKey]time.Time
-
 	// There is only one environment ID active at a given time, and it won't actually be rotated. The mechanism is
 	// here to allow setting it in a deferred manner.
 	primaryEnvironmentID config.EnvironmentID
 
-	// There can be multiple SDK keys active at a given time, but only one is primary.
+	// There can be multiple SDK keys active at a given time, but only one is primary (the anchor).
 	primarySdkKey config.SDKKey
 
-	// Deprecated keys are stored in a map with a started timer for each key representing the deprecation period.
-	// Upon expiration, they are removed.
-	deprecatedSdkKeys map[config.SDKKey]time.Time
+	// acceptedSDKKeys is the full set of accepted SDK keys with optional per-key expiry.
+	// A nil expiry means the key is permanent. The anchor is always present with a nil expiry.
+	acceptedSDKKeys map[config.SDKKey]*acceptedKeyInfo
 
-	// Consumed by ReconcileCredentials API
-	acceptedSDKKeys    map[config.SDKKey]*acceptedKeyInfo
+	// acceptedMobileKeys is the full set of accepted mobile keys with optional per-key expiry.
+	// A nil expiry means the key is permanent.
 	acceptedMobileKeys map[config.MobileKey]*acceptedKeyInfo
 
 	expirations []SDKCredential
@@ -55,11 +50,9 @@ type InitialCredentials struct {
 // contains no credentials and can optionally be initialized via Initialize.
 func NewRotator(loggers ldlog.Loggers) *Rotator {
 	r := &Rotator{
-		loggers:              loggers,
-		deprecatedSdkKeys:    make(map[config.SDKKey]time.Time),
-		deprecatedMobileKeys: make(map[config.MobileKey]time.Time),
-		acceptedSDKKeys:      make(map[config.SDKKey]*acceptedKeyInfo),
-		acceptedMobileKeys:   make(map[config.MobileKey]*acceptedKeyInfo),
+		loggers:            loggers,
+		acceptedSDKKeys:    make(map[config.SDKKey]*acceptedKeyInfo),
+		acceptedMobileKeys: make(map[config.MobileKey]*acceptedKeyInfo),
 	}
 	return r
 }
@@ -108,47 +101,29 @@ func (r *Rotator) EnvironmentID() config.EnvironmentID {
 	return r.primaryEnvironmentID
 }
 
-// PrimaryCredentials returns the primary (non-deprecated) credentials.
+// PrimaryCredentials returns all currently accepted credentials: every accepted SDK key, every
+// accepted mobile key (including those with a future expiry — they still authenticate until then),
+// and the environment ID.
 func (r *Rotator) PrimaryCredentials() []SDKCredential {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.primaryCredentials()
 }
 
-// primaryCredentials returns every accepted, non-deprecated credential: all accepted SDK keys, all
-// accepted mobile keys, and the environment ID. The primary SDK key and primary mobile key are always
-// present in the accepted-set maps (maintained by Initialize, the legacy rotation path, and Reconcile)
-// and are never left marked deprecated, so a plain pass over the maps already includes them.
+// primaryCredentials returns every accepted credential. Expiring keys are included until the
+// cleanup ticker drops them (StepTime). The caller must hold at least a read lock.
 func (r *Rotator) primaryCredentials() []SDKCredential {
 	creds := make([]SDKCredential, 0, len(r.acceptedSDKKeys)+len(r.acceptedMobileKeys)+1)
-
 	for key := range r.acceptedSDKKeys {
-		if _, deprecated := r.deprecatedSdkKeys[key]; deprecated {
-			continue
-		}
 		creds = append(creds, key)
 	}
 	for key := range r.acceptedMobileKeys {
-		if _, deprecated := r.deprecatedMobileKeys[key]; deprecated {
-			continue
-		}
 		creds = append(creds, key)
 	}
 	if r.primaryEnvironmentID.Defined() {
 		creds = append(creds, r.primaryEnvironmentID)
 	}
 	return creds
-}
-
-func (r *Rotator) deprecatedCredentials() []SDKCredential {
-	deprecated := make([]SDKCredential, 0, len(r.deprecatedSdkKeys)+len(r.deprecatedMobileKeys))
-	for key := range r.deprecatedSdkKeys {
-		deprecated = append(deprecated, key)
-	}
-	for key := range r.deprecatedMobileKeys {
-		deprecated = append(deprecated, key)
-	}
-	return deprecated
 }
 
 // DeprecatedCredentials returns the SDK keys being phased out — every accepted SDK key, other than the
@@ -163,12 +138,7 @@ func (r *Rotator) DeprecatedCredentials() []SDKCredential {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	// TEMPORARY (legacy rotation path): keys deprecated via RotateWithGrace live in the
-	// deprecatedSdkKeys / deprecatedMobileKeys buckets, which the reconcile path never populates. Once
-	// the legacy path is removed (SDK-2603) these buckets are always empty; delete this line and the
-	// deprecatedCredentials helper, leaving only the accepted-with-expiry logic below.
-	out := r.deprecatedCredentials()
-
+	var out []SDKCredential
 	for key, info := range r.acceptedSDKKeys {
 		if info.expiry != nil && key != r.primarySdkKey {
 			out = append(out, key)
@@ -177,230 +147,41 @@ func (r *Rotator) DeprecatedCredentials() []SDKCredential {
 	return out
 }
 
-// AllCredentials returns the primary and deprecated credentials as one list.
+// AllCredentials returns all accepted credentials. It is equivalent to PrimaryCredentials; both
+// methods return the full accepted set (accepted keys, including those carrying a future expiry,
+// together with the environment ID).
 func (r *Rotator) AllCredentials() []SDKCredential {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return append(r.primaryCredentials(), r.deprecatedCredentials()...)
-}
-
-// Rotate sets a new primary credential while revoking the previous.
-func (r *Rotator) Rotate(cred SDKCredential) {
-	r.RotateWithGrace(cred, nil)
-}
-
-// GracePeriod represents a grace period (or deprecation period) within which
-// a particular SDK key is still valid, pending revocation.
-type GracePeriod struct {
-	// The SDK key that is being deprecated.
-	key config.SDKKey
-	// When the key will expire.
-	expiry time.Time
-	// The current timestamp.
-	now time.Time
-}
-
-// Expired returns true if the key has already expired.
-func (g *GracePeriod) Expired() bool {
-	return g.now.After(g.expiry)
-}
-
-// NewGracePeriod constructs a new grace period. The current time must be provided in order to
-// determine if the credential is already expired.
-func NewGracePeriod(key config.SDKKey, expiry time.Time, now time.Time) *GracePeriod {
-	return &GracePeriod{key, expiry, now}
-}
-
-// RotateWithGrace sets a new primary credential while deprecating the previous one. When grace is nil
-// the outgoing credential is immediately revoked. It is invalid to specify a grace period for an
-// environment ID. For mobile keys, a non-nil grace period stores the expiry for the outgoing key;
-// the cleanup ticker is responsible for acting on it.
-func (r *Rotator) RotateWithGrace(primary SDKCredential, grace *GracePeriod) {
-	switch primary := primary.(type) {
-	case config.SDKKey:
-		r.updateSDKKey(primary, grace)
-	case config.MobileKey:
-		r.updateMobileKey(primary, grace)
-	case config.EnvironmentID:
-		if grace != nil {
-			panic("programmer error: environment IDs do not support deprecation")
-		}
-		r.updateEnvironmentID(primary)
-	}
-}
-
-func (r *Rotator) updateEnvironmentID(envID config.EnvironmentID) {
-	if envID == r.EnvironmentID() {
-		return
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	previous := r.primaryEnvironmentID
-	r.primaryEnvironmentID = envID
-	r.additions = append(r.additions, envID)
-	if previous.Defined() {
-		r.loggers.Infof("Environment ID %s was rotated, new environment ID is %s", r.primaryEnvironmentID, envID)
-		r.expirations = append(r.expirations, previous)
-	} else {
-		r.loggers.Infof("New environment ID is %s", envID)
-	}
-}
-
-// updateMobileKey sets a new primary mobile key. When grace is nil the outgoing key is
-// immediately revoked; when non-nil its expiry is stored in deprecatedMobileKeys for the
-// cleanup ticker (StepTime) to act on.
-func (r *Rotator) updateMobileKey(mobileKey config.MobileKey, grace *GracePeriod) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if mobileKey == r.primaryMobileKey {
-		return
-	}
-	previous := r.primaryMobileKey
-	r.primaryMobileKey = mobileKey
-	// Keep the accepted-set map (the source of truth for PrimaryCredentials) consistent with the
-	// legacy rotation path.
-	if _, ok := r.acceptedMobileKeys[mobileKey]; !ok {
-		r.acceptedMobileKeys[mobileKey] = &acceptedKeyInfo{}
-	}
-	delete(r.deprecatedMobileKeys, mobileKey)
-	r.additions = append(r.additions, mobileKey)
-	if !previous.Defined() {
-		r.loggers.Infof("New primary mobile key is %s", mobileKey.Masked())
-		return
-	}
-	if grace == nil {
-		delete(r.acceptedMobileKeys, previous)
-		r.expirations = append(r.expirations, previous)
-		r.loggers.Infof("Mobile key %s was rotated, new primary mobile key is %s", previous.Masked(), mobileKey.Masked())
-		return
-	}
-	if grace.Expired() {
-		delete(r.acceptedMobileKeys, previous)
-		r.loggers.Infof("Deprecated mobile key %s already expired at %v; revoking immediately", previous.Masked(), grace.expiry)
-		r.expirations = append(r.expirations, previous)
-		return
-	}
-	r.deprecatedMobileKeys[previous] = grace.expiry
-	r.loggers.Infof("Mobile key %s was marked for deprecation with an expiry at %v, new primary mobile key is %s",
-		previous.Masked(), grace.expiry, mobileKey.Masked())
-}
-
-func (r *Rotator) swapPrimaryKey(newKey config.SDKKey) config.SDKKey {
-	if newKey == r.primarySdkKey {
-		// There's no swap to be done, we already are using this as primary.
-		return ""
-	}
-	previous := r.primarySdkKey
-	r.primarySdkKey = newKey
-	// Keep the accepted-set map (the source of truth for PrimaryCredentials) consistent: the new
-	// primary is accepted and is no longer deprecated, even if it was being phased out before. Mirrors
-	// updateMobileKey for mobile keys.
-	if _, ok := r.acceptedSDKKeys[newKey]; !ok {
-		r.acceptedSDKKeys[newKey] = &acceptedKeyInfo{}
-	}
-	delete(r.deprecatedSdkKeys, newKey)
-	r.additions = append(r.additions, newKey)
-	r.loggers.Infof("New primary SDK key is %s", newKey.Masked())
-
-	return previous
-}
-
-func (r *Rotator) immediatelyRevoke(key config.SDKKey) {
-	if key.Defined() {
-		delete(r.acceptedSDKKeys, key)
-		r.expirations = append(r.expirations, key)
-		r.loggers.Infof("SDK key %s has been immediately revoked", key.Masked())
-	}
-}
-
-func (r *Rotator) updateSDKKey(sdkKey config.SDKKey, grace *GracePeriod) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	// Previous will only be .Defined() if there was a previous primary key.
-	previous := r.swapPrimaryKey(sdkKey)
-
-	// If there's no deprecation notice, then the previous key (if any) needs to be immediately revoked so it doesn't
-	// hang around forever. This case is also true when there is a grace period, but we need to inspect the grace period
-	// in order to find out if immediate revocation is necessary.
-	if grace == nil {
-		r.immediatelyRevoke(previous)
-		return
-	}
-
-	if previousExpiry, ok := r.deprecatedSdkKeys[grace.key]; ok {
-		if previousExpiry != grace.expiry {
-			r.loggers.Warnf("SDK key %s was marked for deprecation with an expiry at %v, but it was previously deprecated with an expiry at %v. The previous expiry will be used. ", grace.key.Masked(), grace.expiry, previousExpiry)
-		}
-		// When a key is deprecated by LD, it will stick around in the deprecated field of the message until something
-		// else is deprecated. This means that if a key is rotated *without* a deprecation period set for the previous key,
-		// then we'll receive that new primary key but the deprecation message will be stale - it'll be referring to the
-		// last time a key was rotated with a deprecation period. We detect this case here (since we already saw the
-		// deprecation message in our map) and ensure the previous key is revoked.
-		r.immediatelyRevoke(previous)
-		return
-	}
-
-	if grace.Expired() {
-		r.loggers.Infof("Deprecated SDK key %s already expired at %v; revoking the previous key immediately", grace.key.Masked(), grace.expiry)
-		r.immediatelyRevoke(previous)
-		return
-	}
-
-	r.loggers.Infof("SDK key %s was marked for deprecation with an expiry at %v", grace.key.Masked(), grace.expiry)
-	r.deprecatedSdkKeys[grace.key] = grace.expiry
-
-	if grace.key != previous {
-		r.loggers.Infof("Deprecated SDK key %s was not previously managed by Relay", grace.key.Masked())
-		r.additions = append(r.additions, grace.key)
-	}
+	return r.primaryCredentials()
 }
 
 func (r *Rotator) expireSDKKey(sdkKey config.SDKKey) {
 	r.loggers.Infof("Deprecated SDK key %s has expired and is no longer valid for authentication", sdkKey.Masked())
-	delete(r.deprecatedSdkKeys, sdkKey)
 	delete(r.acceptedSDKKeys, sdkKey)
 	r.expirations = append(r.expirations, sdkKey)
 }
 
-// expireMobileKey drops a mobile key from both the deprecated grace map and the accepted set, then
-// queues its expiration. Deleting from acceptedMobileKeys is load-bearing: PrimaryCredentials derives
-// from that map, so an expired key would otherwise linger as a primary credential. Mirrors expireSDKKey.
+// expireMobileKey drops a mobile key from the accepted set and queues its expiration.
+// Deleting from acceptedMobileKeys is load-bearing: PrimaryCredentials derives from that map,
+// so an expired key would otherwise linger as an accepted credential. Mirrors expireSDKKey.
 func (r *Rotator) expireMobileKey(mobileKey config.MobileKey) {
 	r.loggers.Infof("Deprecated mobile key %s has expired and is no longer valid for authentication", mobileKey.Masked())
-	delete(r.deprecatedMobileKeys, mobileKey)
 	delete(r.acceptedMobileKeys, mobileKey)
 	r.expirations = append(r.expirations, mobileKey)
 }
 
-// StepTime provides the current time to the Rotator, allowing it to compute the set of additions and expirations
-// for the tracked credentials since the last time this method was called.
+// StepTime provides the current time to the Rotator, allowing it to compute the set of additions and
+// expirations for the tracked credentials since the last time this method was called.
 //
-// It enforces expiry from both expiry mechanisms, for both SDK and mobile keys:
-//   - The legacy grace-period maps (deprecatedSdkKeys / deprecatedMobileKeys), populated by the
-//     RotateWithGrace path, where the expiry lives in the map value.
-//   - The reconcile path, where per-key expiry is stored as data on the accepted entry
-//     (acceptedKeyInfo.expiry); a nil expiry means the key is permanent and is never expired here.
+// It enforces per-key expiry for both SDK and mobile keys: expiry is stored as data on the accepted
+// entry (acceptedKeyInfo.expiry); a nil expiry means the key is permanent and is never expired here.
 //
-// Expiry is strict (now strictly after the expiry timestamp), consistent across all four loops.
+// Expiry is strict (now strictly after the expiry timestamp).
 func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expirations []SDKCredential) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Legacy grace-period deprecations (RotateWithGrace path).
-	for key, expiry := range r.deprecatedSdkKeys {
-		if now.After(expiry) {
-			r.expireSDKKey(key)
-		}
-	}
-	for key, expiry := range r.deprecatedMobileKeys {
-		if now.After(expiry) {
-			r.expireMobileKey(key)
-		}
-	}
-
-	// Reconcile-path per-key expiry, stored on the accepted entry. The anchor and primary mobile key
-	// carry a nil expiry, so this never drops them.
 	for key, info := range r.acceptedSDKKeys {
 		if info.expiry != nil && now.After(*info.expiry) {
 			r.expireSDKKey(key)
@@ -447,22 +228,18 @@ type reconcilableKey interface {
 
 // reconcileAcceptedKeys diffs the desired keys against the currently-accepted ones (SDK or mobile,
 // same algorithm): a desired key not yet accepted is recorded and queued as an addition; an accepted
-// key no longer desired is dropped and queued as an expiration. Either way the key is cleared from the
-// deprecated map — a key the set accepts is not deprecated, and a key it revokes is gone. Per-key
-// expiry is stored as data on the accepted entry; the cleanup ticker is what later acts on it. The
-// caller must hold the write lock.
+// key no longer desired is dropped and queued as an expiration. Per-key expiry is stored as data on
+// the accepted entry; the cleanup ticker is what later acts on it. The caller must hold the write lock.
 func reconcileAcceptedKeys[K reconcilableKey](
 	desired map[K]*time.Time,
 	accepted map[K]*acceptedKeyInfo,
-	deprecated map[K]time.Time,
 	additions *[]SDKCredential,
 	expirations *[]SDKCredential,
 	loggers ldlog.Loggers,
 	kind string,
 ) {
 	// First pass: walk every key the set wants us to accept. If we already accept it, just refresh
-	// its expiry; if it's new, start accepting it and queue it as an addition. Either way, a desired
-	// key can't also be deprecated, so clear any stale deprecation for it.
+	// its expiry; if it's new, start accepting it and queue it as an addition.
 	for key, expiry := range desired {
 		if info, ok := accepted[key]; ok {
 			info.expiry = expiry
@@ -471,17 +248,15 @@ func reconcileAcceptedKeys[K reconcilableKey](
 			*additions = append(*additions, key)
 			loggers.Infof("%s %s is now accepted", kind, key.Masked())
 		}
-		delete(deprecated, key)
 	}
 	// Second pass: walk every key we currently accept and drop the ones the set no longer wants.
 	// Keys still desired were handled above, so skip them; the rest are revoked outright (removed
-	// from both maps) and queued as expirations.
+	// from the map) and queued as expirations.
 	for key := range accepted {
 		if _, ok := desired[key]; ok {
 			continue
 		}
 		delete(accepted, key)
-		delete(deprecated, key)
 		*expirations = append(*expirations, key)
 		loggers.Infof("%s %s is no longer accepted and has been revoked", kind, key.Masked())
 	}
@@ -499,7 +274,7 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 		desired[key] = expiry
 	}
 	desired[anchor] = nil
-	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, r.deprecatedSdkKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
+	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
 	r.primarySdkKey = anchor
 }
 
@@ -517,7 +292,7 @@ func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
 	if set.primaryMobileKey.Defined() {
 		desired[set.primaryMobileKey] = nil
 	}
-	reconcileAcceptedKeys(desired, r.acceptedMobileKeys, r.deprecatedMobileKeys, &r.additions, &r.expirations, r.loggers, "Mobile key")
+	reconcileAcceptedKeys(desired, r.acceptedMobileKeys, &r.additions, &r.expirations, r.loggers, "Mobile key")
 	r.primaryMobileKey = set.primaryMobileKey
 }
 

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -59,7 +59,7 @@ func TestReconcileAnchorOnly(t *testing.T) {
 	assert.ElementsMatch(t, []SDKCredential{anchor}, additions)
 	assert.Empty(t, expirations)
 	assert.Equal(t, anchor, r.SDKKey())
-	assert.ElementsMatch(t, []SDKCredential{anchor}, r.PrimaryCredentials())
+	assert.ElementsMatch(t, []SDKCredential{anchor}, r.AllCredentials())
 	assert.Empty(t, r.DeprecatedCredentials())
 }
 
@@ -77,7 +77,7 @@ func TestReconcileMultipleSDKKeys(t *testing.T) {
 	assert.ElementsMatch(t, []SDKCredential{anchor, other}, additions)
 	assert.Empty(t, expirations)
 	assert.Equal(t, anchor, r.SDKKey())
-	assert.ElementsMatch(t, []SDKCredential{anchor, other}, r.PrimaryCredentials())
+	assert.ElementsMatch(t, []SDKCredential{anchor, other}, r.AllCredentials())
 	assert.Empty(t, r.DeprecatedCredentials())
 }
 
@@ -95,7 +95,7 @@ func TestReconcileMultipleMobileKeys(t *testing.T) {
 	// Every mobile key is accepted; the designated one is the primary.
 	assert.ElementsMatch(t, []SDKCredential{anchor, mob1, mob2}, additions)
 	assert.Equal(t, mob1, r.MobileKey())
-	assert.ElementsMatch(t, []SDKCredential{anchor, mob1, mob2}, r.PrimaryCredentials())
+	assert.ElementsMatch(t, []SDKCredential{anchor, mob1, mob2}, r.AllCredentials())
 }
 
 func TestReconcileRevokesOmittedKeys(t *testing.T) {
@@ -115,12 +115,12 @@ func TestReconcileRevokesOmittedKeys(t *testing.T) {
 
 	assert.Empty(t, additions)
 	assert.ElementsMatch(t, []SDKCredential{other, mob}, expirations)
-	assert.ElementsMatch(t, []SDKCredential{anchor}, r.PrimaryCredentials())
+	assert.ElementsMatch(t, []SDKCredential{anchor}, r.AllCredentials())
 }
 
 func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
 	// Reconcile stores per-key expiry as data on the accepted entry; before that expiry passes, an
-	// expiring key is still accepted (it authenticates and appears in PrimaryCredentials) while also
+	// expiring key is still accepted (it authenticates and appears in AllCredentials) while also
 	// being reported as deprecated — accepted, but on its way out. The cleanup ticker (StepTime) only
 	// drops it once the expiry elapses — see TestReconcileExpiringKeysAreEvictedByStepTime.
 	r := newTestRotator()
@@ -142,7 +142,7 @@ func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
 	assert.ElementsMatch(t, []SDKCredential{anchor, expiringSDK, mob, expiringMobile}, additions)
 	assert.Empty(t, expirations)
 	// Every key is accepted (still authenticates)...
-	assert.ElementsMatch(t, []SDKCredential{anchor, expiringSDK, mob, expiringMobile}, r.PrimaryCredentials())
+	assert.ElementsMatch(t, []SDKCredential{anchor, expiringSDK, mob, expiringMobile}, r.AllCredentials())
 	// ...and the non-anchor SDK key carrying an expiry is also reported as deprecated (being phased
 	// out). The expiring mobile key is not: there is no expiringMobileKey status field, so the reconcile
 	// path treats it as accepted-only.
@@ -151,7 +151,7 @@ func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
 
 func TestReconcilePrimaryMobileKeyIsAlwaysAccepted(t *testing.T) {
 	// Defensive: even if the designated primary mobile key is also listed with a past expiry, it must
-	// stay accepted (mirroring the SDK anchor), so PrimaryCredentials never reports a torn-down key.
+	// stay accepted (mirroring the SDK anchor), so AllCredentials never reports a torn-down key.
 	r := newTestRotator()
 	anchor := config.SDKKey("anchor")
 	mob := config.MobileKey("mob")
@@ -165,7 +165,7 @@ func TestReconcilePrimaryMobileKeyIsAlwaysAccepted(t *testing.T) {
 	r.StepTime(now)
 
 	assert.Equal(t, mob, r.MobileKey())
-	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(mob))
+	assert.Contains(t, r.AllCredentials(), SDKCredential(mob))
 	_, accepted := r.acceptedMobileKeys[mob]
 	assert.True(t, accepted, "the primary mobile key must remain in the accepted set")
 }
@@ -202,9 +202,9 @@ func TestReconcileExpiringKeysAreEvictedByStepTime(t *testing.T) {
 	additions, expirations = r.StepTime(expiry.Add(1 * time.Millisecond))
 	assert.Empty(t, additions)
 	assert.ElementsMatch(t, []SDKCredential{expiringSDK, expiringMobile}, expirations)
-	assert.ElementsMatch(t, []SDKCredential{anchor, mob}, r.PrimaryCredentials())
-	assert.NotContains(t, r.PrimaryCredentials(), SDKCredential(expiringSDK))
-	assert.NotContains(t, r.PrimaryCredentials(), SDKCredential(expiringMobile))
+	assert.ElementsMatch(t, []SDKCredential{anchor, mob}, r.AllCredentials())
+	assert.NotContains(t, r.AllCredentials(), SDKCredential(expiringSDK))
+	assert.NotContains(t, r.AllCredentials(), SDKCredential(expiringMobile))
 }
 
 func TestReconcileAlreadyExpiredKeyIsIgnoredOnAdd(t *testing.T) {
@@ -226,7 +226,7 @@ func TestReconcileAlreadyExpiredKeyIsIgnoredOnAdd(t *testing.T) {
 	// Only the anchor is added; the stale key is never accepted.
 	assert.ElementsMatch(t, []SDKCredential{anchor}, additions)
 	assert.Empty(t, expirations)
-	assert.ElementsMatch(t, []SDKCredential{anchor}, r.PrimaryCredentials())
+	assert.ElementsMatch(t, []SDKCredential{anchor}, r.AllCredentials())
 }
 
 func TestReconcileDeExpiryRestoresKey(t *testing.T) {
@@ -257,11 +257,11 @@ func TestReconcileDeExpiryRestoresKey(t *testing.T) {
 	r.StepTime(now)
 
 	// The key is still accepted and permanent: no longer deprecated, not evicted by StepTime.
-	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(key))
+	assert.Contains(t, r.AllCredentials(), SDKCredential(key))
 	assert.Empty(t, r.DeprecatedCredentials())
 
 	additions, expirations := r.StepTime(expiry.Add(1 * time.Millisecond))
 	assert.Empty(t, additions)
 	assert.Empty(t, expirations)
-	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(key))
+	assert.Contains(t, r.AllCredentials(), SDKCredential(key))
 }

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -1,7 +1,6 @@
 package credential
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -19,281 +18,6 @@ func TestNewRotator(t *testing.T) {
 	mockLog := ldlogtest.NewMockLog()
 	rotator := NewRotator(mockLog.Loggers)
 	assert.NotNil(t, rotator)
-}
-
-func TestImmediateKeyExpiration(t *testing.T) {
-	kinds := []struct {
-		name   string
-		keys   []SDKCredential
-		getKey func(*Rotator) SDKCredential
-	}{
-		{
-			name:   "sdk keys",
-			keys:   []SDKCredential{config.SDKKey("key1"), config.SDKKey("key2"), config.SDKKey("key3")},
-			getKey: func(r *Rotator) SDKCredential { return r.SDKKey() },
-		},
-		{
-			name:   "mobile keys",
-			keys:   []SDKCredential{config.MobileKey("key1"), config.MobileKey("key2"), config.MobileKey("key3")},
-			getKey: func(r *Rotator) SDKCredential { return r.MobileKey() },
-		},
-		{
-			name:   "environment IDs",
-			keys:   []SDKCredential{config.EnvironmentID("id1"), config.EnvironmentID("id2"), config.EnvironmentID("id3")},
-			getKey: func(r *Rotator) SDKCredential { return r.EnvironmentID() },
-		},
-	}
-
-	for _, c := range kinds {
-		t.Run(c.name, func(t *testing.T) {
-			mockLog := ldlogtest.NewMockLog()
-			rotator := NewRotator(mockLog.Loggers)
-
-			// The first rotation shouldn't trigger any expirations because there was no previous key.
-			rotator.Rotate(c.keys[0])
-			additions, _ := rotator.StepTime(time.Now())
-			assert.ElementsMatch(t, c.keys[0:1], additions)
-			assert.Equal(t, c.keys[0], c.getKey(rotator))
-
-			// The second rotation should trigger a deprecation of key1.
-			rotator.Rotate(c.keys[1])
-			additions, expirations := rotator.StepTime(time.Now())
-			assert.ElementsMatch(t, c.keys[1:2], additions)
-			assert.ElementsMatch(t, c.keys[0:1], expirations)
-			assert.Equal(t, c.keys[1], c.getKey(rotator))
-
-			// The third rotation should trigger a deprecation of key2.
-			rotator.Rotate(c.keys[2])
-			additions, expirations = rotator.StepTime(time.Now())
-			assert.ElementsMatch(t, c.keys[2:3], additions)
-			assert.ElementsMatch(t, c.keys[1:2], expirations)
-			assert.Equal(t, c.keys[2], c.getKey(rotator))
-		})
-	}
-}
-
-func TestManyImmediateKeyExpirations(t *testing.T) {
-
-	kinds := []struct {
-		name    string
-		makeKey func(string) SDKCredential
-		getKey  func(*Rotator) SDKCredential
-	}{
-		{
-			name:    "sdk keys",
-			makeKey: func(s string) SDKCredential { return config.SDKKey(s) },
-			getKey:  func(r *Rotator) SDKCredential { return r.SDKKey() },
-		},
-		{
-			name:    "mobile keys",
-			makeKey: func(s string) SDKCredential { return config.MobileKey(s) },
-			getKey:  func(r *Rotator) SDKCredential { return r.MobileKey() },
-		},
-		{
-			name:    "environment IDs",
-			makeKey: func(s string) SDKCredential { return config.EnvironmentID(s) },
-			getKey:  func(r *Rotator) SDKCredential { return r.EnvironmentID() },
-		},
-	}
-
-	for _, c := range kinds {
-		t.Run(c.name, func(t *testing.T) {
-			mockLog := ldlogtest.NewMockLog()
-			rotator := NewRotator(mockLog.Loggers)
-
-			const numKeys = 100
-			for i := 0; i < numKeys; i++ {
-				key := c.makeKey(fmt.Sprintf("key%v", i))
-				rotator.Rotate(key)
-			}
-
-			assert.Equal(t, c.makeKey(fmt.Sprintf("key%v", numKeys-1)), c.getKey(rotator))
-
-			additions, expirations := rotator.StepTime(time.Now())
-			assert.Len(t, additions, numKeys)
-			assert.Len(t, expirations, numKeys-1) // because the last key is still active
-		})
-	}
-}
-
-func TestImmediateSDKKeyDeprecationEvenIfGracePeriodIsPresent(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
-
-	key0 := config.SDKKey("key0")
-	key1 := config.SDKKey("key1")
-	key2 := config.SDKKey("key2")
-
-	rotator.Initialize([]SDKCredential{key0})
-
-	start := time.Unix(1000, 0)
-	halftime := start.Add(30 * time.Minute)
-	expiry := start.Add(1 * time.Hour)
-
-	rotator.RotateWithGrace(key1, NewGracePeriod(key0, expiry, start))
-
-	additions, expirations := rotator.StepTime(halftime)
-	assert.ElementsMatch(t, []SDKCredential{key1}, additions)
-	assert.Empty(t, expirations)
-
-	// The deprecated key0 given here can be thought of as "stale" or otherwise already-seen by the rotator.
-	// In this case, it should be effectively ignored but the new key2 should still trigger rotation of the previous
-	// primary key.
-	rotator.RotateWithGrace(key2, NewGracePeriod(key0, expiry, halftime))
-
-	additions, expirations = rotator.StepTime(halftime)
-	assert.ElementsMatch(t, []SDKCredential{key2}, additions)
-	assert.ElementsMatch(t, []SDKCredential{key1}, expirations)
-
-	additions, expirations = rotator.StepTime(expiry.Add(1 * time.Millisecond))
-	assert.Empty(t, additions)
-	assert.ElementsMatch(t, []SDKCredential{key0}, expirations)
-}
-
-func TestSDKKeyDeprecation(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
-
-	const (
-		key1 = config.SDKKey("key1")
-		key2 = config.SDKKey("key2")
-	)
-
-	start := time.Unix(10000, 0)
-
-	halfTime := start.Add(30 * time.Second)
-	deprecationTime := start.Add(1 * time.Minute)
-
-	rotator.Initialize([]SDKCredential{key1})
-
-	rotator.RotateWithGrace(key2, NewGracePeriod(key1, deprecationTime, halfTime))
-	additions, expirations := rotator.StepTime(halfTime)
-	assert.ElementsMatch(t, []SDKCredential{key2}, additions)
-	assert.Empty(t, expirations)
-
-	additions, expirations = rotator.StepTime(deprecationTime)
-	assert.Empty(t, additions)
-	assert.Empty(t, expirations)
-
-	additions, expirations = rotator.StepTime(deprecationTime.Add(1 * time.Millisecond))
-	assert.Empty(t, additions)
-	assert.ElementsMatch(t, []SDKCredential{key1}, expirations)
-}
-
-func TestManyConcurrentSDKKeyDeprecation(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
-
-	makeKey := func(i int) config.SDKKey {
-		return config.SDKKey(fmt.Sprintf("key%v", i))
-	}
-
-	rotator.Initialize([]SDKCredential{config.SDKKey("key0")})
-
-	const numKeys = 250
-	now := time.Unix(10000, 0)
-	expiryTime := now.Add(1 * time.Hour)
-
-	var keysDeprecated []SDKCredential
-	var keysAdded []SDKCredential
-
-	for i := 0; i < numKeys; i++ {
-		previousKey := makeKey(i)
-		nextKey := makeKey(i + 1)
-
-		keysDeprecated = append(keysDeprecated, previousKey)
-		keysAdded = append(keysAdded, nextKey)
-
-		rotator.RotateWithGrace(nextKey, NewGracePeriod(previousKey, expiryTime, now))
-	}
-
-	// The last key added should be the current primary key.
-	assert.Equal(t, keysAdded[len(keysAdded)-1], rotator.SDKKey())
-
-	// Until and including the exact expiry timestamp, there should be no expirations.
-	additions, expirations := rotator.StepTime(expiryTime)
-	assert.ElementsMatch(t, keysAdded, additions)
-	assert.Empty(t, expirations)
-
-	// One moment after the expiry time, we should now have a batch of expirations.
-	additions, expirations = rotator.StepTime(expiryTime.Add(1 * time.Millisecond))
-	assert.Empty(t, additions)
-	assert.ElementsMatch(t, keysDeprecated, expirations)
-}
-
-func TestSDKKeyExpiredInThePastIsNotAdded(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
-
-	primaryKey := config.SDKKey("primary")
-	obsoleteKey := config.SDKKey("obsolete")
-	obsoleteExpiry := time.Unix(1000000, 0)
-	now := obsoleteExpiry.Add(1 * time.Hour)
-
-	rotator.RotateWithGrace(primaryKey, NewGracePeriod(obsoleteKey, obsoleteExpiry, now))
-
-	additions, expirations := rotator.StepTime(now)
-	assert.ElementsMatch(t, []SDKCredential{primaryKey}, additions)
-	assert.Empty(t, expirations)
-}
-
-func TestSDKKeyDeprecationWithAlreadyExpiredGraceRevokesPreviousPrimary(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
-
-	key1 := config.SDKKey("key1")
-	key2 := config.SDKKey("key2")
-
-	expiry := time.Unix(10000, 0)
-	now := expiry.Add(1 * time.Hour) // now is after the grace period's expiry
-
-	rotator.Initialize([]SDKCredential{key1})
-
-	// Rotate key1 -> key2, but the deprecation grace for the outgoing key1 has already elapsed.
-	// key2 becomes primary; key1 must be revoked immediately rather than lingering forever as an
-	// accepted-but-untracked key. (This mirrors the equivalent mobile-key behavior.)
-	rotator.RotateWithGrace(key2, NewGracePeriod(key1, expiry, now))
-
-	assert.Equal(t, key2, rotator.SDKKey())
-
-	additions, expirations := rotator.StepTime(now)
-	assert.ElementsMatch(t, []SDKCredential{key2}, additions)
-	assert.ElementsMatch(t, []SDKCredential{key1}, expirations)
-	assert.Empty(t, rotator.DeprecatedCredentials())
-}
-
-func TestReAnchoringDeprecatedSDKKeyRemovesItFromDeprecatedSet(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
-
-	key1 := config.SDKKey("key1")
-	key2 := config.SDKKey("key2")
-
-	start := time.Unix(10000, 0)
-	expiry := start.Add(1 * time.Hour)
-
-	rotator.Initialize([]SDKCredential{key1})
-
-	// Rotate key1 -> key2 with grace; key1 enters the deprecated set.
-	rotator.RotateWithGrace(key2, NewGracePeriod(key1, expiry, start))
-	rotator.StepTime(start)
-	assert.ElementsMatch(t, []SDKCredential{key1}, rotator.DeprecatedCredentials())
-
-	// Re-anchor key2 -> key1 before key1's grace expires. key1 must be promoted out of the
-	// deprecated set; otherwise the cleanup ticker would later expire the active primary.
-	rotator.Rotate(key1)
-	assert.Equal(t, key1, rotator.SDKKey())
-	assert.Empty(t, rotator.DeprecatedCredentials())
-
-	additions, expirations := rotator.StepTime(start)
-	assert.ElementsMatch(t, []SDKCredential{key1}, additions)
-	assert.ElementsMatch(t, []SDKCredential{key2}, expirations)
-
-	// Well past the original grace expiry, key1 (the active primary) must NOT be expired.
-	additions, expirations = rotator.StepTime(expiry.Add(1 * time.Hour))
-	assert.Empty(t, additions)
-	assert.Empty(t, expirations)
-	assert.Equal(t, key1, rotator.SDKKey())
 }
 
 func TestInitializePopulatesAcceptedSets(t *testing.T) {
@@ -322,152 +46,6 @@ func TestInitializePopulatesAcceptedSets(t *testing.T) {
 	assert.Equal(t, sdkKey, rotator.SDKKey())
 	assert.Equal(t, mobileKey, rotator.MobileKey())
 	assert.Equal(t, envID, rotator.EnvironmentID())
-}
-
-func TestRotateWithGraceMobileKey(t *testing.T) {
-	t.Run("does not panic with non-nil grace period", func(t *testing.T) {
-		mockLog := ldlogtest.NewMockLog()
-		rotator := NewRotator(mockLog.Loggers)
-
-		mob1 := config.MobileKey("mob1")
-		mob2 := config.MobileKey("mob2")
-
-		start := time.Unix(10000, 0)
-		expiry := start.Add(1 * time.Hour)
-
-		rotator.Initialize([]SDKCredential{mob1})
-
-		// GracePeriod.key is SDK-key typed; pass a zero value since mobile-key rotation
-		// does not use that identifier field.
-		assert.NotPanics(t, func() {
-			rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, start))
-		})
-
-		assert.Equal(t, mob2, rotator.MobileKey())
-
-		// mob2 is a new addition; mob1 is in the deprecated set (not yet expired),
-		// so it should not appear as an expiration here.
-		additions, expirations := rotator.StepTime(start)
-		assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
-		assert.Empty(t, expirations)
-
-		// One moment past the grace period, the cleanup ticker expires mob1 and evicts it from the
-		// accepted set entirely.
-		additions, expirations = rotator.StepTime(expiry.Add(1 * time.Millisecond))
-		assert.Empty(t, additions)
-		assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
-		assert.NotContains(t, rotator.PrimaryCredentials(), SDKCredential(mob1))
-		assert.NotContains(t, rotator.DeprecatedCredentials(), SDKCredential(mob1))
-	})
-
-	t.Run("immediately revokes outgoing key when grace period is already expired", func(t *testing.T) {
-		mockLog := ldlogtest.NewMockLog()
-		rotator := NewRotator(mockLog.Loggers)
-
-		mob1 := config.MobileKey("mob1")
-		mob2 := config.MobileKey("mob2")
-
-		expiry := time.Unix(10000, 0)
-		now := expiry.Add(1 * time.Hour) // now is after expiry
-
-		rotator.Initialize([]SDKCredential{mob1})
-
-		rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, now))
-
-		assert.Equal(t, mob2, rotator.MobileKey())
-
-		additions, expirations := rotator.StepTime(now)
-		assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
-		assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
-		// The immediately-revoked key must leave the accepted set, not linger in PrimaryCredentials.
-		assert.NotContains(t, rotator.PrimaryCredentials(), SDKCredential(mob1))
-	})
-
-	t.Run("immediately revokes outgoing key when grace is nil", func(t *testing.T) {
-		mockLog := ldlogtest.NewMockLog()
-		rotator := NewRotator(mockLog.Loggers)
-
-		mob1 := config.MobileKey("mob1")
-		mob2 := config.MobileKey("mob2")
-
-		rotator.Initialize([]SDKCredential{mob1})
-		rotator.RotateWithGrace(mob2, nil)
-
-		assert.Equal(t, mob2, rotator.MobileKey())
-
-		additions, expirations := rotator.StepTime(time.Now())
-		assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
-		assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
-		// The immediately-revoked key must leave the accepted set, not linger in PrimaryCredentials.
-		assert.NotContains(t, rotator.PrimaryCredentials(), SDKCredential(mob1))
-	})
-
-	t.Run("re-promoting a deprecated key removes it from the deprecated set", func(t *testing.T) {
-		mockLog := ldlogtest.NewMockLog()
-		rotator := NewRotator(mockLog.Loggers)
-
-		mob1 := config.MobileKey("mob1")
-		mob2 := config.MobileKey("mob2")
-
-		start := time.Unix(10000, 0)
-		expiry := start.Add(1 * time.Hour)
-
-		rotator.Initialize([]SDKCredential{mob1})
-
-		// Rotate mob1 → mob2 with grace; mob1 enters deprecatedMobileKeys.
-		rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, start))
-		rotator.StepTime(start)
-
-		// Rotate back mob2 → mob1; mob1 should be promoted out of the deprecated set.
-		rotator.RotateWithGrace(mob1, nil)
-
-		assert.Equal(t, mob1, rotator.MobileKey())
-
-		// mob1 should appear only as an addition, not also as an expiration.
-		additions, expirations := rotator.StepTime(start)
-		assert.ElementsMatch(t, []SDKCredential{mob1}, additions)
-		assert.ElementsMatch(t, []SDKCredential{mob2}, expirations)
-	})
-}
-
-func TestRotateSDKKeyRePromoteClearsDeprecation(t *testing.T) {
-	// Re-promoting a deprecated SDK key back to primary must clear its deprecated mark, so
-	// PrimaryCredentials lists it (mirrors the mobile re-promote behavior).
-	rotator := newTestRotator()
-	key1 := config.SDKKey("key1")
-	key2 := config.SDKKey("key2")
-	start := time.Unix(10000, 0)
-
-	rotator.Initialize([]SDKCredential{key1})
-	rotator.RotateWithGrace(key2, NewGracePeriod(key1, start.Add(time.Hour), start)) // deprecate key1
-	rotator.StepTime(start)
-	assert.ElementsMatch(t, []SDKCredential{key1}, rotator.DeprecatedCredentials())
-
-	rotator.RotateWithGrace(key1, nil) // re-promote key1
-	rotator.StepTime(start)
-
-	assert.Equal(t, key1, rotator.SDKKey())
-	assert.Contains(t, rotator.PrimaryCredentials(), SDKCredential(key1))
-	assert.NotContains(t, rotator.DeprecatedCredentials(), SDKCredential(key1))
-}
-
-func TestRotateSDKKeyWithExpiredGraceRevokesPrevious(t *testing.T) {
-	// A legacy SDK rotation whose grace period is already expired must revoke the swapped-out key,
-	// not leave it enabled alongside the new anchor (mirrors updateMobileKey).
-	rotator := newTestRotator()
-	key1 := config.SDKKey("key1")
-	key2 := config.SDKKey("key2")
-	expiry := time.Unix(10000, 0)
-	now := expiry.Add(time.Hour) // now is after expiry
-
-	rotator.Initialize([]SDKCredential{key1})
-	rotator.RotateWithGrace(key2, NewGracePeriod(key1, expiry, now))
-
-	assert.Equal(t, key2, rotator.SDKKey())
-	additions, expirations := rotator.StepTime(now)
-	assert.ElementsMatch(t, []SDKCredential{key2}, additions)
-	assert.ElementsMatch(t, []SDKCredential{key1}, expirations)
-	assert.NotContains(t, rotator.PrimaryCredentials(), SDKCredential(key1))
 }
 
 func TestReconcileAnchorOnly(t *testing.T) {
@@ -592,33 +170,10 @@ func TestReconcilePrimaryMobileKeyIsAlwaysAccepted(t *testing.T) {
 	assert.True(t, accepted, "the primary mobile key must remain in the accepted set")
 }
 
-func TestReconcileClearsStaleDeprecationForAcceptedKey(t *testing.T) {
-	// A key left in the deprecated set by the legacy rotation path must be treated as fully accepted
-	// once a reconcile includes it, not silently skipped by PrimaryCredentials.
-	r := newTestRotator()
-	old := config.SDKKey("old")
-	anchor := config.SDKKey("anchor")
-	now := time.Unix(1000, 0)
-
-	r.Initialize([]SDKCredential{old})
-	r.RotateWithGrace(anchor, NewGracePeriod(old, now.Add(time.Hour), now)) // deprecate `old` with grace
-	r.StepTime(now)
-	require.ElementsMatch(t, []SDKCredential{old}, r.DeprecatedCredentials())
-
-	// Reconcile to a set that fully accepts both keys.
-	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor).WithSDKKey(old)), now)
-	r.StepTime(now)
-
-	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(old))
-	assert.Empty(t, r.DeprecatedCredentials())
-}
-
 func TestReconcileExpiringKeysAreEvictedByStepTime(t *testing.T) {
 	// End-to-end on the reconcile path: a reconcile records per-key expiry as data on the accepted
 	// entry, and the cleanup ticker (StepTime) later drops both the expiring SDK key and the expiring
-	// mobile key once their expiry elapses — without ever passing through the legacy deprecated maps.
-	// The anchor and primary mobile key carry no expiry and survive.
+	// mobile key once their expiry elapses. The anchor and primary mobile key carry no expiry and survive.
 	r := newTestRotator()
 	anchor := config.SDKKey("anchor")
 	expiringSDK := config.SDKKey("expiring-sdk")
@@ -652,120 +207,61 @@ func TestReconcileExpiringKeysAreEvictedByStepTime(t *testing.T) {
 	assert.NotContains(t, r.PrimaryCredentials(), SDKCredential(expiringMobile))
 }
 
-func TestMobileKeyDeprecation(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
+func TestReconcileAlreadyExpiredKeyIsIgnoredOnAdd(t *testing.T) {
+	// An entry in the reconcile payload whose expiry is already in the past is treated as absent —
+	// the reconcile path filters it before calling reconcileAcceptedKeys, so it is never added.
+	r := newTestRotator()
+	anchor := config.SDKKey("anchor")
+	staleKey := config.SDKKey("stale")
+	now := time.Unix(2000, 0)
+	alreadyExpired := now.Add(-time.Hour)
 
-	const (
-		mob1 = config.MobileKey("mob1")
-		mob2 = config.MobileKey("mob2")
-	)
+	r.Reconcile(
+		mustBuild(t, NewAcceptedSetBuilder().
+			WithPrimarySDKKey(anchor).
+			WithExpiringSDKKey(staleKey, alreadyExpired)),
+		now)
+	additions, expirations := r.StepTime(now)
 
-	start := time.Unix(10000, 0)
-	halfTime := start.Add(30 * time.Second)
-	deprecationTime := start.Add(1 * time.Minute)
-
-	rotator.Initialize([]SDKCredential{mob1})
-
-	rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), deprecationTime, halfTime))
-	additions, expirations := rotator.StepTime(halfTime)
-	assert.ElementsMatch(t, []SDKCredential{mob2}, additions)
+	// Only the anchor is added; the stale key is never accepted.
+	assert.ElementsMatch(t, []SDKCredential{anchor}, additions)
 	assert.Empty(t, expirations)
-
-	// At the exact expiry, not yet expired.
-	additions, expirations = rotator.StepTime(deprecationTime)
-	assert.Empty(t, additions)
-	assert.Empty(t, expirations)
-
-	// One moment past the expiry: mob1 is expired.
-	additions, expirations = rotator.StepTime(deprecationTime.Add(1 * time.Millisecond))
-	assert.Empty(t, additions)
-	assert.ElementsMatch(t, []SDKCredential{mob1}, expirations)
+	assert.ElementsMatch(t, []SDKCredential{anchor}, r.PrimaryCredentials())
 }
 
-func TestManyConcurrentMobileKeyDeprecation(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
+func TestReconcileDeExpiryRestoresKey(t *testing.T) {
+	// When a key was accepted with a future expiry and a subsequent reconcile removes that expiry
+	// (de-expiry), the key becomes permanent: the cleanup ticker will no longer drop it, and it is
+	// no longer reported as deprecated.
+	r := newTestRotator()
+	anchor := config.SDKKey("anchor")
+	key := config.SDKKey("other")
+	now := time.Unix(1000, 0)
+	expiry := now.Add(time.Hour)
 
-	makeKey := func(i int) config.MobileKey {
-		return config.MobileKey(fmt.Sprintf("mob%v", i))
-	}
+	// First reconcile: key is accepted with a future expiry.
+	r.Reconcile(
+		mustBuild(t, NewAcceptedSetBuilder().
+			WithPrimarySDKKey(anchor).
+			WithExpiringSDKKey(key, expiry)),
+		now)
+	r.StepTime(now)
+	require.ElementsMatch(t, []SDKCredential{key}, r.DeprecatedCredentials())
 
-	rotator.Initialize([]SDKCredential{makeKey(0)})
+	// Second reconcile: same key, no expiry (de-expiry).
+	r.Reconcile(
+		mustBuild(t, NewAcceptedSetBuilder().
+			WithPrimarySDKKey(anchor).
+			WithSDKKey(key)),
+		now)
+	r.StepTime(now)
 
-	const numKeys = 50
-	now := time.Unix(10000, 0)
-	expiryTime := now.Add(1 * time.Hour)
+	// The key is still accepted and permanent: no longer deprecated, not evicted by StepTime.
+	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(key))
+	assert.Empty(t, r.DeprecatedCredentials())
 
-	var keysDeprecated []SDKCredential
-	var keysAdded []SDKCredential
-
-	for i := 0; i < numKeys; i++ {
-		nextKey := makeKey(i + 1)
-		keysDeprecated = append(keysDeprecated, makeKey(i))
-		keysAdded = append(keysAdded, nextKey)
-		rotator.RotateWithGrace(nextKey, NewGracePeriod(config.SDKKey(""), expiryTime, now))
-	}
-
-	assert.Equal(t, keysAdded[len(keysAdded)-1], rotator.MobileKey())
-
-	// Until and including the exact expiry timestamp, no expirations.
-	additions, expirations := rotator.StepTime(expiryTime)
-	assert.ElementsMatch(t, keysAdded, additions)
+	additions, expirations := r.StepTime(expiry.Add(1 * time.Millisecond))
+	assert.Empty(t, additions)
 	assert.Empty(t, expirations)
-
-	// One moment after the expiry time: batch of expirations.
-	additions, expirations = rotator.StepTime(expiryTime.Add(1 * time.Millisecond))
-	assert.Empty(t, additions)
-	assert.ElementsMatch(t, keysDeprecated, expirations)
-}
-
-func TestMixedSDKAndMobileKeyExpiry(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
-
-	sdk1 := config.SDKKey("sdk1")
-	sdk2 := config.SDKKey("sdk2")
-	mob1 := config.MobileKey("mob1")
-	mob2 := config.MobileKey("mob2")
-
-	now := time.Unix(10000, 0)
-	expiry := now.Add(1 * time.Hour)
-
-	rotator.Initialize([]SDKCredential{sdk1, mob1})
-
-	rotator.RotateWithGrace(sdk2, NewGracePeriod(sdk1, expiry, now))
-	rotator.StepTime(now)
-
-	rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, now))
-	rotator.StepTime(now)
-
-	// Both sdk1 and mob1 should expire at the same tick.
-	additions, expirations := rotator.StepTime(expiry.Add(1 * time.Millisecond))
-	assert.Empty(t, additions)
-	assert.ElementsMatch(t, []SDKCredential{sdk1, mob1}, expirations)
-}
-
-func TestDeprecatedCredentialsIncludesMobileKeys(t *testing.T) {
-	mockLog := ldlogtest.NewMockLog()
-	rotator := NewRotator(mockLog.Loggers)
-
-	sdk1 := config.SDKKey("sdk1")
-	sdk2 := config.SDKKey("sdk2")
-	mob1 := config.MobileKey("mob1")
-	mob2 := config.MobileKey("mob2")
-
-	now := time.Unix(10000, 0)
-	expiry := now.Add(1 * time.Hour)
-
-	rotator.Initialize([]SDKCredential{sdk1, mob1})
-
-	rotator.RotateWithGrace(sdk2, NewGracePeriod(sdk1, expiry, now))
-	rotator.StepTime(now)
-
-	rotator.RotateWithGrace(mob2, NewGracePeriod(config.SDKKey(""), expiry, now))
-	rotator.StepTime(now)
-
-	deprecated := rotator.DeprecatedCredentials()
-	assert.ElementsMatch(t, []SDKCredential{sdk1, mob1}, deprecated)
+	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(key))
 }

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -625,7 +625,7 @@ func (c *envContextImpl) triggerCredentialChanges(now time.Time) {
 }
 
 func (c *envContextImpl) GetCredentials() []credential.SDKCredential {
-	return c.keyRotator.PrimaryCredentials()
+	return c.keyRotator.AllCredentials()
 }
 
 func (c *envContextImpl) GetSDKKey() config.SDKKey {

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -332,45 +332,6 @@ func TestChangeSDKKey(t *testing.T) {
 
 }
 
-// TestMobileKeyGraceExpiry drives a deprecated mobile key (legacy RotateWithGrace path) to expiry
-// through the cleanup ticker (triggerCredentialChanges → StepTime), mirroring the SDK-key flow in
-// TestChangeSDKKey.
-func TestMobileKeyGraceExpiry(t *testing.T) {
-	envConfig := st.EnvMobile.Config
-	readyCh := make(chan EnvContext, 1)
-
-	mob1 := envConfig.MobileKey
-	mob2 := config.MobileKey("mob2-new-key")
-
-	mockLog := ldlogtest.NewMockLog()
-	defer mockLog.DumpIfTestFailed(t)
-
-	env := makeBasicEnv(t, envConfig, testclient.FakeLDClientFactory(true), mockLog.Loggers, readyCh)
-	defer env.Close()
-	envImpl := env.(*envContextImpl)
-
-	assert.Equal(t, env, requireEnvReady(t, readyCh))
-
-	start := time.Unix(2000, 0)
-	graceDuration := 1 * time.Hour
-
-	// Rotate mob1 → mob2 with a grace period; mob1 is deprecated but still valid.
-	envImpl.keyRotator.RotateWithGrace(mob2, credential.NewGracePeriod(config.SDKKey(""), start.Add(graceDuration), start))
-	envImpl.triggerCredentialChanges(start)
-
-	assert.Contains(t, env.GetDeprecatedCredentials(), mob1)
-
-	// Before the grace period ends, mob1 is still deprecated (not yet expired).
-	envImpl.triggerCredentialChanges(start.Add(30 * time.Minute))
-	assert.Contains(t, env.GetDeprecatedCredentials(), mob1)
-
-	// One moment past the grace period: the cleanup ticker evicts mob1 entirely.
-	envImpl.triggerCredentialChanges(start.Add(graceDuration + 1*time.Millisecond))
-
-	assert.NotContains(t, env.GetCredentials(), mob1)
-	assert.NotContains(t, env.GetDeprecatedCredentials(), mob1)
-}
-
 // TestMobileKeyReconcileExpiry drives a mobile key carrying a per-key expiry end-to-end through the
 // reconcile path: ReconcileCredentials records the expiry as data on the accepted entry, and the
 // cleanup ticker (triggerCredentialChanges → StepTime) later evicts the key once its expiry elapses.

--- a/relay/filedata_actions_test.go
+++ b/relay/filedata_actions_test.go
@@ -1,7 +1,6 @@
 package relay
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -34,8 +33,6 @@ import (
 // Rather than generating actual archive files, the tests here use a stub ArchiveManager that
 // calls the same Relay methods that the real ArchiveManager would call if the file contained
 // such-and-such data.
-
-type foo struct{}
 
 type offlineModeTestParams struct {
 	relayTestHelper
@@ -181,7 +178,7 @@ func TestOfflineModeDeleteEnvironment(t *testing.T) {
 		assert.Contains(t, keys, testFileDataEnv2.Params.SDKKey)
 
 		_ = p.awaitEnvironment(testFileDataEnv1.Params.EnvID)
-		_ = p.awaitEnvironment(testFileDataEnv1.Params.EnvID)
+		_ = p.awaitEnvironment(testFileDataEnv2.Params.EnvID)
 
 		p.updateHandler.DeleteEnvironment(testFileDataEnv1.Params.EnvID, testFileDataEnv1.Params.Identifiers.FilterKey)
 
@@ -286,28 +283,22 @@ func TestOfflineModeSDKKeyCanExpire(t *testing.T) {
 	cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(minimumCleanupInterval)
 
 	offlineModeTest(t, cfg, func(p offlineModeTestParams) {
+		// It's important that the expiry be in the future (so that the key isn't ignored by the key rotator
+		// component), but it should also be in the near future so the test doesn't need to sleep long.
+		keyExpiry := time.Now().Add(10 * time.Millisecond)
+		update1 := RotateSDKKeyWithGracePeriod("key1", "key0", keyExpiry)
+		p.updateHandler.AddEnvironment(update1)
 
-		for i := 0; i < 3; i++ {
-			primary := config.SDKKey(fmt.Sprintf("key%v", i+1))
-			expiring := config.SDKKey(fmt.Sprintf("key%v", i))
+		// Waiting for the environment can take up to 1 second, but it could be much faster. In any case
+		// we'll still need to sleep at least the cleanup interval to ensure the key is expired.
+		env := p.awaitEnvironmentFor(update1.Params.EnvID, time.Second)
+		// Both the primary and the expiring key are in the accepted set until the expiry fires.
+		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.ExpiringSDKKey.Key, update1.Params.EnvID}, env.GetCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.ExpiringSDKKey.Key}, env.GetDeprecatedCredentials())
 
-			// It's important that the expiry be in the future (so that the key isn't ignored by the key rotator
-			// component), but it should also be in the near future so the test doesn't need to sleep long.
-			keyExpiry := time.Now().Add(10 * time.Millisecond)
-			update1 := RotateSDKKeyWithGracePeriod(primary, expiring, keyExpiry)
-			p.updateHandler.AddEnvironment(update1)
-
-			// Waiting for the environment can take up to 1 second, but it could be much faster. In any case
-			// we'll still need to sleep at least the cleanup interval to ensure the key is expired.
-			env := p.awaitEnvironmentFor(update1.Params.EnvID, time.Second)
-			// Both the primary and the expiring key are in the accepted set until the expiry fires.
-			assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.ExpiringSDKKey.Key, update1.Params.EnvID}, env.GetCredentials())
-			assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.ExpiringSDKKey.Key}, env.GetDeprecatedCredentials())
-
-			assert.Eventually(t, func() bool {
-				return len(env.GetDeprecatedCredentials()) == 0
-			}, time.Second, 10*time.Millisecond, "deprecated credentials should be cleaned up after expiry")
-			assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.EnvID}, env.GetCredentials())
-		}
+		assert.Eventually(t, func() bool {
+			return len(env.GetDeprecatedCredentials()) == 0
+		}, time.Second, 10*time.Millisecond, "deprecated credentials should be cleaned up after expiry")
+		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.EnvID}, env.GetCredentials())
 	})
 }


### PR DESCRIPTION
## Summary

Removes the legacy single-key rotation machinery from `internal/credential/rotator.go` now that all production credential flows go through `ReconcileCredentials` (#719 / SDK-2547 removed the last production callers of `RotateWithGrace`/`Rotate`).

[Jira: SDK-2603](https://launchdarkly.atlassian.net/browse/SDK-2603)

## Background

Prior to this project, the `Rotator` tracked credentials through a single-key rotation model: one primary SDK key, one deprecated-with-expiry slot (`deprecatedSdkKeys` / `deprecatedMobileKeys` maps), and `RotateWithGrace`/`Rotate` methods to move between them. The concurrent-keys work added a parallel `Reconcile` path with per-key expiry stored as data on accepted entries, and #719 wired both trusted-source handlers (RAC + offline) to `ReconcileCredentials`, leaving the legacy path with no production callers.

The `TEMPORARY` comment in `DeprecatedCredentials` pointed here as the cleanup step.

## Changes

The key conceptual shift: the old API was **imperative** ("rotate to this new key, here's the grace for the old one"), and the new API is **declarative** ("here is the complete desired accepted set; figure out the diff"). Most removed pieces don't have a 1:1 method replacement — they collapse into `Reconcile` and its helpers. The mapping below is old → new for everything this PR removes.

### Methods / entry points

| Removed | New analog | Notes |
|---|---|---|
| `Rotate(cred)` | `Reconcile(set, now)` | `Rotate` was just `RotateWithGrace(cred, nil)`. Caller now declares the full set instead of pushing one key at a time. |
| `RotateWithGrace(primary, grace)` | `Reconcile(set, now)` | The single declarative entry point; it internally sequences add → set-anchor → remove. |
| `updateSDKKey(sdkKey, grace)` | `reconcileSDKKeys(set, anchor, now)` | |
| `updateMobileKey(mobileKey, grace)` | `reconcileMobileKeys(set, now)` | |
| `updateEnvironmentID(envID)` (legacy) | `reconcileEnvironmentID(set)` | |
| `swapPrimaryKey(newKey)` | _(no dedicated method)_ | "Designate the anchor" is now just `desired[anchor] = nil` + `r.primarySdkKey = anchor` at the tail of `reconcileSDKKeys`. The map-consistency work it did is handled by the generic `reconcileAcceptedKeys`. |
| `immediatelyRevoke(key)` | _(no dedicated method)_ | Immediate revocation = *omit the key from the desired set*; the second pass of `reconcileAcceptedKeys` deletes any accepted key the set no longer wants and queues it as an expiration. |

### Types / data

| Removed | New analog | Notes |
|---|---|---|
| `GracePeriod` type, `NewGracePeriod()` | `acceptedKeyInfo.expiry *time.Time` (data on the accepted entry), supplied via `AcceptedSetBuilder.WithExpiringSDKKey(key, expiry)` / `WithExpiringMobileKey(...)` | A grace period is no longer a standalone object passed alongside a key — it's just an optional expiry field on the key's accepted entry. |
| `GracePeriod.Expired()` | inline time comparisons | On add: `!now.Before(*expiry)` filters in `reconcileSDKKeys`/`reconcileMobileKeys`. On the ticker: `now.After(*info.expiry)` in `StepTime`. |
| `deprecatedSdkKeys` / `deprecatedMobileKeys` maps | folded into `acceptedSDKKeys` / `acceptedMobileKeys` | A "deprecated" key is now just an accepted key with `info.expiry != nil`. One source of truth instead of two parallel maps. |

### Derived views / helpers

| Removed | New analog | Notes |
|---|---|---|
| `deprecatedCredentials()` (internal helper) | the inline loop in `DeprecatedCredentials()` | Now derived: accepted SDK keys where `info.expiry != nil && key != anchor`. |
| legacy grace-period loops in `StepTime` | the per-key-expiry loops in `StepTime` | These already coexisted; now they're the only loops. They read `info.expiry` instead of a separate map's value. |
| `PrimaryCredentials()` | `AllCredentials()` | Both returned the identical accepted set once the deprecated maps were gone, so they were consolidated to one. |

### Notes on imperfect alignment

- `expireSDKKey` / `expireMobileKey` were **not** removed. They're still the eviction routines `StepTime` calls; this PR only stripped the `delete(r.deprecatedSdkKeys, …)` lines out of their bodies.
- There is **no replacement** for the "stale deprecation message" handling. The old `updateSDKKey` had special logic for when LD re-sent a stale deprecation notice (the `previousExpiry, ok := r.deprecatedSdkKeys[grace.key]` branch). That whole class of problem disappears under reconcile — the caller always sends the *full current* desired set, so there is no stale-incremental-message state to reconcile against.

### Test changes

- `rotator_test.go`: all `RotateWithGrace`/`Rotate` tests removed; two new reconcile-path tests added: `TestReconcileAlreadyExpiredKeyIsIgnoredOnAdd` and `TestReconcileDeExpiryRestoresKey`.
- `env_context_impl_test.go`: `TestMobileKeyGraceExpiry` deleted (legacy path; superseded by the adjacent `TestMobileKeyReconcileExpiry`).
- `relay/filedata_actions_test.go`: remove dead `type foo struct{}`; fix `TestOfflineModeDeleteEnvironment` second `awaitEnvironment` call (was `Env1`, should be `Env2`); collapse `TestOfflineModeSDKKeyCanExpire` 3-iteration loop to a single run.
- `internal/credential/accepted_set_test.go`: remove no-op `_ = config.SDKKey(...)` assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication credential lifecycle in `Rotator` and what `GetCredentials` returns, but production paths already use `ReconcileCredentials`; risk is mainly regression in expiry/revocation edge cases covered by updated tests.
> 
> **Overview**
> Removes the legacy **imperative** credential rotation API (`Rotate`, `RotateWithGrace`, `GracePeriod`, and `deprecatedSdkKeys` / `deprecatedMobileKeys`) from `internal/credential/rotator.go`. Credential state is now maintained only through **`Reconcile`** and the `acceptedSDKKeys` / `acceptedMobileKeys` maps, where “deprecated” keys are simply accepted entries with a non-nil `expiry`.
> 
> **`PrimaryCredentials()` is removed** and **`AllCredentials()`** becomes the single view of every accepted key (including those still valid until `StepTime` evicts them). **`DeprecatedCredentials()`** no longer merges legacy grace maps—it only lists non-anchor SDK keys with a future expiry. **`StepTime`** and **`reconcileAcceptedKeys`** drop the parallel deprecated-map logic; expiry is enforced solely from `acceptedKeyInfo.expiry`.
> 
> **`env_context_impl.GetCredentials`** now delegates to **`AllCredentials()`** instead of `PrimaryCredentials()`.
> 
> Tests shed all `Rotate`/`RotateWithGrace` coverage and add reconcile cases (`TestReconcileAlreadyExpiredKeyIsIgnoredOnAdd`, `TestReconcileDeExpiryRestoresKey`); **`TestMobileKeyGraceExpiry`** is removed. **`relay/filedata_actions_test.go`** fixes a wrong second `awaitEnvironment` env ID and simplifies the SDK key expiry test loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d8fc83d997d669b682b9883db4eebb9406f2984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->