### PR TITLE
refactor(credential): carry wire key identifiers through the accepted set

### DIFF
--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -3,7 +3,6 @@ package credential
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 )
@@ -27,12 +26,12 @@ import (
 //
 // Construct an AcceptedSet with AcceptedSetBuilder (see accepted_set_builder.go).
 type AcceptedSet struct {
-	// sdkKeys and mobileKeys store each accepted key once, keyed by value, so duplicates collapse
-	// without a containment scan. The map value is the key's expiry: a nil *time.Time means the key
-	// is permanent. A nil map is a valid empty set (reads return absent; only the builder writes).
-	sdkKeys          map[config.SDKKey]*time.Time
+	// sdkKeys and mobileKeys store each accepted key once, keyed by value (the secret), so duplicates
+	// collapse without a containment scan. The map value carries the key's metadata (see
+	// acceptedKeyInfo). A nil map is a valid empty set (reads return absent; only the builder writes).
+	sdkKeys          map[config.SDKKey]acceptedKeyInfo
 	anchor           config.SDKKey
-	mobileKeys       map[config.MobileKey]*time.Time
+	mobileKeys       map[config.MobileKey]acceptedKeyInfo
 	primaryMobileKey config.MobileKey
 	envID            config.EnvironmentID
 }
@@ -100,15 +99,15 @@ func NewPrimaryMobileKeyNotInSetError() *MalformedCredentialSetError {
 }
 
 // NewEmptyCredentialError returns a MalformedCredentialSetError for a key-array entry whose
-// value field is empty. kind is "sdkKeys" or "mobileKeys"; identifier is the key's identifier
-// string (may be empty for old-format payloads that synthesize from the singular fields).
-func NewEmptyCredentialError(kind, identifier string) *MalformedCredentialSetError {
-	if identifier == "" {
+// value field is empty. kind is "sdkKeys" or "mobileKeys"; key is the entry's wire "key" identifier
+// (may be empty for old-format payloads that synthesize from the singular fields).
+func NewEmptyCredentialError(kind, key string) *MalformedCredentialSetError {
+	if key == "" {
 		return &MalformedCredentialSetError{
 			msg: fmt.Sprintf("malformed credential set: %s entry has an empty value", kind),
 		}
 	}
 	return &MalformedCredentialSetError{
-		msg: fmt.Sprintf("malformed credential set: %s entry %q has an empty value", kind, identifier),
+		msg: fmt.Sprintf("malformed credential set: %s entry %q has an empty value", kind, key),
 	}
 }

--- a/internal/credential/accepted_set_builder.go
+++ b/internal/credential/accepted_set_builder.go
@@ -16,77 +16,69 @@ type AcceptedSetBuilder struct {
 func NewAcceptedSetBuilder() *AcceptedSetBuilder {
 	return &AcceptedSetBuilder{
 		set: AcceptedSet{
-			sdkKeys:    make(map[config.SDKKey]*time.Time),
-			mobileKeys: make(map[config.MobileKey]*time.Time),
+			sdkKeys:    make(map[config.SDKKey]acceptedKeyInfo),
+			mobileKeys: make(map[config.MobileKey]acceptedKeyInfo),
 		},
 	}
 }
 
-// WithSDKKey adds a permanent (non-expiring) SDK key. It is a no-op if the key is undefined or
-// already present.
-func (b *AcceptedSetBuilder) WithSDKKey(key config.SDKKey) *AcceptedSetBuilder {
-	b.addSDKKey(key, nil)
-	return b
+// SDKKeyParams describes one accepted server-side SDK key for the builder: the credential value plus
+// the optional wire "key" identifier (nil when absent) and optional expiry (nil = permanent).
+type SDKKeyParams struct {
+	Value  config.SDKKey
+	Key    *string
+	Expiry *time.Time
 }
 
-// WithExpiringSDKKey adds an SDK key that should be accepted until the given expiry. It is a no-op
-// if the key is undefined or already present.
-func (b *AcceptedSetBuilder) WithExpiringSDKKey(key config.SDKKey, expiry time.Time) *AcceptedSetBuilder {
-	b.addSDKKey(key, &expiry)
-	return b
+// MobileKeyParams describes one accepted mobile key for the builder. See SDKKeyParams.
+type MobileKeyParams struct {
+	Value  config.MobileKey
+	Key    *string
+	Expiry *time.Time
 }
 
-// WithAnchor adds key (if not already present) and designates it as the anchor — the SDK key
-// that owns the environment's upstream connection. It is a no-op if the key is undefined.
-func (b *AcceptedSetBuilder) WithAnchor(key config.SDKKey) *AcceptedSetBuilder {
-	if key.Defined() {
-		b.addSDKKey(key, nil)
-		b.set.anchor = key
+// WithSDKKey adds a server-side SDK key. It is a no-op if the value is undefined or already present
+// (the first metadata recorded for a value wins).
+func (b *AcceptedSetBuilder) WithSDKKey(p SDKKeyParams) *AcceptedSetBuilder {
+	if !p.Value.Defined() || b.set.hasSDKKey(p.Value) {
+		return b
 	}
+	b.set.sdkKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: p.Expiry}
 	return b
 }
 
-// addSDKKey records the key with the given expiry (nil = permanent), skipping undefined keys and
-// keys already in the set (the first expiry recorded for a key wins).
-func (b *AcceptedSetBuilder) addSDKKey(key config.SDKKey, expiry *time.Time) {
-	if !key.Defined() || b.set.hasSDKKey(key) {
-		return
+// WithAnchor adds p.Value and designates it as the anchor — the SDK key that owns the environment's
+// upstream connection. The anchor is always permanent, so p.Expiry is ignored. It is a no-op if the
+// value is undefined. Unlike WithSDKKey it overwrites any existing entry for the value, since
+// designating the anchor takes precedence over an earlier non-anchor add.
+func (b *AcceptedSetBuilder) WithAnchor(p SDKKeyParams) *AcceptedSetBuilder {
+	if !p.Value.Defined() {
+		return b
 	}
-	b.set.sdkKeys[key] = expiry
-}
-
-// WithMobileKey adds a permanent (non-expiring) mobile key. It is a no-op if the key is undefined or
-// already present.
-func (b *AcceptedSetBuilder) WithMobileKey(key config.MobileKey) *AcceptedSetBuilder {
-	b.addMobileKey(key, nil)
+	b.set.sdkKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: nil}
+	b.set.anchor = p.Value
 	return b
 }
 
-// WithExpiringMobileKey adds a mobile key that should be accepted until the given expiry. It is a
-// no-op if the key is undefined or already present.
-func (b *AcceptedSetBuilder) WithExpiringMobileKey(key config.MobileKey, expiry time.Time) *AcceptedSetBuilder {
-	b.addMobileKey(key, &expiry)
-	return b
-}
-
-// WithPrimaryMobileKey adds key (if not already present) and designates it as the primary mobile
-// key — the singular default (the wire's mobKey) used where one mobile key is required, e.g. event
-// forwarding. It is a no-op if the key is undefined.
-func (b *AcceptedSetBuilder) WithPrimaryMobileKey(key config.MobileKey) *AcceptedSetBuilder {
-	if key.Defined() {
-		b.addMobileKey(key, nil)
-		b.set.primaryMobileKey = key
+// WithMobileKey adds a mobile key. It is a no-op if the value is undefined or already present.
+func (b *AcceptedSetBuilder) WithMobileKey(p MobileKeyParams) *AcceptedSetBuilder {
+	if !p.Value.Defined() || b.set.hasMobileKey(p.Value) {
+		return b
 	}
+	b.set.mobileKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: p.Expiry}
 	return b
 }
 
-// addMobileKey records the key with the given expiry (nil = permanent), skipping undefined keys and
-// keys already in the set (the first expiry recorded for a key wins).
-func (b *AcceptedSetBuilder) addMobileKey(key config.MobileKey, expiry *time.Time) {
-	if !key.Defined() || b.set.hasMobileKey(key) {
-		return
+// WithPrimaryMobileKey adds p.Value and designates it as the primary mobile key — the singular
+// default (the wire's mobKey) used where one mobile key is required, e.g. event forwarding. The
+// primary is always permanent, so p.Expiry is ignored. It is a no-op if the value is undefined.
+func (b *AcceptedSetBuilder) WithPrimaryMobileKey(p MobileKeyParams) *AcceptedSetBuilder {
+	if !p.Value.Defined() {
+		return b
 	}
-	b.set.mobileKeys[key] = expiry
+	b.set.mobileKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: nil}
+	b.set.primaryMobileKey = p.Value
+	return b
 }
 
 // WithEnvironmentID sets the environment ID. It is a no-op if the ID is undefined.

--- a/internal/credential/accepted_set_builder_test.go
+++ b/internal/credential/accepted_set_builder_test.go
@@ -12,18 +12,18 @@ import (
 func TestAcceptedSetBuilderValidation(t *testing.T) {
 	// No SDK key at all is a caller error.
 	_, err := NewAcceptedSetBuilder().
-		WithMobileKey(config.MobileKey("mob")).
+		WithMobileKey(MobileKeyParams{Value: "mob"}).
 		WithEnvironmentID(config.EnvironmentID("env")).
 		Build()
 	require.ErrorIs(t, err, errAcceptedSetMissingSDKKey)
 
 	// An SDK key with no designated anchor is malformed.
 	var malformed *MalformedCredentialSetError
-	_, err = NewAcceptedSetBuilder().WithSDKKey(config.SDKKey("sdk")).Build()
+	_, err = NewAcceptedSetBuilder().WithSDKKey(SDKKeyParams{Value: "sdk"}).Build()
 	require.ErrorAs(t, err, &malformed)
 
 	// WithAnchor adds the key and designates it as the anchor, so Build succeeds.
-	set, err := NewAcceptedSetBuilder().WithAnchor(config.SDKKey("sdk")).Build()
+	set, err := NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: "sdk"}).Build()
 	require.NoError(t, err)
 	assert.True(t, set.hasSDKKey(config.SDKKey("sdk")))
 	assert.Equal(t, config.SDKKey("sdk"), set.anchor)
@@ -32,11 +32,11 @@ func TestAcceptedSetBuilderValidation(t *testing.T) {
 func TestAcceptedSetBuilderDeduplicates(t *testing.T) {
 	// Adding the same key more than once (including via WithPrimary*) keeps a single entry.
 	set := mustBuild(t, NewAcceptedSetBuilder().
-		WithSDKKey(config.SDKKey("sdk")).
-		WithAnchor(config.SDKKey("sdk")).
-		WithSDKKey(config.SDKKey("sdk")).
-		WithMobileKey(config.MobileKey("mob")).
-		WithPrimaryMobileKey(config.MobileKey("mob")))
+		WithSDKKey(SDKKeyParams{Value: "sdk"}).
+		WithAnchor(SDKKeyParams{Value: "sdk"}).
+		WithSDKKey(SDKKeyParams{Value: "sdk"}).
+		WithMobileKey(MobileKeyParams{Value: "mob"}).
+		WithPrimaryMobileKey(MobileKeyParams{Value: "mob"}))
 
 	assert.Len(t, set.sdkKeys, 1)
 	assert.Len(t, set.mobileKeys, 1)

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -29,11 +29,11 @@ type Rotator struct {
 
 	// acceptedSDKKeys is the full set of accepted SDK keys with optional per-key expiry.
 	// A nil expiry means the key is permanent. The anchor is always present with a nil expiry.
-	acceptedSDKKeys map[config.SDKKey]*acceptedKeyInfo
+	acceptedSDKKeys map[config.SDKKey]acceptedKeyInfo
 
 	// acceptedMobileKeys is the full set of accepted mobile keys with optional per-key expiry.
 	// A nil expiry means the key is permanent.
-	acceptedMobileKeys map[config.MobileKey]*acceptedKeyInfo
+	acceptedMobileKeys map[config.MobileKey]acceptedKeyInfo
 
 	expirations []SDKCredential
 	additions   []SDKCredential
@@ -52,8 +52,8 @@ type InitialCredentials struct {
 func NewRotator(loggers ldlog.Loggers) *Rotator {
 	r := &Rotator{
 		loggers:            loggers,
-		acceptedSDKKeys:    make(map[config.SDKKey]*acceptedKeyInfo),
-		acceptedMobileKeys: make(map[config.MobileKey]*acceptedKeyInfo),
+		acceptedSDKKeys:    make(map[config.SDKKey]acceptedKeyInfo),
+		acceptedMobileKeys: make(map[config.MobileKey]acceptedKeyInfo),
 	}
 	return r
 }
@@ -71,10 +71,10 @@ func (r *Rotator) Initialize(credentials []SDKCredential) {
 		switch cred := cred.(type) {
 		case config.SDKKey:
 			r.anchorKey = cred
-			r.acceptedSDKKeys[cred] = &acceptedKeyInfo{}
+			r.acceptedSDKKeys[cred] = acceptedKeyInfo{}
 		case config.MobileKey:
 			r.primaryMobileKey = cred
-			r.acceptedMobileKeys[cred] = &acceptedKeyInfo{}
+			r.acceptedMobileKeys[cred] = acceptedKeyInfo{}
 		case config.EnvironmentID:
 			r.primaryEnvironmentID = cred
 		}
@@ -224,26 +224,22 @@ type reconcilableKey interface {
 // the accepted entry; the cleanup ticker is what later acts on it. The caller must hold the write lock.
 func reconcileAcceptedKeys[K reconcilableKey](
 	desired map[K]acceptedKeyInfo,
-	accepted map[K]*acceptedKeyInfo,
+	accepted map[K]acceptedKeyInfo,
 	additions *[]SDKCredential,
 	expirations *[]SDKCredential,
 	loggers ldlog.Loggers,
 	kind string,
 ) {
-	// First pass: walk every key the set wants us to accept. If we already accept it, refresh its
-	// metadata in place — both the expiry and the wire "key" identifier, clearing the identifier when
-	// the new payload carries none so a stale name never lingers in /status. If it's new, start
-	// accepting it and queue it as an addition.
+	// First pass: walk every key the set wants us to accept. Writing the desired entry over the
+	// accepted one refreshes its metadata — both the expiry and the wire "key" identifier, clearing
+	// the identifier when the new payload carries none so a stale name never lingers in /status. A key
+	// we don't yet accept is also queued as an addition.
 	for key, want := range desired {
-		if info, ok := accepted[key]; ok {
-			info.expiry = want.expiry
-			info.key = want.key
-		} else {
-			info := want
-			accepted[key] = &info
+		if _, ok := accepted[key]; !ok {
 			*additions = append(*additions, key)
 			loggers.Infof("%s %s is now accepted", kind, key.Masked())
 		}
+		accepted[key] = want
 	}
 	// Second pass: walk every key we currently accept and drop the ones the set no longer wants.
 	// Keys still desired were handled above, so skip them; the rest are revoked outright (removed
@@ -259,8 +255,9 @@ func reconcileAcceptedKeys[K reconcilableKey](
 }
 
 // reconcileSDKKeys diffs the desired SDK keys against the accepted set and applies the result via
-// reconcileAcceptedKeys. The anchor is always accepted and permanent, regardless of any expiry the
-// payload may carry for it. The caller must hold the write lock.
+// reconcileAcceptedKeys. The set is trusted as well-formed: BuildAcceptedSet / the builder guarantee
+// the anchor is present and permanent (WithAnchor forces a nil expiry), so no special handling is
+// needed here. The caller must hold the write lock.
 func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now time.Time) {
 	desired := make(map[config.SDKKey]acceptedKeyInfo, len(set.sdkKeys))
 	for key, info := range set.sdkKeys {
@@ -269,18 +266,14 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 		}
 		desired[key] = info
 	}
-	// The anchor is always accepted and permanent regardless of any expiry the payload carries; keep
-	// its wire identifier from the set.
-	anchorInfo := set.sdkKeys[anchor]
-	anchorInfo.expiry = nil
-	desired[anchor] = anchorInfo
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
 	r.anchorKey = anchor
 }
 
-// reconcileMobileKeys mirrors reconcileSDKKeys for mobile keys. The primary mobile key — the wire's
-// singular mobKey, used where one mobile key is required (e.g. event forwarding) — is always accepted
-// and permanent; an empty value means the set declared no mobile key. The caller must hold the lock.
+// reconcileMobileKeys mirrors reconcileSDKKeys for mobile keys. The set is trusted as well-formed:
+// when a primary mobile key is designated, the builder guarantees it is present and permanent
+// (WithPrimaryMobileKey forces a nil expiry). An empty primary means the set declared no mobile key.
+// The caller must hold the lock.
 func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
 	desired := make(map[config.MobileKey]acceptedKeyInfo, len(set.mobileKeys))
 	for key, info := range set.mobileKeys {
@@ -288,12 +281,6 @@ func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
 			continue // already expired; treat as absent
 		}
 		desired[key] = info
-	}
-	// The primary mobile key is always accepted and permanent; keep its wire identifier from the set.
-	if set.primaryMobileKey.Defined() {
-		primaryInfo := set.mobileKeys[set.primaryMobileKey]
-		primaryInfo.expiry = nil
-		desired[set.primaryMobileKey] = primaryInfo
 	}
 	reconcileAcceptedKeys(desired, r.acceptedMobileKeys, &r.additions, &r.expirations, r.loggers, "Mobile key")
 	r.primaryMobileKey = set.primaryMobileKey

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -11,6 +11,7 @@ import (
 // acceptedKeyInfo holds per-key metadata for the accepted-set maps.
 type acceptedKeyInfo struct {
 	expiry *time.Time // nil = permanent
+	key    *string    // wire "key" identifier — non-secret human-readable name; nil when absent
 }
 
 type Rotator struct {
@@ -258,14 +259,21 @@ func reconcileAcceptedKeys[K reconcilableKey](
 // payload may carry for it. The caller must hold the write lock.
 func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now time.Time) {
 	desired := make(map[config.SDKKey]*time.Time, len(set.sdkKeys))
-	for key, expiry := range set.sdkKeys {
-		if expiry != nil && !now.Before(*expiry) {
+	for key, info := range set.sdkKeys {
+		if info.expiry != nil && !now.Before(*info.expiry) {
 			continue // already expired; treat as absent
 		}
-		desired[key] = expiry
+		desired[key] = info.expiry
 	}
 	desired[anchor] = nil
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
+	// Refresh the wire "key" identifier for every key now in the accepted set, including clearing it
+	// when the new payload carries none — otherwise a stale identifier would linger in /status.
+	for key, info := range set.sdkKeys {
+		if accepted, ok := r.acceptedSDKKeys[key]; ok {
+			accepted.key = info.key
+		}
+	}
 	r.anchorKey = anchor
 }
 
@@ -274,16 +282,23 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 // and permanent; an empty value means the set declared no mobile key. The caller must hold the lock.
 func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
 	desired := make(map[config.MobileKey]*time.Time, len(set.mobileKeys))
-	for key, expiry := range set.mobileKeys {
-		if expiry != nil && !now.Before(*expiry) {
+	for key, info := range set.mobileKeys {
+		if info.expiry != nil && !now.Before(*info.expiry) {
 			continue // already expired; treat as absent
 		}
-		desired[key] = expiry
+		desired[key] = info.expiry
 	}
 	if set.primaryMobileKey.Defined() {
 		desired[set.primaryMobileKey] = nil
 	}
 	reconcileAcceptedKeys(desired, r.acceptedMobileKeys, &r.additions, &r.expirations, r.loggers, "Mobile key")
+	// Refresh the wire "key" identifier for every key now in the accepted set, including clearing it
+	// when the new payload carries none — otherwise a stale identifier would linger in /status.
+	for key, info := range set.mobileKeys {
+		if accepted, ok := r.acceptedMobileKeys[key]; ok {
+			accepted.key = info.key
+		}
+	}
 	r.primaryMobileKey = set.primaryMobileKey
 }
 

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -223,20 +223,24 @@ type reconcilableKey interface {
 // key no longer desired is dropped and queued as an expiration. Per-key expiry is stored as data on
 // the accepted entry; the cleanup ticker is what later acts on it. The caller must hold the write lock.
 func reconcileAcceptedKeys[K reconcilableKey](
-	desired map[K]*time.Time,
+	desired map[K]acceptedKeyInfo,
 	accepted map[K]*acceptedKeyInfo,
 	additions *[]SDKCredential,
 	expirations *[]SDKCredential,
 	loggers ldlog.Loggers,
 	kind string,
 ) {
-	// First pass: walk every key the set wants us to accept. If we already accept it, just refresh
-	// its expiry; if it's new, start accepting it and queue it as an addition.
-	for key, expiry := range desired {
+	// First pass: walk every key the set wants us to accept. If we already accept it, refresh its
+	// metadata in place — both the expiry and the wire "key" identifier, clearing the identifier when
+	// the new payload carries none so a stale name never lingers in /status. If it's new, start
+	// accepting it and queue it as an addition.
+	for key, want := range desired {
 		if info, ok := accepted[key]; ok {
-			info.expiry = expiry
+			info.expiry = want.expiry
+			info.key = want.key
 		} else {
-			accepted[key] = &acceptedKeyInfo{expiry: expiry}
+			info := want
+			accepted[key] = &info
 			*additions = append(*additions, key)
 			loggers.Infof("%s %s is now accepted", kind, key.Masked())
 		}
@@ -258,22 +262,19 @@ func reconcileAcceptedKeys[K reconcilableKey](
 // reconcileAcceptedKeys. The anchor is always accepted and permanent, regardless of any expiry the
 // payload may carry for it. The caller must hold the write lock.
 func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now time.Time) {
-	desired := make(map[config.SDKKey]*time.Time, len(set.sdkKeys))
+	desired := make(map[config.SDKKey]acceptedKeyInfo, len(set.sdkKeys))
 	for key, info := range set.sdkKeys {
 		if info.expiry != nil && !now.Before(*info.expiry) {
 			continue // already expired; treat as absent
 		}
-		desired[key] = info.expiry
+		desired[key] = info
 	}
-	desired[anchor] = nil
+	// The anchor is always accepted and permanent regardless of any expiry the payload carries; keep
+	// its wire identifier from the set.
+	anchorInfo := set.sdkKeys[anchor]
+	anchorInfo.expiry = nil
+	desired[anchor] = anchorInfo
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
-	// Refresh the wire "key" identifier for every key now in the accepted set, including clearing it
-	// when the new payload carries none — otherwise a stale identifier would linger in /status.
-	for key, info := range set.sdkKeys {
-		if accepted, ok := r.acceptedSDKKeys[key]; ok {
-			accepted.key = info.key
-		}
-	}
 	r.anchorKey = anchor
 }
 
@@ -281,24 +282,20 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 // singular mobKey, used where one mobile key is required (e.g. event forwarding) — is always accepted
 // and permanent; an empty value means the set declared no mobile key. The caller must hold the lock.
 func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
-	desired := make(map[config.MobileKey]*time.Time, len(set.mobileKeys))
+	desired := make(map[config.MobileKey]acceptedKeyInfo, len(set.mobileKeys))
 	for key, info := range set.mobileKeys {
 		if info.expiry != nil && !now.Before(*info.expiry) {
 			continue // already expired; treat as absent
 		}
-		desired[key] = info.expiry
+		desired[key] = info
 	}
+	// The primary mobile key is always accepted and permanent; keep its wire identifier from the set.
 	if set.primaryMobileKey.Defined() {
-		desired[set.primaryMobileKey] = nil
+		primaryInfo := set.mobileKeys[set.primaryMobileKey]
+		primaryInfo.expiry = nil
+		desired[set.primaryMobileKey] = primaryInfo
 	}
 	reconcileAcceptedKeys(desired, r.acceptedMobileKeys, &r.additions, &r.expirations, r.loggers, "Mobile key")
-	// Refresh the wire "key" identifier for every key now in the accepted set, including clearing it
-	// when the new payload carries none — otherwise a stale identifier would linger in /status.
-	for key, info := range set.mobileKeys {
-		if accepted, ok := r.acceptedMobileKeys[key]; ok {
-			accepted.key = info.key
-		}
-	}
 	r.primaryMobileKey = set.primaryMobileKey
 }
 

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
 	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,7 +54,7 @@ func TestReconcileAnchorOnly(t *testing.T) {
 	anchor := config.SDKKey("anchor")
 	now := time.Now()
 
-	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor)), now)
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor})), now)
 	additions, expirations := r.StepTime(now)
 
 	assert.ElementsMatch(t, []SDKCredential{anchor}, additions)
@@ -70,7 +71,7 @@ func TestReconcileMultipleSDKKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor).WithSDKKey(other)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor}).WithSDKKey(SDKKeyParams{Value: other})), now)
 	additions, expirations := r.StepTime(now)
 
 	// Both server keys are accepted; only the anchor is primary.
@@ -89,7 +90,7 @@ func TestReconcileMultipleMobileKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor).WithPrimaryMobileKey(mob1).WithMobileKey(mob2)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor}).WithPrimaryMobileKey(MobileKeyParams{Value: mob1}).WithMobileKey(MobileKeyParams{Value: mob2})), now)
 	additions, _ := r.StepTime(now)
 
 	// Every mobile key is accepted; the designated one is the primary.
@@ -106,11 +107,11 @@ func TestReconcileRevokesOmittedKeys(t *testing.T) {
 	now := time.Now()
 
 	r.Reconcile(
-		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor).WithSDKKey(other).WithPrimaryMobileKey(mob)), now)
+		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor}).WithSDKKey(SDKKeyParams{Value: other}).WithPrimaryMobileKey(MobileKeyParams{Value: mob})), now)
 	r.StepTime(now)
 
 	// Reconciling to just the anchor revokes the omitted server and mobile keys.
-	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(anchor)), now)
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor})), now)
 	additions, expirations := r.StepTime(now)
 
 	assert.Empty(t, additions)
