### PR TITLE
fix: add X-LaunchDarkly-Instance-Id to browser CORS allowlist

### DIFF
--- a/internal/browser/cors.go
+++ b/internal/browser/cors.go
@@ -29,6 +29,7 @@ var DefaultAllowedHeaders = strings.Join([]string{ //nolint:gochecknoglobals
 	"X-LaunchDarkly-User-Agent",
 	"X-LaunchDarkly-Payload-ID",
 	"X-LaunchDarkly-Wrapper",
+	"X-LaunchDarkly-Instance-Id",
 	events.EventSchemaHeader,
 	events.TagsHeader,
 }, ",")


### PR DESCRIPTION
## Summary

Adds `X-LaunchDarkly-Instance-Id` to `browser.DefaultAllowedHeaders` — the `Access-Control-Allow-Headers` value for the browser JS subrouter.

## Context

Ensure CORS allowed headers include instance ID

Only the browser JS subrouter needs this — the server-side and mobile subrouters bypass CORS. Not blocking today, but keeps Relay consistent with what underlying backend systems now advertise and avoids dropped browser preflights if a browser JS SDK begins sending the header.

## Changes

- `internal/browser/cors.go`: append `"X-LaunchDarkly-Instance-Id"` to `DefaultAllowedHeaders`.

## Testing

`go test ./internal/browser/... ./internal/middleware/...` → `ok`

The existing CORS tests reference `DefaultAllowedHeaders` symbolically, so they cover the new value automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-header CORS allowlist change for browser JS with no auth or data-path impact.
> 
> **Overview**
> Adds **`X-LaunchDarkly-Instance-Id`** to `browser.DefaultAllowedHeaders`, so browser JS traffic gets that name in **`Access-Control-Allow-Headers`** via `SetCORSHeaders` and the CORS middleware.
> 
> This aligns Relay with backends that advertise the instance ID header and avoids future browser preflight failures if the JS SDK starts sending it. Scope is the browser subrouter only; existing tests that assert against `DefaultAllowedHeaders` pick up the new value automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5324d076ec4dfc1d762733fee3a8b5e5c74982f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->