### PR TITLE
feat(status): add sdkKeys[] and mobileKeys[] arrays to status endpoint

### DIFF
--- a/internal/api/status_reps.go
+++ b/internal/api/status_reps.go
@@ -15,17 +15,40 @@ type StatusRep struct {
 	ClientVersion string                          `json:"clientVersion"`
 }
 
+// KeyStatus is the JSON representation of one accepted SDK or mobile key in the status endpoint's
+// sdkKeys[] / mobileKeys[] arrays.
+//
+// Key is the non-secret human-readable identifier from the wire format (the "key" field of a
+// sdkKeys/mobileKeys entry). Value is the obscured credential secret (via sdks.ObscureKey). Expiry
+// carries the Unix-millisecond expiry timestamp when the key is being phased out; it is omitted for
+// permanent keys.
+type KeyStatus struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Expiry *int64 `json:"expiry,omitempty"`
+}
+
 // EnvironmentStatusRep is the per-environment JSON representation returned by the status endpoint.
 //
 // This is exported for use in integration test code.
 type EnvironmentStatusRep struct {
-	SDKKey           string               `json:"sdkKey"`
+	// SDKKey is the obscured anchor SDK key — the key relay uses for its upstream connection.
+	// Kept for back-compat; for the full non-anchor accepted set see SDKKeys.
+	SDKKey string `json:"sdkKey"`
+	// SDKKeys carries all non-anchor accepted SDK keys with their identifiers, obscured values, and
+	// optional expiry. Present-but-empty for single-key environments.
+	SDKKeys          []KeyStatus          `json:"sdkKeys"`
 	EnvID            string               `json:"envId,omitempty"`
 	EnvKey           string               `json:"envKey,omitempty"`
 	EnvName          string               `json:"envName,omitempty"`
 	ProjKey          string               `json:"projKey,omitempty"`
 	ProjName         string               `json:"projName,omitempty"`
-	MobileKey        string               `json:"mobileKey,omitempty"`
+	// MobileKey is the obscured primary mobile key. Kept for back-compat; for the full non-primary
+	// accepted set see MobileKeys.
+	MobileKey string `json:"mobileKey,omitempty"`
+	// MobileKeys carries all non-primary accepted mobile keys. Present-but-empty for environments
+	// without additional mobile keys.
+	MobileKeys       []KeyStatus          `json:"mobileKeys"`
 	ExpiringSDKKey   string               `json:"expiringSdkKey,omitempty"`
 	Status           string               `json:"status"`
 	ConnectionStatus ConnectionStatusRep  `json:"connectionStatus"`

--- a/internal/api/status_reps.go
+++ b/internal/api/status_reps.go
@@ -33,8 +33,8 @@ type KeyStatus struct {
 //
 // This is exported for use in integration test code.
 type EnvironmentStatusRep struct {
-	// SDKKey is the obscured anchor SDK key — the key relay uses for its upstream connection. Kept for
-	// back-compat; it designates which SDKKeys entry is the anchor.
+	// SDKKey is the obscured anchor SDK key — the key relay uses for its upstream connection. It
+	// designates which SDKKeys entry is the anchor.
 	SDKKey string `json:"sdkKey"`
 	// SDKKeys carries the full accepted set of server-side SDK keys — including the anchor — with their
 	// identifiers, obscured values, and optional expiry. Always present; always contains at least the
@@ -45,8 +45,7 @@ type EnvironmentStatusRep struct {
 	EnvName  string      `json:"envName,omitempty"`
 	ProjKey  string      `json:"projKey,omitempty"`
 	ProjName string      `json:"projName,omitempty"`
-	// MobileKey is the obscured primary mobile key. Kept for back-compat; it designates which
-	// MobileKeys entry is the primary.
+	// MobileKey is the obscured primary mobile key. It designates which MobileKeys entry is the primary.
 	MobileKey string `json:"mobileKey,omitempty"`
 	// MobileKeys carries the full accepted set of mobile keys — including the primary. Always present;
 	// empty for an environment with no mobile keys (e.g. server-side only).

--- a/internal/api/status_reps.go
+++ b/internal/api/status_reps.go
@@ -19,11 +19,12 @@ type StatusRep struct {
 // sdkKeys[] / mobileKeys[] arrays.
 //
 // Key is the non-secret human-readable identifier from the wire format (the "key" field of a
-// sdkKeys/mobileKeys entry). Value is the obscured credential secret (via sdks.ObscureKey). Expiry
-// carries the Unix-millisecond expiry timestamp when the key is being phased out; it is omitted for
-// permanent keys.
+// sdkKeys/mobileKeys entry); it is omitted when the source carried no identifier (manual config, or
+// an old-format payload predating concurrent keys). Value is the obscured credential secret (via
+// sdks.ObscureKey). Expiry carries the Unix-millisecond expiry timestamp when the key is being phased
+// out; it is omitted for permanent keys.
 type KeyStatus struct {
-	Key    string `json:"key"`
+	Key    string `json:"key,omitempty"`
 	Value  string `json:"value"`
 	Expiry *int64 `json:"expiry,omitempty"`
 }
@@ -32,22 +33,23 @@ type KeyStatus struct {
 //
 // This is exported for use in integration test code.
 type EnvironmentStatusRep struct {
-	// SDKKey is the obscured anchor SDK key — the key relay uses for its upstream connection.
-	// Kept for back-compat; for the full non-anchor accepted set see SDKKeys.
+	// SDKKey is the obscured anchor SDK key — the key relay uses for its upstream connection. Kept for
+	// back-compat; it designates which SDKKeys entry is the anchor.
 	SDKKey string `json:"sdkKey"`
-	// SDKKeys carries all non-anchor accepted SDK keys with their identifiers, obscured values, and
-	// optional expiry. Present-but-empty for single-key environments.
+	// SDKKeys carries the full accepted set of server-side SDK keys — including the anchor — with their
+	// identifiers, obscured values, and optional expiry. Always present; always contains at least the
+	// anchor.
 	SDKKeys  []KeyStatus `json:"sdkKeys"`
 	EnvID    string      `json:"envId,omitempty"`
 	EnvKey   string      `json:"envKey,omitempty"`
 	EnvName  string      `json:"envName,omitempty"`
 	ProjKey  string      `json:"projKey,omitempty"`
 	ProjName string      `json:"projName,omitempty"`
-	// MobileKey is the obscured primary mobile key. Kept for back-compat; for the full non-primary
-	// accepted set see MobileKeys.
+	// MobileKey is the obscured primary mobile key. Kept for back-compat; it designates which
+	// MobileKeys entry is the primary.
 	MobileKey string `json:"mobileKey,omitempty"`
-	// MobileKeys carries all non-primary accepted mobile keys. Present-but-empty for environments
-	// without additional mobile keys.
+	// MobileKeys carries the full accepted set of mobile keys — including the primary. Always present;
+	// empty for an environment with no mobile keys (e.g. server-side only).
 	MobileKeys       []KeyStatus          `json:"mobileKeys"`
 	ExpiringSDKKey   string               `json:"expiringSdkKey,omitempty"`
 	Status           string               `json:"status"`

--- a/internal/api/status_reps.go
+++ b/internal/api/status_reps.go
@@ -37,12 +37,12 @@ type EnvironmentStatusRep struct {
 	SDKKey string `json:"sdkKey"`
 	// SDKKeys carries all non-anchor accepted SDK keys with their identifiers, obscured values, and
 	// optional expiry. Present-but-empty for single-key environments.
-	SDKKeys          []KeyStatus          `json:"sdkKeys"`
-	EnvID            string               `json:"envId,omitempty"`
-	EnvKey           string               `json:"envKey,omitempty"`
-	EnvName          string               `json:"envName,omitempty"`
-	ProjKey          string               `json:"projKey,omitempty"`
-	ProjName         string               `json:"projName,omitempty"`
+	SDKKeys  []KeyStatus `json:"sdkKeys"`
+	EnvID    string      `json:"envId,omitempty"`
+	EnvKey   string      `json:"envKey,omitempty"`
+	EnvName  string      `json:"envName,omitempty"`
+	ProjKey  string      `json:"projKey,omitempty"`
+	ProjName string      `json:"projName,omitempty"`
 	// MobileKey is the obscured primary mobile key. Kept for back-compat; for the full non-primary
 	// accepted set see MobileKeys.
 	MobileKey string `json:"mobileKey,omitempty"`

--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -35,6 +35,12 @@ type AcceptedSet struct {
 	mobileKeys       map[config.MobileKey]*time.Time
 	primaryMobileKey config.MobileKey
 	envID            config.EnvironmentID
+
+	// sdkKeyIdentifiers and mobileKeyIdentifiers carry the wire "key" field — the non-secret
+	// human-readable identifier for each credential. May be absent for entries synthesized from
+	// old-format payloads that only have the singular sdkKey/mobKey fields.
+	sdkKeyIdentifiers    map[config.SDKKey]string
+	mobileKeyIdentifiers map[config.MobileKey]string
 }
 
 // hasSDKKey reports whether key is one of the set's accepted SDK keys.

--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -18,8 +18,8 @@ import (
 //
 // WithAnchor / WithPrimaryMobileKey both add the key to the set and designate it, so adding a
 // single key takes one call. Build requires that an anchor was designated. (Structural validation of
-// the wire payload — undefined credentials, an anchor absent from the array — happens upstream when
-// the payload is parsed into the set; see SDK-2547.)
+// the wire payload — undefined credentials, a designated key absent from its array — happens upstream
+// when the payload is parsed into the set.)
 //
 // A key's expiry is taken from its entry in this set; the legacy sdkKey.expiring{} wire slot is not
 // consulted when building it.
@@ -54,11 +54,13 @@ func (s AcceptedSet) hasMobileKey(key config.MobileKey) bool {
 var errAcceptedSetMissingSDKKey = errors.New("accepted credential set must contain at least one SDK key")
 
 // MalformedCredentialSetError is returned when a credential payload cannot produce a valid
-// AcceptedSet. This covers two cases:
+// AcceptedSet. This covers:
 //
-//  1. The anchor SDK key (sdkKey.value) is absent or undefined — a violation of the backend
-//     invariant that an anchor is always designated.
-//  2. An entry in sdkKeys[] or mobileKeys[] has an empty value — a credential that would be
+//  1. The anchor SDK key (sdkKey.value) is absent or undefined, or defined but not present in
+//     sdkKeys[] — a violation of the invariant that the designated anchor is one of the accepted keys.
+//  2. The primary mobile key (mobKey) is defined but not present in mobileKeys[] — the mobile-key
+//     analogue of the anchor invariant.
+//  3. An entry in sdkKeys[] or mobileKeys[] has an empty value — a credential that would be
 //     accepted by relay but can never authenticate any SDK.
 //
 // Validation happens before Reconcile is called; Rotator.Reconcile trusts the set it is handed.
@@ -86,6 +88,14 @@ func newMissingAnchorError() *MalformedCredentialSetError {
 // anchor value is a secret, so it is deliberately not included in the message.
 func NewAnchorNotInSetError() *MalformedCredentialSetError {
 	return &MalformedCredentialSetError{msg: "malformed credential set: anchor SDK key is not present in sdkKeys[]"}
+}
+
+// NewPrimaryMobileKeyNotInSetError returns a MalformedCredentialSetError for a payload whose
+// designated primary mobile key (mobKey) is defined but not present in the mobileKeys[] array — the
+// mobile-key analogue of NewAnchorNotInSetError. The key value is a secret, so it is deliberately not
+// included in the message.
+func NewPrimaryMobileKeyNotInSetError() *MalformedCredentialSetError {
+	return &MalformedCredentialSetError{msg: "malformed credential set: primary mobile key is not present in mobileKeys[]"}
 }
 
 // NewEmptyCredentialError returns a MalformedCredentialSetError for a key-array entry whose

--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -3,7 +3,6 @@ package credential
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 )
@@ -28,21 +27,13 @@ import (
 // Construct an AcceptedSet with AcceptedSetBuilder (see accepted_set_builder.go).
 type AcceptedSet struct {
 	// sdkKeys and mobileKeys store each accepted key once, keyed by value (the secret), so duplicates
-	// collapse without a containment scan. The map value carries the key's metadata. A nil map is a
-	// valid empty set (reads return absent; only the builder writes).
-	sdkKeys          map[config.SDKKey]acceptedKeyMeta
+	// collapse without a containment scan. The map value carries the key's metadata (see
+	// acceptedKeyInfo). A nil map is a valid empty set (reads return absent; only the builder writes).
+	sdkKeys          map[config.SDKKey]acceptedKeyInfo
 	primarySdkKey    config.SDKKey
-	mobileKeys       map[config.MobileKey]acceptedKeyMeta
+	mobileKeys       map[config.MobileKey]acceptedKeyInfo
 	primaryMobileKey config.MobileKey
 	envID            config.EnvironmentID
-}
-
-// acceptedKeyMeta is the per-key metadata stored in an AcceptedSet alongside the credential value:
-// the optional wire "key" identifier (nil when the source carried none — manual config or an
-// old-format payload) and the optional expiry (nil = permanent).
-type acceptedKeyMeta struct {
-	key    *string
-	expiry *time.Time
 }
 
 // hasSDKKey reports whether key is one of the set's accepted SDK keys.

--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -27,20 +27,22 @@ import (
 //
 // Construct an AcceptedSet with AcceptedSetBuilder (see accepted_set_builder.go).
 type AcceptedSet struct {
-	// sdkKeys and mobileKeys store each accepted key once, keyed by value, so duplicates collapse
-	// without a containment scan. The map value is the key's expiry: a nil *time.Time means the key
-	// is permanent. A nil map is a valid empty set (reads return absent; only the builder writes).
-	sdkKeys          map[config.SDKKey]*time.Time
+	// sdkKeys and mobileKeys store each accepted key once, keyed by value (the secret), so duplicates
+	// collapse without a containment scan. The map value carries the key's metadata. A nil map is a
+	// valid empty set (reads return absent; only the builder writes).
+	sdkKeys          map[config.SDKKey]acceptedKeyMeta
 	primarySdkKey    config.SDKKey
-	mobileKeys       map[config.MobileKey]*time.Time
+	mobileKeys       map[config.MobileKey]acceptedKeyMeta
 	primaryMobileKey config.MobileKey
 	envID            config.EnvironmentID
+}
 
-	// sdkKeyIdentifiers and mobileKeyIdentifiers carry the wire "key" field — the non-secret
-	// human-readable identifier for each credential. May be absent for entries synthesized from
-	// old-format payloads that only have the singular sdkKey/mobKey fields.
-	sdkKeyIdentifiers    map[config.SDKKey]string
-	mobileKeyIdentifiers map[config.MobileKey]string
+// acceptedKeyMeta is the per-key metadata stored in an AcceptedSet alongside the credential value:
+// the optional wire "key" identifier (nil when the source carried none — manual config or an
+// old-format payload) and the optional expiry (nil = permanent).
+type acceptedKeyMeta struct {
+	key    *string
+	expiry *time.Time
 }
 
 // hasSDKKey reports whether key is one of the set's accepted SDK keys.
@@ -96,15 +98,15 @@ func NewAnchorNotInSetError() *MalformedCredentialSetError {
 }
 
 // NewEmptyCredentialError returns a MalformedCredentialSetError for a key-array entry whose
-// value field is empty. kind is "sdkKeys" or "mobileKeys"; identifier is the key's identifier
-// string (may be empty for old-format payloads that synthesize from the singular fields).
-func NewEmptyCredentialError(kind, identifier string) *MalformedCredentialSetError {
-	if identifier == "" {
+// value field is empty. kind is "sdkKeys" or "mobileKeys"; key is the entry's wire "key" identifier
+// (may be empty for old-format payloads that synthesize from the singular fields).
+func NewEmptyCredentialError(kind, key string) *MalformedCredentialSetError {
+	if key == "" {
 		return &MalformedCredentialSetError{
 			msg: fmt.Sprintf("malformed credential set: %s entry has an empty value", kind),
 		}
 	}
 	return &MalformedCredentialSetError{
-		msg: fmt.Sprintf("malformed credential set: %s entry %q has an empty value", kind, identifier),
+		msg: fmt.Sprintf("malformed credential set: %s entry %q has an empty value", kind, key),
 	}
 }

--- a/internal/credential/accepted_set_builder.go
+++ b/internal/credential/accepted_set_builder.go
@@ -16,10 +16,32 @@ type AcceptedSetBuilder struct {
 func NewAcceptedSetBuilder() *AcceptedSetBuilder {
 	return &AcceptedSetBuilder{
 		set: AcceptedSet{
-			sdkKeys:    make(map[config.SDKKey]*time.Time),
-			mobileKeys: make(map[config.MobileKey]*time.Time),
+			sdkKeys:              make(map[config.SDKKey]*time.Time),
+			mobileKeys:           make(map[config.MobileKey]*time.Time),
+			sdkKeyIdentifiers:    make(map[config.SDKKey]string),
+			mobileKeyIdentifiers: make(map[config.MobileKey]string),
 		},
 	}
+}
+
+// WithSDKKeyIdentifier sets the human-readable identifier (the wire "key" field) for an SDK key that
+// was already added to the builder. It is a no-op if the key is undefined, not in the set, or if
+// identifier is empty (old-format payloads synthesise entries without an identifier).
+func (b *AcceptedSetBuilder) WithSDKKeyIdentifier(key config.SDKKey, identifier string) *AcceptedSetBuilder {
+	if key.Defined() && identifier != "" && b.set.hasSDKKey(key) {
+		b.set.sdkKeyIdentifiers[key] = identifier
+	}
+	return b
+}
+
+// WithMobileKeyIdentifier sets the human-readable identifier (the wire "key" field) for a mobile key
+// that was already added to the builder. It is a no-op if the key is undefined, not in the set, or if
+// identifier is empty.
+func (b *AcceptedSetBuilder) WithMobileKeyIdentifier(key config.MobileKey, identifier string) *AcceptedSetBuilder {
+	if key.Defined() && identifier != "" && b.set.hasMobileKey(key) {
+		b.set.mobileKeyIdentifiers[key] = identifier
+	}
+	return b
 }
 
 // WithSDKKey adds a permanent (non-expiring) SDK key. It is a no-op if the key is undefined or

--- a/internal/credential/accepted_set_builder.go
+++ b/internal/credential/accepted_set_builder.go
@@ -16,99 +16,69 @@ type AcceptedSetBuilder struct {
 func NewAcceptedSetBuilder() *AcceptedSetBuilder {
 	return &AcceptedSetBuilder{
 		set: AcceptedSet{
-			sdkKeys:              make(map[config.SDKKey]*time.Time),
-			mobileKeys:           make(map[config.MobileKey]*time.Time),
-			sdkKeyIdentifiers:    make(map[config.SDKKey]string),
-			mobileKeyIdentifiers: make(map[config.MobileKey]string),
+			sdkKeys:    make(map[config.SDKKey]acceptedKeyMeta),
+			mobileKeys: make(map[config.MobileKey]acceptedKeyMeta),
 		},
 	}
 }
 
-// WithSDKKeyIdentifier sets the human-readable identifier (the wire "key" field) for an SDK key that
-// was already added to the builder. It is a no-op if the key is undefined, not in the set, or if
-// identifier is empty (old-format payloads synthesise entries without an identifier).
-func (b *AcceptedSetBuilder) WithSDKKeyIdentifier(key config.SDKKey, identifier string) *AcceptedSetBuilder {
-	if key.Defined() && identifier != "" && b.set.hasSDKKey(key) {
-		b.set.sdkKeyIdentifiers[key] = identifier
+// SDKKeyParams describes one accepted server-side SDK key for the builder: the credential value plus
+// the optional wire "key" identifier (nil when absent) and optional expiry (nil = permanent).
+type SDKKeyParams struct {
+	Value  config.SDKKey
+	Key    *string
+	Expiry *time.Time
+}
+
+// MobileKeyParams describes one accepted mobile key for the builder. See SDKKeyParams.
+type MobileKeyParams struct {
+	Value  config.MobileKey
+	Key    *string
+	Expiry *time.Time
+}
+
+// WithSDKKey adds a server-side SDK key. It is a no-op if the value is undefined or already present
+// (the first metadata recorded for a value wins).
+func (b *AcceptedSetBuilder) WithSDKKey(p SDKKeyParams) *AcceptedSetBuilder {
+	if !p.Value.Defined() || b.set.hasSDKKey(p.Value) {
+		return b
 	}
+	b.set.sdkKeys[p.Value] = acceptedKeyMeta{key: p.Key, expiry: p.Expiry}
 	return b
 }
 
-// WithMobileKeyIdentifier sets the human-readable identifier (the wire "key" field) for a mobile key
-// that was already added to the builder. It is a no-op if the key is undefined, not in the set, or if
-// identifier is empty.
-func (b *AcceptedSetBuilder) WithMobileKeyIdentifier(key config.MobileKey, identifier string) *AcceptedSetBuilder {
-	if key.Defined() && identifier != "" && b.set.hasMobileKey(key) {
-		b.set.mobileKeyIdentifiers[key] = identifier
+// WithPrimarySDKKey adds p.Value and designates it as the anchor — the SDK key that owns the
+// environment's upstream connection. The anchor is always permanent, so p.Expiry is ignored. It is a
+// no-op if the value is undefined. Unlike WithSDKKey it overwrites any existing entry for the value,
+// since designating the anchor takes precedence over an earlier non-anchor add.
+func (b *AcceptedSetBuilder) WithPrimarySDKKey(p SDKKeyParams) *AcceptedSetBuilder {
+	if !p.Value.Defined() {
+		return b
 	}
+	b.set.sdkKeys[p.Value] = acceptedKeyMeta{key: p.Key, expiry: nil}
+	b.set.primarySdkKey = p.Value
 	return b
 }
 
-// WithSDKKey adds a permanent (non-expiring) SDK key. It is a no-op if the key is undefined or
-// already present.
-func (b *AcceptedSetBuilder) WithSDKKey(key config.SDKKey) *AcceptedSetBuilder {
-	b.addSDKKey(key, nil)
-	return b
-}
-
-// WithExpiringSDKKey adds an SDK key that should be accepted until the given expiry. It is a no-op
-// if the key is undefined or already present.
-func (b *AcceptedSetBuilder) WithExpiringSDKKey(key config.SDKKey, expiry time.Time) *AcceptedSetBuilder {
-	b.addSDKKey(key, &expiry)
-	return b
-}
-
-// WithPrimarySDKKey adds key (if not already present) and designates it as the anchor — the SDK key
-// that owns the environment's upstream connection. It is a no-op if the key is undefined.
-func (b *AcceptedSetBuilder) WithPrimarySDKKey(key config.SDKKey) *AcceptedSetBuilder {
-	if key.Defined() {
-		b.addSDKKey(key, nil)
-		b.set.primarySdkKey = key
+// WithMobileKey adds a mobile key. It is a no-op if the value is undefined or already present.
+func (b *AcceptedSetBuilder) WithMobileKey(p MobileKeyParams) *AcceptedSetBuilder {
+	if !p.Value.Defined() || b.set.hasMobileKey(p.Value) {
+		return b
 	}
+	b.set.mobileKeys[p.Value] = acceptedKeyMeta{key: p.Key, expiry: p.Expiry}
 	return b
 }
 
-// addSDKKey records the key with the given expiry (nil = permanent), skipping undefined keys and
-// keys already in the set (the first expiry recorded for a key wins).
-func (b *AcceptedSetBuilder) addSDKKey(key config.SDKKey, expiry *time.Time) {
-	if !key.Defined() || b.set.hasSDKKey(key) {
-		return
+// WithPrimaryMobileKey adds p.Value and designates it as the primary mobile key — the singular
+// default (the wire's mobKey) used where one mobile key is required, e.g. event forwarding. The
+// primary is always permanent, so p.Expiry is ignored. It is a no-op if the value is undefined.
+func (b *AcceptedSetBuilder) WithPrimaryMobileKey(p MobileKeyParams) *AcceptedSetBuilder {
+	if !p.Value.Defined() {
+		return b
 	}
-	b.set.sdkKeys[key] = expiry
-}
-
-// WithMobileKey adds a permanent (non-expiring) mobile key. It is a no-op if the key is undefined or
-// already present.
-func (b *AcceptedSetBuilder) WithMobileKey(key config.MobileKey) *AcceptedSetBuilder {
-	b.addMobileKey(key, nil)
+	b.set.mobileKeys[p.Value] = acceptedKeyMeta{key: p.Key, expiry: nil}
+	b.set.primaryMobileKey = p.Value
 	return b
-}
-
-// WithExpiringMobileKey adds a mobile key that should be accepted until the given expiry. It is a
-// no-op if the key is undefined or already present.
-func (b *AcceptedSetBuilder) WithExpiringMobileKey(key config.MobileKey, expiry time.Time) *AcceptedSetBuilder {
-	b.addMobileKey(key, &expiry)
-	return b
-}
-
-// WithPrimaryMobileKey adds key (if not already present) and designates it as the primary mobile
-// key — the singular default (the wire's mobKey) used where one mobile key is required, e.g. event
-// forwarding. It is a no-op if the key is undefined.
-func (b *AcceptedSetBuilder) WithPrimaryMobileKey(key config.MobileKey) *AcceptedSetBuilder {
-	if key.Defined() {
-		b.addMobileKey(key, nil)
-		b.set.primaryMobileKey = key
-	}
-	return b
-}
-
-// addMobileKey records the key with the given expiry (nil = permanent), skipping undefined keys and
-// keys already in the set (the first expiry recorded for a key wins).
-func (b *AcceptedSetBuilder) addMobileKey(key config.MobileKey, expiry *time.Time) {
-	if !key.Defined() || b.set.hasMobileKey(key) {
-		return
-	}
-	b.set.mobileKeys[key] = expiry
 }
 
 // WithEnvironmentID sets the environment ID. It is a no-op if the ID is undefined.

--- a/internal/credential/accepted_set_builder.go
+++ b/internal/credential/accepted_set_builder.go
@@ -16,8 +16,8 @@ type AcceptedSetBuilder struct {
 func NewAcceptedSetBuilder() *AcceptedSetBuilder {
 	return &AcceptedSetBuilder{
 		set: AcceptedSet{
-			sdkKeys:    make(map[config.SDKKey]acceptedKeyMeta),
-			mobileKeys: make(map[config.MobileKey]acceptedKeyMeta),
+			sdkKeys:    make(map[config.SDKKey]acceptedKeyInfo),
+			mobileKeys: make(map[config.MobileKey]acceptedKeyInfo),
 		},
 	}
 }
@@ -43,7 +43,7 @@ func (b *AcceptedSetBuilder) WithSDKKey(p SDKKeyParams) *AcceptedSetBuilder {
 	if !p.Value.Defined() || b.set.hasSDKKey(p.Value) {
 		return b
 	}
-	b.set.sdkKeys[p.Value] = acceptedKeyMeta{key: p.Key, expiry: p.Expiry}
+	b.set.sdkKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: p.Expiry}
 	return b
 }
 
@@ -55,7 +55,7 @@ func (b *AcceptedSetBuilder) WithPrimarySDKKey(p SDKKeyParams) *AcceptedSetBuild
 	if !p.Value.Defined() {
 		return b
 	}
-	b.set.sdkKeys[p.Value] = acceptedKeyMeta{key: p.Key, expiry: nil}
+	b.set.sdkKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: nil}
 	b.set.primarySdkKey = p.Value
 	return b
 }
@@ -65,7 +65,7 @@ func (b *AcceptedSetBuilder) WithMobileKey(p MobileKeyParams) *AcceptedSetBuilde
 	if !p.Value.Defined() || b.set.hasMobileKey(p.Value) {
 		return b
 	}
-	b.set.mobileKeys[p.Value] = acceptedKeyMeta{key: p.Key, expiry: p.Expiry}
+	b.set.mobileKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: p.Expiry}
 	return b
 }
 
@@ -76,7 +76,7 @@ func (b *AcceptedSetBuilder) WithPrimaryMobileKey(p MobileKeyParams) *AcceptedSe
 	if !p.Value.Defined() {
 		return b
 	}
-	b.set.mobileKeys[p.Value] = acceptedKeyMeta{key: p.Key, expiry: nil}
+	b.set.mobileKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: nil}
 	b.set.primaryMobileKey = p.Value
 	return b
 }

--- a/internal/credential/accepted_set_builder_test.go
+++ b/internal/credential/accepted_set_builder_test.go
@@ -2,7 +2,6 @@ package credential
 
 import (
 	"testing"
-	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 
@@ -52,25 +51,4 @@ func mustBuild(t *testing.T, b *AcceptedSetBuilder) AcceptedSet {
 	set, err := b.Build()
 	require.NoError(t, err)
 	return set
-}
-
-// sdkP / sdkPExp / mobP / mobPExp build credential param structs for the Reconcile tests, mapping an
-// empty identifier to a nil Key pointer.
-func sdkP(value config.SDKKey, key string) SDKKeyParams {
-	return SDKKeyParams{Value: value, Key: strPtrOrNil(key)}
-}
-func sdkPExp(value config.SDKKey, key string, expiry time.Time) SDKKeyParams {
-	return SDKKeyParams{Value: value, Key: strPtrOrNil(key), Expiry: &expiry}
-}
-func mobP(value config.MobileKey, key string) MobileKeyParams {
-	return MobileKeyParams{Value: value, Key: strPtrOrNil(key)}
-}
-func mobPExp(value config.MobileKey, key string, expiry time.Time) MobileKeyParams {
-	return MobileKeyParams{Value: value, Key: strPtrOrNil(key), Expiry: &expiry}
-}
-func strPtrOrNil(s string) *string {
-	if s == "" {
-		return nil
-	}
-	return &s
 }

--- a/internal/credential/accepted_set_builder_test.go
+++ b/internal/credential/accepted_set_builder_test.go
@@ -2,6 +2,7 @@ package credential
 
 import (
 	"testing"
+	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 
@@ -12,18 +13,18 @@ import (
 func TestAcceptedSetBuilderValidation(t *testing.T) {
 	// No SDK key at all is a caller error.
 	_, err := NewAcceptedSetBuilder().
-		WithMobileKey(config.MobileKey("mob")).
+		WithMobileKey(MobileKeyParams{Value: "mob"}).
 		WithEnvironmentID(config.EnvironmentID("env")).
 		Build()
 	require.ErrorIs(t, err, errAcceptedSetMissingSDKKey)
 
 	// An SDK key with no designated anchor is malformed.
 	var malformed *MalformedCredentialSetError
-	_, err = NewAcceptedSetBuilder().WithSDKKey(config.SDKKey("sdk")).Build()
+	_, err = NewAcceptedSetBuilder().WithSDKKey(SDKKeyParams{Value: "sdk"}).Build()
 	require.ErrorAs(t, err, &malformed)
 
 	// WithPrimarySDKKey adds the key and designates it as the anchor, so Build succeeds.
-	set, err := NewAcceptedSetBuilder().WithPrimarySDKKey(config.SDKKey("sdk")).Build()
+	set, err := NewAcceptedSetBuilder().WithPrimarySDKKey(SDKKeyParams{Value: "sdk"}).Build()
 	require.NoError(t, err)
 	assert.True(t, set.hasSDKKey(config.SDKKey("sdk")))
 	assert.Equal(t, config.SDKKey("sdk"), set.primarySdkKey)
@@ -32,11 +33,11 @@ func TestAcceptedSetBuilderValidation(t *testing.T) {
 func TestAcceptedSetBuilderDeduplicates(t *testing.T) {
 	// Adding the same key more than once (including via WithPrimary*) keeps a single entry.
 	set := mustBuild(t, NewAcceptedSetBuilder().
-		WithSDKKey(config.SDKKey("sdk")).
-		WithPrimarySDKKey(config.SDKKey("sdk")).
-		WithSDKKey(config.SDKKey("sdk")).
-		WithMobileKey(config.MobileKey("mob")).
-		WithPrimaryMobileKey(config.MobileKey("mob")))
+		WithSDKKey(SDKKeyParams{Value: "sdk"}).
+		WithPrimarySDKKey(SDKKeyParams{Value: "sdk"}).
+		WithSDKKey(SDKKeyParams{Value: "sdk"}).
+		WithMobileKey(MobileKeyParams{Value: "mob"}).
+		WithPrimaryMobileKey(MobileKeyParams{Value: "mob"}))
 
 	assert.Len(t, set.sdkKeys, 1)
 	assert.Len(t, set.mobileKeys, 1)
@@ -51,4 +52,25 @@ func mustBuild(t *testing.T, b *AcceptedSetBuilder) AcceptedSet {
 	set, err := b.Build()
 	require.NoError(t, err)
 	return set
+}
+
+// sdkP / sdkPExp / mobP / mobPExp build credential param structs for the Reconcile tests, mapping an
+// empty identifier to a nil Key pointer.
+func sdkP(value config.SDKKey, key string) SDKKeyParams {
+	return SDKKeyParams{Value: value, Key: strPtrOrNil(key)}
+}
+func sdkPExp(value config.SDKKey, key string, expiry time.Time) SDKKeyParams {
+	return SDKKeyParams{Value: value, Key: strPtrOrNil(key), Expiry: &expiry}
+}
+func mobP(value config.MobileKey, key string) MobileKeyParams {
+	return MobileKeyParams{Value: value, Key: strPtrOrNil(key)}
+}
+func mobPExp(value config.MobileKey, key string, expiry time.Time) MobileKeyParams {
+	return MobileKeyParams{Value: value, Key: strPtrOrNil(key), Expiry: &expiry}
+}
+func strPtrOrNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -566,49 +566,67 @@ func (r *Rotator) reconcileEnvironmentID(set AcceptedSet) {
 	r.additions = append(r.additions, set.envID)
 }
 
+// nonPrimaryKeyEntries returns metadata for every accepted key except primary, sorted by identifier.
+// It is the shared implementation behind NonAnchorSDKKeyEntries and NonPrimaryMobileKeyEntries; the
+// caller supplies the relevant accepted/deprecated maps and a constructor that builds the concrete
+// entry type. The caller must hold at least the read lock.
+//
+// Keys with no identifier (e.g. keys accepted via the legacy RotateWithGrace path, which predates
+// identifier support) sort after identified keys; ties within no-identifier keys are broken by
+// credential value for determinism.
+func nonPrimaryKeyEntries[K ~string, E any](
+	accepted map[K]*acceptedKeyInfo,
+	deprecated map[K]time.Time,
+	primary K,
+	identifier func(E) string,
+	value func(E) string,
+	construct func(key K, identifier string, expiry *time.Time) E,
+) []E {
+	entries := make([]E, 0, max(0, len(accepted)-1))
+	for key, info := range accepted {
+		if key == primary {
+			continue
+		}
+		expiry := info.expiry
+		// Legacy RotateWithGrace path stores expiry in the deprecated map, not in acceptedKeyInfo.
+		if expiry == nil {
+			if t, ok := deprecated[key]; ok {
+				expiry = &t
+			}
+		}
+		entries = append(entries, construct(key, info.identifier, expiry))
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		ai, bi := identifier(entries[i]), identifier(entries[j])
+		if ai != bi {
+			// Empty identifiers sort last.
+			if ai == "" {
+				return false
+			}
+			if bi == "" {
+				return true
+			}
+			return ai < bi
+		}
+		return value(entries[i]) < value(entries[j])
+	})
+	return entries
+}
+
 // NonAnchorSDKKeyEntries returns metadata for all accepted SDK keys except the anchor, sorted by
 // identifier. Used by the status endpoint to populate the sdkKeys[] response array.
-//
-// Non-anchor keys with no identifier (e.g. keys accepted via the legacy RotateWithGrace path, which
-// predates identifier support) sort after identified keys; ties within no-identifier keys are broken
-// by credential value for determinism.
 func (r *Rotator) NonAnchorSDKKeyEntries() []SDKKeyEntry {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	entries := make([]SDKKeyEntry, 0, max(0, len(r.acceptedSDKKeys)-1))
-	for key, info := range r.acceptedSDKKeys {
-		if key == r.primarySdkKey {
-			continue
-		}
-		expiry := info.expiry
-		// Legacy RotateWithGrace path stores expiry in deprecatedSdkKeys, not in acceptedKeyInfo.
-		if expiry == nil {
-			if t, ok := r.deprecatedSdkKeys[key]; ok {
-				expiry = &t
-			}
-		}
-		entries = append(entries, SDKKeyEntry{
-			Value:      key,
-			Identifier: info.identifier,
-			Expiry:     expiry,
-		})
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		a, b := entries[i], entries[j]
-		if a.Identifier != b.Identifier {
-			// Empty identifiers sort last.
-			if a.Identifier == "" {
-				return false
-			}
-			if b.Identifier == "" {
-				return true
-			}
-			return a.Identifier < b.Identifier
-		}
-		return string(a.Value) < string(b.Value)
-	})
-	return entries
+	return nonPrimaryKeyEntries(
+		r.acceptedSDKKeys, r.deprecatedSdkKeys, r.primarySdkKey,
+		func(e SDKKeyEntry) string { return e.Identifier },
+		func(e SDKKeyEntry) string { return string(e.Value) },
+		func(key config.SDKKey, identifier string, expiry *time.Time) SDKKeyEntry {
+			return SDKKeyEntry{Value: key, Identifier: identifier, Expiry: expiry}
+		},
+	)
 }
 
 // NonPrimaryMobileKeyEntries returns metadata for all accepted mobile keys except the primary,
@@ -617,37 +635,14 @@ func (r *Rotator) NonPrimaryMobileKeyEntries() []MobileKeyEntry {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	entries := make([]MobileKeyEntry, 0, max(0, len(r.acceptedMobileKeys)-1))
-	for key, info := range r.acceptedMobileKeys {
-		if key == r.primaryMobileKey {
-			continue
-		}
-		expiry := info.expiry
-		if expiry == nil {
-			if t, ok := r.deprecatedMobileKeys[key]; ok {
-				expiry = &t
-			}
-		}
-		entries = append(entries, MobileKeyEntry{
-			Value:      key,
-			Identifier: info.identifier,
-			Expiry:     expiry,
-		})
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		a, b := entries[i], entries[j]
-		if a.Identifier != b.Identifier {
-			if a.Identifier == "" {
-				return false
-			}
-			if b.Identifier == "" {
-				return true
-			}
-			return a.Identifier < b.Identifier
-		}
-		return string(a.Value) < string(b.Value)
-	})
-	return entries
+	return nonPrimaryKeyEntries(
+		r.acceptedMobileKeys, r.deprecatedMobileKeys, r.primaryMobileKey,
+		func(e MobileKeyEntry) string { return e.Identifier },
+		func(e MobileKeyEntry) string { return string(e.Value) },
+		func(key config.MobileKey, identifier string, expiry *time.Time) MobileKeyEntry {
+			return MobileKeyEntry{Value: key, Identifier: identifier, Expiry: expiry}
+		},
+	)
 }
 
 // EarliestExpiringNonAnchorSDKKey returns the non-anchor SDK key with the soonest expiry, and true.
@@ -682,4 +677,3 @@ func (r *Rotator) EarliestExpiringNonAnchorSDKKey() (config.SDKKey, bool) {
 
 	return earliest, earliestTime != nil
 }
-

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -25,21 +25,8 @@ const (
 	KeyTypeMobile
 )
 
-// String returns the lowercase wire-style name of the key type ("server" or "mobile").
-func (t KeyType) String() string {
-	switch t {
-	case KeyTypeServer:
-		return "server"
-	case KeyTypeMobile:
-		return "mobile"
-	default:
-		return "unknown"
-	}
-}
-
-// AcceptedKey is metadata for one accepted credential, returned by AcceptedKeys (and, for the legacy
-// grace-period set, DeprecatedSDKKeys). The status endpoint uses it to populate the sdkKeys[] /
-// mobileKeys[] response arrays.
+// AcceptedKey is metadata for one accepted credential, returned by AcceptedKeys. The status endpoint
+// uses it to populate the sdkKeys[] / mobileKeys[] response arrays.
 type AcceptedKey struct {
 	// Type is the kind of key — server-side SDK or mobile.
 	Type KeyType
@@ -159,12 +146,10 @@ func (r *Rotator) allCredentials() []SDKCredential {
 
 // DeprecatedCredentials returns the SDK keys being phased out — every accepted SDK key, other than the
 // anchor, that carries a future expiry. (Per-key expiry is stored as data on the accepted entry; the
-// cleanup ticker drops the key once it elapses.) EnvContext.GetDeprecatedCredentials delegates here to
-// populate the status endpoint's expiringSdkKey field.
+// cleanup ticker drops the key once it elapses.)
 //
 // Mobile keys are deliberately not returned even though they expire the same way SDK keys do — carried
-// as per-key expiry and dropped by the same cleanup ticker. They are omitted only because the status
-// endpoint has no expiringMobileKey field to populate, not because mobile-key expiry is unimplemented.
+// as per-key expiry and dropped by the same cleanup ticker.
 func (r *Rotator) DeprecatedCredentials() []SDKCredential {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -298,18 +298,19 @@ func reconcileAcceptedKeys[K reconcilableKey](
 // payload may carry for it. The caller must hold the write lock.
 func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now time.Time) {
 	desired := make(map[config.SDKKey]*time.Time, len(set.sdkKeys))
-	for key, meta := range set.sdkKeys {
-		if meta.expiry != nil && !now.Before(*meta.expiry) {
+	for key, info := range set.sdkKeys {
+		if info.expiry != nil && !now.Before(*info.expiry) {
 			continue // already expired; treat as absent
 		}
-		desired[key] = meta.expiry
+		desired[key] = info.expiry
 	}
 	desired[anchor] = nil
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
-	// Refresh the wire "key" identifier for every key now in the accepted set.
-	for key, meta := range set.sdkKeys {
-		if info, ok := r.acceptedSDKKeys[key]; ok && meta.key != nil {
-			info.key = meta.key
+	// Refresh the wire "key" identifier for every key now in the accepted set, including clearing it
+	// when the new payload carries none — otherwise a stale identifier would linger in /status.
+	for key, info := range set.sdkKeys {
+		if accepted, ok := r.acceptedSDKKeys[key]; ok {
+			accepted.key = info.key
 		}
 	}
 	r.anchorKey = anchor
@@ -320,19 +321,21 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 // and permanent; an empty value means the set declared no mobile key. The caller must hold the lock.
 func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
 	desired := make(map[config.MobileKey]*time.Time, len(set.mobileKeys))
-	for key, meta := range set.mobileKeys {
-		if meta.expiry != nil && !now.Before(*meta.expiry) {
+	for key, info := range set.mobileKeys {
+		if info.expiry != nil && !now.Before(*info.expiry) {
 			continue // already expired; treat as absent
 		}
-		desired[key] = meta.expiry
+		desired[key] = info.expiry
 	}
 	if set.primaryMobileKey.Defined() {
 		desired[set.primaryMobileKey] = nil
 	}
 	reconcileAcceptedKeys(desired, r.acceptedMobileKeys, &r.additions, &r.expirations, r.loggers, "Mobile key")
-	for key, meta := range set.mobileKeys {
-		if info, ok := r.acceptedMobileKeys[key]; ok && meta.key != nil {
-			info.key = meta.key
+	// Refresh the wire "key" identifier for every key now in the accepted set, including clearing it
+	// when the new payload carries none — otherwise a stale identifier would linger in /status.
+	for key, info := range set.mobileKeys {
+		if accepted, ok := r.acceptedMobileKeys[key]; ok {
+			accepted.key = info.key
 		}
 	}
 	r.primaryMobileKey = set.primaryMobileKey

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -1,6 +1,7 @@
 package credential
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -10,7 +11,27 @@ import (
 
 // acceptedKeyInfo holds per-key metadata for the accepted-set maps.
 type acceptedKeyInfo struct {
-	expiry *time.Time // nil = permanent
+	expiry     *time.Time // nil = permanent
+	identifier string     // wire "key" field — non-secret human-readable name; may be empty
+}
+
+// SDKKeyEntry is metadata for one accepted SDK key, returned by NonAnchorSDKKeyEntries.
+// Used by the status endpoint to populate the sdkKeys[] response array.
+type SDKKeyEntry struct {
+	// Value is the credential secret (relay's SDKKey type — what the wire calls "value").
+	Value config.SDKKey
+	// Identifier is the non-secret human-readable name from the wire's "key" field.
+	Identifier string
+	// Expiry is the key's expiry time. Nil means the key is permanent.
+	Expiry *time.Time
+}
+
+// MobileKeyEntry is metadata for one accepted mobile key, returned by NonPrimaryMobileKeyEntries.
+// Used by the status endpoint to populate the mobileKeys[] response array.
+type MobileKeyEntry struct {
+	Value      config.MobileKey
+	Identifier string
+	Expiry     *time.Time
 }
 
 type Rotator struct {
@@ -500,6 +521,12 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 	}
 	desired[anchor] = nil
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, r.deprecatedSdkKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
+	// Refresh identifiers for every key now in the accepted set.
+	for key, id := range set.sdkKeyIdentifiers {
+		if info, ok := r.acceptedSDKKeys[key]; ok && id != "" {
+			info.identifier = id
+		}
+	}
 	r.primarySdkKey = anchor
 }
 
@@ -518,6 +545,11 @@ func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
 		desired[set.primaryMobileKey] = nil
 	}
 	reconcileAcceptedKeys(desired, r.acceptedMobileKeys, r.deprecatedMobileKeys, &r.additions, &r.expirations, r.loggers, "Mobile key")
+	for key, id := range set.mobileKeyIdentifiers {
+		if info, ok := r.acceptedMobileKeys[key]; ok && id != "" {
+			info.identifier = id
+		}
+	}
 	r.primaryMobileKey = set.primaryMobileKey
 }
 
@@ -533,3 +565,121 @@ func (r *Rotator) reconcileEnvironmentID(set AcceptedSet) {
 	r.primaryEnvironmentID = set.envID
 	r.additions = append(r.additions, set.envID)
 }
+
+// NonAnchorSDKKeyEntries returns metadata for all accepted SDK keys except the anchor, sorted by
+// identifier. Used by the status endpoint to populate the sdkKeys[] response array.
+//
+// Non-anchor keys with no identifier (e.g. keys accepted via the legacy RotateWithGrace path, which
+// predates identifier support) sort after identified keys; ties within no-identifier keys are broken
+// by credential value for determinism.
+func (r *Rotator) NonAnchorSDKKeyEntries() []SDKKeyEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entries := make([]SDKKeyEntry, 0, max(0, len(r.acceptedSDKKeys)-1))
+	for key, info := range r.acceptedSDKKeys {
+		if key == r.primarySdkKey {
+			continue
+		}
+		expiry := info.expiry
+		// Legacy RotateWithGrace path stores expiry in deprecatedSdkKeys, not in acceptedKeyInfo.
+		if expiry == nil {
+			if t, ok := r.deprecatedSdkKeys[key]; ok {
+				expiry = &t
+			}
+		}
+		entries = append(entries, SDKKeyEntry{
+			Value:      key,
+			Identifier: info.identifier,
+			Expiry:     expiry,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.Identifier != b.Identifier {
+			// Empty identifiers sort last.
+			if a.Identifier == "" {
+				return false
+			}
+			if b.Identifier == "" {
+				return true
+			}
+			return a.Identifier < b.Identifier
+		}
+		return string(a.Value) < string(b.Value)
+	})
+	return entries
+}
+
+// NonPrimaryMobileKeyEntries returns metadata for all accepted mobile keys except the primary,
+// sorted by identifier. Used by the status endpoint to populate the mobileKeys[] response array.
+func (r *Rotator) NonPrimaryMobileKeyEntries() []MobileKeyEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entries := make([]MobileKeyEntry, 0, max(0, len(r.acceptedMobileKeys)-1))
+	for key, info := range r.acceptedMobileKeys {
+		if key == r.primaryMobileKey {
+			continue
+		}
+		expiry := info.expiry
+		if expiry == nil {
+			if t, ok := r.deprecatedMobileKeys[key]; ok {
+				expiry = &t
+			}
+		}
+		entries = append(entries, MobileKeyEntry{
+			Value:      key,
+			Identifier: info.identifier,
+			Expiry:     expiry,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.Identifier != b.Identifier {
+			if a.Identifier == "" {
+				return false
+			}
+			if b.Identifier == "" {
+				return true
+			}
+			return a.Identifier < b.Identifier
+		}
+		return string(a.Value) < string(b.Value)
+	})
+	return entries
+}
+
+// EarliestExpiringNonAnchorSDKKey returns the non-anchor SDK key with the soonest expiry, and true.
+// Returns the zero SDKKey and false when no expiring non-anchor key exists. This produces a
+// deterministic value for the status endpoint's legacy expiringSdkKey field, regardless of how many
+// keys are currently expiring.
+func (r *Rotator) EarliestExpiringNonAnchorSDKKey() (config.SDKKey, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var earliest config.SDKKey
+	var earliestTime *time.Time
+
+	updateEarliest := func(key config.SDKKey, t time.Time) {
+		if earliestTime == nil || t.Before(*earliestTime) {
+			earliest = key
+			tt := t
+			earliestTime = &tt
+		}
+	}
+
+	// Reconcile-path: expiry stored on the accepted entry.
+	for key, info := range r.acceptedSDKKeys {
+		if key != r.primarySdkKey && info.expiry != nil {
+			updateEarliest(key, *info.expiry)
+		}
+	}
+	// Legacy RotateWithGrace path: expiry stored in deprecatedSdkKeys.
+	for key, t := range r.deprecatedSdkKeys {
+		updateEarliest(key, t)
+	}
+
+	return earliest, earliestTime != nil
+}
+

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -1,7 +1,6 @@
 package credential
 
 import (
-	"sort"
 	"sync"
 	"time"
 
@@ -11,27 +10,47 @@ import (
 
 // acceptedKeyInfo holds per-key metadata for the accepted-set maps.
 type acceptedKeyInfo struct {
-	expiry     *time.Time // nil = permanent
-	identifier string     // wire "key" field — non-secret human-readable name; may be empty
+	expiry *time.Time // nil = permanent
+	key    *string    // wire "key" identifier — non-secret human-readable name; nil when absent
 }
 
-// SDKKeyEntry is metadata for one accepted SDK key, returned by NonAnchorSDKKeyEntries.
-// Used by the status endpoint to populate the sdkKeys[] response array.
-type SDKKeyEntry struct {
-	// Value is the credential secret (relay's SDKKey type — what the wire calls "value").
-	Value config.SDKKey
-	// Identifier is the non-secret human-readable name from the wire's "key" field.
-	Identifier string
+// KeyType distinguishes a server-side SDK key from a mobile key in an AcceptedKey. Client-side IDs
+// are not part of the accepted-set model and so have no KeyType.
+type KeyType int
+
+const (
+	// KeyTypeServer is a server-side SDK key.
+	KeyTypeServer KeyType = iota
+	// KeyTypeMobile is a mobile key.
+	KeyTypeMobile
+)
+
+// String returns the lowercase wire-style name of the key type ("server" or "mobile").
+func (t KeyType) String() string {
+	switch t {
+	case KeyTypeServer:
+		return "server"
+	case KeyTypeMobile:
+		return "mobile"
+	default:
+		return "unknown"
+	}
+}
+
+// AcceptedKey is metadata for one accepted credential, returned by AcceptedKeys (and, for the legacy
+// grace-period set, DeprecatedSDKKeys). The status endpoint uses it to populate the sdkKeys[] /
+// mobileKeys[] response arrays.
+type AcceptedKey struct {
+	// Type is the kind of key — server-side SDK or mobile.
+	Type KeyType
+	// Value is the credential secret (what the wire calls "value"). Plain, not obscured; the status
+	// handler obscures it before serialising.
+	Value string
+	// Key is the non-secret human-readable identifier (the wire "key" field). Nil when the source
+	// carried no identifier — manual configuration, or an old-format payload predating concurrent keys.
+	Key *string
 	// Expiry is the key's expiry time. Nil means the key is permanent.
 	Expiry *time.Time
-}
-
-// MobileKeyEntry is metadata for one accepted mobile key, returned by NonPrimaryMobileKeyEntries.
-// Used by the status endpoint to populate the mobileKeys[] response array.
-type MobileKeyEntry struct {
-	Value      config.MobileKey
-	Identifier string
-	Expiry     *time.Time
 }
 
 type Rotator struct {
@@ -521,10 +540,11 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 	}
 	desired[anchor] = nil
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, r.deprecatedSdkKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
-	// Refresh identifiers for every key now in the accepted set.
+	// Refresh the wire "key" identifier for every key now in the accepted set.
 	for key, id := range set.sdkKeyIdentifiers {
 		if info, ok := r.acceptedSDKKeys[key]; ok && id != "" {
-			info.identifier = id
+			idCopy := id
+			info.key = &idCopy
 		}
 	}
 	r.primarySdkKey = anchor
@@ -547,7 +567,8 @@ func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
 	reconcileAcceptedKeys(desired, r.acceptedMobileKeys, r.deprecatedMobileKeys, &r.additions, &r.expirations, r.loggers, "Mobile key")
 	for key, id := range set.mobileKeyIdentifiers {
 		if info, ok := r.acceptedMobileKeys[key]; ok && id != "" {
-			info.identifier = id
+			idCopy := id
+			info.key = &idCopy
 		}
 	}
 	r.primaryMobileKey = set.primaryMobileKey
@@ -566,114 +587,48 @@ func (r *Rotator) reconcileEnvironmentID(set AcceptedSet) {
 	r.additions = append(r.additions, set.envID)
 }
 
-// nonPrimaryKeyEntries returns metadata for every accepted key except primary, sorted by identifier.
-// It is the shared implementation behind NonAnchorSDKKeyEntries and NonPrimaryMobileKeyEntries; the
-// caller supplies the relevant accepted/deprecated maps and a constructor that builds the concrete
-// entry type. The caller must hold at least the read lock.
-//
-// Keys with no identifier (e.g. keys accepted via the legacy RotateWithGrace path, which predates
-// identifier support) sort after identified keys; ties within no-identifier keys are broken by
-// credential value for determinism.
-func nonPrimaryKeyEntries[K ~string, E any](
-	accepted map[K]*acceptedKeyInfo,
-	deprecated map[K]time.Time,
-	primary K,
-	identifier func(E) string,
-	value func(E) string,
-	construct func(key K, identifier string, expiry *time.Time) E,
-) []E {
-	entries := make([]E, 0, max(0, len(accepted)-1))
+// acceptedKeysOf snapshots one accepted-key map (SDK or mobile) into a slice of AcceptedKey tagged
+// with kind. Order is unspecified — the status endpoint does not depend on it. A key whose expiry
+// lives only in the legacy grace map (the RotateWithGrace path stores it there, not on the accepted
+// entry) gets that expiry folded in. The caller must hold at least the read lock.
+func acceptedKeysOf[K ~string](accepted map[K]*acceptedKeyInfo, deprecated map[K]time.Time, kind KeyType) []AcceptedKey {
+	out := make([]AcceptedKey, 0, len(accepted))
 	for key, info := range accepted {
-		if key == primary {
-			continue
-		}
 		expiry := info.expiry
-		// Legacy RotateWithGrace path stores expiry in the deprecated map, not in acceptedKeyInfo.
 		if expiry == nil {
 			if t, ok := deprecated[key]; ok {
-				expiry = &t
+				tt := t
+				expiry = &tt
 			}
 		}
-		entries = append(entries, construct(key, info.identifier, expiry))
+		out = append(out, AcceptedKey{Type: kind, Value: string(key), Key: info.key, Expiry: expiry})
 	}
-	sort.Slice(entries, func(i, j int) bool {
-		ai, bi := identifier(entries[i]), identifier(entries[j])
-		if ai != bi {
-			// Empty identifiers sort last.
-			if ai == "" {
-				return false
-			}
-			if bi == "" {
-				return true
-			}
-			return ai < bi
-		}
-		return value(entries[i]) < value(entries[j])
-	})
-	return entries
+	return out
 }
 
-// NonAnchorSDKKeyEntries returns metadata for all accepted SDK keys except the anchor, sorted by
-// identifier. Used by the status endpoint to populate the sdkKeys[] response array.
-func (r *Rotator) NonAnchorSDKKeyEntries() []SDKKeyEntry {
+// AcceptedKeys returns every accepted credential — all server-side SDK keys and all mobile keys,
+// including the anchor and the primary mobile key. The status endpoint partitions the result by Type
+// to populate the full sdkKeys[] / mobileKeys[] arrays. Order is unspecified.
+func (r *Rotator) AcceptedKeys() []AcceptedKey {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	return nonPrimaryKeyEntries(
-		r.acceptedSDKKeys, r.deprecatedSdkKeys, r.primarySdkKey,
-		func(e SDKKeyEntry) string { return e.Identifier },
-		func(e SDKKeyEntry) string { return string(e.Value) },
-		func(key config.SDKKey, identifier string, expiry *time.Time) SDKKeyEntry {
-			return SDKKeyEntry{Value: key, Identifier: identifier, Expiry: expiry}
-		},
-	)
+	keys := acceptedKeysOf(r.acceptedSDKKeys, r.deprecatedSdkKeys, KeyTypeServer)
+	return append(keys, acceptedKeysOf(r.acceptedMobileKeys, r.deprecatedMobileKeys, KeyTypeMobile)...)
 }
 
-// NonPrimaryMobileKeyEntries returns metadata for all accepted mobile keys except the primary,
-// sorted by identifier. Used by the status endpoint to populate the mobileKeys[] response array.
-func (r *Rotator) NonPrimaryMobileKeyEntries() []MobileKeyEntry {
+// DeprecatedSDKKeys returns the server-side SDK keys in the legacy grace-period map (the
+// RotateWithGrace path) with their expiry. These may not be in the accepted set, so the status
+// endpoint folds them into the expiringSdkKey computation for back-compat. The slice is empty once
+// the legacy rotation path is removed (SDK-2603). Order is unspecified.
+func (r *Rotator) DeprecatedSDKKeys() []AcceptedKey {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	return nonPrimaryKeyEntries(
-		r.acceptedMobileKeys, r.deprecatedMobileKeys, r.primaryMobileKey,
-		func(e MobileKeyEntry) string { return e.Identifier },
-		func(e MobileKeyEntry) string { return string(e.Value) },
-		func(key config.MobileKey, identifier string, expiry *time.Time) MobileKeyEntry {
-			return MobileKeyEntry{Value: key, Identifier: identifier, Expiry: expiry}
-		},
-	)
-}
-
-// EarliestExpiringNonAnchorSDKKey returns the non-anchor SDK key with the soonest expiry, and true.
-// Returns the zero SDKKey and false when no expiring non-anchor key exists. This produces a
-// deterministic value for the status endpoint's legacy expiringSdkKey field, regardless of how many
-// keys are currently expiring.
-func (r *Rotator) EarliestExpiringNonAnchorSDKKey() (config.SDKKey, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	var earliest config.SDKKey
-	var earliestTime *time.Time
-
-	updateEarliest := func(key config.SDKKey, t time.Time) {
-		if earliestTime == nil || t.Before(*earliestTime) {
-			earliest = key
-			tt := t
-			earliestTime = &tt
-		}
-	}
-
-	// Reconcile-path: expiry stored on the accepted entry.
-	for key, info := range r.acceptedSDKKeys {
-		if key != r.primarySdkKey && info.expiry != nil {
-			updateEarliest(key, *info.expiry)
-		}
-	}
-	// Legacy RotateWithGrace path: expiry stored in deprecatedSdkKeys.
+	out := make([]AcceptedKey, 0, len(r.deprecatedSdkKeys))
 	for key, t := range r.deprecatedSdkKeys {
-		updateEarliest(key, t)
+		tt := t
+		out = append(out, AcceptedKey{Type: KeyTypeServer, Value: string(key), Expiry: &tt})
 	}
-
-	return earliest, earliestTime != nil
+	return out
 }

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -532,19 +532,18 @@ func reconcileAcceptedKeys[K reconcilableKey](
 // payload may carry for it. The caller must hold the write lock.
 func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now time.Time) {
 	desired := make(map[config.SDKKey]*time.Time, len(set.sdkKeys))
-	for key, expiry := range set.sdkKeys {
-		if expiry != nil && !now.Before(*expiry) {
+	for key, meta := range set.sdkKeys {
+		if meta.expiry != nil && !now.Before(*meta.expiry) {
 			continue // already expired; treat as absent
 		}
-		desired[key] = expiry
+		desired[key] = meta.expiry
 	}
 	desired[anchor] = nil
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, r.deprecatedSdkKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
 	// Refresh the wire "key" identifier for every key now in the accepted set.
-	for key, id := range set.sdkKeyIdentifiers {
-		if info, ok := r.acceptedSDKKeys[key]; ok && id != "" {
-			idCopy := id
-			info.key = &idCopy
+	for key, meta := range set.sdkKeys {
+		if info, ok := r.acceptedSDKKeys[key]; ok && meta.key != nil {
+			info.key = meta.key
 		}
 	}
 	r.primarySdkKey = anchor
@@ -555,20 +554,19 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 // and permanent; an empty value means the set declared no mobile key. The caller must hold the lock.
 func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
 	desired := make(map[config.MobileKey]*time.Time, len(set.mobileKeys))
-	for key, expiry := range set.mobileKeys {
-		if expiry != nil && !now.Before(*expiry) {
+	for key, meta := range set.mobileKeys {
+		if meta.expiry != nil && !now.Before(*meta.expiry) {
 			continue // already expired; treat as absent
 		}
-		desired[key] = expiry
+		desired[key] = meta.expiry
 	}
 	if set.primaryMobileKey.Defined() {
 		desired[set.primaryMobileKey] = nil
 	}
 	reconcileAcceptedKeys(desired, r.acceptedMobileKeys, r.deprecatedMobileKeys, &r.additions, &r.expirations, r.loggers, "Mobile key")
-	for key, id := range set.mobileKeyIdentifiers {
-		if info, ok := r.acceptedMobileKeys[key]; ok && id != "" {
-			idCopy := id
-			info.key = &idCopy
+	for key, meta := range set.mobileKeys {
+		if info, ok := r.acceptedMobileKeys[key]; ok && meta.key != nil {
+			info.key = meta.key
 		}
 	}
 	r.primaryMobileKey = set.primaryMobileKey

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -780,60 +780,70 @@ func reconcileSet(t *testing.T, r *Rotator, build func(*AcceptedSetBuilder)) {
 	r.Reconcile(set, time.Unix(0, 0))
 }
 
-// TestNonAnchorSDKKeyEntries verifies that NonAnchorSDKKeyEntries returns all accepted non-anchor SDK
-// keys sorted by identifier, with anchor excluded and expiry populated from both reconcile and legacy paths.
-func TestNonAnchorSDKKeyEntries(t *testing.T) {
-	t.Run("single anchor returns empty slice", func(t *testing.T) {
+// findAcceptedKey returns the entry with the given value, or nil. Used because AcceptedKeys order is
+// unspecified.
+func findAcceptedKey(entries []AcceptedKey, value string) *AcceptedKey {
+	for i := range entries {
+		if entries[i].Value == value {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
+// TestAcceptedKeys verifies that AcceptedKeys returns the full accepted set — every server and mobile
+// key, including the anchor and primary mobile key — with type, identifier, and expiry populated.
+func TestAcceptedKeys(t *testing.T) {
+	t.Run("single anchor plus primary mobile", func(t *testing.T) {
 		r := newTestRotator()
 		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
 			b.WithPrimarySDKKey("sdk-anchor").
 				WithSDKKeyIdentifier("sdk-anchor", "default").
-				WithPrimaryMobileKey("mob-primary")
+				WithPrimaryMobileKey("mob-primary").
+				WithMobileKeyIdentifier("mob-primary", "mob-1")
 		})
-		entries := r.NonAnchorSDKKeyEntries()
-		assert.Empty(t, entries)
+		entries := r.AcceptedKeys()
+		require.Len(t, entries, 2)
+
+		anchor := findAcceptedKey(entries, "sdk-anchor")
+		require.NotNil(t, anchor)
+		assert.Equal(t, KeyTypeServer, anchor.Type)
+		require.NotNil(t, anchor.Key)
+		assert.Equal(t, "default", *anchor.Key)
+		assert.Nil(t, anchor.Expiry)
+
+		mob := findAcceptedKey(entries, "mob-primary")
+		require.NotNil(t, mob)
+		assert.Equal(t, KeyTypeMobile, mob.Type)
+		require.NotNil(t, mob.Key)
+		assert.Equal(t, "mob-1", *mob.Key)
 	})
 
-	t.Run("multiple keys sorted by identifier", func(t *testing.T) {
+	t.Run("multiple keys include the anchor", func(t *testing.T) {
 		r := newTestRotator()
+		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
 		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
 			b.WithPrimarySDKKey("sdk-anchor").
 				WithSDKKeyIdentifier("sdk-anchor", "default").
 				WithSDKKey("sdk-b").
 				WithSDKKeyIdentifier("sdk-b", "b-service").
-				WithSDKKey("sdk-a").
-				WithSDKKeyIdentifier("sdk-a", "a-service").
-				WithPrimaryMobileKey("mob-primary")
-		})
-		entries := r.NonAnchorSDKKeyEntries()
-		require.Len(t, entries, 2)
-		// Sorted alphabetically by identifier: a-service < b-service.
-		assert.Equal(t, config.SDKKey("sdk-a"), entries[0].Value)
-		assert.Equal(t, "a-service", entries[0].Identifier)
-		assert.Nil(t, entries[0].Expiry)
-		assert.Equal(t, config.SDKKey("sdk-b"), entries[1].Value)
-		assert.Equal(t, "b-service", entries[1].Identifier)
-	})
-
-	t.Run("expiring key expiry populated", func(t *testing.T) {
-		r := newTestRotator()
-		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
-		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithSDKKeyIdentifier("sdk-anchor", "default").
 				WithExpiringSDKKey("sdk-old", expiry).
 				WithSDKKeyIdentifier("sdk-old", "old-key").
 				WithPrimaryMobileKey("mob-primary")
 		})
-		entries := r.NonAnchorSDKKeyEntries()
-		require.Len(t, entries, 1)
-		assert.Equal(t, config.SDKKey("sdk-old"), entries[0].Value)
-		assert.Equal(t, "old-key", entries[0].Identifier)
-		require.NotNil(t, entries[0].Expiry)
-		assert.Equal(t, expiry, *entries[0].Expiry)
+		entries := r.AcceptedKeys()
+		// anchor + sdk-b + sdk-old + mob-primary
+		require.Len(t, entries, 4)
+
+		assert.NotNil(t, findAcceptedKey(entries, "sdk-anchor"), "anchor must be present in the full set")
+
+		old := findAcceptedKey(entries, "sdk-old")
+		require.NotNil(t, old)
+		require.NotNil(t, old.Expiry)
+		assert.Equal(t, expiry, *old.Expiry)
 	})
 
-	t.Run("legacy RotateWithGrace key included with expiry", func(t *testing.T) {
+	t.Run("legacy RotateWithGrace key has expiry and nil identifier", func(t *testing.T) {
 		r := newTestRotator()
 		now := time.Unix(1000, 0)
 		expiry := now.Add(time.Hour)
@@ -841,144 +851,27 @@ func TestNonAnchorSDKKeyEntries(t *testing.T) {
 		r.RotateWithGrace(config.SDKKey("sdk-new"), NewGracePeriod("sdk-old", expiry, now))
 		r.StepTime(now)
 
-		entries := r.NonAnchorSDKKeyEntries()
-		require.Len(t, entries, 1)
-		assert.Equal(t, config.SDKKey("sdk-old"), entries[0].Value)
-		assert.Equal(t, "", entries[0].Identifier) // legacy path has no identifier
-		require.NotNil(t, entries[0].Expiry)
-		assert.Equal(t, expiry, *entries[0].Expiry)
-	})
-
-	t.Run("no-identifier keys sort after identified keys", func(t *testing.T) {
-		r := newTestRotator()
-		now := time.Unix(1000, 0)
-		expiry := now.Add(time.Hour)
-		// sdk-legacy has no identifier (legacy path); sdk-named has one (reconcile path).
-		r.Initialize([]SDKCredential{config.SDKKey("sdk-old")})
-		r.RotateWithGrace(config.SDKKey("sdk-anchor"), NewGracePeriod("sdk-old", expiry, now))
-		r.StepTime(now)
-		// Now add a reconcile key with an identifier.
-		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithSDKKeyIdentifier("sdk-anchor", "default").
-				WithSDKKey("sdk-named").
-				WithSDKKeyIdentifier("sdk-named", "named").
-				WithSDKKey("sdk-old") // keep legacy key in set so it isn't revoked
-		})
-
-		entries := r.NonAnchorSDKKeyEntries()
-		require.Len(t, entries, 2)
-		// "named" has an identifier; sdk-old has none — identified entries sort first.
-		assert.Equal(t, "named", entries[0].Identifier)
-		assert.Equal(t, "", entries[1].Identifier)
+		entries := r.AcceptedKeys()
+		old := findAcceptedKey(entries, "sdk-old")
+		require.NotNil(t, old)
+		assert.Nil(t, old.Key, "legacy path carries no identifier")
+		require.NotNil(t, old.Expiry)
+		assert.Equal(t, expiry, *old.Expiry)
 	})
 }
 
-// TestNonPrimaryMobileKeyEntries verifies NonPrimaryMobileKeyEntries returns all non-primary mobile keys.
-func TestNonPrimaryMobileKeyEntries(t *testing.T) {
-	t.Run("single primary mobile key returns empty slice", func(t *testing.T) {
-		r := newTestRotator()
-		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithPrimaryMobileKey("mob-primary").
-				WithMobileKeyIdentifier("mob-primary", "mob-1")
-		})
-		entries := r.NonPrimaryMobileKeyEntries()
-		assert.Empty(t, entries)
-	})
-
-	t.Run("multiple mobile keys sorted by identifier", func(t *testing.T) {
-		r := newTestRotator()
-		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithMobileKey("mob-primary").
-				WithMobileKeyIdentifier("mob-primary", "mob-1").
-				WithMobileKey("mob-secondary").
-				WithMobileKeyIdentifier("mob-secondary", "mob-2").
-				WithMobileKey("mob-third").
-				WithMobileKeyIdentifier("mob-third", "mob-0").
-				WithPrimaryMobileKey("mob-primary")
-		})
-		entries := r.NonPrimaryMobileKeyEntries()
-		require.Len(t, entries, 2)
-		// mob-0 < mob-2 alphabetically.
-		assert.Equal(t, config.MobileKey("mob-third"), entries[0].Value)
-		assert.Equal(t, "mob-0", entries[0].Identifier)
-		assert.Equal(t, config.MobileKey("mob-secondary"), entries[1].Value)
-		assert.Equal(t, "mob-2", entries[1].Identifier)
-	})
-
-	t.Run("expiring mobile key expiry populated", func(t *testing.T) {
-		r := newTestRotator()
-		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
-		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithMobileKey("mob-primary").
-				WithMobileKeyIdentifier("mob-primary", "mob-1").
-				WithExpiringMobileKey("mob-old", expiry).
-				WithMobileKeyIdentifier("mob-old", "mob-old").
-				WithPrimaryMobileKey("mob-primary")
-		})
-		entries := r.NonPrimaryMobileKeyEntries()
-		require.Len(t, entries, 1)
-		assert.Equal(t, config.MobileKey("mob-old"), entries[0].Value)
-		require.NotNil(t, entries[0].Expiry)
-		assert.Equal(t, expiry, *entries[0].Expiry)
-	})
-}
-
-// TestEarliestExpiringNonAnchorSDKKey verifies the deterministic expiring-key selection used by the
-// status endpoint's legacy expiringSdkKey field.
-func TestEarliestExpiringNonAnchorSDKKey(t *testing.T) {
-	t.Run("no keys returns false", func(t *testing.T) {
+// TestDeprecatedSDKKeys verifies the legacy grace-period accessor used for the expiringSdkKey
+// back-compat computation.
+func TestDeprecatedSDKKeys(t *testing.T) {
+	t.Run("empty when no legacy grace keys", func(t *testing.T) {
 		r := newTestRotator()
 		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
 			b.WithPrimarySDKKey("sdk-anchor").WithPrimaryMobileKey("mob-primary")
 		})
-		_, ok := r.EarliestExpiringNonAnchorSDKKey()
-		assert.False(t, ok)
+		assert.Empty(t, r.DeprecatedSDKKeys())
 	})
 
-	t.Run("only permanent non-anchor keys returns false", func(t *testing.T) {
-		r := newTestRotator()
-		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithSDKKey("sdk-perm").
-				WithPrimaryMobileKey("mob-primary")
-		})
-		_, ok := r.EarliestExpiringNonAnchorSDKKey()
-		assert.False(t, ok)
-	})
-
-	t.Run("single expiring key (reconcile path)", func(t *testing.T) {
-		r := newTestRotator()
-		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
-		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithExpiringSDKKey("sdk-old", expiry).
-				WithPrimaryMobileKey("mob-primary")
-		})
-		key, ok := r.EarliestExpiringNonAnchorSDKKey()
-		assert.True(t, ok)
-		assert.Equal(t, config.SDKKey("sdk-old"), key)
-	})
-
-	t.Run("picks soonest among multiple expiring keys", func(t *testing.T) {
-		r := newTestRotator()
-		sooner := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
-		later := time.Date(2099, 12, 31, 0, 0, 0, 0, time.UTC)
-		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithExpiringSDKKey("sdk-sooner", sooner).
-				WithExpiringSDKKey("sdk-later", later).
-				WithPrimaryMobileKey("mob-primary")
-		})
-		key, ok := r.EarliestExpiringNonAnchorSDKKey()
-		assert.True(t, ok)
-		assert.Equal(t, config.SDKKey("sdk-sooner"), key)
-	})
-
-	t.Run("legacy RotateWithGrace key is found", func(t *testing.T) {
+	t.Run("returns legacy grace key with expiry", func(t *testing.T) {
 		r := newTestRotator()
 		now := time.Unix(1000, 0)
 		expiry := now.Add(time.Hour)
@@ -986,29 +879,11 @@ func TestEarliestExpiringNonAnchorSDKKey(t *testing.T) {
 		r.RotateWithGrace(config.SDKKey("sdk-new"), NewGracePeriod("sdk-old", expiry, now))
 		r.StepTime(now)
 
-		key, ok := r.EarliestExpiringNonAnchorSDKKey()
-		assert.True(t, ok)
-		assert.Equal(t, config.SDKKey("sdk-old"), key)
-	})
-
-	t.Run("picks soonest across both reconcile and legacy paths", func(t *testing.T) {
-		r := newTestRotator()
-		now := time.Unix(1000, 0)
-		legacyExpiry := now.Add(2 * time.Hour)       // later
-		reconcileExpiry := now.Add(30 * time.Minute) // sooner
-
-		r.Initialize([]SDKCredential{config.SDKKey("sdk-legacy")})
-		r.RotateWithGrace(config.SDKKey("sdk-anchor"), NewGracePeriod("sdk-legacy", legacyExpiry, now))
-		r.StepTime(now)
-
-		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithExpiringSDKKey("sdk-reconcile", reconcileExpiry).
-				WithSDKKey("sdk-legacy") // include legacy key so it isn't revoked
-		})
-
-		key, ok := r.EarliestExpiringNonAnchorSDKKey()
-		assert.True(t, ok)
-		assert.Equal(t, config.SDKKey("sdk-reconcile"), key)
+		entries := r.DeprecatedSDKKeys()
+		require.Len(t, entries, 1)
+		assert.Equal(t, "sdk-old", entries[0].Value)
+		assert.Equal(t, KeyTypeServer, entries[0].Type)
+		require.NotNil(t, entries[0].Expiry)
+		assert.Equal(t, expiry, *entries[0].Expiry)
 	})
 }

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -328,3 +328,31 @@ func TestAcceptedKeys(t *testing.T) {
 		assert.Nil(t, mob.Key)
 	})
 }
+
+// TestReconcileClearsStaleKeyIdentifier verifies that when a later reconcile carries no identifier for
+// a key that previously had one (e.g. an old-format payload after a new-format one), the rotator
+// clears the stale identifier rather than retaining it — so /status never shows an identifier the
+// current credential set no longer carries.
+func TestReconcileClearsStaleKeyIdentifier(t *testing.T) {
+	r := newTestRotator()
+	now := time.Unix(0, 0)
+
+	// First reconcile: sdk-b carries the identifier "b-service".
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		WithAnchor(SDKKeyParams{Value: "sdk-anchor"}).
+		WithSDKKey(SDKKeyParams{Value: "sdk-b", Key: util.PtrOrNil("b-service")})), now)
+
+	b := findAcceptedKey(r.AcceptedKeys(), "sdk-b")
+	require.NotNil(t, b)
+	require.NotNil(t, b.Key)
+	assert.Equal(t, "b-service", *b.Key)
+
+	// Second reconcile: same credential value, but no identifier this time.
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		WithAnchor(SDKKeyParams{Value: "sdk-anchor"}).
+		WithSDKKey(SDKKeyParams{Value: "sdk-b"})), now)
+
+	b = findAcceptedKey(r.AcceptedKeys(), "sdk-b")
+	require.NotNil(t, b)
+	assert.Nil(t, b.Key, "identifier must be cleared when the new payload carries none")
+}

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -769,3 +769,246 @@ func TestDeprecatedCredentialsIncludesMobileKeys(t *testing.T) {
 	deprecated := rotator.DeprecatedCredentials()
 	assert.ElementsMatch(t, []SDKCredential{sdk1, mob1}, deprecated)
 }
+
+// reconcileSet is a test helper that builds an AcceptedSet and calls Reconcile on r.
+func reconcileSet(t *testing.T, r *Rotator, build func(*AcceptedSetBuilder)) {
+	t.Helper()
+	b := NewAcceptedSetBuilder()
+	build(b)
+	set, err := b.Build()
+	require.NoError(t, err)
+	r.Reconcile(set, time.Unix(0, 0))
+}
+
+// TestNonAnchorSDKKeyEntries verifies that NonAnchorSDKKeyEntries returns all accepted non-anchor SDK
+// keys sorted by identifier, with anchor excluded and expiry populated from both reconcile and legacy paths.
+func TestNonAnchorSDKKeyEntries(t *testing.T) {
+	t.Run("single anchor returns empty slice", func(t *testing.T) {
+		r := newTestRotator()
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithSDKKeyIdentifier("sdk-anchor", "default").
+				WithPrimaryMobileKey("mob-primary")
+		})
+		entries := r.NonAnchorSDKKeyEntries()
+		assert.Empty(t, entries)
+	})
+
+	t.Run("multiple keys sorted by identifier", func(t *testing.T) {
+		r := newTestRotator()
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithSDKKeyIdentifier("sdk-anchor", "default").
+				WithSDKKey("sdk-b").
+				WithSDKKeyIdentifier("sdk-b", "b-service").
+				WithSDKKey("sdk-a").
+				WithSDKKeyIdentifier("sdk-a", "a-service").
+				WithPrimaryMobileKey("mob-primary")
+		})
+		entries := r.NonAnchorSDKKeyEntries()
+		require.Len(t, entries, 2)
+		// Sorted alphabetically by identifier: a-service < b-service.
+		assert.Equal(t, config.SDKKey("sdk-a"), entries[0].Value)
+		assert.Equal(t, "a-service", entries[0].Identifier)
+		assert.Nil(t, entries[0].Expiry)
+		assert.Equal(t, config.SDKKey("sdk-b"), entries[1].Value)
+		assert.Equal(t, "b-service", entries[1].Identifier)
+	})
+
+	t.Run("expiring key expiry populated", func(t *testing.T) {
+		r := newTestRotator()
+		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithSDKKeyIdentifier("sdk-anchor", "default").
+				WithExpiringSDKKey("sdk-old", expiry).
+				WithSDKKeyIdentifier("sdk-old", "old-key").
+				WithPrimaryMobileKey("mob-primary")
+		})
+		entries := r.NonAnchorSDKKeyEntries()
+		require.Len(t, entries, 1)
+		assert.Equal(t, config.SDKKey("sdk-old"), entries[0].Value)
+		assert.Equal(t, "old-key", entries[0].Identifier)
+		require.NotNil(t, entries[0].Expiry)
+		assert.Equal(t, expiry, *entries[0].Expiry)
+	})
+
+	t.Run("legacy RotateWithGrace key included with expiry", func(t *testing.T) {
+		r := newTestRotator()
+		now := time.Unix(1000, 0)
+		expiry := now.Add(time.Hour)
+		r.Initialize([]SDKCredential{config.SDKKey("sdk-old")})
+		r.RotateWithGrace(config.SDKKey("sdk-new"), NewGracePeriod("sdk-old", expiry, now))
+		r.StepTime(now)
+
+		entries := r.NonAnchorSDKKeyEntries()
+		require.Len(t, entries, 1)
+		assert.Equal(t, config.SDKKey("sdk-old"), entries[0].Value)
+		assert.Equal(t, "", entries[0].Identifier) // legacy path has no identifier
+		require.NotNil(t, entries[0].Expiry)
+		assert.Equal(t, expiry, *entries[0].Expiry)
+	})
+
+	t.Run("no-identifier keys sort after identified keys", func(t *testing.T) {
+		r := newTestRotator()
+		now := time.Unix(1000, 0)
+		expiry := now.Add(time.Hour)
+		// sdk-legacy has no identifier (legacy path); sdk-named has one (reconcile path).
+		r.Initialize([]SDKCredential{config.SDKKey("sdk-old")})
+		r.RotateWithGrace(config.SDKKey("sdk-anchor"), NewGracePeriod("sdk-old", expiry, now))
+		r.StepTime(now)
+		// Now add a reconcile key with an identifier.
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithSDKKeyIdentifier("sdk-anchor", "default").
+				WithSDKKey("sdk-named").
+				WithSDKKeyIdentifier("sdk-named", "named").
+				WithSDKKey("sdk-old") // keep legacy key in set so it isn't revoked
+		})
+
+		entries := r.NonAnchorSDKKeyEntries()
+		require.Len(t, entries, 2)
+		// "named" has an identifier; sdk-old has none — identified entries sort first.
+		assert.Equal(t, "named", entries[0].Identifier)
+		assert.Equal(t, "", entries[1].Identifier)
+	})
+}
+
+// TestNonPrimaryMobileKeyEntries verifies NonPrimaryMobileKeyEntries returns all non-primary mobile keys.
+func TestNonPrimaryMobileKeyEntries(t *testing.T) {
+	t.Run("single primary mobile key returns empty slice", func(t *testing.T) {
+		r := newTestRotator()
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithPrimaryMobileKey("mob-primary").
+				WithMobileKeyIdentifier("mob-primary", "mob-1")
+		})
+		entries := r.NonPrimaryMobileKeyEntries()
+		assert.Empty(t, entries)
+	})
+
+	t.Run("multiple mobile keys sorted by identifier", func(t *testing.T) {
+		r := newTestRotator()
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithMobileKey("mob-primary").
+				WithMobileKeyIdentifier("mob-primary", "mob-1").
+				WithMobileKey("mob-secondary").
+				WithMobileKeyIdentifier("mob-secondary", "mob-2").
+				WithMobileKey("mob-third").
+				WithMobileKeyIdentifier("mob-third", "mob-0").
+				WithPrimaryMobileKey("mob-primary")
+		})
+		entries := r.NonPrimaryMobileKeyEntries()
+		require.Len(t, entries, 2)
+		// mob-0 < mob-2 alphabetically.
+		assert.Equal(t, config.MobileKey("mob-third"), entries[0].Value)
+		assert.Equal(t, "mob-0", entries[0].Identifier)
+		assert.Equal(t, config.MobileKey("mob-secondary"), entries[1].Value)
+		assert.Equal(t, "mob-2", entries[1].Identifier)
+	})
+
+	t.Run("expiring mobile key expiry populated", func(t *testing.T) {
+		r := newTestRotator()
+		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithMobileKey("mob-primary").
+				WithMobileKeyIdentifier("mob-primary", "mob-1").
+				WithExpiringMobileKey("mob-old", expiry).
+				WithMobileKeyIdentifier("mob-old", "mob-old").
+				WithPrimaryMobileKey("mob-primary")
+		})
+		entries := r.NonPrimaryMobileKeyEntries()
+		require.Len(t, entries, 1)
+		assert.Equal(t, config.MobileKey("mob-old"), entries[0].Value)
+		require.NotNil(t, entries[0].Expiry)
+		assert.Equal(t, expiry, *entries[0].Expiry)
+	})
+}
+
+// TestEarliestExpiringNonAnchorSDKKey verifies the deterministic expiring-key selection used by the
+// status endpoint's legacy expiringSdkKey field.
+func TestEarliestExpiringNonAnchorSDKKey(t *testing.T) {
+	t.Run("no keys returns false", func(t *testing.T) {
+		r := newTestRotator()
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").WithPrimaryMobileKey("mob-primary")
+		})
+		_, ok := r.EarliestExpiringNonAnchorSDKKey()
+		assert.False(t, ok)
+	})
+
+	t.Run("only permanent non-anchor keys returns false", func(t *testing.T) {
+		r := newTestRotator()
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithSDKKey("sdk-perm").
+				WithPrimaryMobileKey("mob-primary")
+		})
+		_, ok := r.EarliestExpiringNonAnchorSDKKey()
+		assert.False(t, ok)
+	})
+
+	t.Run("single expiring key (reconcile path)", func(t *testing.T) {
+		r := newTestRotator()
+		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithExpiringSDKKey("sdk-old", expiry).
+				WithPrimaryMobileKey("mob-primary")
+		})
+		key, ok := r.EarliestExpiringNonAnchorSDKKey()
+		assert.True(t, ok)
+		assert.Equal(t, config.SDKKey("sdk-old"), key)
+	})
+
+	t.Run("picks soonest among multiple expiring keys", func(t *testing.T) {
+		r := newTestRotator()
+		sooner := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+		later := time.Date(2099, 12, 31, 0, 0, 0, 0, time.UTC)
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithExpiringSDKKey("sdk-sooner", sooner).
+				WithExpiringSDKKey("sdk-later", later).
+				WithPrimaryMobileKey("mob-primary")
+		})
+		key, ok := r.EarliestExpiringNonAnchorSDKKey()
+		assert.True(t, ok)
+		assert.Equal(t, config.SDKKey("sdk-sooner"), key)
+	})
+
+	t.Run("legacy RotateWithGrace key is found", func(t *testing.T) {
+		r := newTestRotator()
+		now := time.Unix(1000, 0)
+		expiry := now.Add(time.Hour)
+		r.Initialize([]SDKCredential{config.SDKKey("sdk-old")})
+		r.RotateWithGrace(config.SDKKey("sdk-new"), NewGracePeriod("sdk-old", expiry, now))
+		r.StepTime(now)
+
+		key, ok := r.EarliestExpiringNonAnchorSDKKey()
+		assert.True(t, ok)
+		assert.Equal(t, config.SDKKey("sdk-old"), key)
+	})
+
+	t.Run("picks soonest across both reconcile and legacy paths", func(t *testing.T) {
+		r := newTestRotator()
+		now := time.Unix(1000, 0)
+		legacyExpiry := now.Add(2 * time.Hour) // later
+		reconcileExpiry := now.Add(30 * time.Minute) // sooner
+
+		r.Initialize([]SDKCredential{config.SDKKey("sdk-legacy")})
+		r.RotateWithGrace(config.SDKKey("sdk-anchor"), NewGracePeriod("sdk-legacy", legacyExpiry, now))
+		r.StepTime(now)
+
+		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
+			b.WithPrimarySDKKey("sdk-anchor").
+				WithExpiringSDKKey("sdk-reconcile", reconcileExpiry).
+				WithSDKKey("sdk-legacy") // include legacy key so it isn't revoked
+		})
+
+		key, ok := r.EarliestExpiringNonAnchorSDKKey()
+		assert.True(t, ok)
+		assert.Equal(t, config.SDKKey("sdk-reconcile"), key)
+	})
+}

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
 	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -475,7 +476,7 @@ func TestReconcileAnchorOnly(t *testing.T) {
 	anchor := config.SDKKey("anchor")
 	now := time.Now()
 
-	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, ""))), now)
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(SDKKeyParams{Value: anchor})), now)
 	additions, expirations := r.StepTime(now)
 
 	assert.ElementsMatch(t, []SDKCredential{anchor}, additions)
@@ -492,7 +493,7 @@ func TestReconcileMultipleSDKKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, "")).WithSDKKey(sdkP(other, ""))), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(SDKKeyParams{Value: anchor}).WithSDKKey(SDKKeyParams{Value: other})), now)
 	additions, expirations := r.StepTime(now)
 
 	// Both server keys are accepted; only the anchor is primary.
