### PR TITLE
refactor(concurrent-keys): remove dead code identified in final review

### DIFF
--- a/internal/autoconfig/stream_manager.go
+++ b/internal/autoconfig/stream_manager.go
@@ -507,7 +507,7 @@ func (s *StreamManager) dispatchEnvAction(id config.EnvironmentID, rep envfactor
 // not advanced, so the fresh put — which carries the same version — is not deduplicated away by the
 // MessageReceiver. Any error from BuildAcceptedSet is a *MalformedCredentialSetError.
 func (s *StreamManager) validateCredentialPayload(rep envfactory.EnvironmentRep) error {
-	_, _, err := envfactory.BuildAcceptedSet(rep.ToParams())
+	_, err := envfactory.BuildAcceptedSet(rep.ToParams())
 	return err
 }
 

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -14,14 +14,3 @@ type SDKCredential interface {
 	// Masked returns a masked form of the credential suitable for log messages.
 	Masked() string
 }
-
-// AutoConfig represents credentials that are updated via AutoConfig protocol.
-type AutoConfig struct {
-	// SDKKey is the environment's SDK key; if there is more than one active key, it is the latest.
-	SDKKey SDKCredential
-	// ExpiringSDKKey is an additional SDK key that may or may not be present; it represents the fact that a deprecated
-	// key may exist which can still authenticate a given connection.
-	ExpiringSDKKey SDKCredential
-	// MobileKey is the environment's mobile key.
-	MobileKey SDKCredential
-}

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -62,12 +62,6 @@ type Rotator struct {
 	mu sync.RWMutex
 }
 
-type InitialCredentials struct {
-	SDKKey        config.SDKKey
-	MobileKey     config.MobileKey
-	EnvironmentID config.EnvironmentID
-}
-
 // NewRotator constructs a rotator with the provided loggers. A new rotator
 // contains no credentials and can optionally be initialized via Initialize.
 func NewRotator(loggers ldlog.Loggers) *Rotator {

--- a/internal/envfactory/env_params.go
+++ b/internal/envfactory/env_params.go
@@ -26,10 +26,6 @@ type EnvironmentParams struct {
 	// MobileKey is the environment's mobile key.
 	MobileKey config.MobileKey
 
-	// ExpiringSDKKey is an additional SDK key that should also be allowed (but not surfaced as
-	// the canonical one).
-	ExpiringSDKKey ExpiringSDKKey
-
 	// AcceptedSDKKeys is the full accepted set of SDK keys for this environment, including the
 	// anchor. Always non-nil after ToParams(): non-empty sdkKeys arrays populate directly; absent
 	// or empty sdkKeys are synthesized from the singular sdkKey field so there is always at least
@@ -62,15 +58,6 @@ type AcceptedMobileKey struct {
 	Key    string
 	Value  config.MobileKey
 	Expiry time.Time
-}
-
-type ExpiringSDKKey struct {
-	Key        config.SDKKey
-	Expiration time.Time
-}
-
-func (e ExpiringSDKKey) Defined() bool {
-	return e.Key.Defined()
 }
 
 func (e EnvironmentParams) WithFilter(key config.FilterKey) EnvironmentParams {

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -110,17 +110,6 @@ type ConcurrentKeyRep struct {
 	Expiry *int64 `json:"expiry,omitempty"` // Unix-ms; nil = permanent
 }
 
-func (e ExpiringKeyRep) ToParams() ExpiringSDKKey {
-	if e.Value.Defined() {
-		return ExpiringSDKKey{
-			Key:        e.Value,
-			Expiration: ToTime(e.Timestamp),
-		}
-	} else {
-		return ExpiringSDKKey{}
-	}
-}
-
 func ToTime(millisecondTime ldtime.UnixMillisecondTime) time.Time {
 	return time.UnixMilli(int64(millisecondTime)) //nolint: gosec
 }
@@ -135,11 +124,10 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 			ProjKey:  r.ProjKey,
 			ProjName: r.ProjName,
 		},
-		SDKKey:         r.SDKKey.Value,
-		ExpiringSDKKey: r.SDKKey.Expiring.ToParams(),
-		MobileKey:      r.MobKey,
-		TTL:            time.Duration(r.DefaultTTL) * time.Minute,
-		SecureMode:     r.SecureMode,
+		SDKKey:     r.SDKKey.Value,
+		MobileKey:  r.MobKey,
+		TTL:        time.Duration(r.DefaultTTL) * time.Minute,
+		SecureMode: r.SecureMode,
 	}
 
 	if len(r.SDKKeys) > 0 {

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -66,11 +66,7 @@ func TestEnvironmentRepToParams(t *testing.T) {
 			ProjKey:  "projkey2",
 			ProjName: "projname2",
 		},
-		SDKKey: env2.SDKKey.Value,
-		ExpiringSDKKey: ExpiringSDKKey{
-			Key:        env2.SDKKey.Expiring.Value,
-			Expiration: time.UnixMilli(int64(env2.SDKKey.Expiring.Timestamp)),
-		},
+		SDKKey:    env2.SDKKey.Value,
 		MobileKey: env2.MobKey,
 		AcceptedSDKKeys: []AcceptedSDKKey{
 			{Value: env2.SDKKey.Value},

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -1,13 +1,12 @@
 package envfactory
 
 import (
-	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
 	"github.com/launchdarkly/ld-relay/v8/internal/util"
 )
 
-// BuildAcceptedSet converts an EnvironmentParams into the AcceptedSet and anchor
-// credential needed by EnvContext.ReconcileCredentials.
+// BuildAcceptedSet converts an EnvironmentParams into the AcceptedSet needed by
+// EnvContext.ReconcileCredentials.
 //
 // Credential identity is keyed by value (the secret string), not by key (the human-readable
 // identifier). A rename — same value, different identifier — therefore produces the same
@@ -26,7 +25,7 @@ import (
 // is absent from params.AcceptedSDKKeys, or an array entry with an empty value. The caller must
 // preserve the previous accepted state and, for RAC handlers, reconnect the stream with jitter to
 // force a fresh put. This is the single home for the anchor invariant.
-func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.SDKKey, error) {
+func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, error) {
 	anchor := params.SDKKey
 	b := credential.NewAcceptedSetBuilder().WithEnvironmentID(params.EnvID)
 
@@ -40,7 +39,7 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 	anchorInArray := false
 	for _, k := range params.AcceptedSDKKeys {
 		if !k.Value.Defined() {
-			return credential.AcceptedSet{}, anchor, credential.NewEmptyCredentialError("sdkKeys", k.Key)
+			return credential.AcceptedSet{}, credential.NewEmptyCredentialError("sdkKeys", k.Key)
 		}
 		if k.Value == anchor {
 			anchorInArray = true
@@ -54,7 +53,7 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 	// synthesizes it into the array for old-format payloads). A defined anchor absent from the array is
 	// a structurally malformed payload — reject it.
 	if anchor.Defined() && !anchorInArray {
-		return credential.AcceptedSet{}, anchor, credential.NewAnchorNotInSetError()
+		return credential.AcceptedSet{}, credential.NewAnchorNotInSetError()
 	}
 
 	// Add every accepted mobile key, designating the primary as we encounter it. Like the anchor,
@@ -63,7 +62,7 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 	primaryMobileInArray := false
 	for _, k := range params.AcceptedMobileKeys {
 		if !k.Value.Defined() {
-			return credential.AcceptedSet{}, anchor, credential.NewEmptyCredentialError("mobileKeys", k.Key)
+			return credential.AcceptedSet{}, credential.NewEmptyCredentialError("mobileKeys", k.Key)
 		}
 		if k.Value == params.MobileKey {
 			primaryMobileInArray = true
@@ -78,12 +77,12 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, config.
 	// without this guard the primary would be silently left undesignated, clearing it on reconcile and
 	// breaking event forwarding. (An undefined mobKey is valid — a server-side-only environment.)
 	if params.MobileKey.Defined() && !primaryMobileInArray {
-		return credential.AcceptedSet{}, anchor, credential.NewPrimaryMobileKeyNotInSetError()
+		return credential.AcceptedSet{}, credential.NewPrimaryMobileKeyNotInSetError()
 	}
 
 	set, err := b.Build()
 	if err != nil {
-		return credential.AcceptedSet{}, anchor, err
+		return credential.AcceptedSet{}, err
 	}
-	return set, anchor, nil
+	return set, nil
 }

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -365,31 +365,3 @@ func TestBuildAcceptedSet_ExpiringMobileKey(t *testing.T) {
 		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary", Key: util.PtrOrNil("mob-1")}))
 	assert.Equal(t, expected, set, "expiring mobile key must land as an expiring key in the set")
 }
-
-// TestBuildAcceptedSet_TrustTheArray verifies that the legacy sdkKey.expiring slot is not
-// consulted: when EnvironmentParams.ExpiringSDKKey is populated (from the legacy field) but
-// AcceptedSDKKeys does NOT contain that key, the key is absent from the returned AcceptedSet.
-func TestBuildAcceptedSet_TrustTheArray(t *testing.T) {
-	// Simulate an old-relay payload where ExpiringSDKKey is populated from sdkKey.expiring,
-	// but AcceptedSDKKeys only has the anchor (no expiring key in the array).
-	params := EnvironmentParams{
-		EnvID:     "env-abc",
-		SDKKey:    "sdk-anchor",
-		MobileKey: "mob-primary",
-		ExpiringSDKKey: ExpiringSDKKey{ // legacy field — must NOT be consulted
-			Key:        "sdk-legacy-expiring",
-			Expiration: expiry1,
-		},
-		AcceptedSDKKeys:    []AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
-		AcceptedMobileKeys: []AcceptedMobileKey{{Value: "mob-primary"}},
-	}
-
-	set, _, err := BuildAcceptedSet(params)
-
-	require.NoError(t, err)
-	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
-		WithEnvironmentID("env-abc").
-		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
-		WithPrimaryMobileKey(credential.MobileKeyParams{Value: "mob-primary"}))
-	assert.Equal(t, expected, set, "legacy sdkKey.expiring slot must not appear in AcceptedSet")
-}

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -50,11 +50,9 @@ func TestBuildAcceptedSet_HappyPath(t *testing.T) {
 		[]AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
 		"mob-primary",
 	)
-	set, anchor, err := BuildAcceptedSet(params)
+	set, err := BuildAcceptedSet(params)
 
 	require.NoError(t, err)
-	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
-
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
@@ -74,11 +72,9 @@ func TestBuildAcceptedSet_MultipleKeys(t *testing.T) {
 		},
 		"mob-primary",
 	)
-	set, anchor, err := BuildAcceptedSet(params)
+	set, err := BuildAcceptedSet(params)
 
 	require.NoError(t, err)
-	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
-
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}).
@@ -103,8 +99,8 @@ func TestBuildAcceptedSet_Rename(t *testing.T) {
 		"mob-primary",
 	)
 
-	setOld, _, errOld := BuildAcceptedSet(paramsOldName)
-	setNew, _, errNew := BuildAcceptedSet(paramsNewName)
+	setOld, errOld := BuildAcceptedSet(paramsOldName)
+	setNew, errNew := BuildAcceptedSet(paramsNewName)
 
 	require.NoError(t, errOld)
 	require.NoError(t, errNew)
@@ -147,8 +143,8 @@ func TestBuildAcceptedSet_Deexpiry(t *testing.T) {
 		"mob-primary",
 	)
 
-	setWithExpiry, _, errWithExpiry := BuildAcceptedSet(paramsWithExpiry)
-	setNoExpiry, _, errNoExpiry := BuildAcceptedSet(paramsNoExpiry)
+	setWithExpiry, errWithExpiry := BuildAcceptedSet(paramsWithExpiry)
+	setNoExpiry, errNoExpiry := BuildAcceptedSet(paramsNoExpiry)
 
 	require.NoError(t, errWithExpiry)
 	require.NoError(t, errNoExpiry)
@@ -177,7 +173,7 @@ func TestBuildAcceptedSet_AnchorNotInArray(t *testing.T) {
 		},
 		"mob-primary",
 	)
-	_, _, err := BuildAcceptedSet(params)
+	_, err := BuildAcceptedSet(params)
 
 	require.Error(t, err)
 	var malformed *credential.MalformedCredentialSetError
@@ -198,7 +194,7 @@ func TestBuildAcceptedSet_PrimaryMobileNotInArray(t *testing.T) {
 			{Key: "other", Value: "mob-other"}, // ...but NOT in the array
 		},
 	}
-	_, _, err := BuildAcceptedSet(params)
+	_, err := BuildAcceptedSet(params)
 
 	require.Error(t, err)
 	var malformed *credential.MalformedCredentialSetError
@@ -215,11 +211,9 @@ func TestBuildAcceptedSet_NoMobileKey(t *testing.T) {
 		SDKKey: SDKKeyRep{Value: config.SDKKey("sdk-anchor")},
 		// no MobKey, no MobileKeys
 	}
-	set, anchor, err := BuildAcceptedSet(rep.ToParams())
+	set, err := BuildAcceptedSet(rep.ToParams())
 
 	require.NoError(t, err)
-	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
-
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor"}))
@@ -236,7 +230,7 @@ func TestBuildAcceptedSet_AnchorUndefined(t *testing.T) {
 		},
 		"mob-primary",
 	)
-	_, _, err := BuildAcceptedSet(params)
+	_, err := BuildAcceptedSet(params)
 
 	require.Error(t, err)
 	var malformed *credential.MalformedCredentialSetError
@@ -252,7 +246,7 @@ func TestBuildAcceptedSet_NoSDKKeys(t *testing.T) {
 		AcceptedSDKKeys:    []AcceptedSDKKey{},
 		AcceptedMobileKeys: []AcceptedMobileKey{},
 	}
-	_, _, err := BuildAcceptedSet(params)
+	_, err := BuildAcceptedSet(params)
 	require.Error(t, err, "a set with no SDK key at all must be rejected")
 }
 
