### PR TITLE
feat(credential): expose the full accepted key set via AcceptedKeys

### DIFF
--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -28,10 +28,10 @@ import (
 type AcceptedSet struct {
 	// sdkKeys and mobileKeys store each accepted key once, keyed by value (the secret), so duplicates
 	// collapse without a containment scan. The map value carries the key's metadata (see
-	// acceptedKeyInfo). A nil map is a valid empty set (reads return absent; only the builder writes).
-	sdkKeys          map[config.SDKKey]acceptedKeyInfo
+	// AcceptedKey). A nil map is a valid empty set (reads return absent; only the builder writes).
+	sdkKeys          map[config.SDKKey]AcceptedKey
 	anchor           config.SDKKey
-	mobileKeys       map[config.MobileKey]acceptedKeyInfo
+	mobileKeys       map[config.MobileKey]AcceptedKey
 	primaryMobileKey config.MobileKey
 	envID            config.EnvironmentID
 }

--- a/internal/credential/accepted_set_builder.go
+++ b/internal/credential/accepted_set_builder.go
@@ -16,8 +16,8 @@ type AcceptedSetBuilder struct {
 func NewAcceptedSetBuilder() *AcceptedSetBuilder {
 	return &AcceptedSetBuilder{
 		set: AcceptedSet{
-			sdkKeys:    make(map[config.SDKKey]acceptedKeyInfo),
-			mobileKeys: make(map[config.MobileKey]acceptedKeyInfo),
+			sdkKeys:    make(map[config.SDKKey]AcceptedKey),
+			mobileKeys: make(map[config.MobileKey]AcceptedKey),
 		},
 	}
 }
@@ -43,7 +43,7 @@ func (b *AcceptedSetBuilder) WithSDKKey(p SDKKeyParams) *AcceptedSetBuilder {
 	if !p.Value.Defined() || b.set.hasSDKKey(p.Value) {
 		return b
 	}
-	b.set.sdkKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: p.Expiry}
+	b.set.sdkKeys[p.Value] = AcceptedKey{Key: p.Key, Expiry: p.Expiry}
 	return b
 }
 
@@ -55,7 +55,7 @@ func (b *AcceptedSetBuilder) WithAnchor(p SDKKeyParams) *AcceptedSetBuilder {
 	if !p.Value.Defined() {
 		return b
 	}
-	b.set.sdkKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: nil}
+	b.set.sdkKeys[p.Value] = AcceptedKey{Key: p.Key, Expiry: nil}
 	b.set.anchor = p.Value
 	return b
 }
@@ -65,7 +65,7 @@ func (b *AcceptedSetBuilder) WithMobileKey(p MobileKeyParams) *AcceptedSetBuilde
 	if !p.Value.Defined() || b.set.hasMobileKey(p.Value) {
 		return b
 	}
-	b.set.mobileKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: p.Expiry}
+	b.set.mobileKeys[p.Value] = AcceptedKey{Key: p.Key, Expiry: p.Expiry}
 	return b
 }
 
@@ -76,7 +76,7 @@ func (b *AcceptedSetBuilder) WithPrimaryMobileKey(p MobileKeyParams) *AcceptedSe
 	if !p.Value.Defined() {
 		return b
 	}
-	b.set.mobileKeys[p.Value] = acceptedKeyInfo{key: p.Key, expiry: nil}
+	b.set.mobileKeys[p.Value] = AcceptedKey{Key: p.Key, Expiry: nil}
 	b.set.primaryMobileKey = p.Value
 	return b
 }

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -1,6 +1,7 @@
 package credential
 
 import (
+	"maps"
 	"sync"
 	"time"
 
@@ -8,10 +9,29 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/config"
 )
 