@@ -511,7 +512,7 @@ func TestReconcileMultipleMobileKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, "")).WithPrimaryMobileKey(mobP(mob1, "")).WithMobileKey(mobP(mob2, ""))), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(SDKKeyParams{Value: anchor}).WithPrimaryMobileKey(MobileKeyParams{Value: mob1}).WithMobileKey(MobileKeyParams{Value: mob2})), now)
 	additions, _ := r.StepTime(now)
 
 	// Every mobile key is accepted; the designated one is the primary.
@@ -528,11 +529,11 @@ func TestReconcileRevokesOmittedKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, "")).WithSDKKey(sdkP(other, "")).WithPrimaryMobileKey(mobP(mob, ""))), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(SDKKeyParams{Value: anchor}).WithSDKKey(SDKKeyParams{Value: other}).WithPrimaryMobileKey(MobileKeyParams{Value: mob})), now)
 	r.StepTime(now)
 
 	// Reconciling to just the anchor revokes the omitted server and mobile keys.
-	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, ""))), now)
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(SDKKeyParams{Value: anchor})), now)
 	additions, expirations := r.StepTime(now)
 
 	assert.Empty(t, additions)
@@ -554,10 +555,10 @@ func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
 
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithPrimarySDKKey(sdkP(anchor, "")).
-			WithSDKKey(sdkPExp(expiringSDK, "", now.Add(time.Hour))).
-			WithPrimaryMobileKey(mobP(mob, "")).
-			WithMobileKey(mobPExp(expiringMobile, "", now.Add(time.Hour)))),
+			WithPrimarySDKKey(SDKKeyParams{Value: anchor}).
+			WithSDKKey(SDKKeyParams{Value: expiringSDK, Expiry: util.PtrOrNil(now.Add(time.Hour))}).
+			WithPrimaryMobileKey(MobileKeyParams{Value: mob}).
+			WithMobileKey(MobileKeyParams{Value: expiringMobile, Expiry: util.PtrOrNil(now.Add(time.Hour))})),
 		now)
 	additions, expirations := r.StepTime(now)
 