@@ -132,10 +133,10 @@ func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
 
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithAnchor(anchor).
-			WithExpiringSDKKey(expiringSDK, now.Add(time.Hour)).
-			WithPrimaryMobileKey(mob).
-			WithExpiringMobileKey(expiringMobile, now.Add(time.Hour))),
+			WithAnchor(SDKKeyParams{Value: anchor}).
+			WithSDKKey(SDKKeyParams{Value: expiringSDK, Expiry: util.PtrOrNil(now.Add(time.Hour))}).
+			WithPrimaryMobileKey(MobileKeyParams{Value: mob}).
+			WithMobileKey(MobileKeyParams{Value: expiringMobile, Expiry: util.PtrOrNil(now.Add(time.Hour))})),
 		now)
 	additions, expirations := r.StepTime(now)
 
@@ -158,9 +159,9 @@ func TestReconcilePrimaryMobileKeyIsAlwaysAccepted(t *testing.T) {
 	now := time.Unix(1000, 0)
 
 	set := mustBuild(t, NewAcceptedSetBuilder().
-		WithAnchor(anchor).
-		WithExpiringMobileKey(mob, now.Add(-time.Hour)). // already expired in the payload...
-		WithPrimaryMobileKey(mob))                       // ...but designated as the primary
+		WithAnchor(SDKKeyParams{Value: anchor}).
+		WithMobileKey(MobileKeyParams{Value: mob, Expiry: util.PtrOrNil(now.Add(-time.Hour))}). // already expired in the payload...
+		WithPrimaryMobileKey(MobileKeyParams{Value: mob}))                                      // ...but designated as the primary
 	r.Reconcile(set, now)
 	r.StepTime(now)
 