@@ -275,11 +269,9 @@ func TestBuildAcceptedSet_MixedUpdate(t *testing.T) {
 		},
 		"mob-primary",
 	)
-	set, anchor, err := BuildAcceptedSet(params)
+	set, err := BuildAcceptedSet(params)
 
 	require.NoError(t, err)
-	assert.Equal(t, config.SDKKey("sdk-new-anchor"), anchor)
-
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
 		WithAnchor(credential.SDKKeyParams{Value: "sdk-new-anchor", Key: util.PtrOrNil("new-default")}).
@@ -301,11 +293,9 @@ func TestBuildAcceptedSet_AnchorNeverExpiring(t *testing.T) {
 		},
 		"mob-primary",
 	)
-	set, anchor, err := BuildAcceptedSet(params)
+	set, err := BuildAcceptedSet(params)
 
 	require.NoError(t, err)
-	assert.Equal(t, config.SDKKey("sdk-anchor"), anchor)
-
 	// Anchor is permanent (WithAnchor), not expiring — identical to a payload with no anchor expiry.
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
 		WithEnvironmentID("env-abc").
@@ -329,7 +319,7 @@ func TestBuildAcceptedSet_MultipleMobileKeys(t *testing.T) {
 			{Key: "mob-2", Value: "mob-secondary"},
 		},
 	}
