### PR TITLE
feat: Re-anchor big-segment sync onto the new anchor

### DIFF
--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -89,19 +89,23 @@ type EnvContextImplParams struct {
 }
 
 type envContextImpl struct {
-	mu                        sync.RWMutex
-	clients                   map[config.SDKKey]sdks.LDClientContext
-	storeAdapter              *store.SSERelayDataStoreAdapter
-	loggers                   ldlog.Loggers
-	identifiers               EnvIdentifiers
-	secureMode                bool
-	envStreams                *streams.EnvStreams
-	streamProviders           []streams.StreamProvider
-	handlers                  map[streams.StreamProvider]map[credential.SDKCredential]http.Handler
-	jsContext                 JSClientContext
-	evaluator                 ldeval.Evaluator
-	eventDispatcher           *events.EventDispatcher
-	bigSegmentSync            bigsegments.BigSegmentSynchronizer
+	mu              sync.RWMutex
+	clients         map[config.SDKKey]sdks.LDClientContext
+	storeAdapter    *store.SSERelayDataStoreAdapter
+	loggers         ldlog.Loggers
+	identifiers     EnvIdentifiers
+	secureMode      bool
+	envStreams      *streams.EnvStreams
+	streamProviders []streams.StreamProvider
+	handlers        map[streams.StreamProvider]map[credential.SDKCredential]http.Handler
+	jsContext       JSClientContext
+	evaluator       ldeval.Evaluator
+	eventDispatcher *events.EventDispatcher
+	bigSegmentSync  bigsegments.BigSegmentSynchronizer
+	// makeBigSegmentSync builds a BigSegmentSynchronizer for a given anchor SDK key, binding the
+	// construction-time inputs (http config, store, URIs, env ID, loggers). A re-anchor uses it to
+	// rebuild the synchronizer on the new anchor. nil when big segments are not configured.
+	makeBigSegmentSync        func(anchor config.SDKKey) bigsegments.BigSegmentSynchronizer
 	bigSegmentStore           bigsegments.BigSegmentStore
 	bigSegmentsExist          bool
 	sdkBigSegments            *ldstoreimpl.BigSegmentStoreWrapper
@@ -231,33 +235,20 @@ func NewEnvContext(
 		if factory == nil {
 			factory = bigsegments.DefaultBigSegmentSynchronizerFactory
 		}
-		envContext.bigSegmentSync = factory(
-			httpConfig, bigSegmentStore, allConfig.Main.BaseURI.String(), allConfig.Main.StreamURI.String(),
-			envConfig.EnvID, envConfig.SDKKey, envLoggers, logPrefix)
-		thingsToCleanUp.AddFunc(envContext.bigSegmentSync.Close)
-		segmentUpdateCh := envContext.bigSegmentSync.SegmentUpdatesCh()
-		if segmentUpdateCh != nil {
-			go func() {
-				for range segmentUpdateCh {
-					// BigSegmentSynchronizer sends to this channel after processing a batch of
-					// big segment updates. The value it sends is a list of segment keys, but in
-					// the current implementation, we don't care what those keys are because we'll
-					// just be broadcasting a "ping" to all connected client-side SDKs. In the future
-					// if we have real evaluation streams, we'll need to determine which flags should
-					// be re-evaluated based on the segments.
-					if envContext.sdkBigSegments != nil {
-						envContext.sdkBigSegments.ClearCache()
-					}
-					if envContext.envStreams != nil {
-						envContext.envStreams.InvalidateClientSideState()
-					}
-					// If we shut down the environment, the BigSegmentSynchronizer will be closed which
-					// will also cause this channel to be closed, exiting this goroutine.
-				}
-			}()
+		// Bind the construction-time inputs so a re-anchor can rebuild the synchronizer on the new anchor
+		// key (see reanchorBigSegmentSync). The synchronizer authenticates from the SDK key it is handed
+		// (bigsegments/sync sets the Authorization header from it directly), so re-anchoring only needs
+		// the new key; httpConfig is transport configuration and is reused as-is.
+		baseURI := allConfig.Main.BaseURI.String()
+		streamURI := allConfig.Main.StreamURI.String()
+		envContext.makeBigSegmentSync = func(anchor config.SDKKey) bigsegments.BigSegmentSynchronizer {
+			return factory(httpConfig, bigSegmentStore, baseURI, streamURI, envConfig.EnvID, anchor, envLoggers, logPrefix)
 		}
-		// We deliberate do not call bigSegmentSync.Start() here because we don't want the synchronizer to
-		// start until we know that at least one big segment exists. That's implemented by the
+		envContext.bigSegmentSync = envContext.makeBigSegmentSync(envConfig.SDKKey)
+		thingsToCleanUp.AddFunc(envContext.bigSegmentSync.Close)
+		envContext.consumeBigSegmentUpdates(envContext.bigSegmentSync)
+		// We deliberately do not call bigSegmentSync.Start() here because we don't want the synchronizer
+		// to start until we know that at least one big segment exists. That's implemented by the
 		// envContextStreamUpdates methods.
 	}
 
@@ -796,11 +787,9 @@ func (c *envContextImpl) commitReanchor(newAnchor, previousAnchor config.SDKKey,
 		c.eventDispatcher.ReplaceCredential(newAnchor)
 	}
 
-	// Big-segment synchronization is intentionally left pointing at the previous anchor key across a
-	// re-anchor: this matches pre-concurrent-keys behavior (there was no re-anchor, so it never moved)
-	// and does not regress. When big-segment re-anchor is implemented, its re-wire hook belongs right
-	// here, after the event/metrics ReplaceCredential calls — either recreate the BigSegmentSynchronizer
-	// for newAnchor, or add a credential-replacement method to it.
+	// Re-wire big-segment synchronization onto the new anchor: its poll/stream requests authenticate
+	// with the anchor SDK key, so it must follow the anchor like the event/metrics forwarding above.
+	c.reanchorBigSegmentSync(newAnchor)
 
 	c.globalLoggers.Infof("Re-anchored SDK from %s to %s (%s)", previousAnchor.Masked(), newAnchor.Masked(), why)
 	return true
@@ -1061,16 +1050,82 @@ func (c *envContextImpl) Close() error {
 	return nil
 }
 
+// consumeBigSegmentUpdates spawns a goroutine that drains sync's update channel, broadcasting a
+// cache-clear + client-side invalidation for each batch. The goroutine exits when the channel closes
+// (i.e. when sync is Closed). Called for the initial synchronizer and for each re-anchor replacement, so
+// each synchronizer instance gets its own consumer bound to its own channel.
+func (c *envContextImpl) consumeBigSegmentUpdates(sync bigsegments.BigSegmentSynchronizer) {
+	ch := sync.SegmentUpdatesCh()
+	if ch == nil {
+		return
+	}
+	go func() {
+		for range ch {
+			// The batch's segment keys are not needed today: we just ping all connected client-side SDKs.
+			// (A future evaluation-stream design would use the keys to target re-evaluation.)
+			if c.sdkBigSegments != nil {
+				c.sdkBigSegments.ClearCache()
+			}
+			if c.envStreams != nil {
+				c.envStreams.InvalidateClientSideState()
+			}
+		}
+	}()
+}
+
+// reanchorBigSegmentSync rebuilds the big-segment synchronizer on the new anchor when the SDK anchor
+// changes. The synchronizer bakes in its SDK key at construction and is not restartable, so re-anchoring
+// recreates it rather than mutating it. The caller (commitReanchor) holds c.mu.
+//
+// If a big segment had already appeared (bigSegmentsExist -> the old synchronizer was Started), the
+// replacement is Started immediately so synchronization continues without a gap. The old synchronizer is
+// Closed last, which also ends its update-consumer goroutine. When big segments are not configured for
+// this env there is no synchronizer and this is a no-op. sdkBigSegments (the SDK-facing store wrapper)
+// persists across the re-anchor, so its polling-active state does not need re-setting here.
+func (c *envContextImpl) reanchorBigSegmentSync(newAnchor config.SDKKey) {
+	if c.bigSegmentSync == nil {
+		return
+	}
+	wasStarted := c.bigSegmentsExist
+	old := c.bigSegmentSync
+	c.bigSegmentSync = c.makeBigSegmentSync(newAnchor)
+	c.consumeBigSegmentUpdates(c.bigSegmentSync)
+	if wasStarted {
+		c.bigSegmentSync.Start()
+	}
+	old.Close()
+}
+
 func (c *envContextImpl) setBigSegmentsExist() {
 	c.mu.Lock()
-	alreadyExisted := c.bigSegmentsExist
+	firstTime := !c.bigSegmentsExist
 	c.bigSegmentsExist = true
+	// Start the CURRENT synchronizer while holding the lock. Capturing the pointer and starting it after
+	// unlocking would let a concurrent re-anchor swap and Close that instance in between, so we'd Start()
+	// a synchronizer that was just retired. Starting c.bigSegmentSync under the lock guarantees we start
+	// whichever synchronizer is current -- the same one reanchorBigSegmentSync starts under this lock --
+	// and never a retired one. Start() only launches a goroutine (it is non-blocking), so holding c.mu is
+	// fine, exactly as in reanchorBigSegmentSync.
+	started := firstTime && c.bigSegmentSync != nil
+	if started {
+		c.bigSegmentSync.Start()
+	}
 	c.mu.Unlock()
 
-	if !alreadyExisted && c.bigSegmentSync != nil {
-		c.bigSegmentSync.Start()
+	if started {
 		c.sdkBigSegments.SetPollingActive(true) // has no effect if already active
 	}
+}
+
+// bigSegmentSyncConfigured reports whether this env has a big-segment synchronizer. The field's
+// nil-ness is invariant over the env's life (nil iff big segments were never configured; a re-anchor
+// only swaps one non-nil synchronizer for another), but the read must still be synchronized against
+// that concurrent reassign in reanchorBigSegmentSync -- the store-update sink below runs on the SDK
+// data-source goroutine while a re-anchor runs on the reconcile goroutine.
+func (c *envContextImpl) bigSegmentSyncConfigured() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.bigSegmentSync != nil
 }
 
 func (q envContextStoreQueries) IsInitialized() bool {
@@ -1091,7 +1146,7 @@ func (u *envContextStreamUpdates) SendAllDataUpdate(allData []ldstoretypes.Colle
 	// We use this delegator, rather than sending updates directory to context.envStreams, so that we
 	// can detect the presence of a big segment and turn on the big segment synchronizer as needed.
 	u.context.envStreams.SendAllDataUpdate(allData)
-	if u.context.bigSegmentSync == nil {
+	if !u.context.bigSegmentSyncConfigured() {
 		return
 	}
 
@@ -1114,7 +1169,7 @@ func (u *envContextStreamUpdates) SendAllDataUpdate(allData []ldstoretypes.Colle
 func (u *envContextStreamUpdates) SendSingleItemUpdate(kind ldstoretypes.DataKind, key string, item ldstoretypes.ItemDescriptor) {
 	// See comments in SendAllDataUpdate.
 	u.context.envStreams.SendSingleItemUpdate(kind, key, item)
-	if u.context.bigSegmentSync == nil {
+	if !u.context.bigSegmentSyncConfigured() {
 		return
 	}
 	hasBigSegment := false

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -1194,8 +1194,15 @@ func (s *mockBigSegmentSynchronizer) SegmentUpdatesCh() <-chan bigsegments.Updat
 
 func (s *mockBigSegmentSynchronizer) Close() {
 	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return
+	}
 	s.closed = true
-	s.lock.Unlock()
+	// Mirror the real synchronizer: Close closes the update channel, which is what terminates the
+	// consumer goroutine ranging over SegmentUpdatesCh(). Without this the tests would leak a consumer
+	// per re-anchor and never actually exercise the "old consumer exits on Close" invariant.
+	close(s.updateCh)
 }
 
 func (s *mockBigSegmentSynchronizer) isStarted() bool {

--- a/internal/relayenv/env_context_reanchor_bigsegment_test.go
+++ b/internal/relayenv/env_context_reanchor_bigsegment_test.go
@@ -1,0 +1,328 @@
+package relayenv
+
+// Tests for T2.d (SDK-2543): the big-segment synchronizer follows the anchor across a re-anchor.
+// TestReanchorPoC_H3_BigSegmentSyncFollowsAnchorOnReAnchor covers the basic "recreated on the new key,
+// not yet started" case; these cover the started-continues, rollback, and not-configured cases.
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/basictypes"
+	"github.com/launchdarkly/ld-relay/v8/internal/bigsegments"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+	"github.com/launchdarkly/ld-relay/v8/internal/streams"
+
+	"github.com/launchdarkly/eventsource"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	helpers "github.com/launchdarkly/go-test-helpers/v3"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newBigSegmentTestEnv(
+	t *testing.T,
+	storeFactory bigsegments.BigSegmentStoreFactory,
+	clientFactory sdks.ClientFactoryFunc,
+	capturing *capturingBigSegmentSynchronizerFactory,
+	loggers ldlog.Loggers,
+) EnvContext {
+	env, err := NewEnvContext(EnvContextImplParams{
+		Identifiers:                   EnvIdentifiers{ConfiguredName: st.EnvMain.Name},
+		EnvConfig:                     st.EnvMain.Config,
+		AllConfig:                     config.Config{},
+		BigSegmentStoreFactory:        storeFactory,
+		BigSegmentSynchronizerFactory: capturing.create,
+		ClientFactory:                 clientFactory,
+		SDKBigSegmentsConfigFactory: ldcomponents.BigSegments(
+			st.ExistingInstance[subsystems.BigSegmentStore](&st.NoOpSDKBigSegmentStore{}),
+		),
+		ConnectionMapper: mockConnectionMapper{},
+		Loggers:          loggers,
+	}, nil)
+	require.NoError(t, err)
+	return env
+}
+
+func nullBigSegmentStoreFactory(config.EnvConfig, config.Config, ldlog.Loggers) (bigsegments.BigSegmentStore, error) {
+	return bigsegments.NewNullBigSegmentStore(), nil
+}
+
+// TestReanchorBigSegmentSync_StartedSyncContinuesAndOldClosed: once a big segment exists the
+// synchronizer is Started; a re-anchor must recreate it on the new key, Start the replacement (so sync
+// continues without a gap), and Close the old one.
+func TestReanchorBigSegmentSync_StartedSyncContinuesAndOldClosed(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	capturing := &capturingBigSegmentSynchronizerFactory{}
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	env := newBigSegmentTestEnv(t, nullBigSegmentStoreFactory,
+		testclient.FakeLDClientFactoryWithChannel(true, clientCh), capturing, mockLog.Loggers)
+	defer env.Close()
+	envImpl := env.(*envContextImpl)
+
+	// A big segment appears -> the current synchronizer is Started.
+	envImpl.setBigSegmentsExist()
+	oldSync := capturing.latest()
+	require.True(t, oldSync.isStarted(), "the synchronizer is started once a big segment exists")
+
+	// Re-anchor onto a new key (its client builds healthy, so the re-anchor commits).
+	reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, time.Unix(1000, 0))
+
+	count, sdkKey := capturing.snapshot()
+	assert.Equal(t, 2, count, "the synchronizer is recreated on re-anchor")
+	assert.Equal(t, reanchorTestKey2, sdkKey, "on the new anchor key")
+	newSync := capturing.latest()
+	assert.NotSame(t, oldSync, newSync, "a fresh synchronizer instance")
+	assert.True(t, newSync.isStarted(), "the replacement is Started so synchronization continues without a gap")
+	assert.True(t, oldSync.isClosed(), "the old synchronizer is Closed")
+
+	// Closing the old synchronizer closes its update channel, which is what terminates its
+	// update-consumer goroutine (the `for range` in consumeBigSegmentUpdates). Verify the channel is
+	// closed so a re-anchor cannot leak a consumer per rotation.
+	_, ok := <-oldSync.updateCh
+	assert.False(t, ok, "the old synchronizer's update channel is closed, so its consumer goroutine exits")
+}
+
+// TestReanchorBigSegmentSync_RollbackDoesNotRewire: if the re-anchor's new client fails to build, the
+// re-anchor rolls back and the big-segment synchronizer must stay on the previous anchor (not recreated,
+// not closed).
+func TestReanchorBigSegmentSync_RollbackDoesNotRewire(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	capturing := &capturingBigSegmentSynchronizerFactory{}
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	healthy := testclient.FakeLDClientFactoryWithChannel(true, clientCh)
+	clientFactory := func(sdkKey config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		if sdkKey == reanchorTestKey2 {
+			// New anchor fails to init (non-nil uninitialized client + error, as the real SDK returns).
+			return &testclient.FakeLDClient{Key: sdkKey, CloseCh: make(chan struct{})}, ld.ErrInitializationFailed
+		}
+		return healthy(sdkKey, cfg, timeout)
+	}
+
+	env := newBigSegmentTestEnv(t, nullBigSegmentStoreFactory, clientFactory, capturing, mockLog.Loggers)
+	defer env.Close()
+	envImpl := env.(*envContextImpl)
+	envImpl.setBigSegmentsExist() // synchronizer started
+	oldSync := capturing.latest()
+
+	// Re-anchor to the failing key -> rollback.
+	reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, time.Unix(1000, 0))
+
+	count, sdkKey := capturing.snapshot()
+	assert.Equal(t, 1, count, "a rolled-back re-anchor must not recreate the synchronizer")
+	assert.Equal(t, envConfig.SDKKey, sdkKey, "it stays on the previous anchor key")
+	assert.Same(t, oldSync, capturing.latest(), "same synchronizer instance")
+	assert.False(t, oldSync.isClosed(), "the synchronizer is not closed by a rolled-back re-anchor")
+	assert.Equal(t, envConfig.SDKKey, envImpl.keyRotator.AnchorKey(), "anchor unchanged after rollback")
+}
+
+// TestReanchorBigSegmentSync_NotConfiguredIsNoOp: when big segments are not configured there is no
+// synchronizer, and a re-anchor must be a no-op for big-segment sync (no creation, no panic).
+func TestReanchorBigSegmentSync_NotConfiguredIsNoOp(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	capturing := &capturingBigSegmentSynchronizerFactory{}
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	noStore := func(config.EnvConfig, config.Config, ldlog.Loggers) (bigsegments.BigSegmentStore, error) {
+		return nil, nil // no big-segment store -> no synchronizer
+	}
+	env := newBigSegmentTestEnv(t, noStore,
+		testclient.FakeLDClientFactoryWithChannel(true, clientCh), capturing, mockLog.Loggers)
+	defer env.Close()
+
+	reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, time.Unix(1000, 0))
+
+	count, _ := capturing.snapshot()
+	assert.Equal(t, 0, count, "no synchronizer is created when big segments are not configured")
+	assert.Equal(t, reanchorTestKey2, env.(*envContextImpl).keyRotator.AnchorKey(), "the SDK re-anchor still committed")
+}
+
+// TestReanchorBigSegmentSync_NewSyncDrivesClientSideInvalidation is the end-to-end integration case
+// (SDK-2543 AC): with a client-side stream connected across a re-anchor, a big-segment update delivered
+// on the NEW synchronizer must still ping the connected client -- proving the re-wired synchronizer's
+// update consumer is active and drives client-side invalidation.
+func TestReanchorBigSegmentSync_NewSyncDrivesClientSideInvalidation(t *testing.T) {
+	envConfig := st.EnvClientSide.Config
+	capturing := &capturingBigSegmentSynchronizerFactory{}
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	jsClientStreams := streams.NewStreamProvider(basictypes.JSClientPingStream, time.Hour, 0)
+	sdkStartedCh := make(chan EnvContext, 1)
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	env, err := NewEnvContext(EnvContextImplParams{
+		Identifiers:                   EnvIdentifiers{ConfiguredName: st.EnvMain.Name},
+		EnvConfig:                     envConfig,
+		AllConfig:                     config.Config{},
+		BigSegmentStoreFactory:        nullBigSegmentStoreFactory,
+		BigSegmentSynchronizerFactory: capturing.create,
+		ClientFactory:                 testclient.FakeLDClientFactoryWithChannel(true, clientCh),
+		SDKBigSegmentsConfigFactory: ldcomponents.BigSegments(
+			st.ExistingInstance[subsystems.BigSegmentStore](&st.NoOpSDKBigSegmentStore{}),
+		),
+		StreamProviders:  []streams.StreamProvider{jsClientStreams},
+		ConnectionMapper: mockConnectionMapper{},
+		Loggers:          mockLog.Loggers,
+	}, sdkStartedCh)
+	require.NoError(t, err)
+	defer env.Close()
+
+	<-sdkStartedCh
+	_ = env.GetStore().Init(nil) // client-side endpoint only pings once the store is initialized
+	oldSync := capturing.latest()
+
+	streamHandler := env.GetStreamHandler(jsClientStreams, envConfig.EnvID)
+	req, _ := http.NewRequest("GET", "", nil)
+	st.WithStreamRequest(t, req, streamHandler, func(eventCh <-chan eventsource.Event) {
+		initEvent := helpers.RequireValue(t, eventCh, time.Minute)
+		require.Equal(t, "ping", initEvent.Event())
+		helpers.AssertNoMoreValues(t, eventCh, 100*time.Millisecond)
+
+		// Re-anchor mid-subscription; the synchronizer is rebuilt on the new anchor.
+		reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, time.Unix(1000, 0))
+		newSync := capturing.latest()
+		require.NotSame(t, oldSync, newSync, "the synchronizer was rebuilt on re-anchor")
+
+		// A big-segment update on the NEW synchronizer pings the still-connected client-side stream.
+		newSync.updateCh <- bigsegments.UpdatesSummary{SegmentKeysUpdated: []string{"seg"}}
+		pingEvent := helpers.RequireValue(t, eventCh, time.Second)
+		assert.Equal(t, "ping", pingEvent.Event())
+	})
+}
+
+// reanchorTestKey3 is a third anchor SDK key, used to drive A->B->C sequential re-anchors.
+const reanchorTestKey3 = config.SDKKey("reanchor-poc-new-anchor-3")
+
+// TestReanchorBigSegmentSync_ReanchorBeforeFirstSegmentThenStartsNewSync covers the ordering where a
+// re-anchor happens BEFORE any big segment has appeared (so the replacement is built but not started),
+// and then the first segment appears. setBigSegmentsExist must start the CURRENT (new) synchronizer,
+// never the retired one.
+func TestReanchorBigSegmentSync_ReanchorBeforeFirstSegmentThenStartsNewSync(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	capturing := &capturingBigSegmentSynchronizerFactory{}
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	env := newBigSegmentTestEnv(t, nullBigSegmentStoreFactory,
+		testclient.FakeLDClientFactoryWithChannel(true, clientCh), capturing, mockLog.Loggers)
+	defer env.Close()
+	envImpl := env.(*envContextImpl)
+
+	oldSync := capturing.latest()
+	require.False(t, oldSync.isStarted(), "no big segment yet -> the synchronizer is not started")
+
+	// Re-anchor before any segment appears: the replacement is built on the new key but NOT started.
+	reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, time.Unix(1000, 0))
+	newSync := capturing.latest()
+	require.NotSame(t, oldSync, newSync, "a fresh synchronizer instance on the new key")
+	require.False(t, newSync.isStarted(), "still no segment -> the replacement is not started yet")
+	assert.True(t, oldSync.isClosed(), "the old synchronizer is Closed on re-anchor")
+
+	// The first big segment now appears: the CURRENT (new) synchronizer must be started.
+	envImpl.setBigSegmentsExist()
+	assert.True(t, newSync.isStarted(), "the current synchronizer is started when the first segment appears")
+	assert.False(t, oldSync.isStarted(), "the retired synchronizer is never started")
+}
+
+// TestReanchorBigSegmentSync_MultipleSequentialReanchors drives A->B->C and asserts each intermediate
+// synchronizer is Closed, only the final one is current+Started, and the create bookkeeping tracks each
+// anchor key. Guards against synchronizer/consumer accumulation and stale-key bugs across rotations.
+func TestReanchorBigSegmentSync_MultipleSequentialReanchors(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	capturing := &capturingBigSegmentSynchronizerFactory{}
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	env := newBigSegmentTestEnv(t, nullBigSegmentStoreFactory,
+		testclient.FakeLDClientFactoryWithChannel(true, clientCh), capturing, mockLog.Loggers)
+	defer env.Close()
+	envImpl := env.(*envContextImpl)
+
+	envImpl.setBigSegmentsExist()
+	syncA := capturing.latest()
+	require.True(t, syncA.isStarted())
+
+	// A -> B.
+	reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, time.Unix(1000, 0))
+	syncB := capturing.latest()
+	require.NotSame(t, syncA, syncB)
+	assert.True(t, syncA.isClosed(), "A is closed after A->B")
+	assert.True(t, syncB.isStarted(), "B is started (a segment already existed)")
+
+	// B -> C.
+	reanchor(t, env, reanchorTestKey3, reanchorTestKey2, time.Unix(1000, 0))
+	syncC := capturing.latest()
+	require.NotSame(t, syncB, syncC)
+	assert.True(t, syncB.isClosed(), "B is closed after B->C")
+	assert.True(t, syncC.isStarted(), "C is started")
+
+	count, sdkKey := capturing.snapshot()
+	assert.Equal(t, 3, count, "one synchronizer per anchor: A, B, C")
+	assert.Equal(t, reanchorTestKey3, sdkKey, "the current synchronizer is on the final anchor key")
+	assert.Equal(t, reanchorTestKey3, envImpl.keyRotator.AnchorKey(), "the SDK anchor is C")
+}
+
+// TestReanchorBigSegmentSync_ConcurrentStoreUpdateDuringReanchorIsRaceFree is a regression test for the
+// data race introduced when re-anchor made c.bigSegmentSync runtime-mutable: the store-update sink reads
+// that field to decide whether to check for big segments, on the SDK data-source goroutine, while a
+// re-anchor reassigns it under c.mu on the reconcile goroutine. Without synchronizing the read, `go test
+// -race` flags a data race. This test drives the real sink concurrently with a real re-anchor.
+func TestReanchorBigSegmentSync_ConcurrentStoreUpdateDuringReanchorIsRaceFree(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	capturing := &capturingBigSegmentSynchronizerFactory{}
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	env := newBigSegmentTestEnv(t, nullBigSegmentStoreFactory,
+		testclient.FakeLDClientFactoryWithChannel(true, clientCh), capturing, mockLog.Loggers)
+	defer env.Close()
+	envImpl := env.(*envContextImpl)
+
+	// The sink wired into the store adapter; SendAllDataUpdate reads c.bigSegmentSync.
+	sink := &envContextStreamUpdates{context: envImpl}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				sink.SendAllDataUpdate(nil) // reads c.bigSegmentSync via bigSegmentSyncConfigured()
+			}
+		}
+	}()
+
+	// Re-anchor concurrently: reanchorBigSegmentSync reassigns c.bigSegmentSync under c.mu.
+	reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, time.Unix(1000, 0))
+
+	close(stop)
+	<-done
+
+	// Sanity: the re-anchor committed despite the concurrent sink traffic.
+	count, sdkKey := capturing.snapshot()
+	assert.Equal(t, 2, count, "the synchronizer was recreated on re-anchor")
+	assert.Equal(t, reanchorTestKey2, sdkKey, "on the new anchor key")
+}

