### PR TITLE
test(concurrent-keys): integration tests for multi-key downstream auth

### DIFF
--- a/relay/concurrent_keys_auth_test.go
+++ b/relay/concurrent_keys_auth_test.go
@@ -1,19 +1,18 @@
 package relay
 
-// Integration scenarios for multi-key (concurrent SDK keys) downstream authentication.
+// Downstream authentication for environments that accept multiple SDK keys and multiple mobile keys
+// (the sdkKeys[]/mobileKeys[] array wire format), where a single anchor key owns the one upstream
+// connection. These are permanent regression tests for that behavior.
 //
-// These tests exercise the NEW behavior: an environment whose accepted set carries multiple SDK
-// keys and multiple mobile keys via the sdkKeys[]/mobileKeys[] array wire format, with a single
-// anchor key owning the one upstream connection. They complement — and deliberately do not
-// duplicate — existing coverage:
+// They complement — and deliberately do not duplicate — existing coverage:
 //
 //   - Single-key / legacy expiring{}-slot rotation is covered by TestAutoConfigInitWithExpiringSDKKey,
 //     TestOfflineModeDeprecatedSDKKeyIsRespectedIfExpiryInFuture, TestOfflineModeSDKKeyCanExpire, etc.
-//     Those assert on the credential SET via the legacy rotation path; these assert downstream
-//     AUTHENTICATION (and live stream connect/disconnect) via the array path.
+//     Those assert on the credential set via the legacy rotation path; these assert downstream
+//     authentication (and live stream connect/disconnect) via the array path.
 //   - Generic unknown-credential -> 401 is covered at the middleware/end-to-end layer; here we only
-//     test the multi-key-specific rejection (a credential outside a populated accepted set, and a
-//     key removed from the accepted set on reconcile).
+//     test rejection that is specific to a multi-key environment (a credential outside a populated
+//     accepted set, and a key removed from the accepted set on reconcile).
 //
 // The tests reuse the in-process harnesses (autoConfTest for RAC, offlineModeTest for offline) so
 // they get assertSDKEndpointsAvailability (auth accept/reject) and awaitClient/shouldNotCreateClient
@@ -23,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	c "github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"
 	"github.com/launchdarkly/ld-relay/v8/internal/filedata"
@@ -42,125 +41,125 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Shared identifiers for the multi-key environment used across these scenarios. The anchor is the
-// key the singular sdkKey.value/mobKey points to; the "extra" keys are additional accepted entries
-// that are NOT the anchor.
+// Shared identifiers for the multi-key environment used across these tests. The anchor is the key
+// the singular sdkKey.value/mobKey points to; the "extra" keys are additional accepted entries that
+// are NOT the anchor.
 const (
-	ckEnvID     = c.EnvironmentID("ck-multikey-env")
-	ckAnchorSDK = c.SDKKey("sdk-ck-anchor")
-	ckExtraSDK  = c.SDKKey("sdk-ck-extra")
-	ckAnchorMob = c.MobileKey("mob-ck-anchor")
-	ckExtraMob  = c.MobileKey("mob-ck-extra")
-	ckFlagKey   = "ck-flag"
+	multiKeyEnvID   = config.EnvironmentID("multikey-env")
+	anchorSDKKey    = config.SDKKey("sdk-anchor")
+	extraSDKKey     = config.SDKKey("sdk-extra")
+	anchorMobileKey = config.MobileKey("mob-anchor")
+	extraMobileKey  = config.MobileKey("mob-extra")
+	multiKeyFlagKey = "multikey-flag"
 )
 