@@ -184,10 +185,10 @@ func TestReconcileExpiringKeysAreEvictedByStepTime(t *testing.T) {
 
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithAnchor(anchor).
-			WithExpiringSDKKey(expiringSDK, expiry).
-			WithPrimaryMobileKey(mob).
-			WithExpiringMobileKey(expiringMobile, expiry)),
+			WithAnchor(SDKKeyParams{Value: anchor}).
+			WithSDKKey(SDKKeyParams{Value: expiringSDK, Expiry: util.PtrOrNil(expiry)}).
+			WithPrimaryMobileKey(MobileKeyParams{Value: mob}).
+			WithMobileKey(MobileKeyParams{Value: expiringMobile, Expiry: util.PtrOrNil(expiry)})),
 		now)
 	additions, expirations := r.StepTime(now)
 	require.ElementsMatch(t, []SDKCredential{anchor, expiringSDK, mob, expiringMobile}, additions)
@@ -218,8 +219,8 @@ func TestReconcileAlreadyExpiredKeyIsIgnoredOnAdd(t *testing.T) {
 
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithAnchor(anchor).
-			WithExpiringSDKKey(staleKey, alreadyExpired)),
+			WithAnchor(SDKKeyParams{Value: anchor}).
+			WithSDKKey(SDKKeyParams{Value: staleKey, Expiry: util.PtrOrNil(alreadyExpired)})),
 		now)
 	additions, expirations := r.StepTime(now)
 
