### PR TITLE
refactor(relayenv): rename GetStreamHandler param to avoid shadowing credential package

### DIFF
--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -898,12 +898,12 @@ func (c *envContextImpl) GetLoggers() ldlog.Loggers {
 	return c.loggers
 }
 
-func (c *envContextImpl) GetStreamHandler(streamProvider streams.StreamProvider, credential credential.SDKCredential) http.Handler {
+func (c *envContextImpl) GetStreamHandler(streamProvider streams.StreamProvider, cred credential.SDKCredential) http.Handler {
 	// Build the handler on demand rather than storing one per (credential, provider): every handler in a
 	// (filter, provider) slot is identical except for the credential-derived channel id, which we resolve
 	// here from the request's already-authenticated credential. c.filterKey is immutable after
 	// construction, so this needs no lock.
-	if h := streamProvider.Handler(sdkauth.NewScoped(c.filterKey, credential)); h != nil {
+	if h := streamProvider.Handler(sdkauth.NewScoped(c.filterKey, cred)); h != nil {
 		return h
 	}
 	return http.HandlerFunc(invalidStreamHandler)


### PR DESCRIPTION
## Summary

Renames the `GetStreamHandler` parameter `credential` → `cred` in `internal/relayenv/env_context_impl.go` so it no longer shadows the imported `credential` package within the function body.

## Background

`GetStreamHandler` was introduced on `feat/concurrent-keys` by #742 (handler fan-out). The parameter was named `credential`, which shadows the `credential` package (`credential.SDKCredential`, `credential.Rotator`, etc.) inside the function. Fixing it at the source here means every branch off `feat/concurrent-keys` inherits the cleanup, rather than carrying the shadow onto mainline or bundling an unrelated rename into a bugfix PR (#744).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parameter-name-only change with no logic or API type changes.
> 
> **Overview**
> Renames the `GetStreamHandler` parameter from `credential` to `cred` in `env_context_impl.go` so the name no longer shadows the imported `credential` package inside the function.
> 
> Behavior is unchanged: the parameter type remains `credential.SDKCredential`, and the value is still passed to `sdkauth.NewScoped(c.filterKey, cred)` when resolving the stream handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6730cc2852f68fe99cd7b83c996b0687efedc7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->