@@ -580,9 +581,9 @@ func TestReconcilePrimaryMobileKeyIsAlwaysAccepted(t *testing.T) {
 	now := time.Unix(1000, 0)
 
 	set := mustBuild(t, NewAcceptedSetBuilder().
-		WithPrimarySDKKey(sdkP(anchor, "")).
-		WithMobileKey(mobPExp(mob, "", now.Add(-time.Hour))). // already expired in the payload...
-		WithPrimaryMobileKey(mobP(mob, "")))                  // ...but designated as the primary
+		WithPrimarySDKKey(SDKKeyParams{Value: anchor}).
+		WithMobileKey(MobileKeyParams{Value: mob, Expiry: util.PtrOrNil(now.Add(-time.Hour))}). // already expired in the payload...
+		WithPrimaryMobileKey(MobileKeyParams{Value: mob}))                                      // ...but designated as the primary
 	r.Reconcile(set, now)
 	r.StepTime(now)
 
@@ -607,7 +608,7 @@ func TestReconcileClearsStaleDeprecationForAcceptedKey(t *testing.T) {
 
 	// Reconcile to a set that fully accepts both keys.
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, "")).WithSDKKey(sdkP(old, ""))), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(SDKKeyParams{Value: anchor}).WithSDKKey(SDKKeyParams{Value: old})), now)
 	r.StepTime(now)
 
 	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(old))