-// acceptedKeyInfo holds per-key metadata for the accepted-set maps.
-type acceptedKeyInfo struct {
-	expiry *time.Time // nil = permanent
-	key    *string    // wire "key" identifier — non-secret human-readable name; nil when absent
+// AcceptedKey is the metadata for one accepted credential: its optional expiry and optional wire
+// "key" identifier. The credential value itself is the map key wherever AcceptedKey is stored — the
+// rotator's accepted-key maps, the builder's AcceptedSet, and the AcceptedKeySet returned by
+// AcceptedKeys.
+type AcceptedKey struct {
+	// Expiry is the key's expiry. A nil expiry means the key is permanent.
+	Expiry *time.Time
+	// Key is the non-secret wire "key" identifier — a human-readable name. Nil when the source carried
+	// none (manual configuration, or an old-format payload predating concurrent keys).
+	Key *string
+}
+
+// AcceptedKeySet is a point-in-time snapshot of an environment's full accepted credential set,
+// returned by Rotator.AcceptedKeys. Server and Mobile are keyed by credential value (the secret);
+// the value AcceptedKey carries that key's metadata. Anchor and PrimaryMobile name the designated
+// keys within Server and Mobile. The status endpoint maps Server/Mobile to the sdkKeys[]/mobileKeys[]
+// arrays and uses Anchor to mark the anchor entry. Reads of the maps and the designations are taken
+// under a single lock, so they are mutually consistent.
+type AcceptedKeySet struct {
+	Server        map[config.SDKKey]AcceptedKey
+	Mobile        map[config.MobileKey]AcceptedKey
+	Anchor        config.SDKKey
+	PrimaryMobile config.MobileKey
 }
 
 type Rotator struct {
@@ -29,11 +49,11 @@ type Rotator struct {
 
 	// acceptedSDKKeys is the full set of accepted SDK keys with optional per-key expiry.
 	// A nil expiry means the key is permanent. The anchor is always present with a nil expiry.
-	acceptedSDKKeys map[config.SDKKey]acceptedKeyInfo
+	acceptedSDKKeys map[config.SDKKey]AcceptedKey
 
 	// acceptedMobileKeys is the full set of accepted mobile keys with optional per-key expiry.
 	// A nil expiry means the key is permanent.
-	acceptedMobileKeys map[config.MobileKey]acceptedKeyInfo
+	acceptedMobileKeys map[config.MobileKey]AcceptedKey
 
 	expirations []SDKCredential
 	additions   []SDKCredential
@@ -52,8 +72,8 @@ type InitialCredentials struct {
 func NewRotator(loggers ldlog.Loggers) *Rotator {
 	r := &Rotator{
 		loggers:            loggers,
-		acceptedSDKKeys:    make(map[config.SDKKey]acceptedKeyInfo),
-		acceptedMobileKeys: make(map[config.MobileKey]acceptedKeyInfo),
+		acceptedSDKKeys:    make(map[config.SDKKey]AcceptedKey),
+		acceptedMobileKeys: make(map[config.MobileKey]AcceptedKey),
 	}
 	return r
 }
@@ -71,10 +91,10 @@ func (r *Rotator) Initialize(credentials []SDKCredential) {
 		switch cred := cred.(type) {
 		case config.SDKKey:
 			r.anchorKey = cred
-			r.acceptedSDKKeys[cred] = acceptedKeyInfo{}
+			r.acceptedSDKKeys[cred] = AcceptedKey{}
 		case config.MobileKey:
 			r.primaryMobileKey = cred
-			r.acceptedMobileKeys[cred] = acceptedKeyInfo{}
+			r.acceptedMobileKeys[cred] = AcceptedKey{}
 		case config.EnvironmentID:
 			r.primaryEnvironmentID = cred
 		}
@@ -120,19 +140,17 @@ func (r *Rotator) allCredentials() []SDKCredential {
 
 // DeprecatedCredentials returns the SDK keys being phased out — every accepted SDK key, other than the
 // anchor, that carries a future expiry. (Per-key expiry is stored as data on the accepted entry; the
-// cleanup ticker drops the key once it elapses.) EnvContext.GetDeprecatedCredentials delegates here to
-// populate the status endpoint's expiringSdkKey field.
+// cleanup ticker drops the key once it elapses.)
 //
 // Mobile keys are deliberately not returned even though they expire the same way SDK keys do — carried
-// as per-key expiry and dropped by the same cleanup ticker. They are omitted only because the status
-// endpoint has no expiringMobileKey field to populate, not because mobile-key expiry is unimplemented.
+// as per-key expiry and dropped by the same cleanup ticker.
 func (r *Rotator) DeprecatedCredentials() []SDKCredential {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	var out []SDKCredential
 	for key, info := range r.acceptedSDKKeys {
-		if info.expiry != nil && key != r.anchorKey {
+		if info.Expiry != nil && key != r.anchorKey {
 			out = append(out, key)
 		}
 	}
@@ -167,7 +185,7 @@ func (r *Rotator) expireMobileKey(mobileKey config.MobileKey) {
 // expirations for the tracked credentials since the last time this method was called.
 //
 // It enforces per-key expiry for both SDK and mobile keys: expiry is stored as data on the accepted
-// entry (acceptedKeyInfo.expiry); a nil expiry means the key is permanent and is never expired here.
+// entry (AcceptedKey.Expiry); a nil expiry means the key is permanent and is never expired here.
 //
 // Expiry happens strictly after a key's expiry timestamp.
 func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expirations []SDKCredential) {
@@ -175,12 +193,12 @@ func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expiration
 	defer r.mu.Unlock()
 
 	for key, info := range r.acceptedSDKKeys {
-		if info.expiry != nil && now.After(*info.expiry) {
+		if info.Expiry != nil && now.After(*info.Expiry) {
 			r.expireSDKKey(key)
 		}
 	}
 	for key, info := range r.acceptedMobileKeys {
-		if info.expiry != nil && now.After(*info.expiry) {
+		if info.Expiry != nil && now.After(*info.Expiry) {
 			r.expireMobileKey(key)
 		}
 	}
@@ -223,8 +241,8 @@ type reconcilableKey interface {
 // key no longer desired is dropped and queued as an expiration. Per-key expiry is stored as data on
 // the accepted entry; the cleanup ticker is what later acts on it. The caller must hold the write lock.
 func reconcileAcceptedKeys[K reconcilableKey](
-	desired map[K]acceptedKeyInfo,
-	accepted map[K]acceptedKeyInfo,
+	desired map[K]AcceptedKey,
+	accepted map[K]AcceptedKey,
 	additions *[]SDKCredential,
 	expirations *[]SDKCredential,
 	loggers ldlog.Loggers,
@@ -259,9 +277,9 @@ func reconcileAcceptedKeys[K reconcilableKey](
 // the anchor is present and permanent (WithAnchor forces a nil expiry), so no special handling is
 // needed here. The caller must hold the write lock.
 func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now time.Time) {
-	desired := make(map[config.SDKKey]acceptedKeyInfo, len(set.sdkKeys))
+	desired := make(map[config.SDKKey]AcceptedKey, len(set.sdkKeys))
 	for key, info := range set.sdkKeys {
-		if info.expiry != nil && !now.Before(*info.expiry) {
+		if info.Expiry != nil && !now.Before(*info.Expiry) {
 			continue // already expired; treat as absent
 		}
 		desired[key] = info
@@ -275,9 +293,9 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 // (WithPrimaryMobileKey forces a nil expiry). An empty primary means the set declared no mobile key.
 // The caller must hold the lock.
 func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
-	desired := make(map[config.MobileKey]acceptedKeyInfo, len(set.mobileKeys))
+	desired := make(map[config.MobileKey]AcceptedKey, len(set.mobileKeys))
 	for key, info := range set.mobileKeys {
-		if info.expiry != nil && !now.Before(*info.expiry) {
+		if info.Expiry != nil && !now.Before(*info.Expiry) {
 			continue // already expired; treat as absent
 		}
 		desired[key] = info
@@ -297,4 +315,25 @@ func (r *Rotator) reconcileEnvironmentID(set AcceptedSet) {
 	}
 	r.primaryEnvironmentID = set.envID
 	r.additions = append(r.additions, set.envID)
+}
+
+// AcceptedKeys returns a snapshot of the full accepted credential set — all server-side SDK keys and
+// all mobile keys (anchor and primary mobile key included) — grouped by kind, along with which keys
+// are the designated anchor and primary mobile. The maps and the designations are read under a single
+// lock so they are mutually consistent. The status endpoint maps each group to the sdkKeys[] /
+// mobileKeys[] arrays.
+func (r *Rotator) AcceptedKeys() AcceptedKeySet {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	server := make(map[config.SDKKey]AcceptedKey, len(r.acceptedSDKKeys))
+	maps.Copy(server, r.acceptedSDKKeys)
+	mobile := make(map[config.MobileKey]AcceptedKey, len(r.acceptedMobileKeys))
+	maps.Copy(mobile, r.acceptedMobileKeys)
+	return AcceptedKeySet{
+		Server:        server,
+		Mobile:        mobile,
+		Anchor:        r.anchorKey,
+		PrimaryMobile: r.primaryMobileKey,
+	}
 }

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -34,13 +34,13 @@ func TestInitializePopulatesAcceptedSets(t *testing.T) {
 	// Verify accepted SDK key set: one entry, no expiry.
 	assert.Len(t, rotator.acceptedSDKKeys, 1)
 	if info, ok := rotator.acceptedSDKKeys[sdkKey]; assert.True(t, ok, "acceptedSDKKeys should contain the initialized SDK key") {
-		assert.Nil(t, info.expiry, "a key initialized without expiry should have nil expiry in acceptedKeyInfo")
+		assert.Nil(t, info.Expiry, "a key initialized without expiry should have nil expiry in AcceptedKey")
 	}
 
 	// Verify accepted mobile key set: one entry, no expiry.
 	assert.Len(t, rotator.acceptedMobileKeys, 1)
 	if info, ok := rotator.acceptedMobileKeys[mobileKey]; assert.True(t, ok, "acceptedMobileKeys should contain the initialized mobile key") {
-		assert.Nil(t, info.expiry, "a key initialized without expiry should have nil expiry in acceptedKeyInfo")
+		assert.Nil(t, info.Expiry, "a key initialized without expiry should have nil expiry in AcceptedKey")
 	}
 
 	// Existing public API is unchanged.
@@ -265,4 +265,87 @@ func TestReconcileDeExpiryRestoresKey(t *testing.T) {
 	assert.Empty(t, additions)
 	assert.Empty(t, expirations)
 	assert.Contains(t, r.AllCredentials(), SDKCredential(key))
+}
+
+// TestAcceptedKeys verifies that AcceptedKeys returns the full accepted set — every server and mobile
+// key, including the anchor and primary mobile key — grouped by kind with identifier and expiry
+// populated, plus the anchor and primary-mobile designations.
+func TestAcceptedKeys(t *testing.T) {
+	t.Run("single anchor plus primary mobile", func(t *testing.T) {
+		r := newTestRotator()
+		r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+			WithAnchor(SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+			WithPrimaryMobileKey(MobileKeyParams{Value: "mob-primary", Key: util.PtrOrNil("mob-1")})), time.Unix(0, 0))
+
+		set := r.AcceptedKeys()
+		require.Len(t, set.Server, 1)
+		require.Len(t, set.Mobile, 1)
+		assert.Equal(t, config.SDKKey("sdk-anchor"), set.Anchor)
+		assert.Equal(t, config.MobileKey("mob-primary"), set.PrimaryMobile)
+
+		anchor, ok := set.Server["sdk-anchor"]
+		require.True(t, ok)
+		require.NotNil(t, anchor.Key)
+		assert.Equal(t, "default", *anchor.Key)
+		assert.Nil(t, anchor.Expiry)
+
+		mob, ok := set.Mobile["mob-primary"]
+		require.True(t, ok)
+		require.NotNil(t, mob.Key)
+		assert.Equal(t, "mob-1", *mob.Key)
+	})
+
+	t.Run("multiple keys include the anchor; expiry populated", func(t *testing.T) {
+		r := newTestRotator()
+		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
+		r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+			WithAnchor(SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
+			WithSDKKey(SDKKeyParams{Value: "sdk-b", Key: util.PtrOrNil("b-service")}).
+			WithSDKKey(SDKKeyParams{Value: "sdk-old", Key: util.PtrOrNil("old-key"), Expiry: util.PtrOrNil(expiry)}).
+			WithPrimaryMobileKey(MobileKeyParams{Value: "mob-primary"})), time.Unix(0, 0))
+
+		set := r.AcceptedKeys()
+		require.Len(t, set.Server, 3) // anchor + sdk-b + sdk-old
+		require.Len(t, set.Mobile, 1)
+		_, ok := set.Server["sdk-anchor"]
+		assert.True(t, ok, "anchor must be present in the full set")
+
+		old, ok := set.Server["sdk-old"]
+		require.True(t, ok)
+		require.NotNil(t, old.Expiry)
+		assert.Equal(t, expiry, *old.Expiry)
+
+		// A key with no identifier (the primary mobile here) carries a nil Key.
+		mob, ok := set.Mobile["mob-primary"]
+		require.True(t, ok)
+		assert.Nil(t, mob.Key)
+	})
+}
+
+// TestReconcileClearsStaleKeyIdentifier verifies that when a later reconcile carries no identifier for
+// a key that previously had one (e.g. an old-format payload after a new-format one), the rotator
+// clears the stale identifier rather than retaining it — so /status never shows an identifier the
+// current credential set no longer carries.
+func TestReconcileClearsStaleKeyIdentifier(t *testing.T) {
+	r := newTestRotator()
+	now := time.Unix(0, 0)
+
+	// First reconcile: sdk-b carries the identifier "b-service".
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		WithAnchor(SDKKeyParams{Value: "sdk-anchor"}).
+		WithSDKKey(SDKKeyParams{Value: "sdk-b", Key: util.PtrOrNil("b-service")})), now)
+
+	b, ok := r.AcceptedKeys().Server["sdk-b"]
+	require.True(t, ok)
+	require.NotNil(t, b.Key)
+	assert.Equal(t, "b-service", *b.Key)
+
+	// Second reconcile: same credential value, but no identifier this time.
+	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		WithAnchor(SDKKeyParams{Value: "sdk-anchor"}).
+		WithSDKKey(SDKKeyParams{Value: "sdk-b"})), now)
+
+	b, ok = r.AcceptedKeys().Server["sdk-b"]
+	require.True(t, ok)
+	assert.Nil(t, b.Key, "identifier must be cleared when the new payload carries none")
 }

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -50,6 +50,12 @@ type EnvContext interface {
 	// several accepted mobile keys (primary + expiring) in nondeterministic order.
 	GetMobileKey() config.MobileKey
 
+	// GetAcceptedKeys returns a consistent snapshot of the full accepted credential set — all
+	// server-side SDK keys and all mobile keys (anchor and primary mobile key included), grouped by
+	// kind, plus which keys are the designated anchor and primary. The status endpoint maps each group
+	// to the full sdkKeys[] / mobileKeys[] arrays.
+	GetAcceptedKeys() credential.AcceptedKeySet
+
 	// ReconcileCredentials atomically reconciles the environment's accepted credentials to match
 	// newSet. The set names its own anchor (the SDK key that owns the upstream connection) and
 	// primary mobile key. The method owns the order of operations internally (add → re-anchor →

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -640,6 +640,10 @@ func (c *envContextImpl) GetDeprecatedCredentials() []credential.SDKCredential {
 	return c.keyRotator.DeprecatedCredentials()
 }
 
+func (c *envContextImpl) GetAcceptedKeys() credential.AcceptedKeySet {
+	return c.keyRotator.AcceptedKeys()
+}
+
 func (c *envContextImpl) GetClient() sdks.LDClientContext {
 	c.mu.RLock()
 	defer c.mu.RUnlock()


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR — splitting #724:**
> 1. ~~#728 — reject primary mobile key absent from `mobileKeys[]`~~ ✅ merged
> 2. ~~#729 — carry wire key identifiers through the accepted set~~ ✅ merged
> 3. **➡ #730 (this PR)** — expose the full accepted key set via `AcceptedKeys`
> 4. #731 — surface `sdkKeys[]` / `mobileKeys[]` on `/status`
>
> Base: `feat/concurrent-keys`. #731 stacks on this.

## Summary

Expose the full accepted credential set via `Rotator.AcceptedKeys()` and `EnvContext.GetAcceptedKeys()` — every server-side SDK key and mobile key, including the anchor and primary mobile key — so the status endpoint can surface it.

Jira: [SDK-2534](https://launchdarkly.atlassian.net/browse/SDK-2534)

## Background

Second-from-last PR of the stack splitting #724; consumed by #731, which maps the result onto the `sdkKeys[]` / `mobileKeys[]` response arrays.

## Changes

- Promote the per-key metadata struct to an exported **`AcceptedKey{Key, Expiry}`** — a single type used for both the rotator's internal storage and the public snapshot (the credential value is the map key wherever it's stored, so the struct carries no value field).
- Add **`AcceptedKeySet`**: the `Server` / `Mobile` maps keyed by credential value, plus the designated `Anchor` and `PrimaryMobile`. `Rotator.AcceptedKeys()` snapshots both maps and the designations under a single read lock, so callers get a mutually consistent view. `EnvContext.GetAcceptedKeys()` delegates to it.
- Drop the stale `DeprecatedCredentials` doc reference to populating `expiringSdkKey` (that moves to the accepted-set path in #731).


[SDK-2534]: https://launchdarkly.atlassian.net/browse/SDK-2534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