### PR TITLE
fix(store): prevent a startup race from leaving the environment with a closed data store

### DIFF
--- a/internal/store/relay_feature_store.go
+++ b/internal/store/relay_feature_store.go
@@ -78,14 +78,21 @@ func NewSSERelayDataStoreAdapter(
 func (a *SSERelayDataStoreAdapter) Build(
 	context subsystems.ClientContext,
 ) (subsystems.DataStore, error) {
+	// The lock is held across the whole build so two concurrent Build calls cannot each construct and
+	// install their own wrapper (the last writer would win, and if its client were later discarded as
+	// superseded, its Close would tear down the store the adapter is serving). A second caller blocks
+	// until the first installs its store, then adopts it via the fast path below. This can block
+	// GetStore only while a store is built from nothing — the first build at startup — since every
+	// later Build, including a re-anchor handover, returns the already-built wrapper without calling
+	// the wrapped factory.
 	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	if existing := a.store; existing != nil {
 		if sw, ok := existing.(*streamUpdatesStoreWrapper); ok && sw.acquire() {
-			a.mu.Unlock()
 			return sw, nil
 		}
 	}
-	a.mu.Unlock()
 
 	wrappedStore, err := a.wrappedFactory.Build(context)
 	if err != nil {
@@ -96,24 +103,7 @@ func (a *SSERelayDataStoreAdapter) Build(
 		wrappedStore,
 		context.GetLogging().Loggers,
 	)
-
-	a.mu.Lock()
-	if existing := a.store; existing != nil {
-		if esw, ok := existing.(*streamUpdatesStoreWrapper); ok && esw.acquire() {
-			// A concurrent Build installed a wrapper while ours was being constructed. Hand the
-			// installed wrapper over, exactly as the fast path above does, and discard ours: an
-			// unconditional overwrite would let the last writer win, and if the last writer's client
-			// is later discarded as superseded, its Close would tear down the store the adapter is
-			// serving while the live client feeds a store nothing reads. Close the discarded wrapper
-			// outside the lock — a persistent store's Close does I/O, and GetStore must not block
-			// behind it.
-			a.mu.Unlock()
-			_ = sw.Close()
-			return esw, nil
-		}
-	}
 	a.store = sw
-	a.mu.Unlock()
 	return sw, nil
 }
 

--- a/internal/store/relay_feature_store.go
+++ b/internal/store/relay_feature_store.go
@@ -79,12 +79,7 @@ func (a *SSERelayDataStoreAdapter) Build(
 	context subsystems.ClientContext,
 ) (subsystems.DataStore, error) {
 	// The lock is held across the whole build so two concurrent Build calls cannot each construct and
-	// install their own wrapper (the last writer would win, and if its client were later discarded as
-	// superseded, its Close would tear down the store the adapter is serving). A second caller blocks
-	// until the first installs its store, then adopts it via the fast path below. This can block
-	// GetStore only while a store is built from nothing — the first build at startup — since every
-	// later Build, including a re-anchor handover, returns the already-built wrapper without calling
-	// the wrapped factory.
+	// install their own wrapper.
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/internal/store/relay_feature_store.go
+++ b/internal/store/relay_feature_store.go
@@ -75,6 +75,11 @@ func NewSSERelayDataStoreAdapter(
 // only torn down by the final Close (see streamUpdatesStoreWrapper.Close). If the parked wrapper has
 // already been fully closed (acquire returns false), a fresh one is built rather than resurrecting a
 // wrapper whose underlying store is torn down.
+//
+// The already-present check runs again after the wrapped factory builds: two Builds can race through
+// the nil check above (the environment's initial anchor-client build and a re-anchor's synchronous
+// build both run without the env lock held), and the one that finishes last must adopt the wrapper
+// the other installed rather than overwrite it.
 func (a *SSERelayDataStoreAdapter) Build(
 	context subsystems.ClientContext,
 ) (subsystems.DataStore, error) {
@@ -98,8 +103,22 @@ func (a *SSERelayDataStoreAdapter) Build(
 	)
 
 	a.mu.Lock()
-	defer a.mu.Unlock()
+	if existing := a.store; existing != nil {
+		if esw, ok := existing.(*streamUpdatesStoreWrapper); ok && esw.acquire() {
+			// A concurrent Build installed a wrapper while ours was being constructed. Hand the
+			// installed wrapper over, exactly as the fast path above does, and discard ours: an
+			// unconditional overwrite would let the last writer win, and if the last writer's client
+			// is later discarded as superseded, its Close would tear down the store the adapter is
+			// serving while the live client feeds a store nothing reads. Close the discarded wrapper
+			// outside the lock — a persistent store's Close does I/O, and GetStore must not block
+			// behind it.
+			a.mu.Unlock()
+			_ = sw.Close()
+			return esw, nil
+		}
+	}
 	a.store = sw
+	a.mu.Unlock()
 	return sw, nil
 }
 

--- a/internal/store/relay_feature_store.go
+++ b/internal/store/relay_feature_store.go
@@ -75,11 +75,6 @@ func NewSSERelayDataStoreAdapter(
 // only torn down by the final Close (see streamUpdatesStoreWrapper.Close). If the parked wrapper has
 // already been fully closed (acquire returns false), a fresh one is built rather than resurrecting a
 // wrapper whose underlying store is torn down.
-//
-// The already-present check runs again after the wrapped factory builds: two Builds can race through
-// the nil check above (the environment's initial anchor-client build and a re-anchor's synchronous
-// build both run without the env lock held), and the one that finishes last must adopt the wrapper
-// the other installed rather than overwrite it.
 func (a *SSERelayDataStoreAdapter) Build(
 	context subsystems.ClientContext,
 ) (subsystems.DataStore, error) {

--- a/internal/store/store_concurrent_build_test.go
+++ b/internal/store/store_concurrent_build_test.go
@@ -2,12 +2,12 @@ package store
 
 // Regression test for a race in SSERelayDataStoreAdapter.Build: two Build calls that both observe
 // no existing store — the environment's initial anchor-client build racing the first re-anchor's
-// synchronous build — each construct their own wrapper. Build must re-check under the lock before
-// installing, and the build that finishes last must adopt the already-installed wrapper (a normal
-// handover) instead of overwriting it. Without the re-check, the last writer wins adapter.store,
-// and when that writer's client is then discarded as superseded, its Close tears down the store the
-// adapter is serving — evaluations and stream queries read a closed store while the live upstream
-// client feeds one nothing reads.
+// synchronous build — must not each construct and install their own wrapper. If they did, the last
+// writer would win adapter.store, and when that writer's client is later discarded as superseded, its
+// Close would tear down the store the adapter is serving — evaluations and stream queries would read
+// a closed store while the live upstream client fed one nothing reads. Build holds the adapter lock
+// across the whole build, so the two calls are serialized: the first installs its wrapper and the
+// second adopts that same wrapper via the fast path rather than building its own.
 //
 // The realistic trigger is a persistent store whose construction is slow at startup (e.g. Redis
 // briefly unreachable) while a rotation patch re-anchors the environment.
@@ -15,6 +15,7 @@ package store
 import (
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 
@@ -39,12 +40,12 @@ func (f *gatedStoreFactory) Build(ctx subsystems.ClientContext) (subsystems.Data
 	return f.inner.Build(ctx)
 }
 
-func TestConcurrentBuildAdoptsInstalledWrapperInsteadOfOverwriting(t *testing.T) {
+func TestConcurrentBuildSerializesAndSharesOneWrapper(t *testing.T) {
 	factory := &gatedStoreFactory{entered: make(chan struct{}, 1), release: make(chan struct{})}
 	adapter := NewSSERelayDataStoreAdapter(factory, &mockEnvStreamsUpdates{})
 
-	// The initial anchor client's build: passes Build's fast-path nil check, then stalls inside
-	// the wrapped factory before any store assignment.
+	// The initial anchor client's build stalls inside the wrapped factory. Because Build holds the
+	// adapter lock across the whole build, it holds the lock for the duration of this stall.
 	firstResult := make(chan subsystems.DataStore, 1)
 	go func() {
 		sw, err := adapter.Build(subsystems.BasicClientContext{})
@@ -53,41 +54,45 @@ func TestConcurrentBuildAdoptsInstalledWrapperInsteadOfOverwriting(t *testing.T)
 	}()
 	<-factory.entered
 
-	// A re-anchor's synchronous build runs while the first build is stalled: it also sees no
-	// existing store, builds its own wrapper, and installs it. Its client goes on to initialize
-	// and become the committed anchor, so this is the wrapper the environment serves from.
-	secondStore, err := adapter.Build(subsystems.BasicClientContext{})
-	require.NoError(t, err)
-	require.Same(t, secondStore, adapter.GetStore(),
-		"sanity: the second build's wrapper is installed while the first is still stalled")
+	// A re-anchor's synchronous build starts while the first is stalled. It must block on the adapter
+	// lock — it cannot build and install its own wrapper.
+	secondResult := make(chan subsystems.DataStore, 1)
+	go func() {
+		sw, err := adapter.Build(subsystems.BasicClientContext{})
+		assert.NoError(t, err)
+		secondResult <- sw
+	}()
 
-	// The stalled build completes. It must adopt the installed wrapper (handover) rather than
-	// overwrite it with its own.
+	select {
+	case <-secondResult:
+		t.Fatal("the second build returned while the first still held the lock; builds were not serialized")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Release the stalled build. It installs its wrapper; the second build then adopts that same
+	// wrapper via the fast path rather than building its own.
 	close(factory.release)
 	firstStore := <-firstResult
-	require.Same(t, secondStore, firstStore,
-		"the late build must return the already-installed wrapper, not its own")
+	secondStore := <-secondResult
 
-	// The late build's own underlying store was never exposed and must have been closed; the
-	// installed wrapper's underlying store stays open. (The factory builds in completion order:
-	// index 0 is the second/installed build, index 1 is the late/discarded one.)
+	require.Same(t, firstStore, secondStore, "both builds must share the one installed wrapper")
+	require.Same(t, firstStore, adapter.GetStore())
+	require.Equal(t, int32(1), factory.calls.Load(), "the wrapped factory must be built exactly once")
+
 	built := factory.inner.allBuilt()
-	require.Len(t, built, 2)
-	assert.Equal(t, 0, built[0].closeCount(), "the surviving underlying store remains open")
-	assert.Equal(t, 1, built[1].closeCount(), "the discarded build's underlying store is closed once")
+	require.Len(t, built, 1, "no discarded second wrapper was ever constructed")
 
-	// The first build's client is later discarded as superseded and closed. That releases its
-	// handover reference; the adapter keeps serving an open store.
+	// The first build's client is later discarded as superseded and closed. That releases one handover
+	// reference; the adapter keeps serving an open store.
 	require.NoError(t, firstStore.Close())
-	current := adapter.GetStore()
-	require.Same(t, secondStore, current)
-	sw, ok := current.(*streamUpdatesStoreWrapper)
+	require.Same(t, secondStore, adapter.GetStore())
+	sw, ok := adapter.GetStore().(*streamUpdatesStoreWrapper)
 	require.True(t, ok)
 	sw.refMu.Lock()
 	closed := sw.closed
 	sw.refMu.Unlock()
 	require.False(t, closed, "the adapter must not be serving a torn-down store")
-	assert.Equal(t, 0, built[0].closeCount())
+	assert.Equal(t, 0, built[0].closeCount(), "the underlying store remains open while a holder remains")
 
 	// The final holder's release (environment teardown) closes the underlying store exactly once.
 	require.NoError(t, secondStore.Close())

--- a/internal/store/store_concurrent_build_test.go
+++ b/internal/store/store_concurrent_build_test.go
@@ -1,0 +1,95 @@
+package store
+
+// Regression test for a race in SSERelayDataStoreAdapter.Build: two Build calls that both observe
+// no existing store — the environment's initial anchor-client build racing the first re-anchor's
+// synchronous build — each construct their own wrapper. Build must re-check under the lock before
+// installing, and the build that finishes last must adopt the already-installed wrapper (a normal
+// handover) instead of overwriting it. Without the re-check, the last writer wins adapter.store,
+// and when that writer's client is then discarded as superseded, its Close tears down the store the
+// adapter is serving — evaluations and stream queries read a closed store while the live upstream
+// client feeds one nothing reads.
+//
+// The realistic trigger is a persistent store whose construction is slow at startup (e.g. Redis
+// briefly unreachable) while a rotation patch re-anchors the environment.
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gatedStoreFactory stalls its first Build call inside the wrapped factory until released,
+// modelling a slow persistent-store connection at startup. Later calls proceed immediately.
+type gatedStoreFactory struct {
+	inner   countingCloseStoreFactory
+	entered chan struct{}
+	release chan struct{}
+	calls   atomic.Int32
+}
+
+func (f *gatedStoreFactory) Build(ctx subsystems.ClientContext) (subsystems.DataStore, error) {
+	if f.calls.Add(1) == 1 {
+		f.entered <- struct{}{}
+		<-f.release
+	}
+	return f.inner.Build(ctx)
+}
+
+func TestConcurrentBuildAdoptsInstalledWrapperInsteadOfOverwriting(t *testing.T) {
+	factory := &gatedStoreFactory{entered: make(chan struct{}, 1), release: make(chan struct{})}
+	adapter := NewSSERelayDataStoreAdapter(factory, &mockEnvStreamsUpdates{})
+
+	// The initial anchor client's build: passes Build's fast-path nil check, then stalls inside
+	// the wrapped factory before any store assignment.
+	firstResult := make(chan subsystems.DataStore, 1)
+	go func() {
+		sw, err := adapter.Build(subsystems.BasicClientContext{})
+		assert.NoError(t, err)
+		firstResult <- sw
+	}()
+	<-factory.entered
+
+	// A re-anchor's synchronous build runs while the first build is stalled: it also sees no
+	// existing store, builds its own wrapper, and installs it. Its client goes on to initialize
+	// and become the committed anchor, so this is the wrapper the environment serves from.
+	secondStore, err := adapter.Build(subsystems.BasicClientContext{})
+	require.NoError(t, err)
+	require.Same(t, secondStore, adapter.GetStore(),
+		"sanity: the second build's wrapper is installed while the first is still stalled")
+
+	// The stalled build completes. It must adopt the installed wrapper (handover) rather than
+	// overwrite it with its own.
+	close(factory.release)
+	firstStore := <-firstResult
+	require.Same(t, secondStore, firstStore,
+		"the late build must return the already-installed wrapper, not its own")
+
+	// The late build's own underlying store was never exposed and must have been closed; the
+	// installed wrapper's underlying store stays open. (The factory builds in completion order:
+	// index 0 is the second/installed build, index 1 is the late/discarded one.)
+	built := factory.inner.allBuilt()
+	require.Len(t, built, 2)
+	assert.Equal(t, 0, built[0].closeCount(), "the surviving underlying store remains open")
+	assert.Equal(t, 1, built[1].closeCount(), "the discarded build's underlying store is closed once")
+
+	// The first build's client is later discarded as superseded and closed. That releases its
+	// handover reference; the adapter keeps serving an open store.
+	require.NoError(t, firstStore.Close())
+	current := adapter.GetStore()
+	require.Same(t, secondStore, current)
+	sw, ok := current.(*streamUpdatesStoreWrapper)
+	require.True(t, ok)
+	sw.refMu.Lock()
+	closed := sw.closed
+	sw.refMu.Unlock()
+	require.False(t, closed, "the adapter must not be serving a torn-down store")
+	assert.Equal(t, 0, built[0].closeCount())
+
+	// The final holder's release (environment teardown) closes the underlying store exactly once.
+	require.NoError(t, secondStore.Close())
+	assert.Equal(t, 1, built[0].closeCount())
+}


### PR DESCRIPTION
## Summary

Fixes a startup race in the store adapter that could leave an environment reading from a data store that had already been closed. Found during the final pre-merge review of concurrent keys ([SDK-2702](https://launchdarkly.atlassian.net/browse/SDK-2702)).

## What goes wrong

When an environment starts up, two things can try to set up its data store at the same time: the initial client's build, and the first key-rotation re-anchor's build. Neither holds the environment lock, so both can look, see no store yet, and each build its own.

Whichever finished last used to win — it overwrote the store pointer unconditionally. If that "winner" was the client we then throw away (because it was superseded), closing it tore down the very store the environment was serving from. The result: evaluations and stream queries read a closed store, while the live client quietly feeds a store nothing is reading — and it stays that way until the next re-anchor rebuilds everything.

The race detector can't see it (the locking was technically correct), and the existing handover race test only starts after the first store is installed, so it never exercised this window.

## The fix

`Build` now holds the adapter lock across the whole build, so two concurrent builds can't each construct and install their own store. The second caller blocks until the first has installed its store, then adopts it via the normal handover path — one build at a time, so the last-writer-wins hazard simply can't arise.

Holding the lock across the build blocks `GetStore()` only while a store is being built from nothing, which is the first build at startup — every later build, including a re-anchor handover, returns the already-built wrapper without calling the wrapped factory. And for the persistent stores relay supports (Redis, DynamoDB, Consul) the wrapped factory's `Build` only allocates a client or pool; it doesn't connect. The first datastore round-trip happens later on `Init`/`Get`, outside the lock. So the lock is never held across datastore I/O.

A regression test (`store_concurrent_build_test.go`) forces the interleaving deterministically with a gated factory: while the first build stalls inside the factory, a second build blocks on the lock; once released, both return the same wrapper and the factory is built exactly once.

## Alternatives considered

- **Re-check after building and adopt-and-discard** — let both builds run, then have the late one notice the wrapper the other installed, adopt it, and close its own. This never holds the lock across the build, but it adds a subtler "last writer wins is a hazard" path and more machinery to guard a window that (since the factory doesn't connect) is only microseconds wide. Rejected in favor of the simpler invariant.
- **A separate mutex serializing only `Build`** — prevents the double-build without blocking `GetStore()` readers at all, but adds a second lock and more state than just holding the existing one across a build that does no I/O. Rejected as unnecessary.

[SDK-2702]: https://launchdarkly.atlassian.net/browse/SDK-2702

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes locking around environment data-store creation at startup/re-anchor; incorrect serialization could block builds or affect handover, but scope is limited to the adapter and covered by a targeted regression test.
> 
> **Overview**
> Fixes a startup race where the initial anchor client’s `Build` and a concurrent re-anchor `Build` could each create a wrapper; the last install could win, and closing the superseded client would tear down the store the environment still served.
> 
> **`SSERelayDataStoreAdapter.Build`** now holds the adapter mutex for the full build (including the wrapped factory), so concurrent builds serialize: the first installs one wrapper and the second reuses it via the existing handover path instead of building again.
> 
> Adds **`TestConcurrentBuildSerializesAndSharesOneWrapper`** with a gated factory to prove the second build blocks until the first finishes, both share one wrapper, the underlying factory runs once, and closing the superseded holder does not close the live store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a899ff6aba68465e7736012fe597f37cbb6019c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->