@@ -629,10 +630,10 @@ func TestReconcileExpiringKeysAreEvictedByStepTime(t *testing.T) {
 
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithPrimarySDKKey(sdkP(anchor, "")).
-			WithSDKKey(sdkPExp(expiringSDK, "", expiry)).
-			WithPrimaryMobileKey(mobP(mob, "")).
-			WithMobileKey(mobPExp(expiringMobile, "", expiry))),
+			WithPrimarySDKKey(SDKKeyParams{Value: anchor}).
+			WithSDKKey(SDKKeyParams{Value: expiringSDK, Expiry: util.PtrOrNil(expiry)}).
+			WithPrimaryMobileKey(MobileKeyParams{Value: mob}).
+			WithMobileKey(MobileKeyParams{Value: expiringMobile, Expiry: util.PtrOrNil(expiry)})),
 		now)
 	additions, expirations := r.StepTime(now)
 	require.ElementsMatch(t, []SDKCredential{anchor, expiringSDK, mob, expiringMobile}, additions)
@@ -797,8 +798,8 @@ func TestAcceptedKeys(t *testing.T) {
 	t.Run("single anchor plus primary mobile", func(t *testing.T) {
 		r := newTestRotator()
 		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
-				WithPrimaryMobileKey(mobP("mob-primary", "mob-1"))
+			b.WithPrimarySDKKey(SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+				WithPrimaryMobileKey(MobileKeyParams{Value: "mob-primary", Key: util.PtrOrNil("mob-1")})
 		})
 		entries := r.AcceptedKeys()
 		require.Len(t, entries, 2)
@@ -821,10 +822,10 @@ func TestAcceptedKeys(t *testing.T) {
 		r := newTestRotator()
 		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
 		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
-				WithSDKKey(sdkP("sdk-b", "b-service")).
-				WithSDKKey(sdkPExp("sdk-old", "old-key", expiry)).
-				WithPrimaryMobileKey(mobP("mob-primary", ""))
+			b.WithPrimarySDKKey(SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+				WithSDKKey(SDKKeyParams{Value: "sdk-b", Key: util.PtrOrNil("b-service")}).
+				WithSDKKey(SDKKeyParams{Value: "sdk-old", Key: util.PtrOrNil("old-key"), Expiry: util.PtrOrNil(expiry)}).
+				WithPrimaryMobileKey(MobileKeyParams{Value: "mob-primary"})
 		})
 		entries := r.AcceptedKeys()
 		// anchor + sdk-b + sdk-old + mob-primary
@@ -861,7 +862,7 @@ func TestDeprecatedSDKKeys(t *testing.T) {
 	t.Run("empty when no legacy grace keys", func(t *testing.T) {
 		r := newTestRotator()
 		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey(sdkP("sdk-anchor", "")).WithPrimaryMobileKey(mobP("mob-primary", ""))
+			b.WithPrimarySDKKey(SDKKeyParams{Value: "sdk-anchor"}).WithPrimaryMobileKey(MobileKeyParams{Value: "mob-primary"})
 		})
 		assert.Empty(t, r.DeprecatedSDKKeys())
 	})

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -475,7 +475,7 @@ func TestReconcileAnchorOnly(t *testing.T) {
 	anchor := config.SDKKey("anchor")
 	now := time.Now()
 
-	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor)), now)
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, ""))), now)
 	additions, expirations := r.StepTime(now)
 
 	assert.ElementsMatch(t, []SDKCredential{anchor}, additions)
