### PR TITLE
feat: Defer the SDK anchor flip to an explicit CommitAnchor

### DIFF
--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -220,13 +220,57 @@ func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expiration
 // The set is assumed well-formed: AcceptedSetBuilder.Build validates that an anchor was designated
 // (and, because WithAnchor adds the key as it designates it, that the anchor is among the SDK
 // keys), so Reconcile trusts what it is handed rather than re-validating.
-func (r *Rotator) Reconcile(set AcceptedSet, now time.Time) {
+//
+// Reconcile does NOT flip the SDK anchor pointer when the anchor changes. Instead it reports the
+// change in the returned ReconcileResult.AnchorChange so the caller can move the pointer at the right
+// moment via CommitAnchor. The accepted-set diff (additions/expirations) is applied as before.
+func (r *Rotator) Reconcile(set AcceptedSet, now time.Time) ReconcileResult {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.reconcileSDKKeys(set, set.anchor, now)
+	var result ReconcileResult
+
+	previousAnchor := r.anchorKey
+	newAnchor := set.anchor
+	if previousAnchor != newAnchor && newAnchor.Defined() {
+		result.AnchorChange = &AnchorChange{
+			PreviousAnchor: previousAnchor,
+			NewAnchor:      newAnchor,
+		}
+	}
+
+	r.reconcileSDKKeys(set, now)
 	r.reconcileMobileKeys(set, now)
 	r.reconcileEnvironmentID(set)
+
+	return result
+}
+
+// ReconcileResult reports state changes from Reconcile that the caller must act on outside the normal
+// addCredential / removeCredential flow driven by StepTime.
+//
+// AnchorChange is non-nil when the SDK anchor changed. The rotator does NOT flip its anchor pointer in
+// that case -- the caller invokes CommitAnchor to move the pointer once it is ready to do so.
+type ReconcileResult struct {
+	AnchorChange *AnchorChange
+}
+
+// AnchorChange describes an SDK anchor transition produced by Reconcile: the anchor moved from
+// PreviousAnchor to NewAnchor. PreviousAnchor is the undefined (empty) key when the environment is
+// gaining its first SDK anchor.
+type AnchorChange struct {
+	PreviousAnchor config.SDKKey
+	NewAnchor      config.SDKKey
+}
+
+// CommitAnchor atomically moves the rotator's SDK anchor pointer to the given key. Reconcile
+// deliberately does not flip the anchor when it changes; the caller invokes CommitAnchor to move the
+// pointer. Aside from Initialize (which establishes the initial anchor), CommitAnchor is the only path
+// that moves the anchor pointer.
+func (r *Rotator) CommitAnchor(key config.SDKKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.anchorKey = key
 }
 
 // reconcilableKey constrains the generic reconcile helper to a comparable credential (so it can key a
@@ -276,7 +320,10 @@ func reconcileAcceptedKeys[K reconcilableKey](
 // reconcileAcceptedKeys. The set is trusted as well-formed: BuildAcceptedSet / the builder guarantee
 // the anchor is present and permanent (WithAnchor forces a nil expiry), so no special handling is
 // needed here. The caller must hold the write lock.
-func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now time.Time) {
+//
+// reconcileSDKKeys does NOT flip r.anchorKey when the anchor changes. Reconcile reports the change via
+// ReconcileResult.AnchorChange and the caller invokes CommitAnchor to move the pointer.
+func (r *Rotator) reconcileSDKKeys(set AcceptedSet, now time.Time) {
 	desired := make(map[config.SDKKey]AcceptedKey, len(set.sdkKeys))
 	for key, info := range set.sdkKeys {
 		if info.Expiry != nil && !now.Before(*info.Expiry) {
@@ -285,7 +332,6 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, anchor config.SDKKey, now ti
 		desired[key] = info
 	}
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
-	r.anchorKey = anchor
 }
 
 // reconcileMobileKeys mirrors reconcileSDKKeys for mobile keys. The set is trusted as well-formed:

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -54,7 +54,9 @@ func TestReconcileAnchorOnly(t *testing.T) {
 	anchor := config.SDKKey("anchor")
 	now := time.Now()
 
-	r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor})), now)
+	result := r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor})), now)
+	require.NotNil(t, result.AnchorChange, "anchor transition from empty to defined is signaled")
+	r.CommitAnchor(result.AnchorChange.NewAnchor)
 	additions, expirations := r.StepTime(now)
 
 	assert.ElementsMatch(t, []SDKCredential{anchor}, additions)
@@ -70,8 +72,10 @@ func TestReconcileMultipleSDKKeys(t *testing.T) {
 	other := config.SDKKey("other")
 	now := time.Now()
 
-	r.Reconcile(
+	result := r.Reconcile(
 		mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor}).WithSDKKey(SDKKeyParams{Value: other})), now)