-var ckIdentifiers = relayenv.EnvIdentifiers{
-	ProjName: "CK Project",
-	ProjKey:  "ck-proj",
-	EnvName:  "CK Env",
-	EnvKey:   "ck-env",
+var multiKeyIdentifiers = relayenv.EnvIdentifiers{
+	ProjName: "Multi-Key Project",
+	ProjKey:  "multikey-proj",
+	EnvName:  "Multi-Key Env",
+	EnvKey:   "multikey-env",
 }
 
-// ckMultiKeyRep builds a RAC/offline EnvironmentRep for the multi-key env using the array wire
-// format. The anchor is always ckAnchorSDK/ckAnchorMob (singular sdkKey/mobKey); callers pass the
-// full sdkKeys[]/mobileKeys[] arrays (which must include the anchor entry).
-func ckMultiKeyRep(sdkKeys, mobileKeys []envfactory.ConcurrentKeyRep, version int) envfactory.EnvironmentRep {
+// multiKeyEnvRep builds a RAC/offline EnvironmentRep for the multi-key env using the array wire
+// format. The anchor is always anchorSDKKey/anchorMobileKey (singular sdkKey/mobKey); callers pass
+// the full sdkKeys[]/mobileKeys[] arrays (which must include the anchor entry).
+func multiKeyEnvRep(sdkKeys, mobileKeys []envfactory.ConcurrentKeyRep, version int) envfactory.EnvironmentRep {
 	return envfactory.EnvironmentRep{
-		EnvID:      ckEnvID,
-		EnvKey:     ckIdentifiers.EnvKey,
-		EnvName:    ckIdentifiers.EnvName,
-		ProjKey:    ckIdentifiers.ProjKey,
-		ProjName:   ckIdentifiers.ProjName,
-		SDKKey:     envfactory.SDKKeyRep{Value: ckAnchorSDK},
-		MobKey:     ckAnchorMob,
+		EnvID:      multiKeyEnvID,
+		EnvKey:     multiKeyIdentifiers.EnvKey,
+		EnvName:    multiKeyIdentifiers.EnvName,
+		ProjKey:    multiKeyIdentifiers.ProjKey,
+		ProjName:   multiKeyIdentifiers.ProjName,
+		SDKKey:     envfactory.SDKKeyRep{Value: anchorSDKKey},
+		MobKey:     anchorMobileKey,
 		SDKKeys:    sdkKeys,
 		MobileKeys: mobileKeys,
 		Version:    version,
 	}
 }
 
-// ckDefaultSDKKeys / ckDefaultMobileKeys are the standard two-entry arrays (anchor + one extra,
-// both permanent) used by the scenarios that don't involve expiry.
-func ckDefaultSDKKeys() []envfactory.ConcurrentKeyRep {
+// defaultSDKKeyReps / defaultMobileKeyReps are the standard two-entry arrays (anchor + one extra,
+// both permanent) used by the tests that don't involve expiry.
+func defaultSDKKeyReps() []envfactory.ConcurrentKeyRep {
 	return []envfactory.ConcurrentKeyRep{
-		{Key: "anchor-sdk", Value: string(ckAnchorSDK)},
-		{Key: "extra-sdk", Value: string(ckExtraSDK)},
+		{Key: "anchor-sdk", Value: string(anchorSDKKey)},
+		{Key: "extra-sdk", Value: string(extraSDKKey)},
 	}
 }
 
-func ckDefaultMobileKeys() []envfactory.ConcurrentKeyRep {
+func defaultMobileKeyReps() []envfactory.ConcurrentKeyRep {
 	return []envfactory.ConcurrentKeyRep{
-		{Key: "anchor-mob", Value: string(ckAnchorMob)},
-		{Key: "extra-mob", Value: string(ckExtraMob)},
+		{Key: "anchor-mob", Value: string(anchorMobileKey)},
+		{Key: "extra-mob", Value: string(extraMobileKey)},
 	}
 }
 
-// ckArchiveEnv builds the offline-mode ArchiveEnvironment equivalent of ckMultiKeyRep, carrying the
-// accepted SDK/mobile key sets directly plus a single flag so the data store initializes.
-func ckArchiveEnv(sdkKeys []envfactory.AcceptedSDKKey, mobileKeys []envfactory.AcceptedMobileKey) filedata.ArchiveEnvironment {
+// multiKeyArchiveEnv builds the offline-mode ArchiveEnvironment equivalent of multiKeyEnvRep,
+// carrying the accepted SDK/mobile key sets directly plus a single flag so the data store initializes.
+func multiKeyArchiveEnv(sdkKeys []envfactory.AcceptedSDKKey, mobileKeys []envfactory.AcceptedMobileKey) filedata.ArchiveEnvironment {
 	return filedata.ArchiveEnvironment{
 		Params: envfactory.EnvironmentParams{
-			EnvID:              ckEnvID,
-			SDKKey:             ckAnchorSDK,
-			MobileKey:          ckAnchorMob,
+			EnvID:              multiKeyEnvID,
+			SDKKey:             anchorSDKKey,
+			MobileKey:          anchorMobileKey,
 			AcceptedSDKKeys:    sdkKeys,
 			AcceptedMobileKeys: mobileKeys,
-			Identifiers:        ckIdentifiers,
+			Identifiers:        multiKeyIdentifiers,
 		},
-		SDKData: ckSDKData(),
+		SDKData: multiKeySDKData(),
 	}
 }
 
-func ckDefaultAcceptedSDKKeys() []envfactory.AcceptedSDKKey {
-	return []envfactory.AcceptedSDKKey{{Value: ckAnchorSDK}, {Value: ckExtraSDK}}
+func defaultAcceptedSDKKeys() []envfactory.AcceptedSDKKey {
+	return []envfactory.AcceptedSDKKey{{Value: anchorSDKKey}, {Value: extraSDKKey}}
 }
 
-func ckDefaultAcceptedMobileKeys() []envfactory.AcceptedMobileKey {
-	return []envfactory.AcceptedMobileKey{{Value: ckAnchorMob}, {Value: ckExtraMob}}
+func defaultAcceptedMobileKeys() []envfactory.AcceptedMobileKey {
+	return []envfactory.AcceptedMobileKey{{Value: anchorMobileKey}, {Value: extraMobileKey}}
 }
 
-func ckSDKData() []ldstoretypes.Collection {
-	flag := ldbuilders.NewFlagBuilder(ckFlagKey).Version(1).On(true).Build()
+func multiKeySDKData() []ldstoretypes.Collection {
+	flag := ldbuilders.NewFlagBuilder(multiKeyFlagKey).Version(1).On(true).Build()
 	return []ldstoretypes.Collection{
 		{
 			Kind: ldstoreimpl.Features(),
 			Items: []ldstoretypes.KeyedItemDescriptor{
-				{Key: ckFlagKey, Item: sharedtest.FlagDesc(flag)},
+				{Key: multiKeyFlagKey, Item: sharedtest.FlagDesc(flag)},
 			},
 		},
 	}
 }
 
-// --- S5: a valid non-anchor key authenticates downstream; one upstream connection serves all ---
+// A valid non-anchor key authenticates downstream; one upstream connection serves all accepted keys.
 
 func TestConcurrentKeysRAC_NonAnchorKeysAuthenticate(t *testing.T) {
-	putEvent := configsource.MakeAutoConfigPutEvent(ckMultiKeyRep(ckDefaultSDKKeys(), ckDefaultMobileKeys(), 1))
+	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
 	autoConfTest(t, testAutoConfDefaultConfig, &putEvent, func(p autoConfTestParams) {
 		// The anchor opens the single upstream client; no second client for the non-anchor key.
 		anchorClient := p.awaitClient()
-		assert.Equal(t, ckAnchorSDK, anchorClient.Key)
+		assert.Equal(t, anchorSDKKey, anchorClient.Key)
 		p.shouldNotCreateClient(200 * time.Millisecond)
 
-		_ = p.awaitEnvironment(ckEnvID)
+		_ = p.awaitEnvironment(multiKeyEnvID)
 
 		// Every accepted credential authenticates downstream, anchor and non-anchor alike.
-		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
-		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
 	})
 }
 
 func TestConcurrentKeysOffline_NonAnchorKeysAuthenticate(t *testing.T) {
-	offlineModeTest(t, c.Config{}, func(p offlineModeTestParams) {
-		p.updateHandler.AddEnvironment(ckArchiveEnv(ckDefaultAcceptedSDKKeys(), ckDefaultAcceptedMobileKeys()))
+	offlineModeTest(t, config.Config{}, func(p offlineModeTestParams) {
+		p.updateHandler.AddEnvironment(multiKeyArchiveEnv(defaultAcceptedSDKKeys(), defaultAcceptedMobileKeys()))
 
 		anchorClient := p.awaitClient()
-		assert.Equal(t, ckAnchorSDK, anchorClient.Key)
+		assert.Equal(t, anchorSDKKey, anchorClient.Key)
 		p.shouldNotCreateClient(200 * time.Millisecond)
 
-		env := p.awaitEnvironment(ckEnvID)
+		env := p.awaitEnvironment(multiKeyEnvID)
 
-		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
-		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
 
 		// Flag data flows through the shared store that the single anchor connection populates.
 		flags, err := env.GetStore().GetAll(ldstoreimpl.Features())
@@ -169,77 +168,77 @@ func TestConcurrentKeysOffline_NonAnchorKeysAuthenticate(t *testing.T) {
 	})
 }
 
-// --- S4: per-credential rejection within a multi-key env ---
+// Per-credential rejection within a multi-key environment.
 
 func TestConcurrentKeysRAC_RejectsCredentialsOutsideAcceptedSet(t *testing.T) {
-	putEvent := configsource.MakeAutoConfigPutEvent(ckMultiKeyRep(ckDefaultSDKKeys(), ckDefaultMobileKeys(), 1))
+	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
 	autoConfTest(t, testAutoConfDefaultConfig, &putEvent, func(p autoConfTestParams) {
 		_ = p.awaitClient()
-		_ = p.awaitEnvironment(ckEnvID)
+		_ = p.awaitEnvironment(multiKeyEnvID)
 
 		// (a) Accepted siblings authenticate; a credential outside the accepted set is rejected.
-		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
-		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
 		p.assertSDKEndpointsAvailability(false,
-			c.SDKKey("sdk-not-accepted"), c.MobileKey("mob-not-accepted"), c.EnvironmentID("env-not-accepted"))
+			config.SDKKey("sdk-not-accepted"), config.MobileKey("mob-not-accepted"), config.EnvironmentID("env-not-accepted"))
 
 		// (b) Remove the extra keys via a patch that carries only the anchor; they must then be
 		//     rejected, while the anchor (still accepted) keeps authenticating.
-		anchorOnly := ckMultiKeyRep(
-			[]envfactory.ConcurrentKeyRep{{Key: "anchor-sdk", Value: string(ckAnchorSDK)}},
-			[]envfactory.ConcurrentKeyRep{{Key: "anchor-mob", Value: string(ckAnchorMob)}},
+		anchorOnly := multiKeyEnvRep(
+			[]envfactory.ConcurrentKeyRep{{Key: "anchor-sdk", Value: string(anchorSDKKey)}},
+			[]envfactory.ConcurrentKeyRep{{Key: "anchor-mob", Value: string(anchorMobileKey)}},
 			2,
 		)
 		p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(anchorOnly))
 
-		awaitCredentialRemoved(t, p.relay, ckExtraSDK)
+		awaitCredentialRemoved(t, p.relay, extraSDKKey)
 
-		p.assertSDKEndpointsAvailability(false, ckExtraSDK, ckExtraMob, "")
-		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+		p.assertSDKEndpointsAvailability(false, extraSDKKey, extraMobileKey, "")
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
 	})
 }
 
 func TestConcurrentKeysOffline_RejectsCredentialsOutsideAcceptedSet(t *testing.T) {
-	offlineModeTest(t, c.Config{}, func(p offlineModeTestParams) {
-		p.updateHandler.AddEnvironment(ckArchiveEnv(ckDefaultAcceptedSDKKeys(), ckDefaultAcceptedMobileKeys()))
+	offlineModeTest(t, config.Config{}, func(p offlineModeTestParams) {
+		p.updateHandler.AddEnvironment(multiKeyArchiveEnv(defaultAcceptedSDKKeys(), defaultAcceptedMobileKeys()))
 		_ = p.awaitClient()
-		_ = p.awaitEnvironment(ckEnvID)
+		_ = p.awaitEnvironment(multiKeyEnvID)
 
-		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
 		p.assertSDKEndpointsAvailability(false,
-			c.SDKKey("sdk-not-accepted"), c.MobileKey("mob-not-accepted"), c.EnvironmentID("env-not-accepted"))
+			config.SDKKey("sdk-not-accepted"), config.MobileKey("mob-not-accepted"), config.EnvironmentID("env-not-accepted"))
 
 		// Reload with only the anchor accepted; the extra keys are dropped immediately (omitted).
-		p.updateHandler.UpdateEnvironment(ckArchiveEnv(
-			[]envfactory.AcceptedSDKKey{{Value: ckAnchorSDK}},
-			[]envfactory.AcceptedMobileKey{{Value: ckAnchorMob}},
+		p.updateHandler.UpdateEnvironment(multiKeyArchiveEnv(
+			[]envfactory.AcceptedSDKKey{{Value: anchorSDKKey}},
+			[]envfactory.AcceptedMobileKey{{Value: anchorMobileKey}},
 		))
 
-		awaitCredentialRemoved(t, p.relay, ckExtraSDK)
+		awaitCredentialRemoved(t, p.relay, extraSDKKey)
 
-		p.assertSDKEndpointsAvailability(false, ckExtraSDK, ckExtraMob, "")
-		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+		p.assertSDKEndpointsAvailability(false, extraSDKKey, extraMobileKey, "")
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
 	})
 }
 
-// --- S1: a connected SDK is disconnected when its (non-anchor) key expires ---
-
+// A connected SDK is disconnected when its (non-anchor) key expires.
+//
 // The downstream SDK connects on a non-anchor key while that key is still permanent, so the
 // connection establishes independent of expiry timing. We then give the connected key a near-future
 // expiry; once the timestamp passes, the cleanup ticker must drop the key AND disconnect the open
 // stream. Covered for both an SDK key and a mobile key. (The live open-connection teardown is
-// verified on the offline path, which uses a real SDK client that actually serves stream data;
-// the RAC equivalent — TestConcurrentKeysRAC_KeyExpiryRemovesCredential — verifies the same
-// expiry->reject outcome at the auth layer, since FakeLDClient does not serve stream data.)
+// verified on the offline path, which uses a real SDK client that actually serves stream data; the
+// RAC equivalent — TestConcurrentKeysRAC_KeyExpiryRemovesCredential — verifies the same expiry->reject
+// outcome at the auth layer, since FakeLDClient does not serve stream data.)
 func TestConcurrentKeysOffline_ConnectedSDKDisconnectedWhenKeyExpires(t *testing.T) {
 	// The server-side stream (/all) emits "put"; the mobile streams (/meval, /mping) emit "ping".
 	run := func(t *testing.T, streamPath, firstEvent string, connectKey credential.SDKCredential, expiringSDK bool) {
-		cfg := c.Config{}
+		cfg := config.Config{}
 		cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
 		offlineModeTest(t, cfg, func(p offlineModeTestParams) {
-			p.updateHandler.AddEnvironment(ckArchiveEnv(ckDefaultAcceptedSDKKeys(), ckDefaultAcceptedMobileKeys()))
+			p.updateHandler.AddEnvironment(multiKeyArchiveEnv(defaultAcceptedSDKKeys(), defaultAcceptedMobileKeys()))
 			_ = p.awaitClient()
-			env := p.awaitEnvironment(ckEnvID)
+			env := p.awaitEnvironment(multiKeyEnvID)
 			require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
 
 			req := sharedtest.BuildRequestWithAuth("GET", streamPath, connectKey, nil)
@@ -249,14 +248,14 @@ func TestConcurrentKeysOffline_ConnectedSDKDisconnectedWhenKeyExpires(t *testing
 
 				// Give the connected non-anchor key a near-future expiry; keep the anchor permanent.
 				expiry := time.Now().Add(100 * time.Millisecond)
-				sdkKeys := []envfactory.AcceptedSDKKey{{Value: ckAnchorSDK}, {Value: ckExtraSDK}}
-				mobileKeys := []envfactory.AcceptedMobileKey{{Value: ckAnchorMob}, {Value: ckExtraMob}}
+				sdkKeys := []envfactory.AcceptedSDKKey{{Value: anchorSDKKey}, {Value: extraSDKKey}}
+				mobileKeys := []envfactory.AcceptedMobileKey{{Value: anchorMobileKey}, {Value: extraMobileKey}}
 				if expiringSDK {
 					sdkKeys[1].Expiry = expiry
 				} else {
 					mobileKeys[1].Expiry = expiry
 				}
-				p.updateHandler.UpdateEnvironment(ckArchiveEnv(sdkKeys, mobileKeys))
+				p.updateHandler.UpdateEnvironment(multiKeyArchiveEnv(sdkKeys, mobileKeys))
 
 				// The cleanup ticker drops the expired key and disconnects this stream.
 				awaitStreamClosed(t, eventCh, 5*time.Second)
@@ -264,39 +263,39 @@ func TestConcurrentKeysOffline_ConnectedSDKDisconnectedWhenKeyExpires(t *testing
 
 			// After expiry: the dropped key no longer authenticates; the anchor (sibling) still does.
 			if expiringSDK {
-				p.assertSDKEndpointsAvailability(false, ckExtraSDK, "", "")
+				p.assertSDKEndpointsAvailability(false, extraSDKKey, "", "")
 			} else {
-				p.assertSDKEndpointsAvailability(false, "", ckExtraMob, "")
+				p.assertSDKEndpointsAvailability(false, "", extraMobileKey, "")
 			}
-			p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+			p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
 		})
 	}
 
-	t.Run("sdk key", func(t *testing.T) { run(t, "/all", "put", ckExtraSDK, true) })
+	t.Run("sdk key", func(t *testing.T) { run(t, "/all", "put", extraSDKKey, true) })
 	t.Run("mobile key", func(t *testing.T) {
-		run(t, "/meval/eyJrZXkiOiJ1c2Vya2V5In0=", "ping", ckExtraMob, false)
+		run(t, "/meval/eyJrZXkiOiJ1c2Vya2V5In0=", "ping", extraMobileKey, false)
 	})
 }
 
 func TestConcurrentKeysRAC_KeyExpiryRemovesCredential(t *testing.T) {
 	cfg := testAutoConfDefaultConfig
 	cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
-	putEvent := configsource.MakeAutoConfigPutEvent(ckMultiKeyRep(ckDefaultSDKKeys(), ckDefaultMobileKeys(), 1))
+	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
 	autoConfTest(t, cfg, &putEvent, func(p autoConfTestParams) {
 		_ = p.awaitClient()
-		_ = p.awaitEnvironment(ckEnvID)
-		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+		_ = p.awaitEnvironment(multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
 
 		// Patch: the non-anchor keys gain a near-future expiry; the anchor stays permanent.
 		expiry := time.Now().Add(100 * time.Millisecond).UnixMilli()
-		patch := ckMultiKeyRep(
+		patch := multiKeyEnvRep(
 			[]envfactory.ConcurrentKeyRep{
-				{Key: "anchor-sdk", Value: string(ckAnchorSDK)},
-				{Key: "extra-sdk", Value: string(ckExtraSDK), Expiry: msPtr(expiry)},
+				{Key: "anchor-sdk", Value: string(anchorSDKKey)},
+				{Key: "extra-sdk", Value: string(extraSDKKey), Expiry: msPtr(expiry)},
 			},
 			[]envfactory.ConcurrentKeyRep{
-				{Key: "anchor-mob", Value: string(ckAnchorMob)},
-				{Key: "extra-mob", Value: string(ckExtraMob), Expiry: msPtr(expiry)},
+				{Key: "anchor-mob", Value: string(anchorMobileKey)},
+				{Key: "extra-mob", Value: string(extraMobileKey), Expiry: msPtr(expiry)},
 			},
 			2,
 		)
@@ -304,63 +303,63 @@ func TestConcurrentKeysRAC_KeyExpiryRemovesCredential(t *testing.T) {
 
 		// Once the expiry passes, the cleanup ticker drops the keys: they stop authenticating while
 		// the anchor is unaffected.
-		awaitCredentialRemoved(t, p.relay, ckExtraSDK)
-		p.assertSDKEndpointsAvailability(false, ckExtraSDK, ckExtraMob, "")
-		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+		awaitCredentialRemoved(t, p.relay, extraSDKKey)
+		p.assertSDKEndpointsAvailability(false, extraSDKKey, extraMobileKey, "")
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
 	})
 }
 
-// --- S2: a connected SDK stays connected when its key gains a (future) expiry it hasn't reached ---
+// A connected SDK stays connected when its key gains a future expiry it hasn't reached yet.
 
 func TestConcurrentKeysOffline_ConnectionSurvivesWhenKeyGainsFutureExpiry(t *testing.T) {
-	cfg := c.Config{}
+	cfg := config.Config{}
 	cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
 	offlineModeTest(t, cfg, func(p offlineModeTestParams) {
-		p.updateHandler.AddEnvironment(ckArchiveEnv(ckDefaultAcceptedSDKKeys(), ckDefaultAcceptedMobileKeys()))
+		p.updateHandler.AddEnvironment(multiKeyArchiveEnv(defaultAcceptedSDKKeys(), defaultAcceptedMobileKeys()))
 		_ = p.awaitClient()
-		env := p.awaitEnvironment(ckEnvID)
+		env := p.awaitEnvironment(multiKeyEnvID)
 		require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
 
-		req := sharedtest.BuildRequestWithAuth("GET", "/all", ckExtraSDK, nil)
+		req := sharedtest.BuildRequestWithAuth("GET", "/all", extraSDKKey, nil)
 		sharedtest.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
 			sharedtest.AwaitEventOfType(t, eventCh, "put", 5*time.Second)
 
 			// Give the connected non-anchor key a FAR-future expiry; the cleanup ticker must not drop
 			// it during the test, so the open stream stays connected.
 			expiry := time.Now().Add(1 * time.Hour)
-			p.updateHandler.UpdateEnvironment(ckArchiveEnv(
-				[]envfactory.AcceptedSDKKey{{Value: ckAnchorSDK}, {Value: ckExtraSDK, Expiry: expiry}},
-				ckDefaultAcceptedMobileKeys(),
+			p.updateHandler.UpdateEnvironment(multiKeyArchiveEnv(
+				[]envfactory.AcceptedSDKKey{{Value: anchorSDKKey}, {Value: extraSDKKey, Expiry: expiry}},
+				defaultAcceptedMobileKeys(),
 			))
 
 			assertStreamStaysOpen(t, eventCh, 500*time.Millisecond)
 		})
 
 		// The key is now in the deprecated-but-accepted set (its expiry was applied) and still authenticates.
-		require.Eventually(t, func() bool { return credsContain(env.GetDeprecatedCredentials(), ckExtraSDK) },
+		require.Eventually(t, func() bool { return credsContain(env.GetDeprecatedCredentials(), extraSDKKey) },
 			time.Second, 5*time.Millisecond, "expiry was not applied to the connected key")
-		p.assertSDKEndpointsAvailability(true, ckExtraSDK, "", "")
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, "", "")
 	})
 }
 
 func TestConcurrentKeysRAC_KeyWithFutureExpiryStillAuthenticates(t *testing.T) {
 	cfg := testAutoConfDefaultConfig
 	cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
-	putEvent := configsource.MakeAutoConfigPutEvent(ckMultiKeyRep(ckDefaultSDKKeys(), ckDefaultMobileKeys(), 1))
+	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
 	autoConfTest(t, cfg, &putEvent, func(p autoConfTestParams) {
 		_ = p.awaitClient()
-		env := p.awaitEnvironment(ckEnvID)
+		env := p.awaitEnvironment(multiKeyEnvID)
 
 		// Patch: the non-anchor keys gain a FAR-future expiry; they remain accepted (not dropped).
 		expiry := time.Now().Add(1 * time.Hour).UnixMilli()
-		patch := ckMultiKeyRep(
+		patch := multiKeyEnvRep(
 			[]envfactory.ConcurrentKeyRep{
-				{Key: "anchor-sdk", Value: string(ckAnchorSDK)},
-				{Key: "extra-sdk", Value: string(ckExtraSDK), Expiry: msPtr(expiry)},
+				{Key: "anchor-sdk", Value: string(anchorSDKKey)},
+				{Key: "extra-sdk", Value: string(extraSDKKey), Expiry: msPtr(expiry)},
 			},
 			[]envfactory.ConcurrentKeyRep{
-				{Key: "anchor-mob", Value: string(ckAnchorMob)},
-				{Key: "extra-mob", Value: string(ckExtraMob), Expiry: msPtr(expiry)},
+				{Key: "anchor-mob", Value: string(anchorMobileKey)},
+				{Key: "extra-mob", Value: string(extraMobileKey), Expiry: msPtr(expiry)},
 			},
 			2,
 		)
@@ -368,10 +367,10 @@ func TestConcurrentKeysRAC_KeyWithFutureExpiryStillAuthenticates(t *testing.T) {
 
 		// Confirm the expiry was applied (the key is now deprecated-but-accepted) and, after the
 		// cleanup ticker has had time to run, the future-dated key still authenticates.
-		require.Eventually(t, func() bool { return credsContain(env.GetDeprecatedCredentials(), ckExtraSDK) },
+		require.Eventually(t, func() bool { return credsContain(env.GetDeprecatedCredentials(), extraSDKKey) },
 			time.Second, 5*time.Millisecond, "future expiry was not applied")
-		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
-		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
 	})
 }
 

--- a/relay/concurrent_keys_auth_test.go
+++ b/relay/concurrent_keys_auth_test.go
@@ -19,6 +19,7 @@ package relay
 // (proving the anchor owns the only upstream connection).
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -51,6 +52,9 @@ const (
 	anchorMobileKey = config.MobileKey("mob-anchor")
 	extraMobileKey  = config.MobileKey("mob-extra")
 	multiKeyFlagKey = "multikey-flag"
+
+	// rotatedAnchorSDKKey is a brand-new SDK key that becomes the anchor when the anchor is rotated.
+	rotatedAnchorSDKKey = config.SDKKey("sdk-rotated-anchor")
 )
 
 var multiKeyIdentifiers = relayenv.EnvIdentifiers{
@@ -127,6 +131,26 @@ func multiKeySDKData() []ldstoretypes.Collection {
 				{Key: multiKeyFlagKey, Item: sharedtest.FlagDesc(flag)},
 			},
 		},
+	}
+}
+
+// rotatedAnchorRep returns the env rep after the anchor has rotated to newAnchor, keeping the
+// existing non-anchor SDK key (extraSDKKey) accepted and the mobile keys unchanged.
+func rotatedAnchorRep(newAnchor config.SDKKey, version int) envfactory.EnvironmentRep {
+	return envfactory.EnvironmentRep{
+		EnvID:    multiKeyEnvID,
+		EnvKey:   multiKeyIdentifiers.EnvKey,
+		EnvName:  multiKeyIdentifiers.EnvName,
+		ProjKey:  multiKeyIdentifiers.ProjKey,
+		ProjName: multiKeyIdentifiers.ProjName,
+		SDKKey:   envfactory.SDKKeyRep{Value: newAnchor},
+		MobKey:   anchorMobileKey,
+		SDKKeys: []envfactory.ConcurrentKeyRep{
+			{Key: "rotated-anchor-sdk", Value: string(newAnchor)},
+			{Key: "extra-sdk", Value: string(extraSDKKey)},
+		},
+		MobileKeys: defaultMobileKeyReps(),
+		Version:    version,
 	}
 }
 
@@ -273,7 +297,8 @@ func TestConcurrentKeysOffline_ConnectedSDKDisconnectedWhenKeyExpires(t *testing
 
 	t.Run("sdk key", func(t *testing.T) { run(t, "/all", "put", extraSDKKey, true) })
 	t.Run("mobile key", func(t *testing.T) {
-		run(t, "/meval/eyJrZXkiOiJ1c2Vya2V5In0=", "ping", extraMobileKey, false)
+		// base64 of {"key":"userkey","kind":"user"} — a valid context, not the legacy user format.
+		run(t, "/meval/eyJrZXkiOiJ1c2Vya2V5Iiwia2luZCI6InVzZXIifQ==", "ping", extraMobileKey, false)
 	})
 }
 
@@ -374,6 +399,67 @@ func TestConcurrentKeysRAC_KeyWithFutureExpiryStillAuthenticates(t *testing.T) {
 	})
 }
 
+// Rotating the anchor in the accepted set.
+//
+// Both tests run on the FakeLDClient harness, so they verify the routing/credential-level behavior
+// of an anchor swap. The real-upstream store handover (avoiding an empty-store window) and
+// rollback-on-init-failure robustness is the re-anchor work owned by T2.c.
+
+// When a new anchor arrives via RAC (sdkKey.value changes to a brand-new key), the upstream client
+// swaps to the new anchor and the old anchor is dropped, while the non-anchor key stays accepted.
+func TestConcurrentKeysRAC_RotatingAnchorUpdatesUpstreamClient(t *testing.T) {
+	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
+	autoConfTest(t, testAutoConfDefaultConfig, &putEvent, func(p autoConfTestParams) {
+		client1 := p.awaitClient()
+		assert.Equal(t, anchorSDKKey, client1.Key)
+		_ = p.awaitEnvironment(multiKeyEnvID)
+
+		// A new anchor arrives; the old anchor is rotated out, the non-anchor extra key is retained.
+		p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(rotatedAnchorRep(rotatedAnchorSDKKey, 2)))
+
+		// The new anchor opens the single upstream client; the old anchor's client closes.
+		client2 := p.awaitClient()
+		assert.Equal(t, rotatedAnchorSDKKey, client2.Key)
+		client1.AwaitClose(t, 5*time.Second)
+
+		awaitCredentialRemoved(t, p.relay, anchorSDKKey)
+
+		// The new anchor and the retained non-anchor key authenticate; the old anchor no longer does.
+		p.assertSDKEndpointsAvailability(true, rotatedAnchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, "", "")
+		p.assertSDKEndpointsAvailability(false, anchorSDKKey, "", "")
+	})
+}
+
+// A downstream SDK connected on a non-anchor key stays connected when the anchor is rotated out from
+// under it.
+func TestConcurrentKeysRAC_NonAnchorConnectionSurvivesAnchorRotation(t *testing.T) {
+	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
+	autoConfTest(t, testAutoConfDefaultConfig, &putEvent, func(p autoConfTestParams) {
+		client1 := p.awaitClient()
+		assert.Equal(t, anchorSDKKey, client1.Key)
+		env := p.awaitEnvironment(multiKeyEnvID)
+		require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+		// Connect a downstream SDK on the non-anchor key, then rotate the anchor while it is connected.
+		req := sharedtest.BuildRequestWithAuth("GET", "/all", extraSDKKey, nil)
+		sharedtest.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+			p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(rotatedAnchorRep(rotatedAnchorSDKKey, 2)))
+
+			// The new anchor's upstream client comes up...
+			client2 := p.awaitClient()
+			assert.Equal(t, rotatedAnchorSDKKey, client2.Key)
+
+			// ...and the non-anchor key's open stream is not disconnected by the swap.
+			assertStreamStaysOpen(t, eventCh, 500*time.Millisecond)
+		})
+
+		// The non-anchor key still authenticates after the rotation; the old anchor is gone.
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, "", "")
+		awaitCredentialRemoved(t, p.relay, anchorSDKKey)
+	})
+}
+
 // awaitStreamClosed reads from a WithStreamRequest event channel until the stream-closed sentinel
 // (a nil event) arrives, failing if the timeout elapses first. Non-nil events are ignored.
 func awaitStreamClosed(t *testing.T, eventCh <-chan eventsource.Event, timeout time.Duration) {
@@ -414,12 +500,7 @@ func assertStreamStaysOpen(t *testing.T, eventCh <-chan eventsource.Event, windo
 func msPtr(v int64) *int64 { return &v }
 
 func credsContain(creds []credential.SDKCredential, target credential.SDKCredential) bool {
-	for _, cr := range creds {
-		if cr == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(creds, target)
 }
 
 // awaitCredentialRemoved blocks until the given credential no longer resolves to an environment.

--- a/relay/concurrent_keys_auth_test.go
+++ b/relay/concurrent_keys_auth_test.go
@@ -31,9 +31,11 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/configsource"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
 
 	"github.com/launchdarkly/eventsource"
 	"github.com/launchdarkly/go-configtypes"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
@@ -432,32 +434,56 @@ func TestConcurrentKeysRAC_RotatingAnchorUpdatesUpstreamClient(t *testing.T) {
 }
 
 // A downstream SDK connected on a non-anchor key stays connected when the anchor is rotated out from
-// under it.
+// under it. This uses a real (dummy) SDK client + RAC mock — rather than the FakeLDClient harness —
+// because FakeLDClient never serves a put on the SSE stream, so it couldn't confirm the connection
+// was actually established before rotating (and thus couldn't genuinely exercise "rotate while
+// connected"). The connection-survival property holds even before the T2.c store-handover work,
+// which addresses the empty-store data window during the swap, not connection drops.
 func TestConcurrentKeysRAC_NonAnchorConnectionSurvivesAnchorRotation(t *testing.T) {
 	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
-	autoConfTest(t, testAutoConfDefaultConfig, &putEvent, func(p autoConfTestParams) {
-		client1 := p.awaitClient()
-		assert.Equal(t, anchorSDKKey, client1.Key)
-		env := p.awaitEnvironment(multiKeyEnvID)
-		require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+	racMock := configsource.NewRACMock(t, &putEvent)
 
-		// Connect a downstream SDK on the non-anchor key, then rotate the anchor while it is connected.
-		req := sharedtest.BuildRequestWithAuth("GET", "/all", extraSDKKey, nil)
-		sharedtest.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
-			p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(rotatedAnchorRep(rotatedAnchorSDKKey, 2)))
+	cfg := config.Config{AutoConfig: config.AutoConfigConfig{Key: testAutoConfKey}}
+	cfg.Main.StreamURI, _ = configtypes.NewOptURLAbsoluteFromString(racMock.URL)
 
-			// The new anchor's upstream client comes up...
-			client2 := p.awaitClient()
-			assert.Equal(t, rotatedAnchorSDKKey, client2.Key)
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
 
-			// ...and the non-anchor key's open stream is not disconnected by the swap.
-			assertStreamStaysOpen(t, eventCh, 500*time.Millisecond)
-		})
-
-		// The non-anchor key still authenticates after the rotation; the old anchor is gone.
-		p.assertSDKEndpointsAvailability(true, extraSDKKey, "", "")
-		awaitCredentialRemoved(t, p.relay, anchorSDKKey)
+	relay, err := newRelayInternal(cfg, relayInternalOptions{
+		loggers:       mockLog.Loggers,
+		clientFactory: testclient.CreateDummyClient,
 	})
+	require.NoError(t, err)
+	defer relay.Close()
+
+	h := relayTestHelper{t: t, relay: relay}
+	env := h.awaitEnvironment(multiKeyEnvID)
+	require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+	// Connect a downstream SDK on the non-anchor key.
+	req := sharedtest.BuildRequestWithAuth("GET", "/all", extraSDKKey, nil)
+	sharedtest.WithStreamRequest(t, req, relay, func(eventCh <-chan eventsource.Event) {
+		// Confirm the non-anchor stream is live before rotating, so this genuinely exercises
+		// "rotate while connected" rather than racing the connection setup.
+		sharedtest.AwaitEventOfType(t, eventCh, "put", 5*time.Second)
+
+		// Rotate the anchor to a brand-new key while the non-anchor stream is connected.
+		racMock.Send(configsource.MakeAutoConfigPatchEvent(rotatedAnchorRep(rotatedAnchorSDKKey, 2)))
+
+		// Wait for the rotation to take effect: the new anchor resolves, the old anchor is gone.
+		require.Eventually(t, func() bool {
+			_, errNew := relay.getEnvironment(sdkauth.New(rotatedAnchorSDKKey))
+			_, errOld := relay.getEnvironment(sdkauth.New(anchorSDKKey))
+			return errNew == nil && errOld != nil
+		}, 5*time.Second, 5*time.Millisecond)
+
+		// The non-anchor key's open stream is not disconnected by the swap (a duplicate put may
+		// arrive from the new anchor's initial sync — that's fine; only a close would fail here).
+		assertStreamStaysOpen(t, eventCh, 500*time.Millisecond)
+	})
+
+	// The non-anchor key still authenticates after the rotation.
+	h.assertSDKEndpointsAvailability(true, extraSDKKey, "", "")
 }
 
 // awaitStreamClosed reads from a WithStreamRequest event channel until the stream-closed sentinel

--- a/relay/concurrent_keys_auth_test.go
+++ b/relay/concurrent_keys_auth_test.go
@@ -1,0 +1,433 @@
+package relay
+
+// Integration scenarios for multi-key (concurrent SDK keys) downstream authentication.
+//
+// These tests exercise the NEW behavior: an environment whose accepted set carries multiple SDK
+// keys and multiple mobile keys via the sdkKeys[]/mobileKeys[] array wire format, with a single
+// anchor key owning the one upstream connection. They complement — and deliberately do not
+// duplicate — existing coverage:
+//
+//   - Single-key / legacy expiring{}-slot rotation is covered by TestAutoConfigInitWithExpiringSDKKey,
+//     TestOfflineModeDeprecatedSDKKeyIsRespectedIfExpiryInFuture, TestOfflineModeSDKKeyCanExpire, etc.
+//     Those assert on the credential SET via the legacy rotation path; these assert downstream
+//     AUTHENTICATION (and live stream connect/disconnect) via the array path.
+//   - Generic unknown-credential -> 401 is covered at the middleware/end-to-end layer; here we only
+//     test the multi-key-specific rejection (a credential outside a populated accepted set, and a
+//     key removed from the accepted set on reconcile).
+//
+// The tests reuse the in-process harnesses (autoConfTest for RAC, offlineModeTest for offline) so
+// they get assertSDKEndpointsAvailability (auth accept/reject) and awaitClient/shouldNotCreateClient
+// (proving the anchor owns the only upstream connection).
+
+import (
+	"testing"
+	"time"
+
+	c "github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
+	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"
+	"github.com/launchdarkly/ld-relay/v8/internal/filedata"
+	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/configsource"
+
+	"github.com/launchdarkly/eventsource"
+	"github.com/launchdarkly/go-configtypes"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Shared identifiers for the multi-key environment used across these scenarios. The anchor is the
+// key the singular sdkKey.value/mobKey points to; the "extra" keys are additional accepted entries
+// that are NOT the anchor.
+const (
+	ckEnvID     = c.EnvironmentID("ck-multikey-env")
+	ckAnchorSDK = c.SDKKey("sdk-ck-anchor")
+	ckExtraSDK  = c.SDKKey("sdk-ck-extra")
+	ckAnchorMob = c.MobileKey("mob-ck-anchor")
+	ckExtraMob  = c.MobileKey("mob-ck-extra")
+	ckFlagKey   = "ck-flag"
+)
+
+var ckIdentifiers = relayenv.EnvIdentifiers{
+	ProjName: "CK Project",
+	ProjKey:  "ck-proj",
+	EnvName:  "CK Env",
+	EnvKey:   "ck-env",
+}
+
+// ckMultiKeyRep builds a RAC/offline EnvironmentRep for the multi-key env using the array wire
+// format. The anchor is always ckAnchorSDK/ckAnchorMob (singular sdkKey/mobKey); callers pass the
+// full sdkKeys[]/mobileKeys[] arrays (which must include the anchor entry).
+func ckMultiKeyRep(sdkKeys, mobileKeys []envfactory.ConcurrentKeyRep, version int) envfactory.EnvironmentRep {
+	return envfactory.EnvironmentRep{
+		EnvID:      ckEnvID,
+		EnvKey:     ckIdentifiers.EnvKey,
+		EnvName:    ckIdentifiers.EnvName,
+		ProjKey:    ckIdentifiers.ProjKey,
+		ProjName:   ckIdentifiers.ProjName,
+		SDKKey:     envfactory.SDKKeyRep{Value: ckAnchorSDK},
+		MobKey:     ckAnchorMob,
+		SDKKeys:    sdkKeys,
+		MobileKeys: mobileKeys,
+		Version:    version,
+	}
+}
+
+// ckDefaultSDKKeys / ckDefaultMobileKeys are the standard two-entry arrays (anchor + one extra,
+// both permanent) used by the scenarios that don't involve expiry.
+func ckDefaultSDKKeys() []envfactory.ConcurrentKeyRep {
+	return []envfactory.ConcurrentKeyRep{
+		{Key: "anchor-sdk", Value: string(ckAnchorSDK)},
+		{Key: "extra-sdk", Value: string(ckExtraSDK)},
+	}
+}
+
+func ckDefaultMobileKeys() []envfactory.ConcurrentKeyRep {
+	return []envfactory.ConcurrentKeyRep{
+		{Key: "anchor-mob", Value: string(ckAnchorMob)},
+		{Key: "extra-mob", Value: string(ckExtraMob)},
+	}
+}
+
+// ckArchiveEnv builds the offline-mode ArchiveEnvironment equivalent of ckMultiKeyRep, carrying the
+// accepted SDK/mobile key sets directly plus a single flag so the data store initializes.
+func ckArchiveEnv(sdkKeys []envfactory.AcceptedSDKKey, mobileKeys []envfactory.AcceptedMobileKey) filedata.ArchiveEnvironment {
+	return filedata.ArchiveEnvironment{
+		Params: envfactory.EnvironmentParams{
+			EnvID:              ckEnvID,
+			SDKKey:             ckAnchorSDK,
+			MobileKey:          ckAnchorMob,
+			AcceptedSDKKeys:    sdkKeys,
+			AcceptedMobileKeys: mobileKeys,
+			Identifiers:        ckIdentifiers,
+		},
+		SDKData: ckSDKData(),
+	}
+}
+
+func ckDefaultAcceptedSDKKeys() []envfactory.AcceptedSDKKey {
+	return []envfactory.AcceptedSDKKey{{Value: ckAnchorSDK}, {Value: ckExtraSDK}}
+}
+
+func ckDefaultAcceptedMobileKeys() []envfactory.AcceptedMobileKey {
+	return []envfactory.AcceptedMobileKey{{Value: ckAnchorMob}, {Value: ckExtraMob}}
+}
+
+func ckSDKData() []ldstoretypes.Collection {
+	flag := ldbuilders.NewFlagBuilder(ckFlagKey).Version(1).On(true).Build()
+	return []ldstoretypes.Collection{
+		{
+			Kind: ldstoreimpl.Features(),
+			Items: []ldstoretypes.KeyedItemDescriptor{
+				{Key: ckFlagKey, Item: sharedtest.FlagDesc(flag)},
+			},
+		},
+	}
+}
+
+// --- S5: a valid non-anchor key authenticates downstream; one upstream connection serves all ---
+
+func TestConcurrentKeysRAC_NonAnchorKeysAuthenticate(t *testing.T) {
+	putEvent := configsource.MakeAutoConfigPutEvent(ckMultiKeyRep(ckDefaultSDKKeys(), ckDefaultMobileKeys(), 1))
+	autoConfTest(t, testAutoConfDefaultConfig, &putEvent, func(p autoConfTestParams) {
+		// The anchor opens the single upstream client; no second client for the non-anchor key.
+		anchorClient := p.awaitClient()
+		assert.Equal(t, ckAnchorSDK, anchorClient.Key)
+		p.shouldNotCreateClient(200 * time.Millisecond)
+
+		_ = p.awaitEnvironment(ckEnvID)
+
+		// Every accepted credential authenticates downstream, anchor and non-anchor alike.
+		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+	})
+}
+
+func TestConcurrentKeysOffline_NonAnchorKeysAuthenticate(t *testing.T) {
+	offlineModeTest(t, c.Config{}, func(p offlineModeTestParams) {
+		p.updateHandler.AddEnvironment(ckArchiveEnv(ckDefaultAcceptedSDKKeys(), ckDefaultAcceptedMobileKeys()))
+
+		anchorClient := p.awaitClient()
+		assert.Equal(t, ckAnchorSDK, anchorClient.Key)
+		p.shouldNotCreateClient(200 * time.Millisecond)
+
+		env := p.awaitEnvironment(ckEnvID)
+
+		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+
+		// Flag data flows through the shared store that the single anchor connection populates.
+		flags, err := env.GetStore().GetAll(ldstoreimpl.Features())
+		require.NoError(t, err)
+		assert.NotEmpty(t, flags)
+	})
+}
+
+// --- S4: per-credential rejection within a multi-key env ---
+
+func TestConcurrentKeysRAC_RejectsCredentialsOutsideAcceptedSet(t *testing.T) {
+	putEvent := configsource.MakeAutoConfigPutEvent(ckMultiKeyRep(ckDefaultSDKKeys(), ckDefaultMobileKeys(), 1))
+	autoConfTest(t, testAutoConfDefaultConfig, &putEvent, func(p autoConfTestParams) {
+		_ = p.awaitClient()
+		_ = p.awaitEnvironment(ckEnvID)
+
+		// (a) Accepted siblings authenticate; a credential outside the accepted set is rejected.
+		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(false,
+			c.SDKKey("sdk-not-accepted"), c.MobileKey("mob-not-accepted"), c.EnvironmentID("env-not-accepted"))
+
+		// (b) Remove the extra keys via a patch that carries only the anchor; they must then be
+		//     rejected, while the anchor (still accepted) keeps authenticating.
+		anchorOnly := ckMultiKeyRep(
+			[]envfactory.ConcurrentKeyRep{{Key: "anchor-sdk", Value: string(ckAnchorSDK)}},
+			[]envfactory.ConcurrentKeyRep{{Key: "anchor-mob", Value: string(ckAnchorMob)}},
+			2,
+		)
+		p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(anchorOnly))
+
+		awaitCredentialRemoved(t, p.relay, ckExtraSDK)
+
+		p.assertSDKEndpointsAvailability(false, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+	})
+}
+
+func TestConcurrentKeysOffline_RejectsCredentialsOutsideAcceptedSet(t *testing.T) {
+	offlineModeTest(t, c.Config{}, func(p offlineModeTestParams) {
+		p.updateHandler.AddEnvironment(ckArchiveEnv(ckDefaultAcceptedSDKKeys(), ckDefaultAcceptedMobileKeys()))
+		_ = p.awaitClient()
+		_ = p.awaitEnvironment(ckEnvID)
+
+		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(false,
+			c.SDKKey("sdk-not-accepted"), c.MobileKey("mob-not-accepted"), c.EnvironmentID("env-not-accepted"))
+
+		// Reload with only the anchor accepted; the extra keys are dropped immediately (omitted).
+		p.updateHandler.UpdateEnvironment(ckArchiveEnv(
+			[]envfactory.AcceptedSDKKey{{Value: ckAnchorSDK}},
+			[]envfactory.AcceptedMobileKey{{Value: ckAnchorMob}},
+		))
+
+		awaitCredentialRemoved(t, p.relay, ckExtraSDK)
+
+		p.assertSDKEndpointsAvailability(false, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+	})
+}
+
+// --- S1: a connected SDK is disconnected when its (non-anchor) key expires ---
+
+// The downstream SDK connects on a non-anchor key while that key is still permanent, so the
+// connection establishes independent of expiry timing. We then give the connected key a near-future
+// expiry; once the timestamp passes, the cleanup ticker must drop the key AND disconnect the open
+// stream. Covered for both an SDK key and a mobile key. (The live open-connection teardown is
+// verified on the offline path, which uses a real SDK client that actually serves stream data;
+// the RAC equivalent — TestConcurrentKeysRAC_KeyExpiryRemovesCredential — verifies the same
+// expiry->reject outcome at the auth layer, since FakeLDClient does not serve stream data.)
+func TestConcurrentKeysOffline_ConnectedSDKDisconnectedWhenKeyExpires(t *testing.T) {
+	// The server-side stream (/all) emits "put"; the mobile streams (/meval, /mping) emit "ping".
+	run := func(t *testing.T, streamPath, firstEvent string, connectKey credential.SDKCredential, expiringSDK bool) {
+		cfg := c.Config{}
+		cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
+		offlineModeTest(t, cfg, func(p offlineModeTestParams) {
+			p.updateHandler.AddEnvironment(ckArchiveEnv(ckDefaultAcceptedSDKKeys(), ckDefaultAcceptedMobileKeys()))
+			_ = p.awaitClient()
+			env := p.awaitEnvironment(ckEnvID)
+			require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+			req := sharedtest.BuildRequestWithAuth("GET", streamPath, connectKey, nil)
+			sharedtest.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+				// Confirm the stream is live before we expire the key.
+				sharedtest.AwaitEventOfType(t, eventCh, firstEvent, 5*time.Second)
+
+				// Give the connected non-anchor key a near-future expiry; keep the anchor permanent.
+				expiry := time.Now().Add(100 * time.Millisecond)
+				sdkKeys := []envfactory.AcceptedSDKKey{{Value: ckAnchorSDK}, {Value: ckExtraSDK}}
+				mobileKeys := []envfactory.AcceptedMobileKey{{Value: ckAnchorMob}, {Value: ckExtraMob}}
+				if expiringSDK {
+					sdkKeys[1].Expiry = expiry
+				} else {
+					mobileKeys[1].Expiry = expiry
+				}
+				p.updateHandler.UpdateEnvironment(ckArchiveEnv(sdkKeys, mobileKeys))
+
+				// The cleanup ticker drops the expired key and disconnects this stream.
+				awaitStreamClosed(t, eventCh, 5*time.Second)
+			})
+
+			// After expiry: the dropped key no longer authenticates; the anchor (sibling) still does.
+			if expiringSDK {
+				p.assertSDKEndpointsAvailability(false, ckExtraSDK, "", "")
+			} else {
+				p.assertSDKEndpointsAvailability(false, "", ckExtraMob, "")
+			}
+			p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+		})
+	}
+
+	t.Run("sdk key", func(t *testing.T) { run(t, "/all", "put", ckExtraSDK, true) })
+	t.Run("mobile key", func(t *testing.T) {
+		run(t, "/meval/eyJrZXkiOiJ1c2Vya2V5In0=", "ping", ckExtraMob, false)
+	})
+}
+
+func TestConcurrentKeysRAC_KeyExpiryRemovesCredential(t *testing.T) {
+	cfg := testAutoConfDefaultConfig
+	cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
+	putEvent := configsource.MakeAutoConfigPutEvent(ckMultiKeyRep(ckDefaultSDKKeys(), ckDefaultMobileKeys(), 1))
+	autoConfTest(t, cfg, &putEvent, func(p autoConfTestParams) {
+		_ = p.awaitClient()
+		_ = p.awaitEnvironment(ckEnvID)
+		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+
+		// Patch: the non-anchor keys gain a near-future expiry; the anchor stays permanent.
+		expiry := time.Now().Add(100 * time.Millisecond).UnixMilli()
+		patch := ckMultiKeyRep(
+			[]envfactory.ConcurrentKeyRep{
+				{Key: "anchor-sdk", Value: string(ckAnchorSDK)},
+				{Key: "extra-sdk", Value: string(ckExtraSDK), Expiry: msPtr(expiry)},
+			},
+			[]envfactory.ConcurrentKeyRep{
+				{Key: "anchor-mob", Value: string(ckAnchorMob)},
+				{Key: "extra-mob", Value: string(ckExtraMob), Expiry: msPtr(expiry)},
+			},
+			2,
+		)
+		p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(patch))
+
+		// Once the expiry passes, the cleanup ticker drops the keys: they stop authenticating while
+		// the anchor is unaffected.
+		awaitCredentialRemoved(t, p.relay, ckExtraSDK)
+		p.assertSDKEndpointsAvailability(false, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+	})
+}
+
+// --- S2: a connected SDK stays connected when its key gains a (future) expiry it hasn't reached ---
+
+func TestConcurrentKeysOffline_ConnectionSurvivesWhenKeyGainsFutureExpiry(t *testing.T) {
+	cfg := c.Config{}
+	cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
+	offlineModeTest(t, cfg, func(p offlineModeTestParams) {
+		p.updateHandler.AddEnvironment(ckArchiveEnv(ckDefaultAcceptedSDKKeys(), ckDefaultAcceptedMobileKeys()))
+		_ = p.awaitClient()
+		env := p.awaitEnvironment(ckEnvID)
+		require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+		req := sharedtest.BuildRequestWithAuth("GET", "/all", ckExtraSDK, nil)
+		sharedtest.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+			sharedtest.AwaitEventOfType(t, eventCh, "put", 5*time.Second)
+
+			// Give the connected non-anchor key a FAR-future expiry; the cleanup ticker must not drop
+			// it during the test, so the open stream stays connected.
+			expiry := time.Now().Add(1 * time.Hour)
+			p.updateHandler.UpdateEnvironment(ckArchiveEnv(
+				[]envfactory.AcceptedSDKKey{{Value: ckAnchorSDK}, {Value: ckExtraSDK, Expiry: expiry}},
+				ckDefaultAcceptedMobileKeys(),
+			))
+
+			assertStreamStaysOpen(t, eventCh, 500*time.Millisecond)
+		})
+
+		// The key is now in the deprecated-but-accepted set (its expiry was applied) and still authenticates.
+		require.Eventually(t, func() bool { return credsContain(env.GetDeprecatedCredentials(), ckExtraSDK) },
+			time.Second, 5*time.Millisecond, "expiry was not applied to the connected key")
+		p.assertSDKEndpointsAvailability(true, ckExtraSDK, "", "")
+	})
+}
+
+func TestConcurrentKeysRAC_KeyWithFutureExpiryStillAuthenticates(t *testing.T) {
+	cfg := testAutoConfDefaultConfig
+	cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
+	putEvent := configsource.MakeAutoConfigPutEvent(ckMultiKeyRep(ckDefaultSDKKeys(), ckDefaultMobileKeys(), 1))
+	autoConfTest(t, cfg, &putEvent, func(p autoConfTestParams) {
+		_ = p.awaitClient()
+		env := p.awaitEnvironment(ckEnvID)
+
+		// Patch: the non-anchor keys gain a FAR-future expiry; they remain accepted (not dropped).
+		expiry := time.Now().Add(1 * time.Hour).UnixMilli()
+		patch := ckMultiKeyRep(
+			[]envfactory.ConcurrentKeyRep{
+				{Key: "anchor-sdk", Value: string(ckAnchorSDK)},
+				{Key: "extra-sdk", Value: string(ckExtraSDK), Expiry: msPtr(expiry)},
+			},
+			[]envfactory.ConcurrentKeyRep{
+				{Key: "anchor-mob", Value: string(ckAnchorMob)},
+				{Key: "extra-mob", Value: string(ckExtraMob), Expiry: msPtr(expiry)},
+			},
+			2,
+		)
+		p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(patch))
+
+		// Confirm the expiry was applied (the key is now deprecated-but-accepted) and, after the
+		// cleanup ticker has had time to run, the future-dated key still authenticates.
+		require.Eventually(t, func() bool { return credsContain(env.GetDeprecatedCredentials(), ckExtraSDK) },
+			time.Second, 5*time.Millisecond, "future expiry was not applied")
+		p.assertSDKEndpointsAvailability(true, ckExtraSDK, ckExtraMob, "")
+		p.assertSDKEndpointsAvailability(true, ckAnchorSDK, ckAnchorMob, ckEnvID)
+	})
+}
+
+// awaitStreamClosed reads from a WithStreamRequest event channel until the stream-closed sentinel
+// (a nil event) arrives, failing if the timeout elapses first. Non-nil events are ignored.
+func awaitStreamClosed(t *testing.T, eventCh <-chan eventsource.Event, timeout time.Duration) {
+	t.Helper()
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case e := <-eventCh:
+			if e == nil {
+				return // stream closed — the disconnect we expect
+			}
+		case <-deadline.C:
+			t.Fatalf("timed out after %s waiting for the stream to be disconnected", timeout)
+			return
+		}
+	}
+}
+
+// assertStreamStaysOpen verifies that no stream-closed sentinel arrives within the given window.
+func assertStreamStaysOpen(t *testing.T, eventCh <-chan eventsource.Event, window time.Duration) {
+	t.Helper()
+	deadline := time.NewTimer(window)
+	defer deadline.Stop()
+	for {
+		select {
+		case e := <-eventCh:
+			if e == nil {
+				t.Fatalf("stream was unexpectedly disconnected within %s", window)
+				return
+			}
+		case <-deadline.C:
+			return // still open after the window — as expected
+		}
+	}
+}
+
+func msPtr(v int64) *int64 { return &v }
+
+func credsContain(creds []credential.SDKCredential, target credential.SDKCredential) bool {
+	for _, cr := range creds {
+		if cr == target {
+			return true
+		}
+	}
+	return false
+}
+
+// awaitCredentialRemoved blocks until the given credential no longer resolves to an environment.
+func awaitCredentialRemoved(t *testing.T, relay *Relay, cred credential.SDKCredential) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, err := relay.getEnvironment(sdkauth.New(cred))
+		return err != nil
+	}, time.Second, 5*time.Millisecond, "credential was not removed from the accepted set")
+}


### PR DESCRIPTION
## Summary

Adds integration test coverage for the SDK-connection / authentication scenarios of **concurrent SDK keys** — multi-key environments delivered via the new `sdkKeys[]` / `mobileKeys[]` array wire format — on both the RAC and offline-mode paths. This is the connection/auth slice of the M2 catch-up round.

Jira: [SDK-2609](https://launchdarkly.atlassian.net/browse/SDK-2609)

## Background

The multi-key behavior shipped with per-task **unit** tests rather than the harness-based integration scenarios the plan intended, leaving the new array-format auth path with essentially no end-to-end coverage (two recent regressions were caught by Bugbot, not tests). These tests close that gap for the connection/auth scenarios specifically.

They deliberately do **not** duplicate existing coverage:

- Single-key / legacy `expiring{}`-slot rotation is already covered (`TestAutoConfigInitWithExpiringSDKKey`, `TestOfflineModeSDKKeyCanExpire`, etc.) via the credential **set**; these assert downstream **authentication** and live stream connect/disconnect via the **array** path.
- Generic unknown-credential → 401 is already covered at the middleware / end-to-end layer; here only the multi-key-specific rejection cases are added.

## Changes

New file `relay/concurrent_keys_auth_test.go`:

- **Non-anchor keys authenticate** (RAC + offline) — every accepted SDK and mobile key authenticates downstream, with a single upstream connection (the anchor) serving all.
- **Disconnect on expiry** (offline live + RAC auth) — a connected downstream stream is torn down when its non-anchor key expires; sibling keys stay connected; the expired key then returns 401. Covers an SDK key and a mobile key.
- **Survives future expiry** (offline live + RAC auth) — a connected non-anchor key that gains a not-yet-reached expiry keeps its open stream and keeps authenticating.
- **Per-credential rejection** (RAC + offline) — a credential outside a populated accepted set, and a key removed on reconcile, are rejected (401) while siblings continue to work.

Notes for review:

- Built on the existing `autoConfTest` / `offlineModeTest` harnesses, fed array-format `EnvironmentRep`s.
- Live open-connection teardown is asserted on the **offline** path (real SDK client serves stream data). The RAC equivalents use `FakeLDClient`, which doesn't serve stream bodies, so they assert the same expiry → reject / future-expiry → still-accepted outcome at the auth layer. Documented inline.
- Expiry tests connect on a *permanent* key first, then introduce the expiry, so the connection establishes independent of expiry timing.
- Authored ahead of SDK-2604 (anchor rename) and SDK-2603 (legacy-path removal). The tests reference no symbols those PRs rename, so a near-zero rebase is expected once they land.


[SDK-2609]: https://launchdarkly.atlassian.net/browse/SDK-2609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths modified; risk is limited to CI runtime and test maintenance.
> 
> **Overview**
> Adds **`relay/concurrent_keys_auth_test.go`**, a dedicated integration suite for **multi-key** environments (`sdkKeys[]` / `mobileKeys[]`) where one **anchor** owns the single upstream connection.
> 
> Coverage spans **RAC** (`autoConfTest`) and **offline** (`offlineModeTest`): non-anchor SDK/mobile keys authenticate while only the anchor creates an upstream client; credentials outside the accepted set or removed on reconcile are rejected; non-anchor key expiry triggers cleanup, 401, and (offline) live SSE disconnect on `/all` and mobile streams; future expiry keeps streams open and auth working; anchor rotation swaps the upstream client and drops the old anchor while non-anchor keys stay accepted (plus a dummy-client RAC test that a non-anchor stream stays open during rotation).
> 
> Shared helpers build array-format env reps, assert stream open/close, and wait for credential removal from routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e85b8a0816d8d9f45726cbfd1f109a11a255a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->