@@ -492,7 +492,7 @@ func TestReconcileMultipleSDKKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor).WithSDKKey(other)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, "")).WithSDKKey(sdkP(other, ""))), now)
 	additions, expirations := r.StepTime(now)
 
 	// Both server keys are accepted; only the anchor is primary.
@@ -511,7 +511,7 @@ func TestReconcileMultipleMobileKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor).WithPrimaryMobileKey(mob1).WithMobileKey(mob2)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, "")).WithPrimaryMobileKey(mobP(mob1, "")).WithMobileKey(mobP(mob2, ""))), now)
 	additions, _ := r.StepTime(now)
 
 	// Every mobile key is accepted; the designated one is the primary.
@@ -528,11 +528,11 @@ func TestReconcileRevokesOmittedKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor).WithSDKKey(other).WithPrimaryMobileKey(mob)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, "")).WithSDKKey(sdkP(other, "")).WithPrimaryMobileKey(mobP(mob, ""))), now)
 	r.StepTime(now)
 
 	// Reconciling to just the anchor revokes the omitted server and mobile keys.
-	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor)), now)
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, ""))), now)
 	additions, expirations := r.StepTime(now)
 
 	assert.Empty(t, additions)
@@ -554,10 +554,10 @@ func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
 
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithPrimarySDKKey(anchor).
-			WithExpiringSDKKey(expiringSDK, now.Add(time.Hour)).
-			WithPrimaryMobileKey(mob).
-			WithExpiringMobileKey(expiringMobile, now.Add(time.Hour))),
+			WithPrimarySDKKey(sdkP(anchor, "")).
+			WithSDKKey(sdkPExp(expiringSDK, "", now.Add(time.Hour))).
+			WithPrimaryMobileKey(mobP(mob, "")).
+			WithMobileKey(mobPExp(expiringMobile, "", now.Add(time.Hour)))),
 		now)
 	additions, expirations := r.StepTime(now)
 
@@ -580,9 +580,9 @@ func TestReconcilePrimaryMobileKeyIsAlwaysAccepted(t *testing.T) {
 	now := time.Unix(1000, 0)
 
 	set := mustBuild(t, NewAcceptedSetBuilder().
-		WithPrimarySDKKey(anchor).
-		WithExpiringMobileKey(mob, now.Add(-time.Hour)). // already expired in the payload...
-		WithPrimaryMobileKey(mob))                       // ...but designated as the primary
+		WithPrimarySDKKey(sdkP(anchor, "")).
+		WithMobileKey(mobPExp(mob, "", now.Add(-time.Hour))). // already expired in the payload...
+		WithPrimaryMobileKey(mobP(mob, "")))                  // ...but designated as the primary
 	r.Reconcile(set, now)
 	r.StepTime(now)
 
@@ -607,7 +607,7 @@ func TestReconcileClearsStaleDeprecationForAcceptedKey(t *testing.T) {
 
 	// Reconcile to a set that fully accepts both keys.
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(anchor).WithSDKKey(old)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithPrimarySDKKey(sdkP(anchor, "")).WithSDKKey(sdkP(old, ""))), now)
 	r.StepTime(now)
 
 	assert.Contains(t, r.PrimaryCredentials(), SDKCredential(old))
@@ -629,10 +629,10 @@ func TestReconcileExpiringKeysAreEvictedByStepTime(t *testing.T) {
 
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithPrimarySDKKey(anchor).
-			WithExpiringSDKKey(expiringSDK, expiry).
-			WithPrimaryMobileKey(mob).
-			WithExpiringMobileKey(expiringMobile, expiry)),
+			WithPrimarySDKKey(sdkP(anchor, "")).
+			WithSDKKey(sdkPExp(expiringSDK, "", expiry)).
+			WithPrimaryMobileKey(mobP(mob, "")).
+			WithMobileKey(mobPExp(expiringMobile, "", expiry))),
 		now)
 	additions, expirations := r.StepTime(now)
 	require.ElementsMatch(t, []SDKCredential{anchor, expiringSDK, mob, expiringMobile}, additions)
@@ -797,10 +797,8 @@ func TestAcceptedKeys(t *testing.T) {
 	t.Run("single anchor plus primary mobile", func(t *testing.T) {
 		r := newTestRotator()
 		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithSDKKeyIdentifier("sdk-anchor", "default").
-				WithPrimaryMobileKey("mob-primary").
-				WithMobileKeyIdentifier("mob-primary", "mob-1")
+			b.WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
+				WithPrimaryMobileKey(mobP("mob-primary", "mob-1"))
 		})
 		entries := r.AcceptedKeys()
 		require.Len(t, entries, 2)
@@ -823,13 +821,10 @@ func TestAcceptedKeys(t *testing.T) {
 		r := newTestRotator()
 		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
 		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").
-				WithSDKKeyIdentifier("sdk-anchor", "default").
-				WithSDKKey("sdk-b").
-				WithSDKKeyIdentifier("sdk-b", "b-service").
-				WithExpiringSDKKey("sdk-old", expiry).
-				WithSDKKeyIdentifier("sdk-old", "old-key").
-				WithPrimaryMobileKey("mob-primary")
+			b.WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
+				WithSDKKey(sdkP("sdk-b", "b-service")).
+				WithSDKKey(sdkPExp("sdk-old", "old-key", expiry)).
+				WithPrimaryMobileKey(mobP("mob-primary", ""))
 		})
 		entries := r.AcceptedKeys()
 		// anchor + sdk-b + sdk-old + mob-primary
@@ -866,7 +861,7 @@ func TestDeprecatedSDKKeys(t *testing.T) {
 	t.Run("empty when no legacy grace keys", func(t *testing.T) {
 		r := newTestRotator()
 		reconcileSet(t, r, func(b *AcceptedSetBuilder) {
-			b.WithPrimarySDKKey("sdk-anchor").WithPrimaryMobileKey("mob-primary")
+			b.WithPrimarySDKKey(sdkP("sdk-anchor", "")).WithPrimaryMobileKey(mobP("mob-primary", ""))
 		})
 		assert.Empty(t, r.DeprecatedSDKKeys())
 	})

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -994,7 +994,7 @@ func TestEarliestExpiringNonAnchorSDKKey(t *testing.T) {
 	t.Run("picks soonest across both reconcile and legacy paths", func(t *testing.T) {
 		r := newTestRotator()
 		now := time.Unix(1000, 0)
-		legacyExpiry := now.Add(2 * time.Hour) // later
+		legacyExpiry := now.Add(2 * time.Hour)       // later
 		reconcileExpiry := now.Add(30 * time.Minute) // sooner
 
 		r.Initialize([]SDKCredential{config.SDKKey("sdk-legacy")})

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -1,28 +1,10 @@
 package envfactory
 
 import (
-	"time"
-
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 )
-
-// keyPtr returns a pointer to the wire identifier, or nil when it is empty (old-format payloads and
-// manual config carry no identifier).
-func keyPtr(identifier string) *string {
-	if identifier == "" {
-		return nil
-	}
-	return &identifier
-}
-
-// expiryPtr returns a pointer to the expiry time, or nil when it is the zero time (a permanent key).
-func expiryPtr(expiry time.Time) *time.Time {
-	if expiry.IsZero() {
-		return nil
-	}
-	return &expiry
-}
 
 // BuildAcceptedSet converts an EnvironmentParams into the AcceptedSet and anchor
 // credential needed by EnvContext.ReconcileCredentials.
@@ -62,9 +44,9 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 		}
 		if k.Value == anchor {
 			anchorInArray = true
-			b.WithPrimarySDKKey(credential.SDKKeyParams{Value: k.Value, Key: keyPtr(k.Key)})
+			b.WithPrimarySDKKey(credential.SDKKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key)})
 		} else {
-			b.WithSDKKey(credential.SDKKeyParams{Value: k.Value, Key: keyPtr(k.Key), Expiry: expiryPtr(k.Expiry)})
+			b.WithSDKKey(credential.SDKKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key), Expiry: util.PtrOrNil(k.Expiry)})
 		}
 	}
 
@@ -80,9 +62,9 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 			return credential.AcceptedSet{}, anchor, credential.NewEmptyCredentialError("mobileKeys", k.Key)
 		}
 		if k.Value == params.MobileKey {
-			b.WithPrimaryMobileKey(credential.MobileKeyParams{Value: k.Value, Key: keyPtr(k.Key)})
+			b.WithPrimaryMobileKey(credential.MobileKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key)})
 		} else {
-			b.WithMobileKey(credential.MobileKeyParams{Value: k.Value, Key: keyPtr(k.Key), Expiry: expiryPtr(k.Expiry)})
+			b.WithMobileKey(credential.MobileKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key), Expiry: util.PtrOrNil(k.Expiry)})
 		}
 	}
 

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -56,6 +56,7 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 		} else {
 			b.WithExpiringSDKKey(k.Value, k.Expiry)
 		}
+		b.WithSDKKeyIdentifier(k.Value, k.Key)
 	}
 
 	// The anchor must be one of the accepted SDK keys: the backend lists it in sdkKeys[] (and ToParams
@@ -75,6 +76,7 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 		} else {
 			b.WithExpiringMobileKey(k.Value, k.Expiry)
 		}
+		b.WithMobileKeyIdentifier(k.Value, k.Key)
 	}
 
 	set, err := b.Build()

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -52,20 +52,33 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 
 	// The anchor must be one of the accepted SDK keys: the backend lists it in sdkKeys[] (and ToParams
 	// synthesizes it into the array for old-format payloads). A defined anchor absent from the array is
-	// a structurally malformed payload — reject it per §9.
+	// a structurally malformed payload — reject it.
 	if anchor.Defined() && !anchorInArray {
 		return credential.AcceptedSet{}, anchor, credential.NewAnchorNotInSetError()
 	}
 
+	// Add every accepted mobile key, designating the primary as we encounter it. Like the anchor,
+	// WithPrimaryMobileKey forces the primary permanent, so an expiry the payload may carry on the
+	// primary's own entry cannot demote it.
+	primaryMobileInArray := false
 	for _, k := range params.AcceptedMobileKeys {
 		if !k.Value.Defined() {
 			return credential.AcceptedSet{}, anchor, credential.NewEmptyCredentialError("mobileKeys", k.Key)
 		}
 		if k.Value == params.MobileKey {
+			primaryMobileInArray = true
 			b.WithPrimaryMobileKey(credential.MobileKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key)})
 		} else {
 			b.WithMobileKey(credential.MobileKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key), Expiry: util.PtrOrNil(k.Expiry)})
 		}
+	}
+
+	// The primary mobile key, when the environment has one, must be in mobileKeys[] — the mobile
+	// analogue of the anchor invariant above. A defined mobKey absent from the array is malformed:
+	// without this guard the primary would be silently left undesignated, clearing it on reconcile and
+	// breaking event forwarding. (An undefined mobKey is valid — a server-side-only environment.)
+	if params.MobileKey.Defined() && !primaryMobileInArray {
+		return credential.AcceptedSet{}, anchor, credential.NewPrimaryMobileKeyNotInSetError()
 	}
 
 	set, err := b.Build()

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -1,9 +1,28 @@
 package envfactory
 
 import (
+	"time"
+
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 )
+
+// keyPtr returns a pointer to the wire identifier, or nil when it is empty (old-format payloads and
+// manual config carry no identifier).
+func keyPtr(identifier string) *string {
+	if identifier == "" {
+		return nil
+	}
+	return &identifier
+}
+
+// expiryPtr returns a pointer to the expiry time, or nil when it is the zero time (a permanent key).
+func expiryPtr(expiry time.Time) *time.Time {
+	if expiry.IsZero() {
+		return nil
+	}
+	return &expiry
+}
 
 // BuildAcceptedSet converts an EnvironmentParams into the AcceptedSet and anchor
 // credential needed by EnvContext.ReconcileCredentials.
@@ -27,19 +46,12 @@ import (
 // force a fresh put. This is the single home for the anchor invariant.
 func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.SDKKey, error) {
 	anchor := params.SDKKey
+	b := credential.NewAcceptedSetBuilder().WithEnvironmentID(params.EnvID)
 
-	// WithPrimarySDKKey / WithPrimaryMobileKey each add the key and designate it (the anchor and the
-	// wire's mobKey, respectively). An undefined key makes the call a no-op, so an undefined anchor
-	// leaves the set with no designated anchor and Build returns a *MalformedCredentialSetError.
-	b := credential.NewAcceptedSetBuilder().
-		WithEnvironmentID(params.EnvID).
-		WithPrimarySDKKey(anchor).
-		WithPrimaryMobileKey(params.MobileKey)
-
-	// Validate and add the remaining accepted keys. The builder de-duplicates by value, so the
-	// anchor and the primary mobile key — already added permanently above — are ignored when they
-	// reappear in their arrays. That also defends the anchor-never-expiring invariant: a payload
-	// that (wrongly) carries an expiry on the anchor's own entry cannot demote it.
+	// Add every accepted SDK key, designating the anchor as we encounter it. WithPrimarySDKKey both
+	// adds and designates, and forces the anchor permanent — so a payload that (wrongly) carries an
+	// expiry on the anchor's own entry cannot demote it. An undefined anchor never matches a (defined)
+	// array value, so it is never designated and Build returns a *MalformedCredentialSetError.
 	//
 	// Entries with an empty value are structurally malformed: relay would silently accept them but
 	// they can never authenticate any SDK. Reject loudly rather than produce a credential-short env.
@@ -50,19 +62,15 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 		}
 		if k.Value == anchor {
 			anchorInArray = true
-		}
-		if k.Expiry.IsZero() {
-			b.WithSDKKey(k.Value)
+			b.WithPrimarySDKKey(credential.SDKKeyParams{Value: k.Value, Key: keyPtr(k.Key)})
 		} else {
-			b.WithExpiringSDKKey(k.Value, k.Expiry)
+			b.WithSDKKey(credential.SDKKeyParams{Value: k.Value, Key: keyPtr(k.Key), Expiry: expiryPtr(k.Expiry)})
 		}
-		b.WithSDKKeyIdentifier(k.Value, k.Key)
 	}
 
 	// The anchor must be one of the accepted SDK keys: the backend lists it in sdkKeys[] (and ToParams
 	// synthesizes it into the array for old-format payloads). A defined anchor absent from the array is
-	// a structurally malformed payload — reject it per §9 rather than letting WithPrimarySDKKey above
-	// silently synthesize it into the set.
+	// a structurally malformed payload — reject it per §9.
 	if anchor.Defined() && !anchorInArray {
 		return credential.AcceptedSet{}, anchor, credential.NewAnchorNotInSetError()
 	}
@@ -71,12 +79,11 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 		if !k.Value.Defined() {
 			return credential.AcceptedSet{}, anchor, credential.NewEmptyCredentialError("mobileKeys", k.Key)
 		}
-		if k.Expiry.IsZero() {
-			b.WithMobileKey(k.Value)
+		if k.Value == params.MobileKey {
+			b.WithPrimaryMobileKey(credential.MobileKeyParams{Value: k.Value, Key: keyPtr(k.Key)})
 		} else {
-			b.WithExpiringMobileKey(k.Value, k.Expiry)
+			b.WithMobileKey(credential.MobileKeyParams{Value: k.Value, Key: keyPtr(k.Key), Expiry: expiryPtr(k.Expiry)})
 		}
-		b.WithMobileKeyIdentifier(k.Value, k.Key)
 	}
 
 	set, err := b.Build()

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -57,7 +57,8 @@ func TestBuildAcceptedSet_HappyPath(t *testing.T) {
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithPrimarySDKKey("sdk-anchor").
-		WithPrimaryMobileKey("mob-primary"))
+		WithSDKKeyIdentifier("sdk-anchor", "default").
+		WithPrimaryMobileKey("mob-primary")) // mobile has no identifier in makeParams fixture
 	assert.Equal(t, expected, set)
 }
 
@@ -81,16 +82,19 @@ func TestBuildAcceptedSet_MultipleKeys(t *testing.T) {
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithPrimarySDKKey("sdk-anchor").
+		WithSDKKeyIdentifier("sdk-anchor", "default").
 		WithSDKKey("sdk-service-a").
+		WithSDKKeyIdentifier("sdk-service-a", "service-a").
 		WithExpiringSDKKey("sdk-old", expiry1).
+		WithSDKKeyIdentifier("sdk-old", "old-key").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
 }
 