@@ -242,8 +243,8 @@ func TestReconcileDeExpiryRestoresKey(t *testing.T) {
 	// First reconcile: key is accepted with a future expiry.
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithAnchor(anchor).
-			WithExpiringSDKKey(key, expiry)),
+			WithAnchor(SDKKeyParams{Value: anchor}).
+			WithSDKKey(SDKKeyParams{Value: key, Expiry: util.PtrOrNil(expiry)})),
 		now)
 	r.StepTime(now)
 	require.ElementsMatch(t, []SDKCredential{key}, r.DeprecatedCredentials())
@@ -251,8 +252,8 @@ func TestReconcileDeExpiryRestoresKey(t *testing.T) {
 	// Second reconcile: same key, no expiry (de-expiry).
 	r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().
-			WithAnchor(anchor).
-			WithSDKKey(key)),
+			WithAnchor(SDKKeyParams{Value: anchor}).
+			WithSDKKey(SDKKeyParams{Value: key})),
 		now)
 	r.StepTime(now)
 

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -3,6 +3,7 @@ package envfactory
 import (
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 )
 
 // BuildAcceptedSet converts an EnvironmentParams into the AcceptedSet and anchor
@@ -27,19 +28,12 @@ import (
 // force a fresh put. This is the single home for the anchor invariant.
 func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.SDKKey, error) {
 	anchor := params.SDKKey
+	b := credential.NewAcceptedSetBuilder().WithEnvironmentID(params.EnvID)
 
-	// WithAnchor / WithPrimaryMobileKey each add the key and designate it (the anchor and the
-	// wire's mobKey, respectively). An undefined key makes the call a no-op, so an undefined anchor
-	// leaves the set with no designated anchor and Build returns a *MalformedCredentialSetError.
-	b := credential.NewAcceptedSetBuilder().
-		WithEnvironmentID(params.EnvID).
-		WithAnchor(anchor).
-		WithPrimaryMobileKey(params.MobileKey)
-
-	// Validate and add the remaining accepted keys. The builder de-duplicates by value, so the
-	// anchor and the primary mobile key — already added permanently above — are ignored when they
-	// reappear in their arrays. That also defends the anchor-never-expiring invariant: a payload
-	// that (wrongly) carries an expiry on the anchor's own entry cannot demote it.
+	// Add every accepted SDK key, designating the anchor as we encounter it. WithAnchor both adds and
+	// designates, and forces the anchor permanent — so a payload that (wrongly) carries an expiry on
+	// the anchor's own entry cannot demote it. An undefined anchor never matches a (defined) array
+	// value, so it is never designated and Build returns a *MalformedCredentialSetError.
 	//
 	// Entries with an empty value are structurally malformed: relay would silently accept them but
 	// they can never authenticate any SDK. Reject loudly rather than produce a credential-short env.
@@ -50,22 +44,22 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 		}
 		if k.Value == anchor {
 			anchorInArray = true
-		}
-		if k.Expiry.IsZero() {
-			b.WithSDKKey(k.Value)
+			b.WithAnchor(credential.SDKKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key)})
 		} else {
-			b.WithExpiringSDKKey(k.Value, k.Expiry)
+			b.WithSDKKey(credential.SDKKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key), Expiry: util.PtrOrNil(k.Expiry)})
 		}
 	}
 
 	// The anchor must be one of the accepted SDK keys: the backend lists it in sdkKeys[] (and ToParams
 	// synthesizes it into the array for old-format payloads). A defined anchor absent from the array is
