### PR TITLE
test: use a valid context instead of legacy user format in relay tests

### DIFF
--- a/internal/sharedtest/endpoints.go
+++ b/internal/sharedtest/endpoints.go
@@ -13,8 +13,8 @@ import (
 // that configures Relay's endpoint routing, so that if we accidentally change the routing, the tests
 // will fail, rather than succeed based on incorrect paths.
 
-// SimpleUserJSON is a basic user.
-const SimpleUserJSON = `{"key":"userkey"}`
+// SimpleUserJSON is a basic single-kind context.
+const SimpleUserJSON = `{"key":"userkey","kind":"user"}`
 
 // ToBase64 is a shortcut for base64 encoding.
 func ToBase64(s string) string {

--- a/relay/testutils_test.go
+++ b/relay/testutils_test.go
@@ -81,8 +81,8 @@ func (h relayTestHelper) assertSDKEndpointsAvailability(
 	// appropriate HTTP status. These are tested more thoroughly in test suites like DoStreamEndpointsTests,
 	// but we use this simpler test when we're dynamically changing what the credentials are.
 
-	simpleUserJSON := []byte(`{"key":"userkey"}`)
-	simpleUserBase64 := "eyJrZXkiOiJ1c2Vya2V5In0="
+	simpleUserJSON := []byte(`{"key":"userkey","kind":"user"}`)
+	simpleUserBase64 := "eyJrZXkiOiJ1c2Vya2V5Iiwia2luZCI6InVzZXIifQ=="
 	status200Or401, status200Or404 := 200, 200
 	if !shouldBeAvailable {
 		status200Or401 = 401


### PR DESCRIPTION
## Summary

Cherry-picks [#727](https://github.com/launchdarkly/ld-relay/pull/727) (merged to `v8` as `8869b88`) onto `feat/concurrent-keys`, so the feature branch carries the same test-fixture cleanup: the legacy `LDUser` shape (`{"key":"userkey"}`, no `kind`) is replaced with a valid single-kind evaluation context (`{"key":"userkey","kind":"user"}`) in:

- `relay/testutils_test.go` — `simpleUserJSON` / `simpleUserBase64` in `assertSDKEndpointsAvailability`
- `internal/sharedtest/endpoints.go` — the shared `SimpleUserJSON` constant

## Background

#727 landed on `v8`; this applies the identical change to the feature branch directly (rather than waiting for a v8 catch-up merge) so the branch's tests model the canonical context format. The touched lines are identical to v8's, so the cherry-pick applied without conflict, and because the change is textually identical the eventual reconverge with v8 auto-resolves.

Not included here: the separate one-line `relay/concurrent_keys_auth_test.go` inline-base64 cleanup, which is feature-branch-only and tracked separately.

`go test ./relay/... ./internal/sharedtest/...` and `make lint` pass.