-	set, _, err := BuildAcceptedSet(params)
+	set, err := BuildAcceptedSet(params)
 
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
@@ -355,7 +345,7 @@ func TestBuildAcceptedSet_ExpiringMobileKey(t *testing.T) {
 			{Key: "mob-old", Value: "mob-old", Expiry: expiry1}, // expiring
 		},
 	}
-	set, _, err := BuildAcceptedSet(params)
+	set, err := BuildAcceptedSet(params)
 
 	require.NoError(t, err)
 	expected := mustBuild(t, credential.NewAcceptedSetBuilder().

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -427,39 +427,17 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 
 	c.registerCredentialMappings(newCredential)
 
-	// A new SDK key means:
-	//  1. we should start a new SDK client*, but only for the anchor: there is a single upstream
-	//     connection per environment, owned by the anchor key. Non-anchor server keys get their
-	//     credential mappings registered above, but no upstream client — matching today's mobile-key behavior.
-	//  2. we should tell all event forwarding components that use an SDK key to use the new one,
-	//     again only when it is the anchor, since events collapse to the anchor per kind.
-	// A new mobile key does not require starting a new SDK client, but does requiring updating any event forwarding
-	// components that use a mobile key.
-	// *Note: we only start a new SDK client in online mode. This is somewhat of an architectural hack because EnvContextImpl
-	// is used for both offline and online mode, yet starting up an SDK client is only relevant in online mode. This is
-	// because in offline mode, we already have the data (from a file) - there's no need to open a new streaming connection.
-	// So, the effect in offline mode when adding/removing credentials is just setting up the new credential mappings.
-	switch key := newCredential.(type) {
-	case config.SDKKey:
-		if key == c.keyRotator.AnchorKey() {
-			if !c.offline {
-				go c.startSDKClient(key, nil, false, c.anchorClientGen)
-			}
-			if c.metricsEventPub != nil { // metrics event publisher always uses SDK key
-				c.metricsEventPub.ReplaceCredential(key)
-			}
-			if c.eventDispatcher != nil {
-				c.eventDispatcher.ReplaceCredential(key)
-			}
-		}
-	case config.MobileKey:
-		// Mobile-key event forwarding collapses to the primary mobile key, mirroring the anchor-only
-		// behavior for SDK keys above: only the primary mobile key repoints the event dispatcher, so a
-		// non-primary mobile key accepted in the same reconcile does not steal event forwarding.
-		if key == c.keyRotator.MobileKey() {
-			if c.eventDispatcher != nil {
-				c.eventDispatcher.ReplaceCredential(key)
-			}
+	// Registering the credential mappings above is all that most keys require. The one extra step is
+	// event forwarding for mobile keys: mobile-key event forwarding collapses to the primary mobile key,
+	// so a newly added mobile key repoints the event dispatcher only when it is the primary mobile key
+	// (a non-primary mobile key accepted in the same reconcile does not steal event forwarding).
+	// The upstream client lifecycle and SDK-key event repointing are deliberately not handled here: there
+	// is a single upstream connection per environment owned by the anchor key, and it is set up exclusively
+	// by construction (NewEnvContext) and moved by the re-anchor sequence (commitReanchor), which also
+	// repoints the SDK-key event forwarders since events collapse to the anchor per kind.
+	if mobileKey, ok := newCredential.(config.MobileKey); ok && mobileKey == c.keyRotator.MobileKey() {
+		if c.eventDispatcher != nil {
+			c.eventDispatcher.ReplaceCredential(mobileKey)
 		}
 	}
 }
@@ -469,8 +447,8 @@ func (c *envContextImpl) removeCredential(oldCredential credential.SDKCredential
 	defer c.mu.Unlock()
 	c.connectionMapper.RemoveConnectionMapping(sdkauth.NewScoped(c.filterKey, oldCredential))
 	c.envStreams.RemoveCredential(oldCredential)
-	// See the comment in addCredential for more context. In offline mode, there's no need to close the SDK client
-	// because our data comes from a file, not a streaming connection.
+	// In offline mode, there's no need to close the SDK client because our data comes from a file,
+	// not a streaming connection.
 	if !c.offline {
 		if sdkKey, ok := oldCredential.(config.SDKKey); ok {
 			// The SDK client instance is tied to the SDK key, so get rid of it

--- a/relay/autoconfig_actions.go
+++ b/relay/autoconfig_actions.go
@@ -32,7 +32,7 @@ func (a *relayAutoConfigActions) AddEnvironment(params envfactory.EnvironmentPar
 		return
 	}
 
-	set, _, buildErr := envfactory.BuildAcceptedSet(params)
+	set, buildErr := envfactory.BuildAcceptedSet(params)
 	if buildErr != nil {
 		a.r.loggers.Errorf(logMsgAutoConfEnvInitError, params.Identifiers.GetDisplayName(), buildErr)
 		return
@@ -51,7 +51,7 @@ func (a *relayAutoConfigActions) UpdateEnvironment(params envfactory.Environment
 	env.SetTTL(params.TTL)
 	env.SetSecureMode(params.SecureMode)
 
-	set, _, buildErr := envfactory.BuildAcceptedSet(params)
+	set, buildErr := envfactory.BuildAcceptedSet(params)
 	if buildErr != nil {
 		// Credential payloads are validated at the stream parse boundary (see StreamManager) before
 		// being dispatched here, so a malformed set should not reach this point. Log defensively and

--- a/relay/autoconfig_actions.go
+++ b/relay/autoconfig_actions.go
@@ -11,7 +11,6 @@ const (
 	logMsgAutoConfUpdateUnknownEnv        = "Got auto-configuration update for environment %q but did not have previous configuration - will add"
 	logMsgAutoConfDeleteUnknownEnv        = "Got auto-configuration delete message for environment %s but did not have previous configuration - ignoring"
 	logMsgAutoConfReceivedAllEnvironments = "Finished processing auto-configuration data"
-	logMsgKeyExpiryUnknownEnv             = "Got auto-configuration key expiry message for environment %s but did not have previous configuration - ignoring"
 )
 
 // relayAutoConfigActions is an implementation of the autoconfig.MessageHandler interface. The low-level

--- a/relay/autoconfig_actions_test.go
+++ b/relay/autoconfig_actions_test.go
@@ -256,7 +256,7 @@ func TestAutoConfigAddEnvironmentWithExpiringSDKKeyDoesNotPanicWhenInitFails(t *
 	initialEvent := makeAutoConfPutEvent()
 	autoConfTest(t, testAutoConfDefaultConfig, &initialEvent, func(p autoConfTestParams) {
 		params := envWithKeys.params()
-		require.True(t, params.ExpiringSDKKey.Defined(),
+		require.Len(t, params.AcceptedSDKKeys, 2,
 			"precondition: params must carry an expiring SDK key to reach the credential-update branch")
 
 		// Closing the Relay makes the next addEnvironment return (nil, nil, errAlreadyClosed).

--- a/relay/filedata_actions.go
+++ b/relay/filedata_actions.go
@@ -58,7 +58,7 @@ func (a *relayFileDataActions) AddEnvironment(ae filedata.ArchiveEnvironment) {
 		return
 	}
 
-	set, _, buildErr := envfactory.BuildAcceptedSet(ae.Params)
+	set, buildErr := envfactory.BuildAcceptedSet(ae.Params)
 	if buildErr != nil {
 		var malformed *credential.MalformedCredentialSetError
 		if errors.As(buildErr, &malformed) {
@@ -101,7 +101,7 @@ func (a *relayFileDataActions) UpdateEnvironment(ae filedata.ArchiveEnvironment)
 	env.SetTTL(ae.Params.TTL)
 	env.SetSecureMode(ae.Params.SecureMode)
 
-	set, _, buildErr := envfactory.BuildAcceptedSet(ae.Params)
+	set, buildErr := envfactory.BuildAcceptedSet(ae.Params)
 	if buildErr != nil {
 		var malformed *credential.MalformedCredentialSetError
 		if errors.As(buildErr, &malformed) {

--- a/relay/filedata_actions_test.go
+++ b/relay/filedata_actions_test.go
@@ -229,8 +229,8 @@ func TestOfflineModeDeprecatedSDKKeyIsRespectedIfExpiryInFuture(t *testing.T) {
 		env := p.awaitEnvironment(testFileDataEnv1.Params.EnvID)
 
 		// Expiring key is in the accepted set (and thus GetCredentials) until it expires.
-		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.SDKKey, envData.Params.ExpiringSDKKey.Key, envData.Params.EnvID}, env.GetCredentials())
-		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.ExpiringSDKKey.Key}, env.GetDeprecatedCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.SDKKey, envData.Params.AcceptedSDKKeys[1].Value, envData.Params.EnvID}, env.GetCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.AcceptedSDKKeys[1].Value}, env.GetDeprecatedCredentials())
 	})
 }
 
@@ -252,8 +252,8 @@ func TestOfflineModePrimarySDKKeyIsDeprecated(t *testing.T) {
 		p.updateHandler.UpdateEnvironment(update2)
 
 		// Both the new anchor and the expiring old key are accepted until key1 expires.
-		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.SDKKey, update2.Params.ExpiringSDKKey.Key, update1.Params.EnvID}, env.GetCredentials())
-		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.ExpiringSDKKey.Key}, env.GetDeprecatedCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.SDKKey, update2.Params.AcceptedSDKKeys[1].Value, update1.Params.EnvID}, env.GetCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.AcceptedSDKKeys[1].Value}, env.GetDeprecatedCredentials())
 
 		update3 := RotateSDKKey("key3")
 		p.updateHandler.UpdateEnvironment(update3)
@@ -293,8 +293,8 @@ func TestOfflineModeSDKKeyCanExpire(t *testing.T) {
 		// we'll still need to sleep at least the cleanup interval to ensure the key is expired.
 		env := p.awaitEnvironmentFor(update1.Params.EnvID, time.Second)
 		// Both the primary and the expiring key are in the accepted set until the expiry fires.
-		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.ExpiringSDKKey.Key, update1.Params.EnvID}, env.GetCredentials())
-		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.ExpiringSDKKey.Key}, env.GetDeprecatedCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.AcceptedSDKKeys[1].Value, update1.Params.EnvID}, env.GetCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.AcceptedSDKKeys[1].Value}, env.GetDeprecatedCredentials())
 
 		assert.Eventually(t, func() bool {
 			return len(env.GetDeprecatedCredentials()) == 0

--- a/relay/filedata_testdata_test.go
+++ b/relay/filedata_testdata_test.go
@@ -74,12 +74,8 @@ func RotateSDKKeyWithGracePeriod(primary config.SDKKey, expiring config.SDKKey, 
 	}
 	return filedata.ArchiveEnvironment{
 		Params: envfactory.EnvironmentParams{
-			EnvID:  "env1",
-			SDKKey: primary,
-			ExpiringSDKKey: envfactory.ExpiringSDKKey{
-				Key:        expiring,
-				Expiration: expiry,
-			},
+			EnvID:           "env1",
+			SDKKey:          primary,
 			AcceptedSDKKeys: acceptedKeys,
 			Identifiers: relayenv.EnvIdentifiers{
 				ProjName: "Project",


### PR DESCRIPTION
## Summary

Cleanup from the final concurrent-keys review: removes code that no longer runs or is no longer needed. This is the base of a small stack of follow-up PRs.

Three independent removals, one per commit:

- **Unreachable branch in `addCredential` (relayenv).** The `case config.SDKKey` branch only ran for the anchor key, but the anchor is never passed to `addCredential` — so it was dead, and a latent race if it ever ran. The live mobile-key branch stays.
- **Legacy-rotation credential types (envfactory/credential).** Removes `envfactory.ExpiringSDKKey`, `credential.InitialCredentials`, `credential.AutoConfig`, and an unused log constant — all unread since the accepted-set model took over. The old-format back-compat decode path is deliberately kept.
- **`BuildAcceptedSet`'s redundant return value (envfactory).** Drops the echoed anchor SDK key that every caller ignored; it already travels inside the returned `AcceptedSet`. Signature narrows to `(AcceptedSet, error)`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code and API-signature cleanup in credential reconciliation with no change to authentication rules or legacy JSON synthesis; behavior risk is low if anchor/re-anchor paths were already the sole live owners of SDK upstream clients.
> 
> **Overview**
> Removes **dead and redundant credential plumbing** left over after the concurrent-keys / accepted-set model, without changing wire parsing for old `sdkKey.expiring` payloads (that path still synthesizes `AcceptedSDKKeys` in `ToParams`).
> 
> **`addCredential`** no longer contains the `config.SDKKey` branch that started upstream clients and repointed SDK-key event/metrics forwarding for the anchor. That path was unreachable because the anchor is never added through `addCredential`; anchor lifecycle stays in `NewEnvContext` and the re-anchor sequence. The live behavior for **primary mobile** event dispatcher updates is unchanged.
> 
> **Legacy internal types** are dropped: `credential.AutoConfig`, `credential.InitialCredentials`, `envfactory.ExpiringSDKKey`, and `EnvironmentParams.ExpiringSDKKey`. Callers and offline test helpers now rely on **`AcceptedSDKKeys`** (and arrays) only; an unused auto-config log constant is removed.
> 
> **`BuildAcceptedSet`** now returns **`(credential.AcceptedSet, error)`** — the echoed anchor `config.SDKKey` return value is removed because the anchor is already inside the set. Stream validation, auto-config, and file-data handlers are updated accordingly; the redundant “trust the array vs legacy ExpiringSDKKey field” unit test is deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91446d7c44d6823f9e3230e45c4ae82a29634bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->