### PR TITLE
test(concurrent-keys): even more integration tests

### DIFF
--- a/internal/autoconfigcache/reload_restart_redis_test.go
+++ b/internal/autoconfigcache/reload_restart_redis_test.go
@@ -1,0 +1,161 @@
+//go:build redis_unit_tests
+// +build redis_unit_tests
+
+package autoconfigcache
+
+// Verifies that a multi-key environment written to the real Redis-backed AutoConfig cache survives a
+// process restart: a fresh StreamManager, given the same Redis cache but a config stream that delivers
+// nothing, reloads the environment from the cache with its sdkKeys[]/mobileKeys[] arrays intact.
+//
+// This is the restart-survival half of the "cache integrity across restart" scenario (SDK-2609 #10);
+// the malformed-put-preserves-cache half is covered by the StreamManager unit test
+// TestMalformedCredentialPayloadPreservesEnvironmentCache. It exercises the production classes
+// (StreamManager + redisStore) against an actual Redis, with no test doubles for the cache itself.
+//
+// Requires a Redis server on localhost (the redis_unit_tests build tag; CI provides one).
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/autoconfig"
+	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"
+	"github.com/launchdarkly/ld-relay/v8/internal/httpconfig"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/configsource"
+
+	"github.com/launchdarkly/go-configtypes"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	helpers "github.com/launchdarkly/go-test-helpers/v3"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	restartRedisURL   = "redis://localhost:6379"
+	restartCacheKey   = "sdk2609-restart-reload-test"
+	restartProtocolV2 = 2
+)
+
+// capturingHandler is a minimal autoconfig.MessageHandler that records the environments it is told to
+// add, so the test can inspect what a StreamManager reloaded from the cache.
+type capturingHandler struct {
+	added chan envfactory.EnvironmentParams
+}
+
+func newCapturingHandler() *capturingHandler {
+	return &capturingHandler{added: make(chan envfactory.EnvironmentParams, 10)}
+}
+
+func (h *capturingHandler) AddEnvironment(params envfactory.EnvironmentParams)    { h.added <- params }
+func (h *capturingHandler) UpdateEnvironment(params envfactory.EnvironmentParams) { h.added <- params }
+func (h *capturingHandler) DeleteEnvironment(config.EnvironmentID)                {}
+func (h *capturingHandler) ReceivedAllEnvironments()                              {}
+func (h *capturingHandler) AddFilter(envfactory.FilterParams)                     {}
+func (h *capturingHandler) DeleteFilter(config.FilterID)                          {}
+
+func TestConcurrentKeysCacheReloadSurvivesRestart(t *testing.T) {
+	const (
+		envID     = config.EnvironmentID("multikey-env")
+		anchorSDK = config.SDKKey("sdk-anchor")
+		extraSDK  = config.SDKKey("sdk-extra")
+		anchorMob = config.MobileKey("mob-anchor")
+		extraMob  = config.MobileKey("mob-extra")
+	)
+
+	cacheConfig := func() config.Config {
+		cfg := config.Config{}
+		cfg.AutoConfig.Key = config.AutoConfigKey("test-key")
+		cfg.AutoConfig.CacheKey = restartCacheKey
+		cfg.Redis.URL, _ = configtypes.NewOptURLAbsoluteFromString(restartRedisURL)
+		return cfg
+	}
+
+	loggers := ldlog.NewDisabledLoggers()
+	httpConfig, err := httpconfig.NewHTTPConfig(config.ProxyConfig{}, config.HTTPConfig{}, nil, "", loggers)
+	require.NoError(t, err)
+
+	newStreamManager := func(streamURL string, store Store, handler autoconfig.MessageHandler) *autoconfig.StreamManager {
+		u, parseErr := url.Parse(streamURL)
+		require.NoError(t, parseErr)
+		return autoconfig.NewStreamManager(cacheConfig().AutoConfig.Key, u, handler, httpConfig,
+			time.Millisecond, restartProtocolV2, loggers, store)
+	}
+
+	// A multi-key environment (anchor + one extra SDK key, anchor + one extra mobile key) via the array
+	// wire format.
+	rep := envfactory.EnvironmentRep{
+		EnvID:    envID,
+		EnvKey:   "multikey",
+		EnvName:  "Multi-Key Env",
+		ProjKey:  "multikey-proj",
+		ProjName: "Multi-Key Project",
+		SDKKey:   envfactory.SDKKeyRep{Value: anchorSDK},
+		MobKey:   anchorMob,
+		SDKKeys: []envfactory.ConcurrentKeyRep{
+			{Key: "anchor-sdk", Value: string(anchorSDK)},
+			{Key: "extra-sdk", Value: string(extraSDK)},
+		},
+		MobileKeys: []envfactory.ConcurrentKeyRep{
+			{Key: "anchor-mob", Value: string(anchorMob)},
+			{Key: "extra-mob", Value: string(extraMob)},
+		},
+		Version: 1,
+	}
+
+	// Start from a clean cache so a previous run's entry can't stand in for this run's write.
+	seed, err := NewStore(cacheConfig(), loggers)
+	require.NoError(t, err)
+	require.NoError(t, seed.SetAll(context.Background(), autoconfig.PutContent{}))
+	require.NoError(t, seed.Close())
+
+	// First run: a StreamManager receives the multi-key put over its stream and persists it to Redis.
+	store1, err := NewStore(cacheConfig(), loggers)
+	require.NoError(t, err)
+	putEvent := configsource.MakeAutoConfigPutEvent(rep)
+	liveStream := configsource.NewRACMock(t, &putEvent)
+	sm1 := newStreamManager(liveStream.URL, store1, newCapturingHandler())
+	helpers.RequireValue(t, sm1.Start(), 5*time.Second, "timed out waiting for the first stream to be ready")
+
+	require.Eventually(t, func() bool {
+		content, _ := store1.GetAll(context.Background())
+		if content == nil {
+			return false
+		}
+		_, ok := content.Environments[envID]
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "the multi-key env was not persisted to the Redis cache")
+
+	sm1.Close() // simulate process shutdown (also closes store1's Redis client)
+
+	// Second run ("after the restart"): a fresh StreamManager with the same Redis cache but a config
+	// stream that connects and delivers nothing, so the cache is the only possible source.
+	store2, err := NewStore(cacheConfig(), loggers)
+	require.NoError(t, err)
+	silentStream := configsource.NewRACMock(t, nil)
+	handler2 := newCapturingHandler()
+	sm2 := newStreamManager(silentStream.URL, store2, handler2)
+	defer sm2.Close()
+	helpers.RequireValue(t, sm2.Start(), 5*time.Second, "timed out waiting for the second stream to be ready")
+
+	reloaded := helpers.RequireValue(t, handler2.added, 5*time.Second,
+		"the environment was not reloaded from the Redis cache after restart")
+	assert.Equal(t, envID, reloaded.EnvID)
+
+	// The multi-key arrays survived the cache round-trip: both the anchor and the non-anchor key are
+	// present in the reloaded accepted set, for SDK and mobile keys alike.
+	var sdkValues []config.SDKKey
+	for _, k := range reloaded.AcceptedSDKKeys {
+		sdkValues = append(sdkValues, k.Value)
+	}
+	assert.ElementsMatch(t, []config.SDKKey{anchorSDK, extraSDK}, sdkValues)
+
+	var mobValues []config.MobileKey
+	for _, k := range reloaded.AcceptedMobileKeys {
+		mobValues = append(mobValues, k.Value)
+	}
+	assert.ElementsMatch(t, []config.MobileKey{anchorMob, extraMob}, mobValues)
+}

--- a/relay/concurrent_keys_auth_test.go
+++ b/relay/concurrent_keys_auth_test.go
@@ -494,6 +494,61 @@ func TestConcurrentKeysRAC_NonAnchorConnectionSurvivesAnchorRotation(t *testing.
 	h.assertSDKEndpointsAvailability(true, extraSDKKey, "", "")
 }
 
+// multiKeyArchiveEnvWithAnchor is multiKeyArchiveEnv with a caller-chosen anchor SDK key, used to
+// rotate the anchor across an archive reload. The chosen anchor must also appear in sdkKeys.
+func multiKeyArchiveEnvWithAnchor(anchor config.SDKKey, sdkKeys []envfactory.AcceptedSDKKey, mobileKeys []envfactory.AcceptedMobileKey) filedata.ArchiveEnvironment {
+	env := multiKeyArchiveEnv(sdkKeys, mobileKeys)
+	env.Params.SDKKey = anchor
+	return env
+}
+
+// Rotating the anchor via an offline archive reload.
+//
+// A downstream SDK connected on a non-anchor key keeps its stream when the archive reloads with the
+// anchor rotated to a brand-new key: the new anchor authenticates, the old anchor stops, and the
+// non-anchor sibling is undisturbed. Offline re-anchoring reuses the environment's single file-data
+// client rather than swapping an upstream connection (that swap is the RAC path, exercised by
+// TestConcurrentKeysRAC_RotatingAnchorUpdatesUpstreamClient), so no new client is built and the open
+// connection survives. The non-anchor expiry-via-reload half of the offline reload-rotation scenario is
+// covered by TestConcurrentKeysOffline_ConnectedSDKDisconnectedWhenKeyExpires.
+func TestConcurrentKeysOffline_AnchorRotationViaArchiveReload(t *testing.T) {
+	offlineModeTest(t, config.Config{}, func(p offlineModeTestParams) {
+		p.updateHandler.AddEnvironment(multiKeyArchiveEnv(defaultAcceptedSDKKeys(), defaultAcceptedMobileKeys()))
+		anchorClient := p.awaitClient()
+		assert.Equal(t, anchorSDKKey, anchorClient.Key)
+		env := p.awaitEnvironment(multiKeyEnvID)
+		require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+		// Connect a downstream SDK on the non-anchor key and confirm it is live before rotating.
+		req := sharedtest.BuildRequestWithAuth("GET", "/all", extraSDKKey, nil)
+		sharedtest.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+			sharedtest.AwaitEventOfType(t, eventCh, "put", 5*time.Second)
+
+			// Reload the archive with the anchor rotated to a brand-new key; the non-anchor extra SDK key
+			// stays accepted and the mobile keys are unchanged.
+			p.updateHandler.UpdateEnvironment(multiKeyArchiveEnvWithAnchor(
+				rotatedAnchorSDKKey,
+				[]envfactory.AcceptedSDKKey{{Value: rotatedAnchorSDKKey}, {Value: extraSDKKey}},
+				defaultAcceptedMobileKeys(),
+			))
+
+			// The offline re-anchor reuses the single file-data client, so the non-anchor stream is not
+			// torn down by the swap.
+			assertStreamStaysOpen(t, eventCh, 500*time.Millisecond)
+		})
+
+		// Offline re-anchoring commits without building a replacement upstream client.
+		p.shouldNotCreateClient(200 * time.Millisecond)
+
+		awaitCredentialRemoved(t, p.relay, anchorSDKKey)
+
+		// The rotated anchor and the retained non-anchor key authenticate; the old anchor no longer does.
+		p.assertSDKEndpointsAvailability(true, rotatedAnchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, "", "")
+		p.assertSDKEndpointsAvailability(false, anchorSDKKey, "", "")
+	})
+}
+
 // awaitStreamClosed reads from a WithStreamRequest event channel until the stream-closed sentinel
 // (a nil event) arrives, failing if the timeout elapses first. Non-nil events are ignored.
 func awaitStreamClosed(t *testing.T, eventCh <-chan eventsource.Event, timeout time.Duration) {


### PR DESCRIPTION
## Summary

Two more integration tests from [SDK-2609](https://launchdarkly.atlassian.net/browse/SDK-2609). These required a bit more setup than those in #755. Both are test-only — no production code changes.

## Changes

- **Offline anchor rotation via archive reload**: reloading the offline config with a brand-new anchor key swaps it in — the old anchor stops while the non-anchor key and its open stream are undisturbed.
- **Cache reload survives a restart** (`redis_unit_tests`): a multi-key environment persisted to the real Redis-backed auto-config cache is reloaded, with its `sdkKeys[]`/`mobileKeys[]` arrays intact, by a fresh `StreamManager` whose config stream delivers nothing — so the cache is the only possible source. Exercises the production `StreamManager` + `redisStore` against a real Redis.


[SDK-2609]: https://launchdarkly.atlassian.net/browse/SDK-2609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (Redis-tagged integration test and offline relay harness); no runtime behavior modified in this diff.
> 
> **Overview**
> Adds two **SDK-2609** regression tests; no production code in this diff.
> 
> **Redis AutoConfig cache (restart survival):** New `TestConcurrentKeysCacheReloadSurvivesRestart` (`redis_unit_tests`) seeds Redis via a live `StreamManager`, shuts it down, then starts a second manager on the same cache with a silent config stream. It asserts the environment is reloaded from cache with full `AcceptedSDKKeys` / `AcceptedMobileKeys` (anchor + extra for both SDK and mobile).
> 
> **Offline multi-key anchor rotation:** Adds `multiKeyArchiveEnvWithAnchor` and `TestConcurrentKeysOffline_AnchorRotationViaArchiveReload`, which reloads file-data with a new anchor while a downstream SDK stays connected on a non-anchor key. Expects no new upstream client, stream stays open, new anchor + extra key auth, old anchor rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1818d2846d3a7b6a6c18d54b7c6d0b14b77621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
