### PR TITLE
chore(credential): remove DeprecatedCredentials / GetDeprecatedCredentials

### DIFF
--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -144,25 +144,6 @@ func (r *Rotator) allCredentials() []SDKCredential {
 	return creds
 }
 
-// DeprecatedCredentials returns the SDK keys being phased out — every accepted SDK key, other than the
-// anchor, that carries a future expiry. (Per-key expiry is stored as data on the accepted entry; the
-// cleanup ticker drops the key once it elapses.)
-//
-// Mobile keys are deliberately not returned even though they expire the same way SDK keys do — carried
-// as per-key expiry and dropped by the same cleanup ticker.
-func (r *Rotator) DeprecatedCredentials() []SDKCredential {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	var out []SDKCredential
-	for key, info := range r.acceptedSDKKeys {
-		if info.expiry != nil && key != r.anchorKey {
-			out = append(out, key)
-		}
-	}
-	return out
-}
-
 // AllCredentials returns every accepted credential: every accepted SDK key, every accepted mobile
 // key (including those carrying a future expiry — they still authenticate until the cleanup ticker
 // drops them), and the environment ID.

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -61,7 +61,7 @@ func TestReconcileAnchorOnly(t *testing.T) {
 	assert.Empty(t, expirations)
 	assert.Equal(t, anchor, r.AnchorKey())
 	assert.ElementsMatch(t, []SDKCredential{anchor}, r.AllCredentials())
-	assert.Empty(t, r.DeprecatedCredentials())
+	assert.Empty(t, expiringSDKKeys(r))
 }
 
 func TestReconcileMultipleSDKKeys(t *testing.T) {
@@ -79,7 +79,7 @@ func TestReconcileMultipleSDKKeys(t *testing.T) {
 	assert.Empty(t, expirations)
 	assert.Equal(t, anchor, r.AnchorKey())
 	assert.ElementsMatch(t, []SDKCredential{anchor, other}, r.AllCredentials())
-	assert.Empty(t, r.DeprecatedCredentials())
+	assert.Empty(t, expiringSDKKeys(r))
 }
 
 func TestReconcileMultipleMobileKeys(t *testing.T) {
@@ -147,7 +147,7 @@ func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
 	// ...and the non-anchor SDK key carrying an expiry is also reported as deprecated (being phased
 	// out). The expiring mobile key is not: there is no expiringMobileKey status field, so the reconcile
 	// path treats it as accepted-only.
-	assert.ElementsMatch(t, []SDKCredential{expiringSDK}, r.DeprecatedCredentials())
+	assert.ElementsMatch(t, []SDKCredential{expiringSDK}, expiringSDKKeys(r))
 }
 
 func TestReconcilePrimaryMobileKeyIsAlwaysAccepted(t *testing.T) {
@@ -247,7 +247,7 @@ func TestReconcileDeExpiryRestoresKey(t *testing.T) {
 			WithSDKKey(SDKKeyParams{Value: key, Expiry: util.PtrOrNil(expiry)})),
 		now)
 	r.StepTime(now)
-	require.ElementsMatch(t, []SDKCredential{key}, r.DeprecatedCredentials())
+	require.ElementsMatch(t, []SDKCredential{key}, expiringSDKKeys(r))
 
 	// Second reconcile: same key, no expiry (de-expiry).
 	r.Reconcile(
@@ -259,12 +259,26 @@ func TestReconcileDeExpiryRestoresKey(t *testing.T) {
 
 	// The key is still accepted and permanent: no longer deprecated, not evicted by StepTime.
 	assert.Contains(t, r.AllCredentials(), SDKCredential(key))
-	assert.Empty(t, r.DeprecatedCredentials())
+	assert.Empty(t, expiringSDKKeys(r))
 
 	additions, expirations := r.StepTime(expiry.Add(1 * time.Millisecond))
 	assert.Empty(t, additions)
 	assert.Empty(t, expirations)
 	assert.Contains(t, r.AllCredentials(), SDKCredential(key))
+}
+
+// expiringSDKKeys returns the non-anchor accepted SDK keys that carry a non-nil expiry. This is the
+// set that DeprecatedCredentials used to return before it was removed; tests use it to assert
+// rotation/expiry state without depending on that deleted method.
+func expiringSDKKeys(r *Rotator) []SDKCredential {
+	anchor := r.AnchorKey()
+	var out []SDKCredential
+	for _, ak := range r.AcceptedKeys() {
+		if ak.Type == KeyTypeServer && ak.Expiry != nil && ak.Value != string(anchor) {
+			out = append(out, config.SDKKey(ak.Value))
+		}
+	}
+	return out
 }
 
 // findAcceptedKey returns the entry with the given value, or nil. Used because AcceptedKeys order is

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -67,9 +67,6 @@ type EnvContext interface {
 	// GetCredentials returns all currently enabled and non-deprecated credentials for the environment.
 	GetCredentials() []credential.SDKCredential
 
-	// GetDeprecatedCredentials returns all deprecated and not-yet-removed credentials for the environment.
-	GetDeprecatedCredentials() []credential.SDKCredential
-
 	// GetClient returns the SDK client instance for this environment. This is nil if initialization is not yet
 	// complete. Rather than providing the full client object, we use the simpler sdks.LDClientContext which
 	// includes only the operations Relay needs to do.

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -636,10 +636,6 @@ func (c *envContextImpl) GetMobileKey() config.MobileKey {
 	return c.keyRotator.MobileKey()
 }
 
-func (c *envContextImpl) GetDeprecatedCredentials() []credential.SDKCredential {
-	return c.keyRotator.DeprecatedCredentials()
-}
-
 func (c *envContextImpl) GetAcceptedKeys() []credential.AcceptedKey {
 	return c.keyRotator.AcceptedKeys()
 }

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -179,6 +179,20 @@ func TestLogPrefix(t *testing.T) {
 	testPrefix("impossibly short env ID", LogNameIsEnvID, config.SDKKey("1234567890"), config.EnvironmentID("hij"), "[env: hij]")
 }
 
+// expiringSDKKeys returns the non-anchor accepted SDK keys that carry a non-nil expiry. This is the
+// set that GetDeprecatedCredentials used to return before it was removed; tests use it to assert
+// rotation/expiry state without depending on that deleted method.
+func expiringSDKKeys(env EnvContext) []credential.SDKCredential {
+	anchor := env.GetAnchorKey()
+	var out []credential.SDKCredential
+	for _, ak := range env.GetAcceptedKeys() {
+		if ak.Type == credential.KeyTypeServer && ak.Expiry != nil && ak.Value != string(anchor) {
+			out = append(out, config.SDKKey(ak.Value))
+		}
+	}
+	return out
+}
+
 // mustBuildAcceptedSet builds the set from b, failing the test if Build returns an error.
 func mustBuildAcceptedSet(t *testing.T, b *credential.AcceptedSetBuilder) credential.AcceptedSet {
 	t.Helper()
@@ -277,7 +291,7 @@ func TestChangeSDKKey(t *testing.T) {
 	// The environment should have been initialized with a single SDK key (found in the envConfig.)
 	// At this point, there's no deprecated credentials.
 	assert.Equal(t, []credential.SDKCredential{envConfig.SDKKey}, env.GetCredentials())
-	assert.Empty(t, env.GetDeprecatedCredentials())
+	assert.Empty(t, expiringSDKKeys(env))
 
 	// For the purposes of key rotation, we'll make time deterministic. We build an AcceptedSet
 	// with key2 as anchor and envConfig.SDKKey expiring in one hour, then drive the time-injectable
@@ -293,13 +307,12 @@ func TestChangeSDKKey(t *testing.T) {
 	envImpl.reconcileCredentials(rotationSet, start)
 
 	// In the new accepted-set model both keys are accepted (GetCredentials includes both) until
-	// the old key's expiry elapses. GetDeprecatedCredentials reports the expiring accepted key so
-	// callers like the status endpoint can surface it without distinguishing the rotation path.
+	// the old key's expiry elapses. The expiring accepted key is also surfaced via expiringSDKKeys.
 	creds := env.GetCredentials()
 	assert.Len(t, creds, 2)
 	assert.Contains(t, creds, key2)
 	assert.Contains(t, creds, envConfig.SDKKey)
-	assert.Equal(t, []credential.SDKCredential{envConfig.SDKKey}, env.GetDeprecatedCredentials())
+	assert.Equal(t, []credential.SDKCredential{envConfig.SDKKey}, expiringSDKKeys(env))
 
 	client2 := requireClientReady(t, clientCh)
 	assert.NotEqual(t, client1, client2)
@@ -324,7 +337,7 @@ func TestChangeSDKKey(t *testing.T) {
 	// and trigger its client to close.
 	envImpl.triggerCredentialChanges(start.Add(1*time.Hour + 1*time.Millisecond))
 	assert.Equal(t, []credential.SDKCredential{key2}, env.GetCredentials())
-	assert.Empty(t, env.GetDeprecatedCredentials())
+	assert.Empty(t, expiringSDKKeys(env))
 
 	if !helpers.AssertChannelClosed(t, client1.CloseCh, 1*time.Second, "client for envConfig.SDKKey should have been closed") {
 		t.FailNow()
@@ -363,9 +376,8 @@ func TestMobileKeyReconcileExpiry(t *testing.T) {
 			WithMobileKey(credential.MobileKeyParams{Value: expiringMobile, Expiry: util.PtrOrNil(expiry)})),
 		start)
 
-	// Reconcile stores the expiry as data, so before it elapses the key is accepted (not deprecated).
+	// Reconcile stores the expiry as data, so before it elapses the key is accepted.
 	assert.Contains(t, env.GetCredentials(), expiringMobile)
-	assert.NotContains(t, env.GetDeprecatedCredentials(), expiringMobile)
 
 	// Halfway through, still accepted.
 	envImpl.triggerCredentialChanges(start.Add(30 * time.Minute))

--- a/relay/autoconfig_key_change_test.go
+++ b/relay/autoconfig_key_change_test.go
@@ -124,7 +124,7 @@ func TestAutoConfigUpdateEnvironmentSDKKeyWithExpiry(t *testing.T) {
 
 		p.awaitCredentialsUpdated(env, modified.params())
 		p.assertEnvLookup(env, testAutoConfEnv1.params()) // looking up env by old key still works
-		assert.Equal(t, []credential.SDKCredential{testAutoConfEnv1.sdkKey.Value}, env.GetDeprecatedCredentials())
+		assert.Equal(t, []credential.SDKCredential{testAutoConfEnv1.sdkKey.Value}, expiringSDKKeys(env))
 
 		if !helpers.AssertChannelNotClosed(t, client1.CloseCh, time.Millisecond*300, "should not have closed client for deprecated key yet") {
 			t.FailNow()

--- a/relay/filedata_actions_test.go
+++ b/relay/filedata_actions_test.go
@@ -230,7 +230,7 @@ func TestOfflineModeDeprecatedSDKKeyIsRespectedIfExpiryInFuture(t *testing.T) {
 
 		// Expiring key is in the accepted set (and thus GetCredentials) until it expires.
 		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.SDKKey, envData.Params.ExpiringSDKKey.Key, envData.Params.EnvID}, env.GetCredentials())
-		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.ExpiringSDKKey.Key}, env.GetDeprecatedCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.ExpiringSDKKey.Key}, expiringSDKKeys(env))
 	})
 }
 
@@ -246,14 +246,14 @@ func TestOfflineModePrimarySDKKeyIsDeprecated(t *testing.T) {
 		env := p.awaitEnvironment(update1.Params.EnvID)
 
 		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.EnvID}, env.GetCredentials())
-		assert.Empty(t, env.GetDeprecatedCredentials())
+		assert.Empty(t, expiringSDKKeys(env))
 
 		update2 := RotateSDKKeyWithGracePeriod("key2", "key1", time.Now().Add(1*time.Hour))
 		p.updateHandler.UpdateEnvironment(update2)
 
 		// Both the new anchor and the expiring old key are accepted until key1 expires.
 		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.SDKKey, update2.Params.ExpiringSDKKey.Key, update1.Params.EnvID}, env.GetCredentials())
