### PR TITLE
feat: Hand over the data store to the new client on re-anchor

### DIFF
--- a/internal/relayenv/env_context_reanchor_test.go
+++ b/internal/relayenv/env_context_reanchor_test.go
@@ -1,19 +1,16 @@
 package relayenv
 
-// T0 — Re-anchoring PoC (SDK-2453 / SDK-2530).
+// Re-anchoring proof-of-concept tests.
 //
-// These tests validate the upstream SDK-client swap mechanism that T2.c will implement. Each test
-// answers one of the seven hypotheses in .agent-docs/concurrent-keys/phase1-design.md §7. They are
-// written as durable, executable probes of today's primitives so they survive into T2 as regression
-// tests and as the executable spec for the re-anchor implementation.
-//
-// A written summary of the findings lives in
-// .agent-docs/concurrent-keys/phase1-T0-reanchor-poc-findings.md.
+// These tests validate the upstream SDK-client swap mechanism that the re-anchor implementation builds
+// on. Each test answers one of the seven hypotheses about how re-anchoring should behave. They are
+// written as durable, executable probes of today's primitives so they survive as regression tests and
+// as the executable spec for the re-anchor implementation.
 //
 // Terminology: "re-anchor" = swapping the single upstream SDK client when sdkKey.value changes.
 // Today there is no dedicated re-anchor method; the closest existing path is ReconcileCredentials with
 // an expiring (grace-period) key (which rotates the primary SDK key and stands up a new client), so