-	// a structurally malformed payload — reject it per §9 rather than letting WithAnchor above
-	// silently synthesize it into the set.
+	// a structurally malformed payload — reject it.
 	if anchor.Defined() && !anchorInArray {
 		return credential.AcceptedSet{}, anchor, credential.NewAnchorNotInSetError()
 	}
 
+	// Add every accepted mobile key, designating the primary as we encounter it. Like the anchor,
+	// WithPrimaryMobileKey forces the primary permanent, so an expiry the payload may carry on the
+	// primary's own entry cannot demote it.
 	primaryMobileInArray := false
 	for _, k := range params.AcceptedMobileKeys {
 		if !k.Value.Defined() {
@@ -73,11 +67,9 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 		}
 		if k.Value == params.MobileKey {
 			primaryMobileInArray = true
-		}
-		if k.Expiry.IsZero() {
-			b.WithMobileKey(k.Value)
+			b.WithPrimaryMobileKey(credential.MobileKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key)})
 		} else {
-			b.WithExpiringMobileKey(k.Value, k.Expiry)
+			b.WithMobileKey(credential.MobileKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key), Expiry: util.PtrOrNil(k.Expiry)})
 		}
 	}
 

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,8 +57,8 @@ func TestBuildAcceptedSet_HappyPath(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithAnchor("sdk-anchor").
-		WithPrimaryMobileKey("mob-primary"))
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"})) // mobile has no identifier in makeParams fixture
 	assert.Equal(t, expected, set)
 }
 