-		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.ExpiringSDKKey.Key}, env.GetDeprecatedCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.ExpiringSDKKey.Key}, expiringSDKKeys(env))
 
 		update3 := RotateSDKKey("key3")
 		p.updateHandler.UpdateEnvironment(update3)
@@ -262,7 +262,7 @@ func TestOfflineModePrimarySDKKeyIsDeprecated(t *testing.T) {
 
 		// update3 carries no expiring key, so ReconcileCredentials replaces the full accepted set with
 		// just key3; key1 and key2 are removed immediately (not held in the deprecated bucket).
-		assert.Empty(t, env.GetDeprecatedCredentials())
+		assert.Empty(t, expiringSDKKeys(env))
 	})
 }
 
@@ -294,10 +294,10 @@ func TestOfflineModeSDKKeyCanExpire(t *testing.T) {
 		env := p.awaitEnvironmentFor(update1.Params.EnvID, time.Second)
 		// Both the primary and the expiring key are in the accepted set until the expiry fires.
 		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.ExpiringSDKKey.Key, update1.Params.EnvID}, env.GetCredentials())
-		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.ExpiringSDKKey.Key}, env.GetDeprecatedCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.ExpiringSDKKey.Key}, expiringSDKKeys(env))
 
 		assert.Eventually(t, func() bool {
-			return len(env.GetDeprecatedCredentials()) == 0
+			return len(expiringSDKKeys(env)) == 0
 		}, time.Second, 10*time.Millisecond, "deprecated credentials should be cleaned up after expiry")
 		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.EnvID}, env.GetCredentials())
 	})

