### PR TITLE
fix(envfactory): reject primary mobile key absent from mobileKeys[]

### DIFF
--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -19,8 +19,8 @@ import (
 //
 // WithAnchor / WithPrimaryMobileKey both add the key to the set and designate it, so adding a
 // single key takes one call. Build requires that an anchor was designated. (Structural validation of
-// the wire payload — undefined credentials, an anchor absent from the array — happens upstream when
-// the payload is parsed into the set; see SDK-2547.)
+// the wire payload — undefined credentials, a designated key absent from its array — happens upstream
+// when the payload is parsed into the set.)
 //
 // A key's expiry is taken from its entry in this set; the legacy sdkKey.expiring{} wire slot is not
 // consulted when building it.
@@ -55,11 +55,13 @@ func (s AcceptedSet) hasMobileKey(key config.MobileKey) bool {
 var errAcceptedSetMissingSDKKey = errors.New("accepted credential set must contain at least one SDK key")
 
 // MalformedCredentialSetError is returned when a credential payload cannot produce a valid
-// AcceptedSet. This covers two cases:
+// AcceptedSet. This covers:
 //
-//  1. The anchor SDK key (sdkKey.value) is absent or undefined — a violation of the backend
-//     invariant that an anchor is always designated.
-//  2. An entry in sdkKeys[] or mobileKeys[] has an empty value — a credential that would be
+//  1. The anchor SDK key (sdkKey.value) is absent or undefined, or defined but not present in
+//     sdkKeys[] — a violation of the invariant that the designated anchor is one of the accepted keys.
+//  2. The primary mobile key (mobKey) is defined but not present in mobileKeys[] — the mobile-key
+//     analogue of the anchor invariant.
+//  3. An entry in sdkKeys[] or mobileKeys[] has an empty value — a credential that would be
 //     accepted by relay but can never authenticate any SDK.
 //
 // Validation happens before Reconcile is called; Rotator.Reconcile trusts the set it is handed.
@@ -87,6 +89,14 @@ func newMissingAnchorError() *MalformedCredentialSetError {
 // anchor value is a secret, so it is deliberately not included in the message.
 func NewAnchorNotInSetError() *MalformedCredentialSetError {
 	return &MalformedCredentialSetError{msg: "malformed credential set: anchor SDK key is not present in sdkKeys[]"}
+}
+
+// NewPrimaryMobileKeyNotInSetError returns a MalformedCredentialSetError for a payload whose
+// designated primary mobile key (mobKey) is defined but not present in the mobileKeys[] array — the
+// mobile-key analogue of NewAnchorNotInSetError. The key value is a secret, so it is deliberately not
+// included in the message.
+func NewPrimaryMobileKeyNotInSetError() *MalformedCredentialSetError {
+	return &MalformedCredentialSetError{msg: "malformed credential set: primary mobile key is not present in mobileKeys[]"}
 }
 
 // NewEmptyCredentialError returns a MalformedCredentialSetError for a key-array entry whose

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -66,15 +66,27 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 		return credential.AcceptedSet{}, anchor, credential.NewAnchorNotInSetError()
 	}
 
+	primaryMobileInArray := false
 	for _, k := range params.AcceptedMobileKeys {
 		if !k.Value.Defined() {
 			return credential.AcceptedSet{}, anchor, credential.NewEmptyCredentialError("mobileKeys", k.Key)
+		}
+		if k.Value == params.MobileKey {
+			primaryMobileInArray = true
 		}
 		if k.Expiry.IsZero() {
 			b.WithMobileKey(k.Value)
 		} else {
 			b.WithExpiringMobileKey(k.Value, k.Expiry)
 		}
+	}
+
+	// The primary mobile key, when the environment has one, must be in mobileKeys[] — the mobile
+	// analogue of the anchor invariant above. A defined mobKey absent from the array is malformed:
+	// without this guard the primary would be silently left undesignated, clearing it on reconcile and
+	// breaking event forwarding. (An undefined mobKey is valid — a server-side-only environment.)
+	if params.MobileKey.Defined() && !primaryMobileInArray {
+		return credential.AcceptedSet{}, anchor, credential.NewPrimaryMobileKeyNotInSetError()
 	}
 
 	set, err := b.Build()

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -176,6 +176,27 @@ func TestBuildAcceptedSet_AnchorNotInArray(t *testing.T) {
 	assert.Contains(t, malformed.Error(), "not present in sdkKeys[]")
 }
 
+// TestBuildAcceptedSet_PrimaryMobileNotInArray verifies the mobile analogue of the anchor invariant:
+// a defined mobKey absent from mobileKeys[] is rejected. Without this guard the primary mobile key
+// would be silently left undesignated, clearing it on reconcile and breaking event forwarding.
+func TestBuildAcceptedSet_PrimaryMobileNotInArray(t *testing.T) {
+	params := EnvironmentParams{
+		EnvID:           "env-abc",
+		SDKKey:          "sdk-anchor",
+		MobileKey:       "mob-primary", // defined...
+		AcceptedSDKKeys: []AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
+		AcceptedMobileKeys: []AcceptedMobileKey{
+			{Key: "other", Value: "mob-other"}, // ...but NOT in the array
+		},
+	}
+	_, _, err := BuildAcceptedSet(params)
+
+	require.Error(t, err)
+	var malformed *credential.MalformedCredentialSetError
+	require.True(t, errors.As(err, &malformed))
+	assert.Contains(t, malformed.Error(), "not present in mobileKeys[]")
+}
+
 // TestBuildAcceptedSet_NoMobileKey verifies that an environment with no mobile key (e.g. a
 // server-side-only environment) is valid: ToParams must not synthesize a phantom empty mobileKeys
 // entry that BuildAcceptedSet would reject as malformed.


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR — splitting #724 (review/merge bottom-up):**
> 1. **➡ #728 (this PR)** — reject primary mobile key absent from `mobileKeys[]`
> 2. #729 — carry wire key identifiers through the accepted set
> 3. #730 — expose the full accepted key set via `AcceptedKeys`
> 4. #731 — surface `sdkKeys[]` / `mobileKeys[]` on `/status`
>
> Base of the stack (off `feat/concurrent-keys`); every PR above builds on it.

## Summary

Reject a defined primary mobile key (the wire's `mobKey`) that is absent from `mobileKeys[]`, mirroring the existing anchor-not-in-array invariant.

This is the base of the stack that splits #724. It is a small, self-contained correctness fix, but the feature PRs above depend on it: the per-entry primary-mobile designation introduced in #729 and this validation are two halves of one change, so they travel together in the stack.

## Background

`BuildAcceptedSet` already rejects a defined anchor SDK key absent from `sdkKeys[]` (`NewAnchorNotInSetError`). The primary mobile key had no equivalent guard: a defined `mobKey` missing from `mobileKeys[]` would be silently left undesignated, clearing the primary on reconcile and breaking event forwarding.

## Changes

- Add `NewPrimaryMobileKeyNotInSetError` and document the new case on `MalformedCredentialSetError`.
- Add a `primaryMobileInArray` check to `BuildAcceptedSet`.
- Add `TestBuildAcceptedSet_PrimaryMobileNotInArray`.