-// TestBuildAcceptedSet_Rename verifies that a rename — same credential value, different key
-// identifier — is a no-op: the returned AcceptedSet is identical regardless of the identifier.
+// TestBuildAcceptedSet_Rename verifies that a rename — same credential value, different identifier
+// — updates only the identifier in the AcceptedSet, not the accepted credential itself. The sets
+// produced before and after a rename carry the same credentials but different identifier maps.
 func TestBuildAcceptedSet_Rename(t *testing.T) {
-	// Build AcceptedSet for the "before" and "after" of a rename.
 	paramsOldName := makeParams(
 		"sdk-anchor",
 		[]AcceptedSDKKey{{Key: "old-name", Value: "sdk-anchor"}},
@@ -107,7 +111,21 @@ func TestBuildAcceptedSet_Rename(t *testing.T) {
 
 	require.NoError(t, errOld)
 	require.NoError(t, errNew)
-	assert.Equal(t, setOld, setNew, "rename (same value, different key identifier) should produce the same AcceptedSet")
+	// The credential content is the same — only the identifier differs.
+	// When Reconcile applies the new set the display name is refreshed but no credential is added or removed.
+	assert.NotEqual(t, setOld, setNew, "rename changes the identifier map, so the AcceptedSets differ")
+	expectedOld := mustBuild(t, credential.NewAcceptedSetBuilder().
+		WithEnvironmentID("env-abc").
+		WithPrimarySDKKey("sdk-anchor").
+		WithSDKKeyIdentifier("sdk-anchor", "old-name").
+		WithPrimaryMobileKey("mob-primary"))
+	assert.Equal(t, expectedOld, setOld)
+	expectedNew := mustBuild(t, credential.NewAcceptedSetBuilder().
+		WithEnvironmentID("env-abc").
+		WithPrimarySDKKey("sdk-anchor").
+		WithSDKKeyIdentifier("sdk-anchor", "new-name").
+		WithPrimaryMobileKey("mob-primary"))
+	assert.Equal(t, expectedNew, setNew)
 }
 
 // TestBuildAcceptedSet_Deexpiry verifies that removing the expiry from an existing key (a
@@ -144,7 +162,9 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 	expectedPermanent := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithPrimarySDKKey("sdk-anchor").
+		WithSDKKeyIdentifier("sdk-anchor", "default").
 		WithSDKKey("sdk-old"). // permanent, no expiry
+		WithSDKKeyIdentifier("sdk-old", "old-key").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expectedPermanent, setNoExpiry)
 
@@ -253,8 +273,11 @@ func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithPrimarySDKKey("sdk-new-anchor").
+		WithSDKKeyIdentifier("sdk-new-anchor", "new-default").
 		WithSDKKey("sdk-b").
+		WithSDKKeyIdentifier("sdk-b", "service-b").
 		WithSDKKey("sdk-c").
+		WithSDKKeyIdentifier("sdk-c", "service-c").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
 }
@@ -280,7 +303,9 @@ func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithPrimarySDKKey("sdk-anchor").
+		WithSDKKeyIdentifier("sdk-anchor", "default").
 		WithSDKKey("sdk-service-a").
+		WithSDKKeyIdentifier("sdk-service-a", "service-a").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
 }
@@ -305,8 +330,11 @@ func TestBuildAcceptedSet_MultipleMobileKeys(t *testing.T) {
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithPrimarySDKKey("sdk-anchor").
+		WithSDKKeyIdentifier("sdk-anchor", "default").
 		WithMobileKey("mob-primary").
+		WithMobileKeyIdentifier("mob-primary", "mob-1").
 		WithMobileKey("mob-secondary").
+		WithMobileKeyIdentifier("mob-secondary", "mob-2").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set)
 }
@@ -332,8 +360,11 @@ func TestBuildAcceptedSet_ExpiringMobileKey(t *testing.T) {
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithPrimarySDKKey("sdk-anchor").
+		WithSDKKeyIdentifier("sdk-anchor", "default").
 		WithMobileKey("mob-primary").
+		WithMobileKeyIdentifier("mob-primary", "mob-1").
 		WithExpiringMobileKey("mob-old", expiry1).
+		WithMobileKeyIdentifier("mob-old", "mob-old").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set, "expiring mobile key must land as an expiring key in the set")
 }
@@ -362,6 +393,7 @@ func TestBuildAcceptedSet_TrustTheArray(t *testing.T) {
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithPrimarySDKKey("sdk-anchor").
+		WithSDKKeyIdentifier("sdk-anchor", "default").
 		WithPrimaryMobileKey("mob-primary"))
 	assert.Equal(t, expected, set, "legacy sdkKey.expiring slot must not appear in AcceptedSet")
 }

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,21 +23,6 @@ func mustBuild(t *testing.T, b *credential.AcceptedSetBuilder) credential.Accept
 	set, err := b.Build()
 	require.NoError(t, err)
 	return set
-}
-
-// sdkP / sdkPExp / mobP / mobPExp build the credential param structs for the expected-set builders.
-// They mirror reconcile_helper's own keyPtr/expiryPtr conversion so an empty identifier becomes nil.
-func sdkP(value config.SDKKey, key string) credential.SDKKeyParams {
-	return credential.SDKKeyParams{Value: value, Key: keyPtr(key)}
-}
-func sdkPExp(value config.SDKKey, key string, expiry time.Time) credential.SDKKeyParams {
-	return credential.SDKKeyParams{Value: value, Key: keyPtr(key), Expiry: expiryPtr(expiry)}
-}
-func mobP(value config.MobileKey, key string) credential.MobileKeyParams {
-	return credential.MobileKeyParams{Value: value, Key: keyPtr(key)}
-}
-func mobPExp(value config.MobileKey, key string, expiry time.Time) credential.MobileKeyParams {
-	return credential.MobileKeyParams{Value: value, Key: keyPtr(key), Expiry: expiryPtr(expiry)}
 }
 
 // makeParams is a convenience builder for EnvironmentParams test fixtures.
@@ -71,8 +57,8 @@ func TestBuildAcceptedSet_HappyPath(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
-		WithPrimaryMobileKey(mobP("mob-primary", ""))) // mobile has no identifier in makeParams fixture
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"})) // mobile has no identifier in makeParams fixture
 	assert.Equal(t, expected, set)
 }
 
@@ -95,10 +81,10 @@ func TestBuildAcceptedSet_MultipleKeys(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
-		WithSDKKey(sdkP("sdk-service-a", "service-a")).
-		WithSDKKey(sdkPExp("sdk-old", "old-key", expiry1)).
-		WithPrimaryMobileKey(mobP("mob-primary", "")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-service-a", Key: util.PtrOrNil("service-a")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-old", Key: util.PtrOrNil("old-key"), Expiry: util.PtrOrNil(expiry1)}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expected, set)
 }
 
@@ -127,13 +113,13 @@ func TestBuildAcceptedSet_Rename(t *testing.T) {
 	assert.NotEqual(t, setOld, setNew, "rename changes the identifier map, so the AcceptedSets differ")
 	expectedOld := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "old-name")).
-		WithPrimaryMobileKey(mobP("mob-primary", "")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("old-name")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expectedOld, setOld)
 	expectedNew := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "new-name")).
-		WithPrimaryMobileKey(mobP("mob-primary", "")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("new-name")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expectedNew, setNew)
 }
 
@@ -170,9 +156,9 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 	// The set built without expiry must include sdk-old as a permanent key.
 	expectedPermanent := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
-		WithSDKKey(sdkP("sdk-old", "old-key")). // permanent, no expiry
-		WithPrimaryMobileKey(mobP("mob-primary", "")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-old", Key: util.PtrOrNil("old-key")}). // permanent, no expiry
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expectedPermanent, setNoExpiry)
 
 	// Sanity: the expiring and non-expiring versions are different.
@@ -219,7 +205,7 @@ func TestBuildAcceptedSet_NoMobileKey(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor"}))
 	assert.Equal(t, expected, set)
 }
 
@@ -279,10 +265,10 @@ func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-new-anchor", "new-default")).
-		WithSDKKey(sdkP("sdk-b", "service-b")).
-		WithSDKKey(sdkP("sdk-c", "service-c")).
-		WithPrimaryMobileKey(mobP("mob-primary", "")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-new-anchor", Key: util.PtrOrNil("new-default")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-b", Key: util.PtrOrNil("service-b")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-c", Key: util.PtrOrNil("service-c")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expected, set)
 }
 
@@ -306,9 +292,9 @@ func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
 	// Anchor is permanent (WithPrimarySDKKey), not expiring — identical to a payload with no anchor expiry.
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
-		WithSDKKey(sdkP("sdk-service-a", "service-a")).
-		WithPrimaryMobileKey(mobP("mob-primary", "")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-service-a", Key: util.PtrOrNil("service-a")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expected, set)
 }
 
@@ -331,9 +317,9 @@ func TestBuildAcceptedSet_MultipleMobileKeys(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
-		WithMobileKey(mobP("mob-secondary", "mob-2")).
-		WithPrimaryMobileKey(mobP("mob-primary", "mob-1")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithMobileKey(credential.MobileKeyParams{Value: "mob-secondary", Key: util.PtrOrNil("mob-2")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary", Key: util.PtrOrNil("mob-1")}))
 	assert.Equal(t, expected, set)
 }
 
@@ -357,9 +343,9 @@ func TestBuildAcceptedSet_ExpiringMobileKey(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
-		WithMobileKey(mobPExp("mob-old", "mob-old", expiry1)).
-		WithPrimaryMobileKey(mobP("mob-primary", "mob-1")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithMobileKey(credential.MobileKeyParams{Value: "mob-old", Key: util.PtrOrNil("mob-old"), Expiry: util.PtrOrNil(expiry1)}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary", Key: util.PtrOrNil("mob-1")}))
 	assert.Equal(t, expected, set, "expiring mobile key must land as an expiring key in the set")
 }
 
@@ -386,7 +372,7 @@ func TestBuildAcceptedSet_TrustTheArray(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
-		WithPrimaryMobileKey(mobP("mob-primary", "")))
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expected, set, "legacy sdkKey.expiring slot must not appear in AcceptedSet")
 }

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -189,6 +189,27 @@ func TestBuildAcceptedSet_AnchorNotInArray(t *testing.T) {
 	assert.Contains(t, malformed.Error(), "not present in sdkKeys[]")
 }
 
+// TestBuildAcceptedSet_PrimaryMobileNotInArray verifies the mobile analogue of the anchor invariant:
+// a defined mobKey absent from mobileKeys[] is rejected. Without this guard the primary mobile key
+// would be silently left undesignated, clearing it on reconcile and breaking event forwarding.
+func TestBuildAcceptedSet_PrimaryMobileNotInArray(t *testing.T) {
+	params := EnvironmentParams{
+		EnvID:           "env-abc",
+		SDKKey:          "sdk-anchor",
+		MobileKey:       "mob-primary", // defined...
+		AcceptedSDKKeys: []AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
+		AcceptedMobileKeys: []AcceptedMobileKey{
+			{Key: "other", Value: "mob-other"}, // ...but NOT in the array
+		},
+	}
+	_, _, err := BuildAcceptedSet(params)
+
+	require.Error(t, err)
+	var malformed *credential.MalformedCredentialSetError
+	require.True(t, errors.As(err, &malformed))
+	assert.Contains(t, malformed.Error(), "not present in mobileKeys[]")
+}
+
 // TestBuildAcceptedSet_NoMobileKey verifies that an environment with no mobile key (e.g. a
 // server-side-only environment) is valid: ToParams must not synthesize a phantom empty mobileKeys
 // entry that BuildAcceptedSet would reject as malformed.

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -165,14 +165,10 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 	assert.NotEqual(t, setWithExpiry, setNoExpiry)
 }
 
-// TestBuildAcceptedSet_AnchorNotInArray verifies that an anchor absent from AcceptedSDKKeys is no
-// longer rejected here: WithPrimarySDKKey adds and designates the anchor regardless, so the
-// resulting set contains both the anchor and the array entry. Structural validation of the wire
-// payload (anchor-absent-from-array) happens upstream when the payload is parsed into params.
 // TestBuildAcceptedSet_AnchorNotInArray verifies that a defined anchor absent from the sdkKeys[] array
-// yields a *credential.MalformedCredentialSetError per design §9: the payload is structurally
-// inconsistent (the designated primary is not in the authoritative array), so it must be rejected
-// rather than silently synthesized into the set.
+// yields a *credential.MalformedCredentialSetError: the payload is structurally inconsistent (the
+// designated anchor is not in the authoritative array), so it must be rejected rather than silently
+// synthesized into the set.
 func TestBuildAcceptedSet_AnchorNotInArray(t *testing.T) {
 	params := makeParams(
 		"sdk-anchor",
@@ -310,7 +306,7 @@ func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
 
-	// Anchor is permanent (WithPrimarySDKKey), not expiring — identical to a payload with no anchor expiry.
+	// Anchor is permanent (WithAnchor), not expiring — identical to a payload with no anchor expiry.
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -24,6 +24,21 @@ func mustBuild(t *testing.T, b *credential.AcceptedSetBuilder) credential.Accept
 	return set
 }
 
+// sdkP / sdkPExp / mobP / mobPExp build the credential param structs for the expected-set builders.
+// They mirror reconcile_helper's own keyPtr/expiryPtr conversion so an empty identifier becomes nil.
+func sdkP(value config.SDKKey, key string) credential.SDKKeyParams {
+	return credential.SDKKeyParams{Value: value, Key: keyPtr(key)}
+}
+func sdkPExp(value config.SDKKey, key string, expiry time.Time) credential.SDKKeyParams {
+	return credential.SDKKeyParams{Value: value, Key: keyPtr(key), Expiry: expiryPtr(expiry)}
+}
+func mobP(value config.MobileKey, key string) credential.MobileKeyParams {
+	return credential.MobileKeyParams{Value: value, Key: keyPtr(key)}
+}
+func mobPExp(value config.MobileKey, key string, expiry time.Time) credential.MobileKeyParams {
+	return credential.MobileKeyParams{Value: value, Key: keyPtr(key), Expiry: expiryPtr(expiry)}
+}
+
 // makeParams is a convenience builder for EnvironmentParams test fixtures.
 // sdkKey is the anchor, sdkKeys are the full accepted set (must include the anchor),
 // mobileKey is the single (primary) mobile key to include.
@@ -56,9 +71,8 @@ func TestBuildAcceptedSet_HappyPath(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
-		WithSDKKeyIdentifier("sdk-anchor", "default").
-		WithPrimaryMobileKey("mob-primary")) // mobile has no identifier in makeParams fixture
+		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
+		WithPrimaryMobileKey(mobP("mob-primary", ""))) // mobile has no identifier in makeParams fixture
 	assert.Equal(t, expected, set)
 }
 
@@ -81,13 +95,10 @@ func TestBuildAcceptedSet_MultipleKeys(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
-		WithSDKKeyIdentifier("sdk-anchor", "default").
-		WithSDKKey("sdk-service-a").
-		WithSDKKeyIdentifier("sdk-service-a", "service-a").
-		WithExpiringSDKKey("sdk-old", expiry1).
-		WithSDKKeyIdentifier("sdk-old", "old-key").
-		WithPrimaryMobileKey("mob-primary"))
+		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
+		WithSDKKey(sdkP("sdk-service-a", "service-a")).
+		WithSDKKey(sdkPExp("sdk-old", "old-key", expiry1)).
+		WithPrimaryMobileKey(mobP("mob-primary", "")))
 	assert.Equal(t, expected, set)
 }
 
@@ -116,15 +127,13 @@ func TestBuildAcceptedSet_Rename(t *testing.T) {
 	assert.NotEqual(t, setOld, setNew, "rename changes the identifier map, so the AcceptedSets differ")
 	expectedOld := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
-		WithSDKKeyIdentifier("sdk-anchor", "old-name").
-		WithPrimaryMobileKey("mob-primary"))
+		WithPrimarySDKKey(sdkP("sdk-anchor", "old-name")).
+		WithPrimaryMobileKey(mobP("mob-primary", "")))
 	assert.Equal(t, expectedOld, setOld)
 	expectedNew := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
-		WithSDKKeyIdentifier("sdk-anchor", "new-name").
-		WithPrimaryMobileKey("mob-primary"))
+		WithPrimarySDKKey(sdkP("sdk-anchor", "new-name")).
+		WithPrimaryMobileKey(mobP("mob-primary", "")))
 	assert.Equal(t, expectedNew, setNew)
 }
 
@@ -161,11 +170,9 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 	// The set built without expiry must include sdk-old as a permanent key.
 	expectedPermanent := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
-		WithSDKKeyIdentifier("sdk-anchor", "default").
-		WithSDKKey("sdk-old"). // permanent, no expiry
-		WithSDKKeyIdentifier("sdk-old", "old-key").
-		WithPrimaryMobileKey("mob-primary"))
+		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
+		WithSDKKey(sdkP("sdk-old", "old-key")). // permanent, no expiry
+		WithPrimaryMobileKey(mobP("mob-primary", "")))
 	assert.Equal(t, expectedPermanent, setNoExpiry)
 
 	// Sanity: the expiring and non-expiring versions are different.
@@ -212,7 +219,7 @@ func TestBuildAcceptedSet_NoMobileKey(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor"))
+		WithPrimarySDKKey(sdkP("sdk-anchor", "")))
 	assert.Equal(t, expected, set)
 }
 
@@ -272,13 +279,10 @@ func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-new-anchor").
-		WithSDKKeyIdentifier("sdk-new-anchor", "new-default").
-		WithSDKKey("sdk-b").
-		WithSDKKeyIdentifier("sdk-b", "service-b").
-		WithSDKKey("sdk-c").
-		WithSDKKeyIdentifier("sdk-c", "service-c").
-		WithPrimaryMobileKey("mob-primary"))
+		WithPrimarySDKKey(sdkP("sdk-new-anchor", "new-default")).
+		WithSDKKey(sdkP("sdk-b", "service-b")).
+		WithSDKKey(sdkP("sdk-c", "service-c")).
+		WithPrimaryMobileKey(mobP("mob-primary", "")))
 	assert.Equal(t, expected, set)
 }
 
@@ -302,11 +306,9 @@ func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
 	// Anchor is permanent (WithPrimarySDKKey), not expiring — identical to a payload with no anchor expiry.
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
-		WithSDKKeyIdentifier("sdk-anchor", "default").
-		WithSDKKey("sdk-service-a").
-		WithSDKKeyIdentifier("sdk-service-a", "service-a").
-		WithPrimaryMobileKey("mob-primary"))
+		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
+		WithSDKKey(sdkP("sdk-service-a", "service-a")).
+		WithPrimaryMobileKey(mobP("mob-primary", "")))
 	assert.Equal(t, expected, set)
 }
 
@@ -329,13 +331,9 @@ func TestBuildAcceptedSet_MultipleMobileKeys(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
-		WithSDKKeyIdentifier("sdk-anchor", "default").
-		WithMobileKey("mob-primary").
-		WithMobileKeyIdentifier("mob-primary", "mob-1").
-		WithMobileKey("mob-secondary").
-		WithMobileKeyIdentifier("mob-secondary", "mob-2").
-		WithPrimaryMobileKey("mob-primary"))
+		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
+		WithMobileKey(mobP("mob-secondary", "mob-2")).
+		WithPrimaryMobileKey(mobP("mob-primary", "mob-1")))
 	assert.Equal(t, expected, set)
 }
 
@@ -359,13 +357,9 @@ func TestBuildAcceptedSet_ExpiringMobileKey(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
-		WithSDKKeyIdentifier("sdk-anchor", "default").
-		WithMobileKey("mob-primary").
-		WithMobileKeyIdentifier("mob-primary", "mob-1").
-		WithExpiringMobileKey("mob-old", expiry1).
-		WithMobileKeyIdentifier("mob-old", "mob-old").
-		WithPrimaryMobileKey("mob-primary"))
+		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
+		WithMobileKey(mobPExp("mob-old", "mob-old", expiry1)).
+		WithPrimaryMobileKey(mobP("mob-primary", "mob-1")))
 	assert.Equal(t, expected, set, "expiring mobile key must land as an expiring key in the set")
 }
 