--- a/relay/testutils_test.go
+++ b/relay/testutils_test.go
@@ -175,6 +175,20 @@ func assertEnvProps(t *testing.T, expected envfactory.EnvironmentParams, env rel
 		env.GetIdentifiers().GetDisplayName())
 }
 
+// expiringSDKKeys returns the non-anchor accepted SDK keys that carry a non-nil expiry. This is the
+// set that GetDeprecatedCredentials used to return before it was removed; tests use it to assert
+// rotation/expiry state without depending on that deleted method.
+func expiringSDKKeys(env relayenv.EnvContext) []credential.SDKCredential {
+	anchor := env.GetAnchorKey()
+	var out []credential.SDKCredential
+	for _, ak := range env.GetAcceptedKeys() {
+		if ak.Type == credential.KeyTypeServer && ak.Expiry != nil && ak.Value != string(anchor) {
+			out = append(out, config.SDKKey(ak.Value))
+		}
+	}
+	return out
+}
+
 func credentialsAsSet(cs ...credential.SDKCredential) map[credential.SDKCredential]struct{} {
 	ret := make(map[credential.SDKCredential]struct{}, len(cs))
 	for _, c := range cs {


### PR DESCRIPTION
## Summary
Remove `Rotator.DeprecatedCredentials()` and `EnvContext.GetDeprecatedCredentials()` — both methods are now dead code following PR #724.

## Background
PR #724 (T4 — status endpoint arrays) rewired the `/status` handler to compute the `expiringSdkKey` field from `GetAcceptedKeys()` instead of `GetDeprecatedCredentials()`. After that change, `GetDeprecatedCredentials` had no production callers — only tests referenced it.

Tests that asserted rotation/expiry state through the deleted methods are rewritten to filter `AcceptedKeys()` / `GetAcceptedKeys()` for non-anchor SDK keys with a non-nil expiry — the same semantics, expressed through a surviving accessor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no remaining references; credential rotation and auth behavior are unchanged aside from dropping unused accessors.
> 
> **Overview**
> Removes **`Rotator.DeprecatedCredentials()`**, **`EnvContext.GetDeprecatedCredentials()`**, and the **`envContextImpl`** passthrough — APIs that had no production callers after `/status` started deriving expiring SDK keys from **`GetAcceptedKeys()`**.
> 
> Tests that previously depended on those methods now use a local **`expiringSDKKeys`** helper (on the rotator, env context, and relay test packages) that returns non-anchor accepted server SDK keys with a non-nil expiry — same semantics as the deleted methods, without keeping the public surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c785fecadbec878c10781598655308f3523432b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->