-// several tests drive that path and observe where it falls short of the §7 requirements.
+// several tests drive that path and observe where it falls short of the requirements.
 
 import (
 	"errors"
@@ -119,12 +116,10 @@ func TestReanchorPoC_H1_SharedStoreAdapterRebuildSemantics(t *testing.T) {
 	featureKind := ldstoreimpl.Features()
 	flagKey := st.Flag1ServerSide.Flag.Key
 
-	// The design (§7) assumes "two SDK clients pointed at the same env can feed the same store as a
-	// side-effect." This sub-test shows that assumption is FALSE for the default in-memory store: each
-	// client init calls storeAdapter.Build, which constructs a brand-new wrapper around a brand-new
-	// underlying store and atomically swaps it in. No corruption occurs, but the new client starts from
-	// an empty store.
-	t.Run("in-memory factory builds a fresh empty store on each client init", func(t *testing.T) {
+	// A second storeAdapter.Build hands back the SAME wrapper, with its data still in place, rather
+	// than constructing a fresh wrapper around a fresh (empty) underlying store. This is what lets a
+	// re-anchor's new client keep serving the populated store instead of starting empty.
+	t.Run("in-memory factory reuses the existing store on a second client init (store handover)", func(t *testing.T) {
 		rec := &recordingStreamUpdates{}
 		adapter := store.NewSSERelayDataStoreAdapter(ldcomponents.InMemoryDataStore(), rec)
 
@@ -142,20 +137,19 @@ func TestReanchorPoC_H1_SharedStoreAdapterRebuildSemantics(t *testing.T) {
 		s2, err := adapter.Build(subsystems.BasicClientContext{})
 		require.NoError(t, err)
 
-		// FINDING: Build swaps in a new store instance...
-		assert.NotSame(t, s1, s2, "each Build creates a new store wrapper")
-		assert.Same(t, s2, adapter.GetStore(), "the adapter now points at the new store")
+		// Post-fix: Build hands the existing wrapper to the new client and the adapter still points at it.
+		assert.Same(t, s1, s2, "store handover: Build returns the existing wrapper")
+		assert.Same(t, s2, adapter.GetStore(), "the adapter still points at the shared wrapper")
 
-		// ...and that store is empty + uninitialized. So the two clients do NOT share data through the
-		// in-memory store; the new anchor must re-sync from scratch.
-		assert.False(t, adapter.GetStore().IsInitialized(), "the new in-memory store starts uninitialized")
+		// The wrapper stays initialized and the data survives — no empty-store window for the new anchor.
+		assert.True(t, adapter.GetStore().IsInitialized(), "the shared store remains initialized")
 		got2, err := adapter.GetStore().Get(featureKind, flagKey)
 		require.NoError(t, err)
-		assert.Nil(t, got2.Item, "the new in-memory store starts empty")
+		assert.NotNil(t, got2.Item, "data persists across handover")
 	})
 
 	// With a persistent store, the underlying data lives outside the wrapper, so the swap preserves it.
-	// This is the configuration in which the §7 "shared store" assumption actually holds.
+	// This is the configuration in which the "shared store" assumption actually holds.
 	t.Run("shared (persistent) underlying store preserves data across client init", func(t *testing.T) {
 		underlying, err := ldcomponents.InMemoryDataStore().Build(subsystems.BasicClientContext{})
 		require.NoError(t, err)
@@ -273,7 +267,7 @@ func TestReanchorPoC_H2_NewClientInitialSyncRebroadcastsPut(t *testing.T) {
 
 	// FINDING: the new anchor's initial sync produces a second full "put" to every connected downstream
 	// stream. From a downstream SDK's perspective this is a duplicate put. It is tolerable (SDKs apply
-	// puts idempotently) but T2.c must expect it; it is not a corruption.
+	// puts idempotently) but the re-anchor implementation must expect it; it is not a corruption.
 	assert.Equal(t, 2, rec.allDataCount(), "the new anchor's initial sync re-broadcasts a full put")
 }
 
@@ -367,8 +361,8 @@ func TestReanchorPoC_H3_BigSegmentSyncIsNotReWiredOnReAnchor(t *testing.T) {
 	// FINDING: big-segment sync is wired to the SDK key at construction and is NOT re-wired by today's
 	// swap path -- the synchronizer is neither recreated nor told about the new key (the
 	// BigSegmentSynchronizer interface has no credential-replacement method). After re-anchor it keeps
-	// polling/streaming on the OLD anchor key. T2.d must add a re-wire path (a ReplaceCredential-style
-	// method) or recreate the synchronizer on each re-anchor.
+	// polling/streaming on the OLD anchor key. The big-segment re-wire (follow-up work) must add a
+	// re-wire path (a ReplaceCredential-style method) or recreate the synchronizer on each re-anchor.
 	count, sdkKey = capturing.snapshot()
 	assert.Equal(t, 1, count, "synchronizer was not recreated on re-anchor")
 	assert.Equal(t, envConfig.SDKKey, sdkKey, "synchronizer still references the old anchor key")
@@ -417,7 +411,12 @@ func TestReanchorPoC_H4_HTTPConfigIsKeyIndependentExceptAuthHeader(t *testing.T)
 // Hypothesis 5: Order of operations / the in-memory store window.
 // -----------------------------------------------------------------------------------------------
 
-func TestReanchorPoC_H5_InMemoryStoreIsWipedByReAnchor(t *testing.T) {
+// TestReanchorPoC_H5_StoreSurvivesReAnchor asserts that a re-anchor keeps the env's in-memory data
+// store instance intact: the same instance, still initialized, with its data preserved. This holds
+// because SSERelayDataStoreAdapter.Build hands its existing wrapper over to the new anchor's client
+// (with refcounted Close) rather than building a fresh, empty store. It is the end-to-end proof that
+// store handover holds through env_context.
+func TestReanchorPoC_H5_StoreSurvivesReAnchor(t *testing.T) {
 	featureKind := ldstoreimpl.Features()
 	flagKey := st.Flag1ServerSide.Flag.Key
 	envConfig := st.EnvMain.Config
@@ -450,33 +449,27 @@ func TestReanchorPoC_H5_InMemoryStoreIsWipedByReAnchor(t *testing.T) {
 	require.Eventually(t, func() bool { return env.GetClient() == client2 }, time.Second, 10*time.Millisecond,
 		"GetClient should return the new anchor's client once it is registered")
 
-	// FINDING: starting the new client replaced the data store with a fresh, empty, uninitialized one.
-	// This happens regardless of operation order, because building the new client is what rebuilds the
-	// store. So "start-new -> swap-pointer -> close-old" alone is NOT sufficient with an in-memory store:
-	// there is a window in which evaluations see an empty store until the new anchor finishes its initial
-	// sync. T2.c must either (a) keep the old store/anchor authoritative until the new client reports
-	// Initialized()==true, (b) require a persistent store for graceful re-anchor, or (c) decouple the
-	// data store lifecycle from the client lifecycle so a new client does not rebuild it.
+	// Post-fix: the adapter handed the existing wrapper to the new client, so the env's store is the
+	// same instance, still initialized, and the data is intact. There is no empty-store window for the
+	// new anchor.
 	newStore := env.GetStore()
-	assert.NotSame(t, oldStore, newStore, "the data store instance was replaced by the new client")
-	assert.False(t, newStore.IsInitialized(), "the new store is uninitialized until the new anchor re-syncs")
+	assert.Same(t, oldStore, newStore, "the data store instance survives re-anchor (store handover)")
+	assert.True(t, newStore.IsInitialized(), "the store stays initialized across re-anchor")
 	got2, err := newStore.Get(featureKind, flagKey)
 	require.NoError(t, err)
-	assert.Nil(t, got2.Item, "data is absent in the new store until the new anchor re-syncs")
+	assert.NotNil(t, got2.Item, "data is preserved across re-anchor")
 }
 
-// TestReanchorPoC_H5_StoreHandoverAvoidsEmptyWindow validates the reviewer suggestion that, because
-// relay owns the data store implementation (it hands the SDK a single storeAdapter), the re-anchor can
-// hand the existing store over to the new client instead of letting it build a fresh one. Modeled here
-// by a DataStoreFactory that returns the same underlying store on every Build; the production change
-// (T2.c/T2.d) is to make SSERelayDataStoreAdapter reuse its store across the swap. With handover the
-// new anchor's client sees the populated, initialized store immediately -- no empty-store window
-// (contrast TestReanchorPoC_H5_InMemoryStoreIsWipedByReAnchor).
+// TestReanchorPoC_H5_StoreHandoverAvoidsEmptyWindow exercises store handover at the store layer:
+// because relay owns the data store implementation (it hands the SDK a single storeAdapter), the
+// re-anchor hands the existing store to the new client instead of letting it build a fresh one. It is
+// modeled here by a DataStoreFactory that returns the same underlying store on every Build, so the new
+// anchor's client sees the populated, initialized store immediately with no empty-store window.
 //
-// CAVEAT for the implementation (not reproducible with the fake client, so documented here and in the
-// findings): streamUpdatesStoreWrapper.Close() closes the underlying store. If the new client wraps the
-// SAME underlying store, closing the retiring client must NOT close it -- the store's lifecycle has to
-// be owned by the adapter, not by the client being retired.
+// The store's lifecycle is owned by the adapter, not the client: streamUpdatesStoreWrapper.Close()
+// closes the underlying store, so when the retiring and new clients share one underlying store the
+// retiring client's Close() must not tear it down. The fake client cannot exercise the real client's
+// Close(), so that half of the contract is covered by TestRealClient_HandoverPreservesUnderlyingStore.
 func TestReanchorPoC_H5_StoreHandoverAvoidsEmptyWindow(t *testing.T) {
 	featureKind := ldstoreimpl.Features()
 	flagKey := st.Flag1ServerSide.Flag.Key

--- a/internal/relayenv/store_handover_realclient_test.go
+++ b/internal/relayenv/store_handover_realclient_test.go
@@ -1,0 +1,204 @@
+package relayenv
+
+// Spike verifying the real ld.LDClient's Close() behavior against the SSERelayDataStoreAdapter /
+// streamUpdatesStoreWrapper pair, which the fake-client PoC could not exercise. This is the single
+// remaining piece the fake-client PoC could not validate:
+//
+//   > streamUpdatesStoreWrapper.Close() closes the underlying store. With handover the retiring
+//   > and new clients share one underlying store, so closing the retiring client must NOT close
+//   > it — the adapter (not the client) must own the store's lifecycle. (Not reproducible with
+//   > the fake client; verified here against the real client.)
+//
+// We answer two questions:
+//   Q1. Does ld.LDClient.Close() invoke Close() on its data store (the wrapper)?
+//   Q2. After the wrapper's Close() runs, is the underlying store still usable for reads?
+//
+// Q1 determines whether store handover is at risk at all. Q2 determines whether the remedy needs to
+// gate the wrapper's Close (case A: in-memory Close is destructive) or whether it can stay as-is
+// (case B: in-memory Close is a no-op and reads still work).
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/internal/store"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// closeObservingStore wraps an in-memory data store factory so we can directly observe when the
+// underlying store's Close() is invoked. This is the unambiguous signal that ld.LDClient.Close()
+// propagates through streamUpdatesStoreWrapper.Close() to the wrapped store.
+type closeObservingStore struct {
+	inner      subsystems.DataStore
+	closeCount int
+}
+
+func (c *closeObservingStore) Close() error {
+	c.closeCount++
+	return c.inner.Close()
+}
+func (c *closeObservingStore) Init(d []ldstoretypes.Collection) error { return c.inner.Init(d) }
+func (c *closeObservingStore) Get(k ldstoretypes.DataKind, key string) (ldstoretypes.ItemDescriptor, error) {
+	return c.inner.Get(k, key)
+}
+func (c *closeObservingStore) GetAll(k ldstoretypes.DataKind) ([]ldstoretypes.KeyedItemDescriptor, error) {
+	return c.inner.GetAll(k)
+}
+func (c *closeObservingStore) Upsert(k ldstoretypes.DataKind, key string, item ldstoretypes.ItemDescriptor) (bool, error) {
+	return c.inner.Upsert(k, key, item)
+}
+func (c *closeObservingStore) IsInitialized() bool             { return c.inner.IsInitialized() }
+func (c *closeObservingStore) IsStatusMonitoringEnabled() bool { return c.inner.IsStatusMonitoringEnabled() }
+
+type closeObservingStoreFactory struct {
+	observed *closeObservingStore
+}
+
+func (f *closeObservingStoreFactory) Build(ctx subsystems.ClientContext) (subsystems.DataStore, error) {
+	inner, err := ldcomponents.InMemoryDataStore().Build(ctx)
+	if err != nil {
+		return nil, err
+	}
+	f.observed = &closeObservingStore{inner: inner}
+	return f.observed, nil
+}
+
+// realClientUsingAdapter spins up a real ld.LDClient backed by the relay store adapter. Using
+// ExternalUpdatesOnly as the data source avoids any network calls (no upstream streaming connection
+// is opened), so the test is hermetic. The adapter sees the real client's DataStore.Build() call
+// and the real Close() lifecycle on shutdown.
+func realClientUsingAdapter(t *testing.T, adapter *store.SSERelayDataStoreAdapter) *ld.LDClient {
+	t.Helper()
+	cfg := ld.Config{
+		DataStore:  adapter,
+		DataSource: ldcomponents.ExternalUpdatesOnly(),
+		Events:     ldcomponents.NoEvents(),
+	}
+	client, err := ld.MakeCustomClient("fake-sdk-key", cfg, 5*time.Second)
+	require.NoError(t, err)
+	return client
+}
+
+// TestRealClient_CloseInvokesWrapperClose verifies that closing a real ld.LDClient causes the
+// wrapped store's Close() to fire. This is the precondition that makes store handover dangerous —
+// if Close did not propagate, there would be no lifecycle hazard to design around.
+func TestRealClient_CloseInvokesWrapperClose(t *testing.T) {
+	factory := &closeObservingStoreFactory{}
+	rec := &recordingStreamUpdates{}
+	adapter := store.NewSSERelayDataStoreAdapter(factory, rec)
+
+	client := realClientUsingAdapter(t, adapter)
+	require.NotNil(t, factory.observed, "the adapter must have built the observed store")
+	require.Equal(t, 0, factory.observed.closeCount, "no Close yet before client.Close")
+
+	wrapper := adapter.GetStore()
+	require.NoError(t, wrapper.Init(st.AllData))
+	require.True(t, wrapper.IsInitialized())
+
+	require.NoError(t, client.Close())
+
+	// The headline finding: closing the real client propagates Close() to the underlying store via
+	// streamUpdatesStoreWrapper.Close(). If this assertion fails, the lifecycle caveat is not a real
+	// hazard for this combination and the store-handover fix only needs the Build() reuse, not a
+	// Close() lifecycle change.
+	assert.Equal(t, 1, factory.observed.closeCount,
+		"ld.LDClient.Close should propagate to the underlying data store via the wrapper")
+}
+
+// TestRealClient_ReadsAfterCloseAreStillFunctional asks the second question: after Close runs, is
+// the underlying in-memory store still usable for Get? The answer tells us whether the store-handover
+// fix needs to actually prevent Close (because reads will fail after it) or whether reads coincidentally
+// still work (because the in-memory store's Close is effectively a no-op for read behavior). Even
+// if reads happen to work, the fix should still gate Close — relying on undocumented "Close is a
+// no-op" behavior is brittle and breaks when persistent stores enter the picture.
+func TestRealClient_ReadsAfterCloseAreStillFunctional(t *testing.T) {
+	factory := &closeObservingStoreFactory{}
+	rec := &recordingStreamUpdates{}
+	adapter := store.NewSSERelayDataStoreAdapter(factory, rec)
+
+	client := realClientUsingAdapter(t, adapter)
+	wrapper := adapter.GetStore()
+	require.NoError(t, wrapper.Init(st.AllData))
+
+	featureKind := ldstoreimpl.Features()
+	flagKey := st.Flag1ServerSide.Flag.Key
+
+	got, err := wrapper.Get(featureKind, flagKey)
+	require.NoError(t, err)
+	require.NotNil(t, got.Item, "sanity: data is readable before close")
+
+	require.NoError(t, client.Close())
+
+	// Read after Close. The outcome here is informational, not a pass/fail design gate:
+	//   - If the read succeeds, the in-memory store's Close is effectively a no-op for queries; the fix
+	//     can still safely gate Close to be defensive (persistent stores may differ).
+	//   - If the read fails, the fix MUST gate Close, since the new anchor would observe a broken store.
+	gotAfter, errAfter := wrapper.Get(featureKind, flagKey)
+	t.Logf("Get after client.Close: item=%v err=%v initialized=%v",
+		gotAfter.Item != nil, errAfter, wrapper.IsInitialized())
+}
+
+// TestRealClient_HandoverPreservesUnderlyingStore exercises the production store-handover behavior:
+// when a second real ld.LDClient is built against the same SSERelayDataStoreAdapter — the re-anchor
+// case — the adapter hands the existing wrapper (and underlying store) to the new client rather
+// than rebuilding it. Closing the first client must not tear the underlying store down while the
+// second client is still holding it; only the final Close releases it.
+//
+// Sequence:
+//  1. Build client1; init data on its wrapper.
+//  2. Build client2 — adapter returns the SAME wrapper; no second underlying store is built.
+//  3. Close client1 — store stays open because client2 still holds it.
+//  4. Close client2 — final release; underlying store closes exactly once.
+func TestRealClient_HandoverPreservesUnderlyingStore(t *testing.T) {
+	factory := &countingStoreFactory{}
+	rec := &recordingStreamUpdates{}
+	adapter := store.NewSSERelayDataStoreAdapter(factory, rec)
+
+	client1 := realClientUsingAdapter(t, adapter)
+	wrapper1 := adapter.GetStore()
+	require.NoError(t, wrapper1.Init(st.AllData))
+	require.Equal(t, 1, factory.buildCount, "one Build for client1")
+	underlying := factory.lastObserved
+
+	client2 := realClientUsingAdapter(t, adapter)
+	wrapper2 := adapter.GetStore()
+	require.Equal(t, 1, factory.buildCount, "client2 reuses the existing wrapper — no second Build")
+	assert.Same(t, wrapper1, wrapper2, "the adapter hands the same wrapper to both clients")
+	assert.True(t, wrapper2.IsInitialized(), "the shared store stays initialized across handover")
+
+	require.NoError(t, client1.Close())
+	assert.Equal(t, 0, underlying.closeCount,
+		"client1.Close must NOT tear down the underlying store while client2 still holds it")
+
+	require.NoError(t, client2.Close())
+	assert.Equal(t, 1, underlying.closeCount,
+		"client2.Close is the final release; the underlying store is closed exactly once")
+}
+
+// countingStoreFactory tracks every Build call and exposes the most recently built store so the
+// handover test can compare instances across builds. Each build wraps a real in-memory store in a
+// closeObservingStore so close events are visible.
+type countingStoreFactory struct {
+	buildCount   int
+	lastObserved *closeObservingStore
+}
+
+func (f *countingStoreFactory) Build(ctx subsystems.ClientContext) (subsystems.DataStore, error) {
+	inner, err := ldcomponents.InMemoryDataStore().Build(ctx)
+	if err != nil {
+		return nil, err
+	}
+	observed := &closeObservingStore{inner: inner}
+	f.buildCount++
+	f.lastObserved = observed
+	return observed, nil
+}

--- a/internal/store/relay_feature_store.go
+++ b/internal/store/relay_feature_store.go
@@ -150,6 +150,14 @@ func (sw *streamUpdatesStoreWrapper) acquire() bool {
 
 func (sw *streamUpdatesStoreWrapper) Close() error {
 	sw.refMu.Lock()
+	if sw.closed {
+		// Already fully torn down. A stray extra Close (the SDK's LDClient.Close is not idempotent, so
+		// this depends on caller discipline) must not decrement below zero and re-satisfy the final
+		// guard — that would close the underlying store a second time, double-releasing a persistent
+		// store's connection pool. Close is idempotent past the final release.
+		sw.refMu.Unlock()
+		return nil
+	}
 	sw.refCount--
 	final := sw.refCount <= 0
 	if final {

--- a/internal/store/relay_feature_store.go
+++ b/internal/store/relay_feature_store.go
@@ -67,15 +67,31 @@ func NewSSERelayDataStoreAdapter(
 }
 
 // Build is called by the SDK when the LDClient is being created.
+//
+// Store handover (concurrent-keys re-anchor): if the adapter already holds a wrapper from
+// a prior client construction, that wrapper is returned again instead of building a fresh one. This
+// hands the populated, initialized data store over to the new anchor's client during a re-anchor —
+// no empty-store window, no re-sync. The wrapper refcounts its holders so the underlying store is
+// only torn down by the final Close (see streamUpdatesStoreWrapper.Close). If the parked wrapper has
+// already been fully closed (acquire returns false), a fresh one is built rather than resurrecting a
+// wrapper whose underlying store is torn down.
 func (a *SSERelayDataStoreAdapter) Build(
 	context subsystems.ClientContext,
 ) (subsystems.DataStore, error) {
-	var sw *streamUpdatesStoreWrapper
+	a.mu.Lock()
+	if existing := a.store; existing != nil {
+		if sw, ok := existing.(*streamUpdatesStoreWrapper); ok && sw.acquire() {
+			a.mu.Unlock()
+			return sw, nil
+		}
+	}
+	a.mu.Unlock()
+
 	wrappedStore, err := a.wrappedFactory.Build(context)
 	if err != nil {
 		return nil, err // this will cause client initialization to fail immediately
 	}
-	sw = newStreamUpdatesStoreWrapper(
+	sw := newStreamUpdatesStoreWrapper(
 		a.updates,
 		wrappedStore,
 		context.GetLogging().Loggers,
@@ -93,6 +109,15 @@ type streamUpdatesStoreWrapper struct {
 	store   subsystems.DataStore
 	updates streams.EnvStreamUpdates
 	loggers ldlog.Loggers
+
+	// refCount tracks how many SDK clients hold this wrapper. The first holder is implicit
+	// (count starts at 1 in newStreamUpdatesStoreWrapper). Each handover (Build reuse) calls
+	// acquire to bump the count; each client's Close decrements. The underlying store is torn
+	// down only when the count reaches zero, at which point closed is set so a later acquire
+	// refuses to hand back a wrapper whose underlying store is gone. Guarded by refMu.
+	refMu    sync.Mutex
+	refCount int
+	closed   bool
 }
 
 func newStreamUpdatesStoreWrapper(
@@ -101,14 +126,42 @@ func newStreamUpdatesStoreWrapper(
 	loggers ldlog.Loggers,
 ) *streamUpdatesStoreWrapper {
 	relayStore := &streamUpdatesStoreWrapper{
-		store:   baseFeatureStore,
-		updates: updates,
-		loggers: loggers,
+		store:    baseFeatureStore,
+		updates:  updates,
+		loggers:  loggers,
+		refCount: 1,
 	}
 	return relayStore
 }
 
+// acquire records an additional holder of the wrapper, used by SSERelayDataStoreAdapter.Build when it
+// hands this wrapper to a new client during a concurrent-keys re-anchor. It returns false if the
+// wrapper has already been fully closed (refCount reached zero and the underlying store was torn
+// down); the caller must then build a fresh wrapper rather than resurrect a dead one.
+func (sw *streamUpdatesStoreWrapper) acquire() bool {
+	sw.refMu.Lock()
+	defer sw.refMu.Unlock()
+	if sw.closed {
+		return false
+	}
+	sw.refCount++
+	return true
+}
+
 func (sw *streamUpdatesStoreWrapper) Close() error {
+	sw.refMu.Lock()
+	sw.refCount--
+	final := sw.refCount <= 0
+	if final {
+		sw.closed = true
+	}
+	sw.refMu.Unlock()
+	if !final {
+		// Re-anchor handover in progress: another client is still using this underlying store.
+		// The retiring client's Close must not tear it down — see SSERelayDataStoreAdapter.Build
+		// for the other half of this contract.
+		return nil
+	}
 	return sw.store.Close()
 }
 

--- a/internal/store/store_rebuild_after_close_test.go
+++ b/internal/store/store_rebuild_after_close_test.go
@@ -1,0 +1,66 @@
+package store
+
+// Regression test for the store-handover refcount contract (concurrent-keys re-anchor).
+//
+// SSERelayDataStoreAdapter.Build reuses whatever wrapper is parked in a.store so a re-anchor can hand
+// the populated store to the new client. The hazard: once the wrapper's refCount reaches zero and its
+// underlying store is torn down, a later Build must NOT hand that same, now-closed wrapper back to a
+// new client (a use-after-close for a persistent store whose Close releases its connection pool). The
+// fix marks a fully-closed wrapper and has acquire refuse it, so Build rebuilds a fresh wrapper.
+//
+// (The re-anchor flow keeps the anchor client permanent, so refCount doesn't reach zero while the env
+// is alive today; this guards the wrapper/adapter contract itself against a future caller.)
+
+import (
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// freshStoreFactory builds a new underlying store on every Build, mirroring a real DataStore factory
+// (mockStoreFactory returns a single fixed instance, which can't model a rebuild).
+type freshStoreFactory struct {
+	built []*mockStore
+}
+
+func (f *freshStoreFactory) Build(_ subsystems.ClientContext) (subsystems.DataStore, error) {
+	s := &mockStore{realStore: sharedtest.NewInMemoryStore()}
+	f.built = append(f.built, s)
+	return s, nil
+}
+
+func TestStoreAdapterRebuildsAfterFullClose(t *testing.T) {
+	factory := &freshStoreFactory{}
+	updates := &mockEnvStreamsUpdates{}
+	adapter := NewSSERelayDataStoreAdapter(factory, updates)
+	ctx := subsystems.BasicClientContext{}
+
+	// First client builds the wrapper: refCount = 1.
+	first, err := adapter.Build(ctx)
+	require.NoError(t, err)
+	sw1 := first.(*streamUpdatesStoreWrapper)
+	require.Equal(t, 1, sw1.refCount)
+
+	// The sole client shuts down: refCount 1 -> 0, wrapper marked closed, underlying store torn down.
+	require.NoError(t, first.Close())
+	require.True(t, factory.built[0].closed, "final Close tears down the underlying store")
+
+	// A subsequent Build (e.g. a later re-anchor) must NOT resurrect the fully-closed wrapper — it
+	// rebuilds a fresh wrapper backed by a fresh, open store.
+	second, err := adapter.Build(ctx)
+	require.NoError(t, err)
+	sw2 := second.(*streamUpdatesStoreWrapper)
+
+	assert.NotSame(t, sw1, sw2, "adapter must rebuild rather than hand back the torn-down wrapper")
+	assert.Equal(t, 1, sw2.refCount, "the fresh wrapper starts at refCount 1")
+	assert.False(t, sw2.store.(*mockStore).closed, "the fresh wrapper's underlying store is open")
+	assert.Same(t, sw2, adapter.GetStore(), "the adapter now points at the fresh wrapper")
+
+	// acquire on the fully-closed wrapper refuses, so it can never be resurrected.
+	assert.False(t, sw1.acquire(), "acquire on a fully-closed wrapper must return false")
+}

--- a/internal/store/store_rebuild_after_close_test.go
+++ b/internal/store/store_rebuild_after_close_test.go
@@ -44,7 +44,7 @@ func TestStoreAdapterRebuildsAfterFullClose(t *testing.T) {
 	first, err := adapter.Build(ctx)
 	require.NoError(t, err)
 	sw1 := first.(*streamUpdatesStoreWrapper)
-	require.Equal(t, 1, sw1.refCount)
+	require.Equal(t, 1, sw1.currentRefCount())
 
 	// The sole client shuts down: refCount 1 -> 0, wrapper marked closed, underlying store torn down.
 	require.NoError(t, first.Close())
@@ -57,7 +57,7 @@ func TestStoreAdapterRebuildsAfterFullClose(t *testing.T) {
 	sw2 := second.(*streamUpdatesStoreWrapper)
 
 	assert.NotSame(t, sw1, sw2, "adapter must rebuild rather than hand back the torn-down wrapper")
-	assert.Equal(t, 1, sw2.refCount, "the fresh wrapper starts at refCount 1")
+	assert.Equal(t, 1, sw2.currentRefCount(), "the fresh wrapper starts at refCount 1")
 	assert.False(t, sw2.store.(*mockStore).closed, "the fresh wrapper's underlying store is open")
 	assert.Same(t, sw2, adapter.GetStore(), "the adapter now points at the fresh wrapper")
 

--- a/internal/store/store_refcount_test.go
+++ b/internal/store/store_refcount_test.go
@@ -1,0 +1,148 @@
+package store
+
+// Refcount contract tests for the store-handover wrapper (concurrent-keys re-anchor).
+//
+// These cover the two properties the refcount design hinges on but the original suite left
+// unexercised (multi-agent review, PR #736): Close idempotency past the final release, and safety of a
+// Build-reuse (acquire) racing the retiring client's Close. Run the package with -race.
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingCloseStore counts how many times Close is invoked on the underlying store, so a double
+// teardown is observable. Count is mutex-guarded so the concurrency test can read it safely.
+type countingCloseStore struct {
+	subsystems.DataStore
+	mu    sync.Mutex
+	count int
+}
+
+func (s *countingCloseStore) Close() error {
+	s.mu.Lock()
+	s.count++
+	s.mu.Unlock()
+	return s.DataStore.Close()
+}
+
+func (s *countingCloseStore) closeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.count
+}
+
+type countingCloseStoreFactory struct {
+	mu    sync.Mutex
+	built []*countingCloseStore
+}
+
+func (f *countingCloseStoreFactory) Build(_ subsystems.ClientContext) (subsystems.DataStore, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s := &countingCloseStore{DataStore: sharedtest.NewInMemoryStore()}
+	f.built = append(f.built, s)
+	return s, nil
+}
+
+func (f *countingCloseStoreFactory) allBuilt() []*countingCloseStore {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]*countingCloseStore(nil), f.built...)
+}
+
+// currentRefCount reads the wrapper's holder count under refMu, so tests can inspect it while other
+// goroutines may be calling acquire/Close. Test-only helper (kept out of the production file so the
+// unused linter doesn't flag it).
+func (sw *streamUpdatesStoreWrapper) currentRefCount() int {
+	sw.refMu.Lock()
+	defer sw.refMu.Unlock()
+	return sw.refCount
+}
+
+// TestWrapperCloseIsIdempotent: once the final holder has released the wrapper and torn down the
+// underlying store, a stray extra Close must be a no-op — not decrement refCount below zero and
+// re-close the underlying store (which double-releases a persistent store's connection pool).
+func TestWrapperCloseIsIdempotent(t *testing.T) {
+	factory := &countingCloseStoreFactory{}
+	adapter := NewSSERelayDataStoreAdapter(factory, &mockEnvStreamsUpdates{})
+
+	sw, err := adapter.Build(subsystems.BasicClientContext{})
+	require.NoError(t, err)
+
+	require.NoError(t, sw.Close())
+	require.Equal(t, 1, factory.built[0].closeCount(), "final Close tears down the underlying store once")
+
+	require.NoError(t, sw.Close())
+	assert.Equal(t, 1, factory.built[0].closeCount(),
+		"Close is idempotent: a second Close must not re-close the underlying store")
+}
+
+// TestWrapperConcurrentCloseClosesExactlyOnce fires many concurrent Close calls on a single wrapper
+// (modelling stray/duplicate client Closes arriving at once) and asserts the underlying store is torn
+// down exactly once. This directly exercises the idempotent early-return branch under -race and is
+// non-vacuous: against a non-idempotent Close, concurrent duplicates drive refCount past zero and
+// re-close the underlying store (closeCount > 1).
+func TestWrapperConcurrentCloseClosesExactlyOnce(t *testing.T) {
+	const iterations = 300
+	for i := 0; i < iterations; i++ {
+		factory := &countingCloseStoreFactory{}
+		adapter := NewSSERelayDataStoreAdapter(factory, &mockEnvStreamsUpdates{})
+
+		sw, err := adapter.Build(subsystems.BasicClientContext{})
+		require.NoError(t, err)
+
+		const closers = 8
+		var wg sync.WaitGroup
+		wg.Add(closers)
+		for c := 0; c < closers; c++ {
+			go func() { defer wg.Done(); assert.NoError(t, sw.Close()) }()
+		}
+		wg.Wait()
+
+		require.Equal(t, 1, factory.built[0].closeCount(),
+			"the underlying store must be closed exactly once regardless of duplicate concurrent Closes")
+	}
+}
+
+// TestWrapperHandoverCloseRace: a re-anchor's second Build (reuse -> acquire, or a fresh rebuild if the
+// wrapper is already closed) racing the retiring client's Close must never close a single underlying
+// store more than once, and -race must stay clean.
+func TestWrapperHandoverCloseRace(t *testing.T) {
+	const iterations = 500
+	for i := 0; i < iterations; i++ {
+		factory := &countingCloseStoreFactory{}
+		adapter := NewSSERelayDataStoreAdapter(factory, &mockEnvStreamsUpdates{})
+
+		first, err := adapter.Build(subsystems.BasicClientContext{})
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		// A re-anchor stands up a second client: Build reuses the live wrapper (acquire) or, if the
+		// retiring Close already tore it down, rebuilds a fresh one.
+		go func() {
+			defer wg.Done()
+			second, buildErr := adapter.Build(subsystems.BasicClientContext{})
+			assert.NoError(t, buildErr)
+			_ = second
+		}()
+		// The retiring client closes concurrently.
+		go func() {
+			defer wg.Done()
+			_ = first.Close()
+		}()
+		wg.Wait()
+
+		for _, s := range factory.allBuilt() {
+			require.LessOrEqual(t, s.closeCount(), 1, "an underlying store was closed more than once")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

First slice carved out of #720 (the re-anchor mechanism, SDK-2542), split for reviewability. This is the **store-handover** piece and is independent of the credential and relayenv changes -- it adds a latent capability that the synchronous re-anchor will use in a later PR.

`SSERelayDataStoreAdapter.Build` now reuses its existing wrapper when one is already present, so a concurrent-keys re-anchor can hand the populated, initialized store to the new anchor's client instead of building a fresh, empty one -- no empty-store window, no re-sync. The wrapper is refcounted: `acquire()` bumps the holder count on each `Build` reuse and `Close()` decrements, tearing down the underlying store only on the final release. This keeps a retiring client's `Close()` from pulling the store out from under the new anchor. A fully-closed wrapper refuses re-acquisition, so `Build` rebuilds rather than resurrecting a dead store.

### Tests

- Inverts the H1/H5 re-anchor PoC tests from asserting the pre-fix (store wiped) behavior to asserting handover. H6/H7 are intentionally left as-is; they invert with the synchronous re-anchor change in a later slice.
- Adds `TestRealClient_HandoverPreservesUnderlyingStore` -- a real-client spike verifying `ld.LDClient.Close()` does not tear down the shared underlying store.
- Adds `store_rebuild_after_close_test.go` -- a refcount-contract regression covering the "fully-closed wrapper refuses re-acquisition" path.

### Split sequence

This is PR 1 of a 4-slice split of #720: **store handover** (this PR) -> relayenv refactors -> credential rotator deferred-flip API -> synchronous re-anchor core.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core data-store lifecycle on SDK client swap (refcounted Close and Build reuse); impact is limited to the store adapter layer in this slice, with broad regression and race tests, but mistakes could cause use-after-close or double-close on persistent stores.
> 
> **Overview**
> Adds **store handover** so a concurrent-keys re-anchor can stand up a new upstream `LDClient` without wiping the in-memory feature store.
> 
> `SSERelayDataStoreAdapter.Build` now returns the existing `streamUpdatesStoreWrapper` when one is already parked, using **`acquire()`** to bump a holder refcount instead of building a fresh empty wrapper. **`Close()`** on the wrapper only tears down the underlying store on the **final** release, so a retiring client’s shutdown does not close the store while the new anchor still holds it. Fully closed wrappers refuse re-acquisition so a later `Build` creates a new wrapper rather than resurrecting a dead store.
> 
> Re-anchor PoC tests **H1/H5** are flipped to expect handover (same store instance, data preserved through `env_context`). New coverage includes real-`LDClient` handover, rebuild-after-full-close, and refcount **idempotency** / **handover-vs-Close race** tests (intended for `-race`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e598fa998e33830a36566aae417ed671f77462d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->