@@ -392,8 +386,7 @@ func TestBuildAcceptedSet_TrustTheArray(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithPrimarySDKKey("sdk-anchor").
-		WithSDKKeyIdentifier("sdk-anchor", "default").
-		WithPrimaryMobileKey("mob-primary"))
+		WithPrimarySDKKey(sdkP("sdk-anchor", "default")).
+		WithPrimaryMobileKey(mobP("mob-primary", "")))
 	assert.Equal(t, expected, set, "legacy sdkKey.expiring slot must not appear in AcceptedSet")
 }

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -50,19 +50,14 @@ type EnvContext interface {
 	// several accepted mobile keys (primary + expiring) in nondeterministic order.
 	GetMobileKey() config.MobileKey
 
-	// GetAcceptedSDKKeys returns metadata for all non-anchor accepted SDK keys, sorted by identifier.
-	// Used by the status endpoint to populate the sdkKeys[] array. Returns an empty slice for
-	// single-key environments (those with only the anchor key).
-	GetAcceptedSDKKeys() []credential.SDKKeyEntry
+	// GetAcceptedKeys returns metadata for every accepted credential — all server-side SDK keys and
+	// all mobile keys, including the anchor and the primary mobile key. The status endpoint partitions
+	// the result by type to populate the full sdkKeys[] / mobileKeys[] arrays.
+	GetAcceptedKeys() []credential.AcceptedKey
 
-	// GetAcceptedMobileKeys returns metadata for all non-primary accepted mobile keys, sorted by
-	// identifier. Used by the status endpoint to populate the mobileKeys[] array.
-	GetAcceptedMobileKeys() []credential.MobileKeyEntry
-
-	// GetEarliestExpiringSDKKey returns the non-anchor SDK key with the soonest expiry, and true.
-	// Returns the zero SDKKey and false when no expiring non-anchor key exists. Used by the status
-	// endpoint to populate expiringSdkKey deterministically.
-	GetEarliestExpiringSDKKey() (config.SDKKey, bool)
+	// GetDeprecatedSDKKeys returns server-side SDK keys in the legacy grace-period map with their
+	// expiry. The status endpoint folds these into the expiringSdkKey computation for back-compat.
+	GetDeprecatedSDKKeys() []credential.AcceptedKey
 
 	// ReconcileCredentials atomically reconciles the environment's accepted credentials to match
 	// newSet. The set names its own anchor (the SDK key that owns the upstream connection) and

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -50,6 +50,20 @@ type EnvContext interface {
 	// several accepted mobile keys (primary + expiring) in nondeterministic order.
 	GetMobileKey() config.MobileKey
 
+	// GetAcceptedSDKKeys returns metadata for all non-anchor accepted SDK keys, sorted by identifier.
+	// Used by the status endpoint to populate the sdkKeys[] array. Returns an empty slice for
+	// single-key environments (those with only the anchor key).
+	GetAcceptedSDKKeys() []credential.SDKKeyEntry
+
+	// GetAcceptedMobileKeys returns metadata for all non-primary accepted mobile keys, sorted by
+	// identifier. Used by the status endpoint to populate the mobileKeys[] array.
+	GetAcceptedMobileKeys() []credential.MobileKeyEntry
+
+	// GetEarliestExpiringSDKKey returns the non-anchor SDK key with the soonest expiry, and true.
+	// Returns the zero SDKKey and false when no expiring non-anchor key exists. Used by the status
+	// endpoint to populate expiringSdkKey deterministically.
+	GetEarliestExpiringSDKKey() (config.SDKKey, bool)
+
 	// ReconcileCredentials atomically reconciles the environment's accepted credentials to match
 	// newSet. The set names its own anchor (the SDK key that owns the upstream connection) and
 	// primary mobile key. The method owns the order of operations internally (add → re-anchor →

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -640,16 +640,12 @@ func (c *envContextImpl) GetDeprecatedCredentials() []credential.SDKCredential {
 	return c.keyRotator.DeprecatedCredentials()
 }
 
-func (c *envContextImpl) GetAcceptedSDKKeys() []credential.SDKKeyEntry {
-	return c.keyRotator.NonAnchorSDKKeyEntries()
+func (c *envContextImpl) GetAcceptedKeys() []credential.AcceptedKey {
+	return c.keyRotator.AcceptedKeys()
 }
 
-func (c *envContextImpl) GetAcceptedMobileKeys() []credential.MobileKeyEntry {
-	return c.keyRotator.NonPrimaryMobileKeyEntries()
-}
-
-func (c *envContextImpl) GetEarliestExpiringSDKKey() (config.SDKKey, bool) {
-	return c.keyRotator.EarliestExpiringNonAnchorSDKKey()
+func (c *envContextImpl) GetDeprecatedSDKKeys() []credential.AcceptedKey {
+	return c.keyRotator.DeprecatedSDKKeys()
 }
 
 func (c *envContextImpl) GetClient() sdks.LDClientContext {

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -640,6 +640,18 @@ func (c *envContextImpl) GetDeprecatedCredentials() []credential.SDKCredential {
 	return c.keyRotator.DeprecatedCredentials()
 }
 
+func (c *envContextImpl) GetAcceptedSDKKeys() []credential.SDKKeyEntry {
+	return c.keyRotator.NonAnchorSDKKeyEntries()
+}
+
+func (c *envContextImpl) GetAcceptedMobileKeys() []credential.MobileKeyEntry {
+	return c.keyRotator.NonPrimaryMobileKeyEntries()
+}
+
+func (c *envContextImpl) GetEarliestExpiringSDKKey() (config.SDKKey, bool) {
+	return c.keyRotator.EarliestExpiringNonAnchorSDKKey()
+}
+
 func (c *envContextImpl) GetClient() sdks.LDClientContext {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -187,6 +187,9 @@ func mustBuildAcceptedSet(t *testing.T, b *credential.AcceptedSetBuilder) creden
 	return set
 }
 
+// expiryPtr returns a pointer to t, for building credential param structs in these tests.
+func expiryPtr(t time.Time) *time.Time { return &t }
+
 func TestAddRemoveCredential(t *testing.T) {
 	envConfig := st.EnvMain.Config
 
@@ -203,7 +206,7 @@ func TestAddRemoveCredential(t *testing.T) {
 
 	// Reconcile to the full set: the SDK key (anchor) plus a mobile key and an environment ID.
 	env.ReconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(envConfig.SDKKey).WithPrimaryMobileKey(mobileKey).WithEnvironmentID(envID)))
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey}).WithPrimaryMobileKey(credential.MobileKeyParams{Value: mobileKey}).WithEnvironmentID(envID)))
 
 	creds := env.GetCredentials()
 	assert.Len(t, creds, 3)
@@ -214,7 +217,7 @@ func TestAddRemoveCredential(t *testing.T) {
 	// Reconciling with a different mobile key evicts the previous one.
 	newMobileKey := config.MobileKey("evict-the-previous-key")
 	env.ReconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(envConfig.SDKKey).WithPrimaryMobileKey(newMobileKey).WithEnvironmentID(envID)))
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey}).WithPrimaryMobileKey(credential.MobileKeyParams{Value: newMobileKey}).WithEnvironmentID(envID)))
 
 	creds = env.GetCredentials()
 	assert.Len(t, creds, 3)
@@ -236,7 +239,7 @@ func TestAddExistingCredentialDoesNothing(t *testing.T) {
 	assert.Equal(t, []credential.SDKCredential{envConfig.SDKKey}, env.GetCredentials())
 
 	mobileKey := st.EnvWithAllCredentials.Config.MobileKey
-	set := mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(envConfig.SDKKey).WithPrimaryMobileKey(mobileKey))
+	set := mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey}).WithPrimaryMobileKey(credential.MobileKeyParams{Value: mobileKey}))
 
 	env.ReconcileCredentials(set)
 
@@ -286,8 +289,8 @@ func TestChangeSDKKey(t *testing.T) {
 
 	// Upon rotating to key2, the original key should still be valid for an hour.
 	rotationSet, err := credential.NewAcceptedSetBuilder().
-		WithPrimarySDKKey(key2).
-		WithExpiringSDKKey(envConfig.SDKKey, start.Add(1*time.Hour)).
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: key2}).
+		WithSDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey, Expiry: expiryPtr(start.Add(1 * time.Hour))}).
 		Build()
 	require.NoError(t, err)
 	envImpl.reconcileCredentials(rotationSet, start)
@@ -397,9 +400,9 @@ func TestMobileKeyReconcileExpiry(t *testing.T) {
 	// carries a per-key expiry.
 	envImpl.reconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(envConfig.SDKKey).
-			WithPrimaryMobileKey(primaryMobile).
-			WithExpiringMobileKey(expiringMobile, expiry)),
+			WithPrimarySDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey}).
+			WithPrimaryMobileKey(credential.MobileKeyParams{Value: primaryMobile}).
+			WithMobileKey(credential.MobileKeyParams{Value: expiringMobile, Expiry: expiryPtr(expiry)})),
 		start)
 
 	// Reconcile stores the expiry as data, so before it elapses the key is accepted (not deprecated).
@@ -442,9 +445,9 @@ func TestNonAnchorSDKKeysDoNotOpenUpstreamClient(t *testing.T) {
 	// open an upstream client.
 	env.ReconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(envConfig.SDKKey).
-			WithSDKKey(nonAnchorKey1).
-			WithSDKKey(nonAnchorKey2)))
+			WithPrimarySDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey}).
+			WithSDKKey(credential.SDKKeyParams{Value: nonAnchorKey1}).
+			WithSDKKey(credential.SDKKeyParams{Value: nonAnchorKey2})))
 
 	// All three SDK keys are accepted...
 	creds := env.GetCredentials()
@@ -487,9 +490,9 @@ func TestGetClientReturnsAnchorInMultiKeyEnv(t *testing.T) {
 
 	env.ReconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(envConfig.SDKKey).
-			WithSDKKey(nonAnchorKey1).
-			WithSDKKey(nonAnchorKey2)))
+			WithPrimarySDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey}).
+			WithSDKKey(credential.SDKKeyParams{Value: nonAnchorKey1}).
+			WithSDKKey(credential.SDKKeyParams{Value: nonAnchorKey2})))
 
 	// No new upstream client was created for the non-anchor keys.
 	if !helpers.AssertNoMoreValues(t, clientCh, 200*time.Millisecond) {
@@ -530,9 +533,9 @@ func TestNonPrimaryMobileKeyDoesNotStealEventForwarding(t *testing.T) {
 		// non-primary mobile key. Accepting the non-primary key must NOT repoint event forwarding —
 		// events collapse to the primary mobile key, mirroring the SDK anchor.
 		env.ReconcileCredentials(mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(envConfig.SDKKey).
-			WithPrimaryMobileKey(primaryMobile).
-			WithMobileKey(nonPrimaryMobile).
+			WithPrimarySDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey}).
+			WithPrimaryMobileKey(credential.MobileKeyParams{Value: primaryMobile}).
+			WithMobileKey(credential.MobileKeyParams{Value: nonPrimaryMobile}).
 			WithEnvironmentID(envConfig.EnvID)))
 
 		ed := envImpl.GetEventDispatcher()
@@ -590,8 +593,8 @@ func TestReAnchoringToKeyStillInGraceReusesItsClient(t *testing.T) {
 	// alive because keyA is still accepted during the grace window.
 	env.(*envContextImpl).reconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithPrimarySDKKey(keyB).
-			WithExpiringSDKKey(keyA, start.Add(1*time.Hour))),
+			WithPrimarySDKKey(credential.SDKKeyParams{Value: keyB}).
+			WithSDKKey(credential.SDKKeyParams{Value: keyA, Expiry: expiryPtr(start.Add(1 * time.Hour))})),
 		start)
 
 	clientB := requireClientReady(t, clientCh)
@@ -605,7 +608,7 @@ func TestReAnchoringToKeyStillInGraceReusesItsClient(t *testing.T) {
 	// being started -- so there is no stale client to orphan. keyB is omitted from the set (no expiry),
 	// so it is revoked immediately and its client is closed.
 	env.(*envContextImpl).reconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(keyA)),
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(credential.SDKKeyParams{Value: keyA})),
 		start.Add(10*time.Minute))
 
 	// keyB was revoked by the re-anchor, so its client is closed.
@@ -680,7 +683,7 @@ func TestRevokingSDKKeyWhileClientIsStartingDoesNotLeakTheClient(t *testing.T) {
 	// runs now -- but c.clients[keyA] is still nil because the initial goroutine is blocked in the factory,
 	// so nothing is closed and the mapping is simply removed.
 	env.(*envContextImpl).reconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(keyB)),
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithPrimarySDKKey(credential.SDKKeyParams{Value: keyB})),
 		time.Unix(1000, 0))
 
 	creds := env.GetCredentials()

--- a/internal/relayenv/env_context_reanchor_test.go
+++ b/internal/relayenv/env_context_reanchor_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/basictypes"
-	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/bigsegments"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/httpconfig"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
@@ -103,8 +103,8 @@ func (f *sharedStoreFactory) Build(_ subsystems.ClientContext) (subsystems.DataS
 func reanchor(t *testing.T, env EnvContext, newKey, oldKey config.SDKKey, now time.Time) {
 	t.Helper()
 	set, err := credential.NewAcceptedSetBuilder().
-		WithPrimarySDKKey(newKey).
-		WithExpiringSDKKey(oldKey, now.Add(time.Hour)).
+		WithPrimarySDKKey(credential.SDKKeyParams{Value: newKey}).
+		WithSDKKey(credential.SDKKeyParams{Value: oldKey, Expiry: expiryPtr(now.Add(time.Hour))}).
 		Build()
 	require.NoError(t, err)
 	env.(*envContextImpl).reconcileCredentials(set, now)

--- a/internal/util/pointer.go
+++ b/internal/util/pointer.go
@@ -1,0 +1,11 @@
+package util
+
+// PtrOrNil returns a pointer to v, or nil when v is the zero value for its type. It is used to model
+// optional fields where the zero value (e.g. an empty string or the zero time.Time) means "absent".
+func PtrOrNil[T comparable](v T) *T {
+	var zero T
+	if v == zero {
+		return nil
+	}
+	return &v
+}

--- a/internal/util/pointer_test.go
+++ b/internal/util/pointer_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPtrOrNil(t *testing.T) {
+	t.Run("empty string yields nil", func(t *testing.T) {
+		assert.Nil(t, PtrOrNil(""))
+	})
+
+	t.Run("non-empty string yields pointer to value", func(t *testing.T) {
+		p := PtrOrNil("default")
+		require.NotNil(t, p)
+		assert.Equal(t, "default", *p)
+	})
+
+	t.Run("zero time yields nil", func(t *testing.T) {
+		assert.Nil(t, PtrOrNil(time.Time{}))
+	})
+
+	t.Run("non-zero time yields pointer to value", func(t *testing.T) {
+		now := time.Unix(1000, 0)
+		p := PtrOrNil(now)
+		require.NotNil(t, p)
+		assert.Equal(t, now, *p)
+	})
+}

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/api"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 
@@ -46,9 +47,7 @@ func statusHandler(relay *Relay) http.Handler {
 				ProjName: identifiers.ProjName,
 			}
 
-			// Use the anchor SDK key and primary mobile key specifically — GetCredentials() may return
-			// multiple SDK and mobile keys (primary + expiring), so iterating it for these singular
-			// status fields would give a non-deterministic result.
+			// Scalar fields: anchor SDK key and primary mobile key.
 			if key := clientCtx.GetSDKKey(); key.Defined() {
 				status.SDKKey = sdks.ObscureKey(string(key))
 			}
@@ -60,10 +59,17 @@ func statusHandler(relay *Relay) http.Handler {
 					status.EnvID = string(envID)
 				}
 			}
-			for _, c := range clientCtx.GetDeprecatedCredentials() {
-				if key, ok := c.(config.SDKKey); ok {
-					status.ExpiringSDKKey = sdks.ObscureKey(string(key))
-				}
+
+			// sdkKeys[]: non-anchor accepted SDK keys, sorted by identifier.
+			status.SDKKeys = buildKeyStatusSlice(clientCtx.GetAcceptedSDKKeys())
+
+			// mobileKeys[]: non-primary accepted mobile keys, sorted by identifier.
+			status.MobileKeys = buildMobileKeyStatusSlice(clientCtx.GetAcceptedMobileKeys())
+
+			// expiringSdkKey: pick the non-anchor SDK key with the soonest expiry for a deterministic
+			// value; with multiple expiring keys the previous loop-overwrite was nondeterministic.
+			if key, ok := clientCtx.GetEarliestExpiringSDKKey(); ok {
+				status.ExpiringSDKKey = sdks.ObscureKey(string(key))
 			}
 
 			client := clientCtx.GetClient()
@@ -154,4 +160,40 @@ func statusHandler(relay *Relay) http.Handler {
 
 		_, _ = w.Write(data)
 	})
+}
+
+// buildKeyStatusSlice converts SDK key entries from the rotator into the JSON-serialisable slice for
+// the sdkKeys[] response field. The entries are pre-sorted by the rotator.
+func buildKeyStatusSlice(entries []credential.SDKKeyEntry) []api.KeyStatus {
+	result := make([]api.KeyStatus, 0, len(entries))
+	for _, e := range entries {
+		ks := api.KeyStatus{
+			Key:   e.Identifier,
+			Value: sdks.ObscureKey(string(e.Value)),
+		}
+		if e.Expiry != nil {
+			ms := e.Expiry.UnixMilli()
+			ks.Expiry = &ms
+		}
+		result = append(result, ks)
+	}
+	return result
+}
+
+// buildMobileKeyStatusSlice converts mobile key entries into the JSON-serialisable slice for the
+// mobileKeys[] response field. The entries are pre-sorted by the rotator.
+func buildMobileKeyStatusSlice(entries []credential.MobileKeyEntry) []api.KeyStatus {
+	result := make([]api.KeyStatus, 0, len(entries))
+	for _, e := range entries {
+		ks := api.KeyStatus{
+			Key:   e.Identifier,
+			Value: sdks.ObscureKey(string(e.Value)),
+		}
+		if e.Expiry != nil {
+			ms := e.Expiry.UnixMilli()
+			ks.Expiry = &ms
+		}
+		result = append(result, ks)
+	}
+	return result
 }

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
@@ -60,16 +61,41 @@ func statusHandler(relay *Relay) http.Handler {
 				}
 			}
 
-			// sdkKeys[]: non-anchor accepted SDK keys, sorted by identifier.
-			status.SDKKeys = buildKeyStatusSlice(clientCtx.GetAcceptedSDKKeys())
+			// sdkKeys[] / mobileKeys[]: the full accepted set — including the anchor and primary mobile
+			// key — partitioned by type. The scalar sdkKey/mobileKey above designate which entry is the
+			// anchor/primary. Order is unspecified.
+			anchor := string(clientCtx.GetSDKKey())
+			var expiringCandidates []credential.AcceptedKey
+			for _, k := range clientCtx.GetAcceptedKeys() {
+				ks := keyStatus(k)
+				switch k.Type {
+				case credential.KeyTypeServer:
+					status.SDKKeys = append(status.SDKKeys, ks)
+					// expiringSdkKey considers non-anchor server keys that carry an expiry.
+					if k.Value != anchor && k.Expiry != nil {
+						expiringCandidates = append(expiringCandidates, k)
+					}
+				case credential.KeyTypeMobile:
+					status.MobileKeys = append(status.MobileKeys, ks)
+				}
+			}
+			// Arrays are always present (never null): a server-only env has an empty mobileKeys.
+			if status.SDKKeys == nil {
+				status.SDKKeys = []api.KeyStatus{}
+			}
+			if status.MobileKeys == nil {
+				status.MobileKeys = []api.KeyStatus{}
+			}
 
-			// mobileKeys[]: non-primary accepted mobile keys, sorted by identifier.
-			status.MobileKeys = buildMobileKeyStatusSlice(clientCtx.GetAcceptedMobileKeys())
-
-			// expiringSdkKey: pick the non-anchor SDK key with the soonest expiry for a deterministic
-			// value; with multiple expiring keys the previous loop-overwrite was nondeterministic.
-			if key, ok := clientCtx.GetEarliestExpiringSDKKey(); ok {
-				status.ExpiringSDKKey = sdks.ObscureKey(string(key))
+			// expiringSdkKey (back-compat): the soonest-expiring non-anchor SDK key. Fold in the legacy
+			// grace-period keys, which may not appear in the accepted set above. Picking the soonest
+			// expiry makes the value deterministic when several keys are expiring at once.
+			expiringCandidates = append(expiringCandidates, clientCtx.GetDeprecatedSDKKeys()...)
+			if len(expiringCandidates) > 0 {
+				earliest := slices.MinFunc(expiringCandidates, func(a, b credential.AcceptedKey) int {
+					return a.Expiry.Compare(*b.Expiry)
+				})
+				status.ExpiringSDKKey = sdks.ObscureKey(earliest.Value)
 			}
 
 			client := clientCtx.GetClient()
@@ -162,38 +188,16 @@ func statusHandler(relay *Relay) http.Handler {
 	})
 }
 