@@ -80,17 +81,17 @@ func TestBuildAcceptedSet_MultipleKeys(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithAnchor("sdk-anchor").
-		WithSDKKey("sdk-service-a").
-		WithExpiringSDKKey("sdk-old", expiry1).
-		WithPrimaryMobileKey("mob-primary"))
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-service-a", Key: util.PtrOrNil("service-a")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-old", Key: util.PtrOrNil("old-key"), Expiry: util.PtrOrNil(expiry1)}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expected, set)
 }
 
-// TestBuildAcceptedSet_Rename verifies that a rename — same credential value, different key
-// identifier — is a no-op: the returned AcceptedSet is identical regardless of the identifier.
+// TestBuildAcceptedSet_Rename verifies that a rename — same credential value, different identifier
+// — updates only the identifier in the AcceptedSet, not the accepted credential itself. The sets
+// produced before and after a rename carry the same credentials but different identifier maps.
 func TestBuildAcceptedSet_Rename(t *testing.T) {
-	// Build AcceptedSet for the "before" and "after" of a rename.
 	paramsOldName := makeParams(
 		"sdk-anchor",
 		[]AcceptedSDKKey{{Key: "old-name", Value: "sdk-anchor"}},
@@ -107,7 +108,19 @@ func TestBuildAcceptedSet_Rename(t *testing.T) {
 
 	require.NoError(t, errOld)
 	require.NoError(t, errNew)
-	assert.Equal(t, setOld, setNew, "rename (same value, different key identifier) should produce the same AcceptedSet")
+	// The credential content is the same — only the identifier differs.
+	// When Reconcile applies the new set the display name is refreshed but no credential is added or removed.
+	assert.NotEqual(t, setOld, setNew, "rename changes the identifier map, so the AcceptedSets differ")
+	expectedOld := mustBuild(t, credential.NewAcceptedSetBuilder().
+		WithEnvironmentID("env-abc").
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("old-name")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
+	assert.Equal(t, expectedOld, setOld)
+	expectedNew := mustBuild(t, credential.NewAcceptedSetBuilder().
+		WithEnvironmentID("env-abc").
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("new-name")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
+	assert.Equal(t, expectedNew, setNew)
 }
 
 // TestBuildAcceptedSet_Deexpiry verifies that removing the expiry from an existing key (a
@@ -143,23 +156,19 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 	// The set built without expiry must include sdk-old as a permanent key.
 	expectedPermanent := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithAnchor("sdk-anchor").
-		WithSDKKey("sdk-old"). // permanent, no expiry
-		WithPrimaryMobileKey("mob-primary"))
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-old", Key: util.PtrOrNil("old-key")}). // permanent, no expiry
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expectedPermanent, setNoExpiry)
 
 	// Sanity: the expiring and non-expiring versions are different.
 	assert.NotEqual(t, setWithExpiry, setNoExpiry)
 }
 
-// TestBuildAcceptedSet_AnchorNotInArray verifies that an anchor absent from AcceptedSDKKeys is no
-// longer rejected here: WithAnchor adds and designates the anchor regardless, so the
-// resulting set contains both the anchor and the array entry. Structural validation of the wire
-// payload (anchor-absent-from-array) happens upstream when the payload is parsed into params.
 // TestBuildAcceptedSet_AnchorNotInArray verifies that a defined anchor absent from the sdkKeys[] array
-// yields a *credential.MalformedCredentialSetError per design §9: the payload is structurally
-// inconsistent (the designated primary is not in the authoritative array), so it must be rejected
-// rather than silently synthesized into the set.
+// yields a *credential.MalformedCredentialSetError: the payload is structurally inconsistent (the
+// designated anchor is not in the authoritative array), so it must be rejected rather than silently
+// synthesized into the set.
 func TestBuildAcceptedSet_AnchorNotInArray(t *testing.T) {
 	params := makeParams(
 		"sdk-anchor",
@@ -213,7 +222,7 @@ func TestBuildAcceptedSet_NoMobileKey(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithAnchor("sdk-anchor"))
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor"}))
 	assert.Equal(t, expected, set)
 }
 
@@ -273,10 +282,10 @@ func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
 
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithAnchor("sdk-new-anchor").
-		WithSDKKey("sdk-b").
-		WithSDKKey("sdk-c").
-		WithPrimaryMobileKey("mob-primary"))
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-new-anchor", Key: util.PtrOrNil("new-default")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-b", Key: util.PtrOrNil("service-b")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-c", Key: util.PtrOrNil("service-c")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expected, set)
 }
 
@@ -300,9 +309,9 @@ func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
 	// Anchor is permanent (WithAnchor), not expiring — identical to a payload with no anchor expiry.
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithAnchor("sdk-anchor").
-		WithSDKKey("sdk-service-a").
-		WithPrimaryMobileKey("mob-primary"))
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithSDKKey(credential.SDKKeyParams{Value: "sdk-service-a", Key: util.PtrOrNil("service-a")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expected, set)
 }
 