--- a/internal/relayenv/env_context_reanchor_test.go
+++ b/internal/relayenv/env_context_reanchor_test.go
@@ -246,7 +246,11 @@ func TestReanchorPoC_H2_DownstreamConnectionSurvivesReAnchor(t *testing.T) {
 		}, time.Second, 10*time.Millisecond, "rotation to the new anchor should be applied")
 
 		// FINDING: the open client-side connection survives the swap and still delivers events.
-		synchronizer.updateCh <- bigsegments.UpdatesSummary{SegmentKeysUpdated: []string{"fake-segment-key"}}
+		// T2.d re-anchors the big-segment synchronizer, so a post-re-anchor update arrives on the CURRENT
+		// (rebuilt) synchronizer, not the retired one (whose channel is now closed).
+		current := fakeSynchronizerFactory.synchronizer
+		require.NotSame(t, synchronizer, current, "the synchronizer was rebuilt on re-anchor")
+		current.updateCh <- bigsegments.UpdatesSummary{SegmentKeysUpdated: []string{"fake-segment-key"}}
 		pingEvent := helpers.RequireValue(t, eventCh, time.Second)
 		assert.Equal(t, "ping", pingEvent.Event(), "downstream connection should survive the re-anchor")
 	})
@@ -310,7 +314,14 @@ func (f *capturingBigSegmentSynchronizerFactory) snapshot() (int, config.SDKKey)
 	return f.createCount, f.lastSDKKey
 }
 
