### PR TITLE
fix(autoconfig): prevent StreamManager.Close hang on shutdown race

### DIFF
--- a/internal/autoconfig/stream_manager.go
+++ b/internal/autoconfig/stream_manager.go
@@ -311,14 +311,25 @@ func (s *StreamManager) subscribe(readyCh chan<- error) {
 }
 
 func (s *StreamManager) consumeStream(stream *es.Stream) {
-	// Consume remaining Events and Errors so we can garbage collect
+	// Drain any remaining Events and Errors so the eventsource Stream's goroutines can be garbage
+	// collected. This MUST run in a separate goroutine and must not block consumeStream from
+	// returning: the eventsource library (v1.11.0) can deadlock internally when Close races with an
+	// in-flight event. Its Stream.stream loop, on close, drains its internal errs channel before its
+	// events channel (eventsource stream.go discardCurrentStream), but the decoder goroutine may be
+	// blocked sending on events, so neither side progresses and stream.Events is never closed. If we
+	// drained inline, "for range stream.Events" would block forever, so subscribe would never return,
+	// s.done would never close, and StreamManager.Close (hence Relay.Close) would hang until the test
+	// or process timed out. Backgrounding the drain leaks those wedged goroutines in that rare race,
+	// but only at shutdown, and keeps Close bounded.
 	defer func() {
-		for range stream.Events {
-		} // COVERAGE: no way to cause this condition in unit tests
-		if stream.Errors != nil {
-			for range stream.Errors { // COVERAGE: no way to cause this condition in unit tests
+		go func() {
+			for range stream.Events {
 			}
-		}
+			if stream.Errors != nil {
+				for range stream.Errors {
+				}
+			}
+		}()
 	}()
 
 	for {

--- a/internal/autoconfig/stream_manager_close_test.go
+++ b/internal/autoconfig/stream_manager_close_test.go
@@ -1,0 +1,54 @@
+package autoconfig
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/go-test-helpers/v3/httphelpers"
+)
+
+// TestStreamManagerCloseDuringStreamingDoesNotHang is a regression test for a hang in which
+// StreamManager.Close blocked forever (and so did Relay.Close, which calls it). consumeStream's
+// deferred drain of stream.Events could never complete because the eventsource library can deadlock
+// internally when Close races with an in-flight event, leaving stream.Events unclosed. The drain is
+// now backgrounded so consumeStream returns and s.done closes regardless. See consumeStream.
+//
+// The race is timing-dependent, so this floods the stream with events and then closes, repeated many
+// times to make the close-vs-event-delivery interleaving overwhelmingly likely. On regression the
+// process hangs until the timeout below fires, printing all goroutines to pinpoint the block.
+func TestStreamManagerCloseDuringStreamingDoesNotHang(t *testing.T) {
+	heartbeat := httphelpers.SSEEvent{Event: "heartbeat", Data: "{}"}
+
+	for i := 0; i < 60; i++ {
+		streamManagerTest(t, &emptyPutMessage, func(p streamManagerTestParams) {
+			p.startStream()
+			p.requireReceivedAllMessage()
+
+			// Flood the stream so eventsource is very likely mid-delivery of a decoded event when we
+			// Close, exercising the close-vs-event-delivery race. These are unknown events, so the
+			// message handler is never called and consumeStream loops without blocking on it.
+			go func() {
+				for j := 0; j < 2000; j++ {
+					p.stream.Enqueue(heartbeat)
+				}
+			}()
+
+			time.Sleep(2 * time.Millisecond)
+
+			done := make(chan struct{})
+			go func() {
+				p.streamManager.Close()
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				buf := make([]byte, 1<<20)
+				n := runtime.Stack(buf, true)
+				t.Fatalf("StreamManager.Close() hung on iteration %d (regression)\n%s", i, buf[:n])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`TestAutoConfigAddEnvironmentWithExpiringSDKKeyDoesNotPanicWhenInitFails` would occasionally hang and take the whole `relay` test package down with `panic: test timed out after 10m0s`. The surprising part: the test wasn't stuck in its own assertions — it was stuck in the `relay.Close()` call that runs as the test tears down. Jira: [SDK-2549](https://launchdarkly.atlassian.net/browse/SDK-2549).

The real bug is a deadlock inside the `eventsource` library that Relay can't avoid, only work around. This PR adds the workaround.

## Background

When Relay shuts down, `relay.Close()` tells the auto-config stream to stop and then waits for that stream's background goroutine to fully exit before returning. That wait is where it hung. Here is the chain, top to bottom:

```
relay.Close()
  └─ StreamManager.Close()        // waits here: <-s.done  (never fires)
       └─ subscribe goroutine
            └─ consumeStream()     // returned, but its deferred cleanup is stuck:
                 └─ for range stream.Events { }   // stream.Events is never closed
```

`consumeStream` has a `defer` that drains any leftover items from the stream's `Events` channel — purely so the `eventsource` library's goroutines can be garbage-collected. A `for range` over a channel only ends when that channel is **closed**. Normally `eventsource` closes `Events` shortly after we call `Close()`. In this bug, it never does.

Why it never closes is a flaw in `eventsource` itself (v1.11.0, the latest release). When `Close()` races with an event that's mid-delivery, the library's own shutdown path wedges:

- Its internal shutdown drains an `errs` channel **before** an `events` channel.
- But the goroutine decoding the HTTP response is blocked trying to send the next event on `events`.
- So the drain waits for `errs` that will never arrive, the decoder waits for someone to take its `events` send, and neither moves. `Events` is never closed.

Our inline `for range stream.Events` then blocks forever, so `subscribe` never returns, `s.done` never closes, and `relay.Close()` waits out the full 10-minute test timeout.

It's intermittent because it needs that exact close-while-an-event-is-arriving timing. I reproduced it locally with a stress test that floods the stream and then closes — the resulting hang stack matches the CI dump line for line.

## The fix

Run the cleanup drain in its own goroutine instead of inline, so `consumeStream` returns immediately on shutdown no matter what `eventsource` does:

```go
// internal/autoconfig/stream_manager.go — consumeStream
defer func() {
    go func() {                       // was: drained inline, which could block forever
        for range stream.Events {
        }
        if stream.Errors != nil {
            for range stream.Errors {
            }
        }
    }()
}()
```

`Close()` is now bounded: it can't be held hostage by the library's deadlock. In the rare case the race does fire, a couple of `eventsource` goroutines leak — but only at shutdown, when the process or test is ending anyway. A proper upstream fix in `eventsource` (drain `events` before `errs`, or both at once) would remove the leak entirely; v1.11.0 has no such fix and there's no newer version to bump to.

## Changes

- `internal/autoconfig/stream_manager.go` — background the `consumeStream` cleanup drain.
- `internal/autoconfig/stream_manager_close_test.go` — new regression test. It floods the stream with events, then closes, repeated many times to make the close-during-delivery race overwhelmingly likely. On failure it dumps all goroutines so the block is easy to spot. It hangs on the old code and passes on the new.

## Verification

- New test: **hangs** without the fix (stack matches the CI failure), **passes** with it — `-count=10`, and under `-race -count=3`.
- `go build ./...`, `go vet ./internal/autoconfig/`, `golangci-lint run ./internal/autoconfig/` — all clean.
- `go test ./internal/autoconfig/ ./relay/ -race` — green, including the formerly-flaky test.

## Note (out of scope)

Saw one rare *assertion* flake (not a hang) in a `relay` eval/streaming test under `-race -count=3` that didn't recur. It's unrelated to this change — this PR only touches auto-config shutdown — so it's left alone here.


[SDK-2549]: https://launchdarkly.atlassian.net/browse/SDK-2549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-config shutdown behavior on a timing-sensitive path; bounded Close is the goal, with acceptable rare goroutine leaks only at exit.
> 
> **Overview**
> Fixes an intermittent shutdown hang where **`Relay.Close()`** could block indefinitely because **`StreamManager.Close()`** waited on **`s.done`** while **`consumeStream`** never returned.
> 
> The **`eventsource`** library (v1.11.0) can deadlock when **`Close()`** races with an in-flight event, leaving **`stream.Events`** open. The old inline **`for range stream.Events`** drain in **`consumeStream`**’s defer then blocked forever. The drain of **`stream.Events`** and **`stream.Errors`** now runs in a **background goroutine** so **`consumeStream`** returns, **`s.done`** closes, and shutdown stays bounded; rare races may leak a few library goroutines at process exit only.
> 
> Adds **`TestStreamManagerCloseDuringStreamingDoesNotHang`**, which floods the SSE stream and closes repeatedly to stress the race and fail with a goroutine dump if **`Close()`** regresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e43636e2cad6703e9a88d12290e979378bb2ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->