-// buildKeyStatusSlice converts SDK key entries from the rotator into the JSON-serialisable slice for
-// the sdkKeys[] response field. The entries are pre-sorted by the rotator.
-func buildKeyStatusSlice(entries []credential.SDKKeyEntry) []api.KeyStatus {
-	result := make([]api.KeyStatus, 0, len(entries))
-	for _, e := range entries {
-		ks := api.KeyStatus{
-			Key:   e.Identifier,
-			Value: sdks.ObscureKey(string(e.Value)),
-		}
-		if e.Expiry != nil {
-			ms := e.Expiry.UnixMilli()
-			ks.Expiry = &ms
-		}
-		result = append(result, ks)
+// keyStatus converts an accepted key into its status-endpoint JSON representation, obscuring the
+// secret value and surfacing the optional identifier and expiry.
+func keyStatus(k credential.AcceptedKey) api.KeyStatus {
+	ks := api.KeyStatus{Value: sdks.ObscureKey(k.Value)}
+	if k.Key != nil {
+		ks.Key = *k.Key
 	}
-	return result
-}
-
-// buildMobileKeyStatusSlice converts mobile key entries into the JSON-serialisable slice for the
-// mobileKeys[] response field. The entries are pre-sorted by the rotator.
-func buildMobileKeyStatusSlice(entries []credential.MobileKeyEntry) []api.KeyStatus {
-	result := make([]api.KeyStatus, 0, len(entries))
-	for _, e := range entries {
-		ks := api.KeyStatus{
-			Key:   e.Identifier,
-			Value: sdks.ObscureKey(string(e.Value)),
-		}
-		if e.Expiry != nil {
-			ms := e.Expiry.UnixMilli()
-			ks.Expiry = &ms
-		}
-		result = append(result, ks)
+	if k.Expiry != nil {
+		ms := k.Expiry.UnixMilli()
+		ks.Expiry = &ms
 	}
-	return result
+	return ks
 }

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
@@ -87,11 +88,15 @@ func statusHandler(relay *Relay) http.Handler {
 				status.MobileKeys = []api.KeyStatus{}
 			}
 
-			// expiringSdkKey: the soonest-expiring non-anchor SDK key. Picking the soonest expiry makes
-			// the value deterministic when several keys are expiring at once.
+			// expiringSdkKey: the soonest-expiring non-anchor SDK key. Comparing by expiry then by value
+			// gives a total order, so the chosen key is deterministic even when several keys share the
+			// same expiry (map iteration order, and hence MinFunc's pick on a tie, is otherwise unstable).
 			if len(expiringCandidates) > 0 {
 				earliest := slices.MinFunc(expiringCandidates, func(a, b credential.AcceptedKey) int {
-					return a.Expiry.Compare(*b.Expiry)
+					if c := a.Expiry.Compare(*b.Expiry); c != 0 {
+						return c
+					}
+					return strings.Compare(a.Value, b.Value)
 				})
 				status.ExpiringSDKKey = sdks.ObscureKey(earliest.Value)
 			}

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -87,8 +87,8 @@ func statusHandler(relay *Relay) http.Handler {
 				status.MobileKeys = []api.KeyStatus{}
 			}
 
-			// expiringSdkKey (back-compat): the soonest-expiring non-anchor SDK key. Picking the soonest
-			// expiry makes the value deterministic when several keys are expiring at once.
+			// expiringSdkKey: the soonest-expiring non-anchor SDK key. Picking the soonest expiry makes
+			// the value deterministic when several keys are expiring at once.
 			if len(expiringCandidates) > 0 {
 				earliest := slices.MinFunc(expiringCandidates, func(a, b credential.AcceptedKey) int {
 					return a.Expiry.Compare(*b.Expiry)

--- a/relay/endpoints_status_test.go
+++ b/relay/endpoints_status_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
 
 	c "github.com/launchdarkly/ld-relay/v8/config"
@@ -129,5 +130,77 @@ func TestEndpointsStatus(t *testing.T) {
 
 			st.AssertJSONPathMatch(t, "degraded", status, "status")
 		})
+	})
+}
+
+// TestBuildKeyStatusSlice verifies the sdkKeys[] helper that converts rotator entries to the JSON
+// representation used by the status endpoint.
+func TestBuildKeyStatusSlice(t *testing.T) {
+	t.Run("empty entries yields empty slice", func(t *testing.T) {
+		result := buildKeyStatusSlice(nil)
+		assert.Empty(t, result)
+	})
+
+	t.Run("permanent key has no expiry field", func(t *testing.T) {
+		entries := []credential.SDKKeyEntry{
+			{Value: c.SDKKey("sdk-abc123"), Identifier: "default", Expiry: nil},
+		}
+		result := buildKeyStatusSlice(entries)
+		require.Len(t, result, 1)
+		assert.Equal(t, "default", result[0].Key)
+		assert.Equal(t, sdks.ObscureKey("sdk-abc123"), result[0].Value)
+		assert.Nil(t, result[0].Expiry)
+	})
+
+	t.Run("expiring key has expiry in Unix milliseconds", func(t *testing.T) {
+		expiry := time.Date(2099, 6, 1, 12, 0, 0, 0, time.UTC)
+		entries := []credential.SDKKeyEntry{
+			{Value: c.SDKKey("sdk-old"), Identifier: "old-key", Expiry: &expiry},
+		}
+		result := buildKeyStatusSlice(entries)
+		require.Len(t, result, 1)
+		require.NotNil(t, result[0].Expiry)
+		assert.Equal(t, expiry.UnixMilli(), *result[0].Expiry)
+	})
+
+	t.Run("preserves entry order from input", func(t *testing.T) {
+		entries := []credential.SDKKeyEntry{
+			{Value: c.SDKKey("sdk-a"), Identifier: "a"},
+			{Value: c.SDKKey("sdk-b"), Identifier: "b"},
+		}
+		result := buildKeyStatusSlice(entries)
+		require.Len(t, result, 2)
+		assert.Equal(t, "a", result[0].Key)
+		assert.Equal(t, "b", result[1].Key)
+	})
+}
+
+// TestBuildMobileKeyStatusSlice verifies the mobileKeys[] helper mirrors buildKeyStatusSlice behaviour.
+func TestBuildMobileKeyStatusSlice(t *testing.T) {
+	t.Run("empty entries yields empty slice", func(t *testing.T) {
+		result := buildMobileKeyStatusSlice(nil)
+		assert.Empty(t, result)
+	})
+
+	t.Run("mobile key value is obscured", func(t *testing.T) {
+		entries := []credential.MobileKeyEntry{
+			{Value: c.MobileKey("mob-secret"), Identifier: "mob-1", Expiry: nil},
+		}
+		result := buildMobileKeyStatusSlice(entries)
+		require.Len(t, result, 1)
+		assert.Equal(t, "mob-1", result[0].Key)
+		assert.Equal(t, sdks.ObscureKey("mob-secret"), result[0].Value)
+		assert.Nil(t, result[0].Expiry)
+	})
+
+	t.Run("expiring mobile key has expiry in Unix milliseconds", func(t *testing.T) {
+		expiry := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+		entries := []credential.MobileKeyEntry{
+			{Value: c.MobileKey("mob-old"), Identifier: "mob-old", Expiry: &expiry},
+		}
+		result := buildMobileKeyStatusSlice(entries)
+		require.Len(t, result, 1)
+		require.NotNil(t, result[0].Expiry)
+		assert.Equal(t, expiry.UnixMilli(), *result[0].Expiry)
 	})
 }

--- a/relay/endpoints_status_test.go
+++ b/relay/endpoints_status_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 
 	ct "github.com/launchdarkly/go-configtypes"
 	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
@@ -159,6 +160,90 @@ func TestEndpointsStatus(t *testing.T) {
 			st.AssertJSONPathMatch(t, "VALID", status, "environments", st.EnvMobile.Name, "connectionStatus", "state")
 
 			st.AssertJSONPathMatch(t, "degraded", status, "status")
+		})
+	})
+}
+
+// findKeyStatusByValue returns the sdkKeys[]/mobileKeys[] entry whose obscured "value" matches, or a
+// null value. Array entry order is unspecified, so callers look entries up by value.
+func findKeyStatusByValue(arr ldvalue.Value, obscuredValue string) ldvalue.Value {
+	for i := 0; i < arr.Count(); i++ {
+		if arr.GetByIndex(i).GetByKey("value").StringValue() == obscuredValue {
+			return arr.GetByIndex(i)
+		}
+	}
+	return ldvalue.Null()
+}
+
+// TestEndpointsStatusExpiringSDKKey drives a multi-key environment through the real /status handler:
+// it reconciles an env to an anchor plus two non-anchor expiring SDK keys and asserts the
+// expiringSdkKey selection, the per-key expiry/identifier serialization in sdkKeys[], and that the
+// soonest-expiry pick is deterministic on an exact expiry tie.
+func TestEndpointsStatusExpiringSDKKey(t *testing.T) {
+	getStatus := func(t *testing.T, p relayTestParams, set credential.AcceptedSet) ldvalue.Value {
+		env, err := p.relay.getEnvironment(sdkauth.New(st.EnvMain.Config.SDKKey))
+		require.NoError(t, err)
+		require.NotNil(t, env)
+		env.ReconcileCredentials(set)
+
+		r, _ := http.NewRequest("GET", "http://localhost/status", nil)
+		result, body := st.DoRequest(r, p.relay)
+		require.Equal(t, http.StatusOK, result.StatusCode)
+		return ldvalue.Parse(body).GetByKey("environments").GetByKey(st.EnvMain.Name)
+	}
+
+	t.Run("soonest-expiring non-anchor key, with expiry and identifier surfaced", func(t *testing.T) {
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(st.EnvMain)
+		withStartedRelay(t, config, func(p relayTestParams) {
+			anchor := st.EnvMain.Config.SDKKey
+			soon := time.Now().Add(1 * time.Hour)
+			later := time.Now().Add(2 * time.Hour)
+			set, err := credential.NewAcceptedSetBuilder().
+				WithAnchor(credential.SDKKeyParams{Value: anchor}).
+				WithSDKKey(credential.SDKKeyParams{Value: "sdk-soon", Key: util.PtrOrNil("soon-key"), Expiry: util.PtrOrNil(soon)}).
+				WithSDKKey(credential.SDKKeyParams{Value: "sdk-later", Expiry: util.PtrOrNil(later)}).
+				Build()
+			require.NoError(t, err)
+
+			envStatus := getStatus(t, p, set)
+
+			// expiringSdkKey is the obscured soonest-expiring non-anchor key.
+			st.AssertJSONPathMatch(t, sdks.ObscureKey("sdk-soon"), envStatus, "expiringSdkKey")
+
+			// sdkKeys[] carries the full set (anchor + both non-anchor keys).
+			sdkKeys := envStatus.GetByKey("sdkKeys")
+			require.Equal(t, 3, sdkKeys.Count())
+
+			// The expiring key surfaces its identifier and Unix-millis expiry.
+			soonEntry := findKeyStatusByValue(sdkKeys, sdks.ObscureKey("sdk-soon"))
+			require.False(t, soonEntry.IsNull())
+			assert.Equal(t, "soon-key", soonEntry.GetByKey("key").StringValue())
+			assert.Equal(t, float64(soon.UnixMilli()), soonEntry.GetByKey("expiry").Float64Value())
+
+			// A key with no identifier omits "key" entirely (omitempty, nil pointer).
+			laterEntry := findKeyStatusByValue(sdkKeys, sdks.ObscureKey("sdk-later"))
+			require.False(t, laterEntry.IsNull())
+			assert.True(t, laterEntry.GetByKey("key").IsNull(), `"key" must be omitted when the source carried no identifier`)
+		})
+	})
+
+	t.Run("tie on expiry resolves deterministically to the smaller value", func(t *testing.T) {
+		var config c.Config
+		config.Environment = st.MakeEnvConfigs(st.EnvMain)
+		withStartedRelay(t, config, func(p relayTestParams) {
+			anchor := st.EnvMain.Config.SDKKey
+			sameExpiry := time.Now().Add(1 * time.Hour)
+			set, err := credential.NewAcceptedSetBuilder().
+				WithAnchor(credential.SDKKeyParams{Value: anchor}).
+				WithSDKKey(credential.SDKKeyParams{Value: "sdk-bbb", Expiry: util.PtrOrNil(sameExpiry)}).
+				WithSDKKey(credential.SDKKeyParams{Value: "sdk-aaa", Expiry: util.PtrOrNil(sameExpiry)}).
+				Build()
+			require.NoError(t, err)
+
+			envStatus := getStatus(t, p, set)
+			// With equal expiries, the smaller value (sdk-aaa) wins deterministically.
+			st.AssertJSONPathMatch(t, sdks.ObscureKey("sdk-aaa"), envStatus, "expiringSdkKey")
 		})
 	})
 }

--- a/relay/endpoints_status_test.go
+++ b/relay/endpoints_status_test.go
@@ -57,6 +57,36 @@ func TestEndpointsStatus(t *testing.T) {
 			st.AssertJSONPathMatch(t, p.relay.version, status, "version")
 			st.AssertJSONPathMatch(t, ld.Version, status, "clientVersion")
 		})
+
+		t.Run("sdkKeys/mobileKeys arrays carry the full accepted set including the anchor", func(t *testing.T) {
+			var config c.Config
+			config.Environment = st.MakeEnvConfigs(st.EnvMain, st.EnvMobile)
+
+			withStartedRelay(t, config, func(p relayTestParams) {
+				r, _ := http.NewRequest("GET", "http://localhost/status", nil)
+				result, body := st.DoRequest(r, p.relay)
+				assert.Equal(t, http.StatusOK, result.StatusCode)
+				status := ldvalue.Parse(body)
+
+				// EnvMain is a manually-configured single-key env: sdkKeys[] is present and contains
+				// exactly the anchor (full set includes it); manual config carries no key identifier.
+				sdkKeys := status.GetByKey("environments").GetByKey(st.EnvMain.Name).GetByKey("sdkKeys")
+				require.Equal(t, 1, sdkKeys.Count(), "sdkKeys must contain the anchor")
+				assert.Equal(t, sdks.ObscureKey(string(st.EnvMain.Config.SDKKey)),
+					sdkKeys.GetByIndex(0).GetByKey("value").StringValue())
+
+				// EnvMain has no mobile key — mobileKeys is present but empty.
+				mobileKeys := status.GetByKey("environments").GetByKey(st.EnvMain.Name).GetByKey("mobileKeys")
+				assert.Equal(t, 0, mobileKeys.Count())
+				assert.Equal(t, ldvalue.ArrayType, mobileKeys.Type(), "mobileKeys present (not null) even when empty")
+
+				// EnvMobile has both: its mobile key appears in mobileKeys[].
+				mobMobileKeys := status.GetByKey("environments").GetByKey(st.EnvMobile.Name).GetByKey("mobileKeys")
+				require.Equal(t, 1, mobMobileKeys.Count())
+				assert.Equal(t, sdks.ObscureKey(string(st.EnvMobile.Config.MobileKey)),
+					mobMobileKeys.GetByIndex(0).GetByKey("value").StringValue())
+			})
+		})
 	})
 
 	t.Run("connection interruption - less than DisconnectedStatusTime", func(t *testing.T) {
@@ -133,74 +163,39 @@ func TestEndpointsStatus(t *testing.T) {
 	})
 }
 
-// TestBuildKeyStatusSlice verifies the sdkKeys[] helper that converts rotator entries to the JSON
-// representation used by the status endpoint.
-func TestBuildKeyStatusSlice(t *testing.T) {
-	t.Run("empty entries yields empty slice", func(t *testing.T) {
-		result := buildKeyStatusSlice(nil)
-		assert.Empty(t, result)
+// TestKeyStatus verifies the helper that converts an accepted key into its status-endpoint JSON form.
+func TestKeyStatus(t *testing.T) {
+	strptr := func(s string) *string { return &s }
+
+	t.Run("permanent key with identifier", func(t *testing.T) {
+		ks := keyStatus(credential.AcceptedKey{
+			Type: credential.KeyTypeServer, Value: "sdk-abc123", Key: strptr("default"),
+		})
+		assert.Equal(t, "default", ks.Key)
+		assert.Equal(t, sdks.ObscureKey("sdk-abc123"), ks.Value)
+		assert.Nil(t, ks.Expiry)
 	})
 
-	t.Run("permanent key has no expiry field", func(t *testing.T) {
-		entries := []credential.SDKKeyEntry{
-			{Value: c.SDKKey("sdk-abc123"), Identifier: "default", Expiry: nil},
-		}
-		result := buildKeyStatusSlice(entries)
-		require.Len(t, result, 1)
-		assert.Equal(t, "default", result[0].Key)
-		assert.Equal(t, sdks.ObscureKey("sdk-abc123"), result[0].Value)
-		assert.Nil(t, result[0].Expiry)
+	t.Run("nil identifier yields empty Key (omitted in JSON)", func(t *testing.T) {
+		ks := keyStatus(credential.AcceptedKey{
+			Type: credential.KeyTypeServer, Value: "sdk-legacy", Key: nil,
+		})
+		assert.Equal(t, "", ks.Key)
 	})
 
 	t.Run("expiring key has expiry in Unix milliseconds", func(t *testing.T) {
 		expiry := time.Date(2099, 6, 1, 12, 0, 0, 0, time.UTC)
-		entries := []credential.SDKKeyEntry{
-			{Value: c.SDKKey("sdk-old"), Identifier: "old-key", Expiry: &expiry},
-		}
-		result := buildKeyStatusSlice(entries)
-		require.Len(t, result, 1)
-		require.NotNil(t, result[0].Expiry)
-		assert.Equal(t, expiry.UnixMilli(), *result[0].Expiry)
-	})
-
-	t.Run("preserves entry order from input", func(t *testing.T) {
-		entries := []credential.SDKKeyEntry{
-			{Value: c.SDKKey("sdk-a"), Identifier: "a"},
-			{Value: c.SDKKey("sdk-b"), Identifier: "b"},
-		}
-		result := buildKeyStatusSlice(entries)
-		require.Len(t, result, 2)
-		assert.Equal(t, "a", result[0].Key)
-		assert.Equal(t, "b", result[1].Key)
-	})
-}
-
-// TestBuildMobileKeyStatusSlice verifies the mobileKeys[] helper mirrors buildKeyStatusSlice behaviour.
-func TestBuildMobileKeyStatusSlice(t *testing.T) {
-	t.Run("empty entries yields empty slice", func(t *testing.T) {
-		result := buildMobileKeyStatusSlice(nil)
-		assert.Empty(t, result)
+		ks := keyStatus(credential.AcceptedKey{
+			Type: credential.KeyTypeServer, Value: "sdk-old", Key: strptr("old-key"), Expiry: &expiry,
+		})
+		require.NotNil(t, ks.Expiry)
+		assert.Equal(t, expiry.UnixMilli(), *ks.Expiry)
 	})
 
 	t.Run("mobile key value is obscured", func(t *testing.T) {
-		entries := []credential.MobileKeyEntry{
-			{Value: c.MobileKey("mob-secret"), Identifier: "mob-1", Expiry: nil},
-		}
-		result := buildMobileKeyStatusSlice(entries)
-		require.Len(t, result, 1)
-		assert.Equal(t, "mob-1", result[0].Key)
-		assert.Equal(t, sdks.ObscureKey("mob-secret"), result[0].Value)
-		assert.Nil(t, result[0].Expiry)
-	})
-
-	t.Run("expiring mobile key has expiry in Unix milliseconds", func(t *testing.T) {
-		expiry := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
-		entries := []credential.MobileKeyEntry{
-			{Value: c.MobileKey("mob-old"), Identifier: "mob-old", Expiry: &expiry},
-		}
-		result := buildMobileKeyStatusSlice(entries)
-		require.Len(t, result, 1)
-		require.NotNil(t, result[0].Expiry)
-		assert.Equal(t, expiry.UnixMilli(), *result[0].Expiry)
+		ks := keyStatus(credential.AcceptedKey{
+			Type: credential.KeyTypeMobile, Value: "mob-secret", Key: strptr("mob-1"),
+		})
+		assert.Equal(t, sdks.ObscureKey("mob-secret"), ks.Value)
 	})
 }


### PR DESCRIPTION
> [!NOTE]
> **Closed without merging — superseded by a stack of smaller PRs.** This change grew to mix a credential-model refactor with the endpoint feature, so it was split into:
> - #728 — fix: reject primary mobile key absent from `mobileKeys[]` (independent correctness fix)
> - #729 → #730 → #731 — the feature stack (model: store identifiers → expose accepted set → surface on `/status`)
>
> Combined, those reconstruct the reviewed code here. This branch is kept as reference until the stack lands.

---

## Summary

Implements [SDK-2534](https://launchdarkly.atlassian.net/browse/SDK-2534) (T4 of concurrent-keys epic [SDK-2453](https://launchdarkly.atlassian.net/browse/SDK-2453)): adds `sdkKeys[]` and `mobileKeys[]` array fields to the `/status` endpoint response, surfacing the **full accepted key set** for each environment. The existing scalar `sdkKey`/`mobileKey` fields are preserved for back-compat and now designate which array entry is the anchor / primary.

Also makes the legacy `expiringSdkKey` field deterministic: the previous code overwrote on each loop iteration (arbitrary with multiple expiring keys); it now reports the key with the soonest expiry.

## Background

The concurrent-keys epic (SDK-2453) lets an environment accept multiple SDK keys and mobile keys at once. Per the backend tech spec and RAC payload spec, the `sdkKeys`/`mobileKeys` arrays are the authoritative **full accepted set, including the default/anchor key** (which is also duplicated on the legacy scalar fields). The status endpoint mirrors that: the arrays carry every accepted key; the scalars designate the anchor / primary.

The wire format carries a non-secret `key` identifier alongside each credential's `value`. This PR threads that identifier through to the status response. The identifier is genuinely optional — manual configuration and old-format (pre-concurrent-keys) payloads carry none — so it is modeled as a pointer and omitted from the JSON when absent.

## Response schema

`EnvironmentStatusRep` gains two arrays plus a `KeyStatus` element type. The scalar fields are unchanged.

```go
// KeyStatus is one accepted credential in the sdkKeys[] / mobileKeys[] arrays.
type KeyStatus struct {
    Key    string `json:"key,omitempty"`    // non-secret identifier; omitted when the source carried none
    Value  string `json:"value"`            // obscured credential secret
    Expiry *int64 `json:"expiry,omitempty"` // Unix-millis expiry; omitted for permanent keys
}

type EnvironmentStatusRep struct {
    SDKKey           string               `json:"sdkKey"`                   // obscured ANCHOR (designates which SDKKeys entry is the anchor)
    SDKKeys          []KeyStatus          `json:"sdkKeys"`                  // full server-key set, incl. anchor; always present, always ≥1
    EnvID            string               `json:"envId,omitempty"`
    EnvKey           string               `json:"envKey,omitempty"`
    EnvName          string               `json:"envName,omitempty"`
    ProjKey          string               `json:"projKey,omitempty"`
    ProjName         string               `json:"projName,omitempty"`
    MobileKey        string               `json:"mobileKey,omitempty"`      // obscured PRIMARY mobile key
    MobileKeys       []KeyStatus          `json:"mobileKeys"`               // full mobile-key set, incl. primary; always present, may be empty
    ExpiringSDKKey   string               `json:"expiringSdkKey,omitempty"` // soonest-expiring non-anchor SDK key (deterministic)
    Status           string               `json:"status"`
    ConnectionStatus ConnectionStatusRep  `json:"connectionStatus"`
    DataStoreStatus  DataStoreStatusRep   `json:"dataStoreStatus"`
    BigSegmentStatus *BigSegmentStatusRep `json:"bigSegmentStatus,omitempty"`
}
```

Array entry order is unspecified. The arrays are always present (never null): `sdkKeys` always contains at least the anchor; `mobileKeys` is empty for an environment with no mobile key (e.g. server-side only).

### Example (environment mid-rotation, an extra service key + an expiring key)

```json
"environment1": {
  "sdkKey": "sdk-********-****-****-****-*******00001",
  "sdkKeys": [
    { "key": "default",   "value": "sdk-********-****-****-****-*******00001" },
    { "key": "service-a", "value": "sdk-********-****-****-****-*******00002" },
    { "key": "old-key",   "value": "sdk-********-****-****-****-*******00003", "expiry": 1735689600000 }
  ],
  "mobileKey": "mob-********-****-****-****-*******00009",
  "mobileKeys": [
    { "key": "default-mobile", "value": "mob-********-****-****-****-*******00009" }
  ],
  "expiringSdkKey": "sdk-********-****-****-****-*******00003",
  "status": "connected",
  "connectionStatus": { "state": "VALID", "stateSince": 10000000 },
  "dataStoreStatus":  { "state": "VALID", "stateSince": 10000000 }
}
```

## Changes

The rotator exposes `AcceptedKeys()` — the full accepted set as `[]AcceptedKey`, each entry tagged server or mobile via a `KeyType` and carrying the credential value, the optional wire `key` identifier (`*string`, nil when absent), and the optional expiry. The status handler partitions that slice by type into the `sdkKeys[]`/`mobileKeys[]` arrays (obscuring each value) and selects the soonest-expiring non-anchor SDK key for `expiringSdkKey` via `slices.MinFunc`.

On the build side, `AcceptedSetBuilder`'s `WithAnchor` / `WithSDKKey` / `WithMobileKey` / `WithPrimaryMobileKey` take `SDKKeyParams` / `MobileKeyParams` structs carrying the value plus the optional identifier and expiry; `AcceptedSet` stores each as an `acceptedKeyInfo`, and `BuildAcceptedSet` threads the wire `key` through (converting empty → nil via the shared `util.PtrOrNil` helper).


[SDK-2534]: https://launchdarkly.atlassian.net/browse/SDK-2534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2453]: https://launchdarkly.atlassian.net/browse/SDK-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential reconcile/build validation and a public status JSON schema; mis-validation could block RAC updates or confuse operators, but behavior is heavily tested and scalars stay backward-compatible.
> 
> **Overview**
> Extends **`/status`** so each environment reports the **full accepted SDK and mobile key sets** via new **`sdkKeys[]`** and **`mobileKeys[]`** arrays (`KeyStatus`: optional wire identifier, obscured value, optional expiry). Legacy scalar **`sdkKey`** / **`mobileKey`** remain and still mark the anchor and primary entries.
> 
> Credential plumbing now carries per-key **wire identifiers** end-to-end: **`AcceptedSetBuilder`** takes **`SDKKeyParams` / `MobileKeyParams`**, **`Rotator.AcceptedKeys()`** exposes metadata for the handler, and reconcile **refreshes or clears** identifiers so `/status` does not show stale names after payload changes. **`BuildAcceptedSet`** rejects a defined **`mobKey`** missing from **`mobileKeys[]`** (parallel to the anchor invariant).
> 
> **`expiringSdkKey`** is now the **soonest-expiring non-anchor** SDK key, with a deterministic tie-break on credential value instead of loop-order luck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6761994bf1d4acdd253c0f81980e0cb7e85d08b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