@@ -325,10 +334,9 @@ func TestBuildAcceptedSet_MultipleMobileKeys(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithAnchor("sdk-anchor").
-		WithMobileKey("mob-primary").
-		WithMobileKey("mob-secondary").
-		WithPrimaryMobileKey("mob-primary"))
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithMobileKey(credential.MobileKeyParams{Value: "mob-secondary", Key: util.PtrOrNil("mob-2")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary", Key: util.PtrOrNil("mob-1")}))
 	assert.Equal(t, expected, set)
 }
 
@@ -352,10 +360,9 @@ func TestBuildAcceptedSet_ExpiringMobileKey(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithAnchor("sdk-anchor").
-		WithMobileKey("mob-primary").
-		WithExpiringMobileKey("mob-old", expiry1).
-		WithPrimaryMobileKey("mob-primary"))
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithMobileKey(credential.MobileKeyParams{Value: "mob-old", Key: util.PtrOrNil("mob-old"), Expiry: util.PtrOrNil(expiry1)}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary", Key: util.PtrOrNil("mob-1")}))
 	assert.Equal(t, expected, set, "expiring mobile key must land as an expiring key in the set")
 }
 
@@ -382,7 +389,7 @@ func TestBuildAcceptedSet_TrustTheArray(t *testing.T) {
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
-		WithAnchor("sdk-anchor").
-		WithPrimaryMobileKey("mob-primary"))
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
 	assert.Equal(t, expected, set, "legacy sdkKey.expiring slot must not appear in AcceptedSet")
 }

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -203,7 +203,7 @@ func TestAddRemoveCredential(t *testing.T) {
 
 	// Reconcile to the full set: the SDK key (anchor) plus a mobile key and an environment ID.
 	env.ReconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(envConfig.SDKKey).WithPrimaryMobileKey(mobileKey).WithEnvironmentID(envID)))
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(credential.SDKKeyParams{Value: envConfig.SDKKey}).WithPrimaryMobileKey(credential.MobileKeyParams{Value: mobileKey}).WithEnvironmentID(envID)))
 
 	creds := env.GetCredentials()
 	assert.Len(t, creds, 3)
@@ -214,7 +214,7 @@ func TestAddRemoveCredential(t *testing.T) {
 	// Reconciling with a different mobile key evicts the previous one.
 	newMobileKey := config.MobileKey("evict-the-previous-key")
 	env.ReconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(envConfig.SDKKey).WithPrimaryMobileKey(newMobileKey).WithEnvironmentID(envID)))
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(credential.SDKKeyParams{Value: envConfig.SDKKey}).WithPrimaryMobileKey(credential.MobileKeyParams{Value: newMobileKey}).WithEnvironmentID(envID)))
 
 	creds = env.GetCredentials()
 	assert.Len(t, creds, 3)
@@ -236,7 +236,7 @@ func TestAddExistingCredentialDoesNothing(t *testing.T) {
 	assert.Equal(t, []credential.SDKCredential{envConfig.SDKKey}, env.GetCredentials())
 
 	mobileKey := st.EnvWithAllCredentials.Config.MobileKey
-	set := mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(envConfig.SDKKey).WithPrimaryMobileKey(mobileKey))
+	set := mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(credential.SDKKeyParams{Value: envConfig.SDKKey}).WithPrimaryMobileKey(credential.MobileKeyParams{Value: mobileKey}))
 
 	env.ReconcileCredentials(set)
 
@@ -286,8 +286,8 @@ func TestChangeSDKKey(t *testing.T) {
 
 	// Upon rotating to key2, the original key should still be valid for an hour.
 	rotationSet, err := credential.NewAcceptedSetBuilder().
-		WithAnchor(key2).
-		WithExpiringSDKKey(envConfig.SDKKey, start.Add(1*time.Hour)).
+		WithAnchor(credential.SDKKeyParams{Value: key2}).
+		WithSDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey, Expiry: util.PtrOrNil(start.Add(1 * time.Hour))}).
 		Build()
 	require.NoError(t, err)
 	envImpl.reconcileCredentials(rotationSet, start)
@@ -358,9 +358,9 @@ func TestMobileKeyReconcileExpiry(t *testing.T) {
 	// carries a per-key expiry.
 	envImpl.reconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithAnchor(envConfig.SDKKey).
-			WithPrimaryMobileKey(primaryMobile).
-			WithExpiringMobileKey(expiringMobile, expiry)),
+			WithAnchor(credential.SDKKeyParams{Value: envConfig.SDKKey}).
+			WithPrimaryMobileKey(credential.MobileKeyParams{Value: primaryMobile}).
+			WithMobileKey(credential.MobileKeyParams{Value: expiringMobile, Expiry: util.PtrOrNil(expiry)})),
 		start)
 
 	// Reconcile stores the expiry as data, so before it elapses the key is accepted (not deprecated).
@@ -403,9 +403,9 @@ func TestNonAnchorSDKKeysDoNotOpenUpstreamClient(t *testing.T) {
 	// open an upstream client.
 	env.ReconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithAnchor(envConfig.SDKKey).
-			WithSDKKey(nonAnchorKey1).
-			WithSDKKey(nonAnchorKey2)))
+			WithAnchor(credential.SDKKeyParams{Value: envConfig.SDKKey}).
+			WithSDKKey(credential.SDKKeyParams{Value: nonAnchorKey1}).
+			WithSDKKey(credential.SDKKeyParams{Value: nonAnchorKey2})))
 
 	// All three SDK keys are accepted...
 	creds := env.GetCredentials()
@@ -448,9 +448,9 @@ func TestGetClientReturnsAnchorInMultiKeyEnv(t *testing.T) {
 
 	env.ReconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithAnchor(envConfig.SDKKey).
-			WithSDKKey(nonAnchorKey1).
-			WithSDKKey(nonAnchorKey2)))
+			WithAnchor(credential.SDKKeyParams{Value: envConfig.SDKKey}).
+			WithSDKKey(credential.SDKKeyParams{Value: nonAnchorKey1}).
+			WithSDKKey(credential.SDKKeyParams{Value: nonAnchorKey2})))
 
 	// No new upstream client was created for the non-anchor keys.
 	if !helpers.AssertNoMoreValues(t, clientCh, 200*time.Millisecond) {
@@ -491,9 +491,9 @@ func TestNonPrimaryMobileKeyDoesNotStealEventForwarding(t *testing.T) {
 		// non-primary mobile key. Accepting the non-primary key must NOT repoint event forwarding —
 		// events collapse to the primary mobile key, mirroring the SDK anchor.
 		env.ReconcileCredentials(mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithAnchor(envConfig.SDKKey).
-			WithPrimaryMobileKey(primaryMobile).
-			WithMobileKey(nonPrimaryMobile).
+			WithAnchor(credential.SDKKeyParams{Value: envConfig.SDKKey}).
+			WithPrimaryMobileKey(credential.MobileKeyParams{Value: primaryMobile}).
+			WithMobileKey(credential.MobileKeyParams{Value: nonPrimaryMobile}).
 			WithEnvironmentID(envConfig.EnvID)))
 
 		ed := envImpl.GetEventDispatcher()
@@ -551,8 +551,8 @@ func TestReAnchoringToKeyStillInGraceReusesItsClient(t *testing.T) {
 	// alive because keyA is still accepted during the grace window.
 	env.(*envContextImpl).reconcileCredentials(
 		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().
-			WithAnchor(keyB).
-			WithExpiringSDKKey(keyA, start.Add(1*time.Hour))),
+			WithAnchor(credential.SDKKeyParams{Value: keyB}).
+			WithSDKKey(credential.SDKKeyParams{Value: keyA, Expiry: util.PtrOrNil(start.Add(1 * time.Hour))})),
 		start)
 
 	clientB := requireClientReady(t, clientCh)
