### PR TITLE
test: use a valid context instead of legacy user format in relay tests

### DIFF
--- a/internal/sharedtest/endpoints.go
+++ b/internal/sharedtest/endpoints.go
@@ -13,8 +13,8 @@ import (
 // that configures Relay's endpoint routing, so that if we accidentally change the routing, the tests
 // will fail, rather than succeed based on incorrect paths.
 
-// SimpleUserJSON is a basic user.
-const SimpleUserJSON = `{"key":"userkey"}`
+// SimpleUserJSON is a basic single-kind context.
+const SimpleUserJSON = `{"key":"userkey","kind":"user"}`
 
 // ToBase64 is a shortcut for base64 encoding.
 func ToBase64(s string) string {

--- a/relay/testutils_test.go
+++ b/relay/testutils_test.go
@@ -82,8 +82,8 @@ func (h relayTestHelper) assertSDKEndpointsAvailability(
 	// appropriate HTTP status. These are tested more thoroughly in test suites like DoStreamEndpointsTests,
 	// but we use this simpler test when we're dynamically changing what the credentials are.
 
-	simpleUserJSON := []byte(`{"key":"userkey"}`)
-	simpleUserBase64 := "eyJrZXkiOiJ1c2Vya2V5In0="
+	simpleUserJSON := []byte(`{"key":"userkey","kind":"user"}`)
+	simpleUserBase64 := "eyJrZXkiOiJ1c2Vya2V5Iiwia2luZCI6InVzZXIifQ=="
 	status200Or401, status200Or404 := 200, 200
 	if !shouldBeAvailable {
 		status200Or401 = 401


### PR DESCRIPTION
## Summary

Updates two relay test fixtures that still modeled the eval context they send to the SDK endpoints as a legacy `LDUser` (`{"key":"userkey"}`, no `kind`) to use a valid single-kind evaluation context (`{"key":"userkey","kind":"user"}`):

1. **`relay/testutils_test.go`** — `simpleUserJSON` / `simpleUserBase64` in the `assertSDKEndpointsAvailability` helper, which feeds the mobile `/meval/<base64>` and JS `/eval/<envID>/<base64>` streaming endpoints (plus the REPORT variants) for many relay endpoint tests.
2. **`internal/sharedtest/endpoints.go`** — the shared `SimpleUserJSON` constant, consumed by the stream/eval request builders in `relay/relay_environments_test.go` and `relay/relay_end_to_end_test.go`.

## Background

Evaluation contexts (the `kind` field) have been the canonical format since contexts shipped in **7.0.0 (2022-12-07)** and are fully present in production v8. The bare no-`kind` user shape is the legacy form, accepted today only via the SDK's backward-compatibility path in `ldcontext.UnmarshalJSON`. These fixtures only need the payload to parse — none assert on its literal value or on evaluation results, and `assertSDKEndpointsAvailability` checks only HTTP status codes — so behavior is unchanged.

`go test ./relay/...` and `golangci-lint run ./internal/sharedtest/... ./relay/...` pass.