+	require.NotNil(t, result.AnchorChange)
+	r.CommitAnchor(result.AnchorChange.NewAnchor)
 	additions, expirations := r.StepTime(now)
 
 	// Both server keys are accepted; only the anchor is primary.
@@ -80,6 +84,49 @@ func TestReconcileMultipleSDKKeys(t *testing.T) {
 	assert.Equal(t, anchor, r.AnchorKey())
 	assert.ElementsMatch(t, []SDKCredential{anchor, other}, r.AllCredentials())
 	assert.Empty(t, r.DeprecatedCredentials())
+}
+
+func TestReconcileDefersAnchorFlipUntilCommit(t *testing.T) {
+	r := newTestRotator()
+	first := config.SDKKey("first-anchor")
+	second := config.SDKKey("second-anchor")
+	now := time.Now()
+
+	// Establishing the initial anchor is itself a transition from the undefined key.
+	result := r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: first})), now)
+	require.NotNil(t, result.AnchorChange)
+	assert.Equal(t, config.SDKKey(""), result.AnchorChange.PreviousAnchor)
+	assert.Equal(t, first, result.AnchorChange.NewAnchor)
+	r.CommitAnchor(result.AnchorChange.NewAnchor)
+	require.Equal(t, first, r.AnchorKey())
+
+	// Re-anchor to a new key while the old one stays valid in a grace period. Reconcile must report
+	// the change but leave the pointer on the previous anchor until CommitAnchor is called.
+	result = r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		WithAnchor(SDKKeyParams{Value: second}).
+		WithSDKKey(SDKKeyParams{Value: first, Expiry: util.PtrOrNil(now.Add(time.Hour))})), now)
+	require.NotNil(t, result.AnchorChange)
+	assert.Equal(t, first, result.AnchorChange.PreviousAnchor)
+	assert.Equal(t, second, result.AnchorChange.NewAnchor)
+	assert.Equal(t, first, r.AnchorKey(), "Reconcile must not flip the anchor before CommitAnchor")
+
+	r.CommitAnchor(result.AnchorChange.NewAnchor)
+	assert.Equal(t, second, r.AnchorKey())
+}
+
+func TestReconcileWithoutAnchorChangeSignalsNil(t *testing.T) {
+	r := newTestRotator()
+	anchor := config.SDKKey("anchor")
+	now := time.Now()
+
+	result := r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor})), now)
+	require.NotNil(t, result.AnchorChange)
+	r.CommitAnchor(result.AnchorChange.NewAnchor)
+
+	// Reconciling again with the same anchor is not a transition.
+	result = r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: anchor})), now)
+	assert.Nil(t, result.AnchorChange, "no anchor change when the anchor is unchanged")
+	assert.Equal(t, anchor, r.AnchorKey())
 }
 
 func TestReconcileMultipleMobileKeys(t *testing.T) {
@@ -273,9 +320,11 @@ func TestReconcileDeExpiryRestoresKey(t *testing.T) {
 func TestAcceptedKeys(t *testing.T) {
 	t.Run("single anchor plus primary mobile", func(t *testing.T) {
 		r := newTestRotator()
-		r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		result := r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
 			WithAnchor(SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
 			WithPrimaryMobileKey(MobileKeyParams{Value: "mob-primary", Key: util.PtrOrNil("mob-1")})), time.Unix(0, 0))
+		require.NotNil(t, result.AnchorChange)
+		r.CommitAnchor(result.AnchorChange.NewAnchor)
 
 		set := r.AcceptedKeys()
 		require.Len(t, set.Server, 1)
@@ -298,11 +347,13 @@ func TestAcceptedKeys(t *testing.T) {
 	t.Run("multiple keys include the anchor; expiry populated", func(t *testing.T) {
 		r := newTestRotator()
 		expiry := time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC)
-		r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		result := r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
 			WithAnchor(SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
 			WithSDKKey(SDKKeyParams{Value: "sdk-b", Key: util.PtrOrNil("b-service")}).
 			WithSDKKey(SDKKeyParams{Value: "sdk-old", Key: util.PtrOrNil("old-key"), Expiry: util.PtrOrNil(expiry)}).
 			WithPrimaryMobileKey(MobileKeyParams{Value: "mob-primary"})), time.Unix(0, 0))
+		require.NotNil(t, result.AnchorChange)
+		r.CommitAnchor(result.AnchorChange.NewAnchor)
 
 		set := r.AcceptedKeys()
 		require.Len(t, set.Server, 3) // anchor + sdk-b + sdk-old

--- a/internal/relayenv/env_context_credential_serialization_test.go
+++ b/internal/relayenv/env_context_credential_serialization_test.go
@@ -1,0 +1,62 @@
+package relayenv
+
+// Regression for the deferred-flip concurrency hazard: the cleanup ticker's triggerCredentialChanges
+// must be serialized against reconcileCredentials via reconcileMu. Because Reconcile queues the new
+// anchor's addition but defers the pointer flip to CommitAnchor, a ticker that drained that addition in
+// the window between them would run addCredential with the anchor still on the old key, skip the new
+// anchor's startSDKClient, and leave the env with no upstream client. reconcileMu closes that window.
+
+import (
+	"testing"
+	"time"
+
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialTickerIsSerializedAgainstReconcile(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, envConfig, testclient.FakeLDClientFactoryWithChannel(true, clientCh), mockLog.Loggers, readyCh)
+	defer env.Close()
+
+	require.Equal(t, env, requireEnvReady(t, readyCh))
+	requireClientReady(t, clientCh)
+
+	envImpl := env.(*envContextImpl)
+
+	// Stand in for an in-flight reconcileCredentials by holding reconcileMu: while it is held, the
+	// cleanup ticker's triggerCredentialChanges must NOT run (that is exactly the interleaving that would
+	// steal a queued addition mid-re-anchor).
+	envImpl.reconcileMu.Lock()
+
+	tickerDone := make(chan struct{})
+	go func() {
+		envImpl.triggerCredentialChanges(time.Unix(3000, 0))
+		close(tickerDone)
+	}()
+
+	select {
+	case <-tickerDone:
+		envImpl.reconcileMu.Unlock()
+		t.Fatal("triggerCredentialChanges ran while reconcileMu was held: the ticker is not serialized against reconcile")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: the ticker is blocked on reconcileMu.
+	}
+
+	// Once the "reconcile" releases the lock, the ticker proceeds.
+	envImpl.reconcileMu.Unlock()
+	select {
+	case <-tickerDone:
+	case <-time.After(time.Second):
+		t.Fatal("triggerCredentialChanges did not proceed after reconcileMu was released")
+	}
+}

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -123,6 +123,12 @@ type envContextImpl struct {
 	connectionMapper          ConnectionMapper
 	offline                   bool
 	closed                    bool
+
+	// reconcileMu serializes credential reconciliation. Both reconcileCredentials and the cleanup
+	// ticker's triggerCredentialChanges hold it, so they never interleave: the anchor flip (deferred
+	// to CommitAnchor) stays atomic with the addition it queues, and the ticker cannot drain a queued
+	// addition while reconcile has committed the accepted set but not yet moved the anchor pointer.
+	reconcileMu sync.Mutex
 }
 
 // Implementation of the DataStoreQueries interface that the streams package uses as an abstraction of
@@ -606,15 +612,43 @@ func (c *envContextImpl) ReconcileCredentials(newSet credential.AcceptedSet) {
 // reference time for expiry math; production callers pass time.Now() via ReconcileCredentials.
 //
 // The Rotator owns the diff (add → re-anchor → remove) and queues the resulting additions and
-// expirations; triggerCredentialChanges then applies them, draining additions before expirations so
+// expirations; drainCredentialChanges then applies them, draining additions before expirations so
 // the accepted set is a superset during the transition. addCredential opens an upstream client only
 // for the anchor, so non-anchor server keys are accepted and routed without a second connection.
+//
+// Reconcile no longer flips the SDK anchor pointer itself; it reports an anchor change and the pointer
+// is moved here via CommitAnchor. Committing immediately (before the drain) reproduces the previous
+// in-place-flip behavior: by the time addCredential runs for the new anchor, AnchorKey() already names
+// it, so its upstream client is started exactly as before.
+//
+// reconcileMu is held across Reconcile → CommitAnchor → drain so the whole sequence is atomic against
+// the cleanup ticker's triggerCredentialChanges. Without it, the ticker could drain the queued new-anchor
+// addition in the window after Reconcile queued it but before CommitAnchor moved the pointer, so
+// addCredential's anchor gate would not fire and the new anchor would never get its upstream client.
 func (c *envContextImpl) reconcileCredentials(newSet credential.AcceptedSet, now time.Time) {
-	c.keyRotator.Reconcile(newSet, now)
-	c.triggerCredentialChanges(now)
+	c.reconcileMu.Lock()
+	defer c.reconcileMu.Unlock()
+
+	result := c.keyRotator.Reconcile(newSet, now)
+	if result.AnchorChange != nil {
+		c.keyRotator.CommitAnchor(result.AnchorChange.NewAnchor)
+	}
+	c.drainCredentialChanges(now)
 }
 
+// triggerCredentialChanges is the cleanup ticker's entry point (cleanupExpiredCredentials). It takes
+// reconcileMu so it is serialized against reconcileCredentials the same way concurrent reconciles are —
+// it never interleaves with an in-flight reconcile's Reconcile/CommitAnchor pair. reconcileCredentials
+// must NOT call this (it would re-enter reconcileMu); it calls drainCredentialChanges directly.
 func (c *envContextImpl) triggerCredentialChanges(now time.Time) {
+	c.reconcileMu.Lock()
+	defer c.reconcileMu.Unlock()
+	c.drainCredentialChanges(now)
+}
+
+// drainCredentialChanges applies the rotator's queued additions (before expirations, so the accepted
+// set is a superset during the transition). The caller must hold reconcileMu.
+func (c *envContextImpl) drainCredentialChanges(now time.Time) {
 	additions, expirations := c.keyRotator.StepTime(now)
 	for _, cred := range additions {
 		c.addCredential(cred)


### PR DESCRIPTION
## Summary

Third slice carved out of #720 (the re-anchor mechanism, SDK-2542), split for reviewability. Introduces the **deferred anchor-flip seam** the synchronous re-anchor is built on. Sibling of #736 (store handover, merged) and #737 (relayenv refactors) off `feat/concurrent-keys`.

`Rotator.Reconcile` no longer flips the SDK anchor pointer when the anchor changes. It returns a `ReconcileResult` reporting the `AnchorChange` (previous -> new), and a new `CommitAnchor` method moves the pointer. This is the seam the re-anchor needs: it lets the caller build (and initialize) the new anchor's SDK client *before* the pointer moves, instead of flipping first and racing an async build.

### Serialization (why this is safe under concurrency)

Deferring the flip means it is now a **second** lock acquisition (`CommitAnchor`) rather than done in place inside `Reconcile`. That would open a window where `Reconcile` has queued the new anchor's addition but the pointer has not moved yet -- and the per-env cleanup ticker (`triggerCredentialChanges`) could drain that addition, run `addCredential` with the anchor still on the old key, skip `startSDKClient`, and leave the env with no upstream client. To close it, a new `reconcileMu` serializes `reconcileCredentials` against the cleanup ticker: the Reconcile -> CommitAnchor -> drain sequence is atomic against the ticker, exactly as concurrent reconciles already were. `reconcileCredentials` drains via a lock-free `drainCredentialChanges` (not `triggerCredentialChanges`) to avoid re-entering `reconcileMu`.

Behavior-preserving, including under concurrency: by the time `addCredential` runs for the new anchor, `AnchorKey()` already names it, so its upstream client starts exactly as before. Verified with `go test -race`, `go vet`, and `make lint`.

### Tests

- Rotator unit tests: `Reconcile` reports the change but leaves the pointer until `CommitAnchor`, and signals `nil` when unchanged.
- Serialization regression: the cleanup ticker's `triggerCredentialChanges` blocks while a reconcile holds `reconcileMu`, then proceeds once released.

### Deliberately out of scope (they land with the synchronous re-anchor, #739)

Stripping the new anchor from `additions`, rollback (`RevertAnchorChange`), and the mobile-primary repoint -- each depends on the synchronous client build to be correct, so they are not in this PR.

### Split sequence

PR 3 of 4: store handover (#736, merged) -> relayenv refactors (#737) -> **credential deferred-flip** (this PR) -> synchronous re-anchor core (#739).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential rotation and per-env upstream client startup under concurrency; behavior is intended to stay equivalent when `CommitAnchor` runs before drain, but the new mutex and API contract are on a critical path for SDK key re-anchoring.
> 
> **Overview**
> Introduces a **deferred SDK anchor flip** so callers can move the upstream anchor only when ready (e.g. after building the new client), instead of updating the pointer inside `Rotator.Reconcile`.
> 
> **Credential rotator:** `Reconcile` now returns `ReconcileResult` with an optional `AnchorChange` (previous → new anchor) and no longer assigns `anchorKey` in `reconcileSDKKeys`. Callers apply the transition with new `CommitAnchor`. Accepted-set diffs and queued additions/expirations behave as before.
> 
> **Relay environment:** `reconcileCredentials` runs `Reconcile` → `CommitAnchor` (when needed) → `drainCredentialChanges` under new `reconcileMu`, so that sequence cannot interleave with the cleanup ticker’s `triggerCredentialChanges`. Draining is split into `drainCredentialChanges` to avoid re-entering the mutex from reconcile. Immediate `CommitAnchor` before drain preserves today’s behavior: when `addCredential` runs for the new anchor, `AnchorKey()` already matches it.
> 
> **Tests:** Rotator tests cover deferred flip, nil `AnchorChange` when unchanged, and updated flows that call `CommitAnchor`. A relayenv regression asserts the ticker blocks on `reconcileMu` while reconcile holds it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7b4fb265385a4566481a1b0354aeb2024c6763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->