@@ -566,7 +566,7 @@ func TestReAnchoringToKeyStillInGraceReusesItsClient(t *testing.T) {
 	// being started -- so there is no stale client to orphan. keyB is omitted from the set (no expiry),
 	// so it is revoked immediately and its client is closed.
 	env.(*envContextImpl).reconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(keyA)),
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(credential.SDKKeyParams{Value: keyA})),
 		start.Add(10*time.Minute))
 
 	// keyB was revoked by the re-anchor, so its client is closed.
@@ -641,7 +641,7 @@ func TestRevokingSDKKeyWhileClientIsStartingDoesNotLeakTheClient(t *testing.T) {
 	// runs now -- but c.clients[keyA] is still nil because the initial goroutine is blocked in the factory,
 	// so nothing is closed and the mapping is simply removed.
 	env.(*envContextImpl).reconcileCredentials(
-		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(keyB)),
+		mustBuildAcceptedSet(t, credential.NewAcceptedSetBuilder().WithAnchor(credential.SDKKeyParams{Value: keyB})),
 		time.Unix(1000, 0))
 
 	creds := env.GetCredentials()

--- a/internal/relayenv/env_context_reanchor_test.go
+++ b/internal/relayenv/env_context_reanchor_test.go
@@ -24,14 +24,15 @@ import (
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/basictypes"
-	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/bigsegments"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/httpconfig"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
 	"github.com/launchdarkly/ld-relay/v8/internal/store"
 	"github.com/launchdarkly/ld-relay/v8/internal/streams"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 
 	"github.com/launchdarkly/eventsource"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
@@ -103,8 +104,8 @@ func (f *sharedStoreFactory) Build(_ subsystems.ClientContext) (subsystems.DataS
 func reanchor(t *testing.T, env EnvContext, newKey, oldKey config.SDKKey, now time.Time) {
 	t.Helper()
 	set, err := credential.NewAcceptedSetBuilder().
-		WithAnchor(newKey).
-		WithExpiringSDKKey(oldKey, now.Add(time.Hour)).
+		WithAnchor(credential.SDKKeyParams{Value: newKey}).
+		WithSDKKey(credential.SDKKeyParams{Value: oldKey, Expiry: util.PtrOrNil(now.Add(time.Hour))}).
 		Build()
 	require.NoError(t, err)
 	env.(*envContextImpl).reconcileCredentials(set, now)

--- a/internal/util/pointer.go
+++ b/internal/util/pointer.go
@@ -1,0 +1,11 @@
+package util
+
+// PtrOrNil returns a pointer to v, or nil when v is the zero value for its type. It is used to model
+// optional fields where the zero value (e.g. an empty string or the zero time.Time) means "absent".
+func PtrOrNil[T comparable](v T) *T {
+	var zero T
+	if v == zero {
+		return nil
+	}
+	return &v
+}

--- a/internal/util/pointer_test.go
+++ b/internal/util/pointer_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPtrOrNil(t *testing.T) {
+	t.Run("empty string yields nil", func(t *testing.T) {
+		assert.Nil(t, PtrOrNil(""))
+	})
+
+	t.Run("non-empty string yields pointer to value", func(t *testing.T) {
+		p := PtrOrNil("default")
+		require.NotNil(t, p)
+		assert.Equal(t, "default", *p)
+	})
+
+	t.Run("zero time yields nil", func(t *testing.T) {
+		assert.Nil(t, PtrOrNil(time.Time{}))
+	})
+
+	t.Run("non-zero time yields pointer to value", func(t *testing.T) {
+		now := time.Unix(1000, 0)
+		p := PtrOrNil(now)
+		require.NotNil(t, p)
+		assert.Equal(t, now, *p)
+	})
+}


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR — splitting #724 (review/merge bottom-up):**
> 1. #728 — reject primary mobile key absent from `mobileKeys[]`
> 2. **➡ #729 (this PR)** — carry wire key identifiers through the accepted set
> 3. #730 — expose the full accepted key set via `AcceptedKeys`
> 4. #731 — surface `sdkKeys[]` / `mobileKeys[]` on `/status`
>
> Base: #728.

## Summary

Carry the wire `key` identifier through the credential accepted-set model so it can later be surfaced on the `/status` endpoint. This is the storage/model layer only — no externally visible behaviour changes yet.

Jira: [SDK-2534](https://launchdarkly.atlassian.net/browse/SDK-2534)

## Background

Second in the stack splitting #724, based on #728. Each accepted key needs to carry its optional non-secret identifier alongside its value and expiry.

Because this PR sits on #728, the per-entry primary-mobile designation introduced here is paired with #728's `mobKey`-not-in-`mobileKeys[]` rejection: a defined primary that is absent from the array is rejected outright rather than silently left undesignated.

## Changes

- Replace the builder's `WithExpiring{SDK,Mobile}Key` with a param-struct API (`SDKKeyParams` / `MobileKeyParams`).
- `AcceptedSet` map values become `acceptedKeyInfo` (value, expiry, optional `key`).
- Rotator reconcile loops thread the identifier through, refreshing it each reconcile and clearing it when a later payload carries none.
- Add `util.PtrOrNil` for optional-field modelling.


[SDK-2534]: https://launchdarkly.atlassian.net/browse/SDK-2534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the credential reconcile/build path that gates which keys are accepted, but authentication semantics are unchanged; the main new behavior is metadata refresh on reconcile (identifiers can clear or update).
> 
> **Overview**
> Extends the credential **accepted-set** model so each SDK/mobile key stores optional wire **`key`** identifiers (plus expiry) alongside the secret value, preparing later **`/status`** exposure without changing auth behavior in this PR.
> 
> The **`AcceptedSetBuilder`** API is consolidated: separate expiring-key helpers are replaced by **`SDKKeyParams`** / **`MobileKeyParams`** (value, optional identifier, optional expiry). **`WithAnchor`** / **`WithPrimaryMobileKey`** still force permanent keys and can overwrite earlier entries for the same value.
> 
> **`BuildAcceptedSet`** now designates anchor and primary mobile keys while walking the wire arrays and passes identifiers through **`util.PtrOrNil`**. Rename tests expect **`AcceptedSet`** equality to differ when only the display identifier changes.
> 
> The **rotator** stores **`acceptedKeyInfo`** by value and, on reconcile, **replaces** full per-key metadata so identifiers refresh and absent wire **`key`** fields clear stale names. Reconcile no longer re-injects anchor/primary into the desired map separately; it trusts the built set from the builder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eceeb4a8b16c2fa2f682d2c20e9d24f2481d6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->