### PR TITLE
refactor: Extract rebuildEvaluator and registerCredentialMappings

### DIFF
--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -430,17 +430,13 @@ func (c *envContextImpl) cleanupExpiredCredentials(interval time.Duration) {
 func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.envStreams.AddCredential(newCredential)
-	for streamProvider, handlers := range c.handlers {
-		if h := streamProvider.Handler(sdkauth.NewScoped(c.filterKey, newCredential)); h != nil {
-			handlers[newCredential] = h
-		}
-	}
+
+	c.registerCredentialMappings(newCredential)
 
 	// A new SDK key means:
 	//  1. we should start a new SDK client*, but only for the anchor: there is a single upstream
-	//     connection per environment, owned by the anchor key. Non-anchor server keys get envStreams
-	//     + handler bundles above, but no upstream client — matching today's mobile-key behavior.
+	//     connection per environment, owned by the anchor key. Non-anchor server keys get their
+	//     credential mappings registered above, but no upstream client — matching today's mobile-key behavior.
 	//  2. we should tell all event forwarding components that use an SDK key to use the new one,
 	//     again only when it is the anchor, since events collapse to the anchor per kind.
 	// A new mobile key does not require starting a new SDK client, but does requiring updating any event forwarding
@@ -472,8 +468,21 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 			}
 		}
 	}
+}
 
-	c.connectionMapper.AddConnectionMapping(sdkauth.NewScoped(c.filterKey, newCredential), c)
+// registerCredentialMappings wires relay's downstream-facing routing for cred: it registers the
+// credential with the env's stream machinery, builds the per-stream-provider HTTP handlers, and adds
+// the connection->env mapping, so incoming SDK/client connections that authenticate with cred are
+// served by this env. It does NOT start the upstream SDK client or repoint event/metrics forwarding --
+// those are anchor-only concerns owned by the caller. The caller must hold c.mu.
+func (c *envContextImpl) registerCredentialMappings(cred credential.SDKCredential) {
+	c.envStreams.AddCredential(cred)
+	for streamProvider, handlers := range c.handlers {
+		if h := streamProvider.Handler(sdkauth.NewScoped(c.filterKey, cred)); h != nil {
+			handlers[cred] = h
+		}
+	}
+	c.connectionMapper.AddConnectionMapping(sdkauth.NewScoped(c.filterKey, cred), c)
 }
 
 func (c *envContextImpl) removeCredential(oldCredential credential.SDKCredential) {
@@ -526,21 +535,9 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 		}
 		c.clients[sdkKey] = client
 
-		// The data store instance is created by the SDK when it creates the client. Now that
-		// we have a data store, we can finish setting up the Evaluator that we'll use for this
-		// environment.
-		store := c.storeAdapter.GetStore()
-		dataProvider := ldstoreimpl.NewDataStoreEvaluatorDataProvider(store, c.loggers)
-		evalOptions := []ldeval.EvaluatorOption{
-			// We're setting EnableSecondaryKey because we may be doing evaluations for client-side SDKs that
-			// are sending old-style user data with the "secondary" attribute. This option doesn't affect
-			// evaluations done for newer client-side SDKs that send contexts.
-			ldeval.EvaluatorOptionEnableSecondaryKey(true),
-		}
-		if c.sdkBigSegments != nil {
-			evalOptions = append(evalOptions, ldeval.EvaluatorOptionBigSegmentProvider(c.sdkBigSegments))
-		}
-		c.evaluator = ldeval.NewEvaluatorWithOptions(dataProvider, evalOptions...)
+		// The data store instance is created by the SDK when it creates the client. Now that we have a
+		// data store, we can finish setting up the Evaluator for this environment.
+		c.rebuildEvaluator()
 	}
 	c.initErr = err
 	c.mu.Unlock()
@@ -570,6 +567,24 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 	if readyCh != nil {
 		readyCh <- c
 	}
