### PR TITLE
fix: include basis in FDv2 replay singleflight key

### DIFF
--- a/internal/streams/stream_provider_server_side.go
+++ b/internal/streams/stream_provider_server_side.go
@@ -227,7 +227,11 @@ func (r *serverSideEnvStreamRepository) getReplayEventsV1() ([]eventsource.Event
 }
 
 func (r *serverSideEnvStreamRepository) getReplayEventsV2(basis string) ([]eventsource.Event, error) {
-	data, err, _ := r.flightGroup.Do("getReplayEventV2", func() (interface{}, error) {
+	// The result depends on the caller's basis: a client whose basis matches the current
+	// selector state gets an "up-to-date" event, while any other client gets a full data
+	// transfer. Only requests with the same basis may share a result, so the basis must be
+	// part of the key.
+	data, err, _ := r.flightGroup.Do("getReplayEventV2:"+basis, func() (interface{}, error) {
 		snapshot, selector, err := r.store.Snapshot()
 		if err != nil {
 			r.logger.Error("error getting all flags", "error", err)

--- a/internal/streams/stream_provider_server_side_test.go
+++ b/internal/streams/stream_provider_server_side_test.go
@@ -341,5 +341,57 @@ func TestStreamProviderServerSide(t *testing.T) {
 			assert.Equal(t, 1, getFlagFromEventData(t, events1[0]).Version)
 			assert.Equal(t, 1, getFlagFromEventData(t, events2[0]).Version) // only one computation was done
 		})
+
+		t.Run("v2 clients with different basis values connect concurrently", func(t *testing.T) {
+			const currentState = "current-state"
+			flag := ldbuilders.NewFlagBuilder(flagKey).Version(1).Build()
+			replayStarted := make(chan struct{}, 2)
+			replayCanFinish := make(chan struct{})
+			var gateFirstReplay sync.Once
+			store := newMockStoreQueries()
+			store.setupSnapshotFn(func() (map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor, subsystems.Selector, error) {
+				replayStarted <- struct{}{}
+				gateFirstReplay.Do(func() {
+					<-replayCanFinish
+				})
+				return map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor{
+					ldstoreimpl.Features(): {ldstoretypes.KeyedItemDescriptor{Key: flagKey, Item: sharedtest.FlagDesc(flag)}},
+					ldstoreimpl.Segments(): {},
+				}, subsystems.NewSelector(currentState, 1), nil
+			})
+			repo := &serverSideEnvStreamRepository{store: store, logger: slog.Default(), isV2: true}
+
+			// The first client's basis matches the store's current state, so its replay should be
+			// an "up-to-date" intent with no data.
+			eventCh1 := repo.Replay("", currentState)
+			<-replayStarted
+
+			// The second client has no basis, so it needs a full data transfer. Its result must
+			// not be shared with the first client's, even though the two replays are concurrent.
+			eventCh2 := repo.Replay("", "")
+
+			time.Sleep(time.Millisecond * 200)
+			// This delay gives the second replay's goroutine time to reach the flight group while
+			// the first computation is still in progress, which is the scenario under test. (See
+			// the comment in the previous subtest about timing sensitivity.)
+
+			close(replayCanFinish)
+
+			events1 := expectReplayedEvents(t, eventCh1)
+			require.Len(t, events1, 1)
+			assert.Equal(t, string(subsystems.EventServerIntent), events1[0].Event())
+			assert.Contains(t, events1[0].Data(), `"intentCode":"none"`)
+
+			events2 := expectReplayedEvents(t, eventCh2)
+			eventNames := make([]string, 0, len(events2))
+			for _, e := range events2 {
+				eventNames = append(eventNames, e.Event())
+			}
+			assert.Equal(t, []string{
+				string(subsystems.EventServerIntent),
+				string(subsystems.EventPutObject),
+				string(subsystems.EventPayloadTransferred),
+			}, eventNames)
+		})
 	})
 }


### PR DESCRIPTION
## Problem

`serverSideEnvStreamRepository.getReplayEventsV2` uses a singleflight group to collapse concurrent FDv2 stream replay requests into one store snapshot. The flight key was the constant `"getReplayEventV2"`, but the computed result depends on the per-request `basis` parameter:

- If the request's basis matches the current selector state, the result is an `intent: none` / `up-to-date` event with no data.
- Otherwise, the result is a full basis transfer (`server-intent` + `put-object`s + `payload-transferred`).

Because the key ignored the basis, all concurrent replay requests shared whichever result the first caller's basis produced:

- A fresh SDK (no basis, or a stale one) coalescing onto an "up-to-date" flight received only the up-to-date intent event and never received flag data, while believing it was current.
- An up-to-date SDK coalescing onto a full-transfer flight received a redundant full payload (wasteful but correct).

This is most likely to happen exactly when the singleflight engages: a reconnect burst after a Relay restart or deploy, where most SDKs reconnect with a current basis while some connect fresh.

## Fix

Include the basis in the singleflight key so only requests with the same basis share a result. Snapshot work is still collapsed within each basis group during reconnect bursts. The FDv1 path is unaffected; its result has no request-dependent input.

## Testing

Added a regression test in which one client replays with a basis matching the current selector state while a second, basis-less client replays concurrently. The test asserts the first client gets the up-to-date intent and the second gets a full transfer. It fails on the previous code (the second client received the first client's up-to-date replay) and passes with the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches server-side stream replay and SDK initial sync on reconnect bursts; the change is narrow and covered by a new concurrent-basis test.
> 
> **Overview**
> **FDv2 stream replay** no longer shares one `singleflight` result across clients with different `basis` values. The flight key changes from a fixed `"getReplayEventV2"` to `"getReplayEventV2:" + basis`, so only callers with the same basis coalesce.
> 
> That matters because replay output is **basis-dependent**: a matching basis gets an up-to-date intent with no payload, while other clients need a full transfer (`server-intent`, `put-object`, `payload-transferred`). With the old key, concurrent reconnects could hand a fresh or stale SDK the “up-to-date” replay from another client and **skip flag data**.
> 
> A regression test covers two **concurrent** v2 `Replay` calls—one with basis equal to the current selector state and one with an empty basis—and asserts each gets the correct event sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39bec278cc6c54ae4c5505ea587dbf5e6d7d0a55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->