-func TestReanchorPoC_H3_BigSegmentSyncIsNotReWiredOnReAnchor(t *testing.T) {
+// latest returns the most recently created synchronizer (the current one after a re-anchor rebuild).
+func (f *capturingBigSegmentSynchronizerFactory) latest() *mockBigSegmentSynchronizer {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.synchronizer
+}
+
+func TestReanchorPoC_H3_BigSegmentSyncFollowsAnchorOnReAnchor(t *testing.T) {
 	envConfig := st.EnvMain.Config
 
 	fakeBigSegmentStoreFactory := func(config.EnvConfig, config.Config, ldlog.Loggers) (bigsegments.BigSegmentStore, error) {
@@ -354,20 +365,13 @@ func TestReanchorPoC_H3_BigSegmentSyncIsNotReWiredOnReAnchor(t *testing.T) {
 		return false
 	}, time.Second, 10*time.Millisecond, "rotation to the new anchor should be applied")
 
-	// Give any (hypothetical) re-wire a chance to run.
-	require.Never(t, func() bool {
-		c, _ := capturing.snapshot()
-		return c != 1
-	}, 200*time.Millisecond, 20*time.Millisecond, "synchronizer must not be recreated by the re-anchor")
-
-	// FINDING: big-segment sync is wired to the SDK key at construction and is NOT re-wired by today's
-	// swap path -- the synchronizer is neither recreated nor told about the new key (the
-	// BigSegmentSynchronizer interface has no credential-replacement method). After re-anchor it keeps
-	// polling/streaming on the OLD anchor key. The big-segment re-wire (follow-up work) must add a
-	// re-wire path (a ReplaceCredential-style method) or recreate the synchronizer on each re-anchor.
+	// T2.d: the re-anchor recreates the big-segment synchronizer on the NEW anchor key, so its
+	// poll/stream requests authenticate with the current anchor instead of the retired one. The
+	// synchronizer bakes its SDK key in at construction and is not restartable, so re-anchoring rebuilds
+	// it. (reconcileCredentials -> commitReanchor -> reanchorBigSegmentSync runs synchronously.)
 	count, sdkKey = capturing.snapshot()
-	assert.Equal(t, 1, count, "synchronizer was not recreated on re-anchor")
-	assert.Equal(t, envConfig.SDKKey, sdkKey, "synchronizer still references the old anchor key")
+	assert.Equal(t, 2, count, "the synchronizer is recreated on re-anchor")
+	assert.Equal(t, reanchorTestKey2, sdkKey, "the new synchronizer references the new anchor key")
 }
 
 // -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When an environment re-anchors (its upstream SDK key changes), the big-segment synchronizer must follow the new anchor. The synchronizer bakes its SDK key in at construction and authenticates its poll/stream requests with that key directly, and it is not restartable (single-use `startOnce`/`closeOnce`). Left unchanged it would keep polling with the retired key after a re-anchor.

This recreates the synchronizer on the new anchor as part of the synchronous re-anchor commit:

- A `makeBigSegmentSync(anchor)` closure captured at construction binds the transport-only httpConfig, store, URIs, env ID, and loggers; only the anchor SDK key varies per rebuild.
- `commitReanchor` calls `reanchorBigSegmentSync(newAnchor)` under `c.mu`: build the replacement on the new key, re-attach its update consumer, start it iff a big segment had already appeared (so synchronization continues without a gap), then close the old synchronizer (which ends its consumer goroutine). No-op when big segments are not configured, and never runs on a rolled-back re-anchor.
- The update consumer was extracted to `consumeBigSegmentUpdates`, spawned per synchronizer instance so each rebuild gets its own consumer bound to its own channel.
- The store-update sink's read of the (now runtime-mutable) synchronizer field is synchronized, and `setBigSegmentsExist` starts the current synchronizer under the lock, so a concurrent re-anchor can never leave the wrong instance started.

Stacked on #739; targets `feat/concurrent-keys`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential re-anchor commit path and adds goroutine lifecycle around synchronizer swaps; mitigated by extensive tests including rollback, ordering, and race regression coverage.
> 
> **Overview**
> **Big-segment sync now follows SDK re-anchors** instead of staying on the retired anchor key. On `commitReanchor`, `reanchorBigSegmentSync` rebuilds the synchronizer (key is fixed at construction), re-attaches an update consumer, **starts** the replacement immediately if big segments were already active, then **closes** the old instance.
> 
> Construction stores a **`makeBigSegmentSync(anchor)`** closure so rebuilds reuse transport/store/URIs and only swap the anchor SDK key. Update handling moves to **`consumeBigSegmentUpdates`**, with one consumer goroutine per synchronizer instance.
> 
> Concurrency fixes: **`setBigSegmentsExist`** starts the current synchronizer under `c.mu` so a concurrent re-anchor cannot start a retired instance; store-update paths use **`bigSegmentSyncConfigured()`** (RLock) because `bigSegmentSync` is reassigned during re-anchor.
> 
> Tests cover started-sync continuity, rollback (no rewire), not-configured no-op, client-side invalidation after re-anchor, ordering before first segment, sequential A→B→C re-anchors, and concurrent store updates; mocks now close the update channel on `Close`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a73e3eb07cab8998a2f08f62113b4fbcf3ac14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->