+}
+
+// rebuildEvaluator constructs the environment's Evaluator against the current data store. It is called
+// after (re)creating an SDK client, once the store is available. It reads and writes envContextImpl
+// fields directly, so the caller must hold c.mu.
+//
+// EnableSecondaryKey is set because we may evaluate for client-side SDKs sending old-style user data
+// with the "secondary" attribute; it has no effect for newer SDKs that send contexts.
+func (c *envContextImpl) rebuildEvaluator() {
+	store := c.storeAdapter.GetStore()
+	dataProvider := ldstoreimpl.NewDataStoreEvaluatorDataProvider(store, c.loggers)
+	evalOptions := []ldeval.EvaluatorOption{
+		ldeval.EvaluatorOptionEnableSecondaryKey(true),
+	}
+	if c.sdkBigSegments != nil {
+		evalOptions = append(evalOptions, ldeval.EvaluatorOptionBigSegmentProvider(c.sdkBigSegments))
+	}
+	c.evaluator = ldeval.NewEvaluatorWithOptions(dataProvider, evalOptions...)
 }
 
 // sdkKeyIsActive reports whether the given SDK key is still a tracked credential -- either the primary


### PR DESCRIPTION
## Summary

Second slice carved out of #720 (the re-anchor mechanism, SDK-2542), split for reviewability. A **pure, behavior-preserving refactor** that extracts two blocks out of `envContextImpl` into methods the synchronous re-anchor path will also call. Independent of the store-handover slice (#736); both are siblings off `feat/concurrent-keys`.

- **`rebuildEvaluator`** -- the evaluator-build block lifted out of `startSDKClient`, so the re-anchor path can rebuild the evaluator against the (handed-over) store without duplicating it.
- **`registerCredentialMappings`** -- the envStreams / handler / connection-mapper wiring lifted out of `addCredential`, so the re-anchor path can register a brand-new anchor's downstream routing on its own.

No behavior change. The one reordering: `addCredential` now adds the connection mapping at the top (inside `registerCredentialMappings`) rather than at the end.

Why the reorder is safe: it is **not** because `c.mu` hides it -- the connection map (`envsByCredential`) has its own lock, so a request can resolve the newly-added credential the instant `AddConnectionMapping` returns, while `addCredential` still holds `c.mu`. Rather, every env field such a request then reads -- `GetClient`, `GetEvaluator`, `GetStreamHandler`, `GetInitError` -- takes `c.mu.RLock`, so the request blocks until `addCredential` completes and observes the same committed state regardless of where the mapping was registered inside the lock. The pre-existing window in which a credential is routable before its async SDK client is installed (`startSDKClient` is `go`-spawned and blocks on `c.mu` in both versions) is unchanged. The only new sub-window -- credential routable before `eventDispatcher.ReplaceCredential` repoints forwarding -- is benign: the event-relay endpoint converges under its own lock and forwards under the new anchor either way, and during a rotation both the old and new anchor keys are valid (grace period).

Verified with `go test -race ./internal/relayenv/`, `go vet`, and `make lint`.

### Split sequence

PR 2 of a 4-slice split of #720: store handover (#736) -> **relayenv refactors** (this PR) -> credential rotator deferred-flip API -> synchronous re-anchor core.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential routing and evaluator setup on the hot path for SDK key rotation; intended as no-op refactor but reorders when credentials become routable relative to event forwarding under `c.mu`.
> 
> **Overview**
> **Behavior-preserving refactor** in `envContextImpl` that pulls two blocks into dedicated helpers so an upcoming synchronous re-anchor path can reuse them without duplicating logic.
> 
> **`registerCredentialMappings`** centralizes downstream routing for a credential: `envStreams`, per-stream HTTP handlers, and `connectionMapper`. **`addCredential`** now calls it first, then keeps anchor-only work (async `startSDKClient`, metrics/event `ReplaceCredential`). Connection mapping runs **earlier** in the lock than before (with stream/handler setup) instead of at the end of `addCredential`.
> 
> **`rebuildEvaluator`** holds the evaluator construction that used to live inline in **`startSDKClient`** (data store → evaluator options, including secondary key and big segments).
> 
> Comments were updated to describe the split; no new call sites beyond the extractions in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a535418df69c59dca0c357d3790957b0431717bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->