### PR TITLE
fix(concurrent-keys): reject mobile-key payloads that arrive without a primary mobile key

### DIFF
--- a/internal/autoconfig/stream_manager_errors_test.go
+++ b/internal/autoconfig/stream_manager_errors_test.go
@@ -34,55 +34,81 @@ func eventShouldCauseStreamRestart(t *testing.T, event httphelpers.SSEEvent) {
 }
 
 // A credential payload that is valid JSON and a structurally valid event, but whose credential set
-// cannot be built (here: an undefined anchor SDK key), must be caught at the parse boundary: the
-// previous state is preserved (no AddEnvironment/UpdateEnvironment dispatched) and the stream is
-// restarted so the backend resends a fresh put (design §9). This is verified for both patch and put,
-// since both paths run the validation before the version is recorded.
+// cannot be built (e.g. an undefined anchor SDK key, or mobile keys with no designated primary), must
+// be caught at the parse boundary: the previous state is preserved (no AddEnvironment/UpdateEnvironment
+// dispatched) and the stream is restarted so the backend resends a fresh put (design §9). This is
+// verified for both patch and put, since both paths run the validation before the version is recorded.
 func TestMalformedCredentialPayloadCausesStreamRestart(t *testing.T) {
-	malformedEnv := testEnv1
-	malformedEnv.SDKKey = envfactory.SDKKeyRep{Value: config.SDKKey("")} // undefined anchor
+	// Each shape is a distinct way BuildAcceptedSet rejects a structurally malformed payload; all ride
+	// the same malformed-payload machinery.
+	malformedShapes := []struct {
+		name string
+		make func(envfactory.EnvironmentRep) envfactory.EnvironmentRep
+	}{
+		{
+			name: "undefined anchor SDK key",
+			make: func(env envfactory.EnvironmentRep) envfactory.EnvironmentRep {
+				env.SDKKey = envfactory.SDKKeyRep{Value: config.SDKKey("")}
+				return env
+			},
+		},
+		{
+			name: "mobile keys without a designated primary",
+			make: func(env envfactory.EnvironmentRep) envfactory.EnvironmentRep {
+				env.MobKey = config.MobileKey("")                                                // no primary designated...
+				env.MobileKeys = []envfactory.ConcurrentKeyRep{{Key: "mob-1", Value: "mobkey1"}} // ...but non-empty
+				return env
+			},
+		},
+	}
 
-	t.Run("patch", func(t *testing.T) {
-		streamManagerTest(t, nil, func(p streamManagerTestParams) {
-			p.startStream()
-			<-p.requestsCh
-			p.stream.Enqueue(makePatchEnvEvent(malformedEnv))
-			select {
-			case m := <-p.messageHandler.received:
-				require.Failf(t, "unexpected message",
-					"must not dispatch for a malformed payload, got %s", m)
-			case <-p.requestsCh: // reconnect request == stream restart
-				p.mockLog.AssertMessageMatch(t, true, ldlog.Error, "malformed credential payload")
-			case <-time.After(time.Second):
-				require.Fail(t, "timed out waiting for stream restart")
-			}
-		})
-	})
+	for _, shape := range malformedShapes {
+		t.Run(shape.name, func(t *testing.T) {
+			malformedEnv := shape.make(testEnv1)
 
-	t.Run("put", func(t *testing.T) {
-		streamManagerTest(t, nil, func(p streamManagerTestParams) {
-			p.startStream()
-			<-p.requestsCh
-			p.stream.Enqueue(makeEnvPutEvent(malformedEnv))
-			// The malformed env is skipped (no add/update); a put still reports ReceivedAllEnvironments,
-			// which we tolerate. We require that the stream restarts and that no add/update is dispatched.
-			deadline := time.After(2 * time.Second)
-			for {
-				select {
-				case m := <-p.messageHandler.received:
-					if m.add != nil || m.update != nil {
+			t.Run("patch", func(t *testing.T) {
+				streamManagerTest(t, nil, func(p streamManagerTestParams) {
+					p.startStream()
+					<-p.requestsCh
+					p.stream.Enqueue(makePatchEnvEvent(malformedEnv))
+					select {
+					case m := <-p.messageHandler.received:
 						require.Failf(t, "unexpected message",
-							"must not dispatch add/update for a malformed payload, got %s", m)
+							"must not dispatch for a malformed payload, got %s", m)
+					case <-p.requestsCh: // reconnect request == stream restart
+						p.mockLog.AssertMessageMatch(t, true, ldlog.Error, "malformed credential payload")
+					case <-time.After(time.Second):
+						require.Fail(t, "timed out waiting for stream restart")
 					}
-				case <-p.requestsCh: // reconnect request == stream restart
-					p.mockLog.AssertMessageMatch(t, true, ldlog.Error, "malformed credential payload")
-					return
-				case <-deadline:
-					require.Fail(t, "timed out waiting for stream restart")
-				}
-			}
+				})
+			})
+
+			t.Run("put", func(t *testing.T) {
+				streamManagerTest(t, nil, func(p streamManagerTestParams) {
+					p.startStream()
+					<-p.requestsCh
+					p.stream.Enqueue(makeEnvPutEvent(malformedEnv))
+					// The malformed env is skipped (no add/update); a put still reports ReceivedAllEnvironments,
+					// which we tolerate. We require that the stream restarts and that no add/update is dispatched.
+					deadline := time.After(2 * time.Second)
+					for {
+						select {
+						case m := <-p.messageHandler.received:
+							if m.add != nil || m.update != nil {
+								require.Failf(t, "unexpected message",
+									"must not dispatch add/update for a malformed payload, got %s", m)
+							}
+						case <-p.requestsCh: // reconnect request == stream restart
+							p.mockLog.AssertMessageMatch(t, true, ldlog.Error, "malformed credential payload")
+							return
+						case <-deadline:
+							require.Fail(t, "timed out waiting for stream restart")
+						}
+					}
+				})
+			})
 		})
-	})
+	}
 }
 
 // A put carrying malformed credential payloads must not corrupt the persistent cache: valid envs are

--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -60,7 +60,10 @@ var errAcceptedSetMissingSDKKey = errors.New("accepted credential set must conta
 //     sdkKeys[] — a violation of the invariant that the designated anchor is one of the accepted keys.
 //  2. The primary mobile key (mobKey) is defined but not present in mobileKeys[] — the mobile-key
 //     analogue of the anchor invariant.
-//  3. An entry in sdkKeys[] or mobileKeys[] has an empty value — a credential that would be
+//  3. mobileKeys[] is non-empty but no primary mobile key (mobKey) is designated — accepting it would
+//     clear the environment's primary mobile key on reconcile with no repoint, so event forwarding
+//     would keep using the previous (possibly revoked) primary. (No mobile keys at all is valid.)
+//  4. An entry in sdkKeys[] or mobileKeys[] has an empty value — a credential that would be
 //     accepted by relay but can never authenticate any SDK.
 //
 // Validation happens before Reconcile is called; Rotator.Reconcile trusts the set it is handed.
@@ -96,6 +99,15 @@ func NewAnchorNotInSetError() *MalformedCredentialSetError {
 // included in the message.
 func NewPrimaryMobileKeyNotInSetError() *MalformedCredentialSetError {
 	return &MalformedCredentialSetError{msg: "malformed credential set: primary mobile key is not present in mobileKeys[]"}
+}
+
+// NewPrimaryMobileKeyMissingError returns a MalformedCredentialSetError for a payload that carries a
+// non-empty mobileKeys[] array but leaves the primary mobile key (mobKey) undefined — no default is
+// designated. Accepting it would clear the environment's primary mobile key on reconcile with no
+// repoint, so event forwarding would keep using the previous (possibly revoked) primary. There are no
+// secrets to omit from the message.
+func NewPrimaryMobileKeyMissingError() *MalformedCredentialSetError {
+	return &MalformedCredentialSetError{msg: "malformed credential set: mobileKeys[] is non-empty but no primary mobile key is designated"}
 }
 
 // NewEmptyCredentialError returns a MalformedCredentialSetError for a key-array entry whose

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -22,7 +22,9 @@ import (
 //
 // A *credential.MalformedCredentialSetError is returned (with an empty AcceptedSet) for a
 // structurally malformed payload: an undefined anchor (params.SDKKey not set), a defined anchor that
-// is absent from params.AcceptedSDKKeys, or an array entry with an empty value. The caller must
+// is absent from params.AcceptedSDKKeys, a defined primary mobile key (params.MobileKey) that is
+// absent from params.AcceptedMobileKeys, a non-empty params.AcceptedMobileKeys with no designated
+// primary (params.MobileKey undefined), or an array entry with an empty value. The caller must
 // preserve the previous accepted state and, for RAC handlers, reconnect the stream with jitter to
 // force a fresh put. This is the single home for the anchor invariant.
 func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, error) {
@@ -78,6 +80,16 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, error) 
 	// breaking event forwarding. (An undefined mobKey is valid — a server-side-only environment.)
 	if params.MobileKey.Defined() && !primaryMobileInArray {
 		return credential.AcceptedSet{}, credential.NewPrimaryMobileKeyNotInSetError()
+	}
+
+	// A non-empty mobileKeys[] with no designated primary (undefined mobKey) is malformed: the reconcile
+	// would clear the rotator's primary mobile key without a repoint, so event forwarding would keep
+	// using the previous (possibly revoked) primary — silent misattribution rather than a loud
+	// rejection. (No mobile keys at all — empty array and undefined mobKey — stays valid: a
+	// server-side-only environment. Old-format payloads synthesize the array from mobKey only, so an
+	// undefined mobKey yields an empty array and is unaffected.)
+	if len(params.AcceptedMobileKeys) > 0 && !params.MobileKey.Defined() {
+		return credential.AcceptedSet{}, credential.NewPrimaryMobileKeyMissingError()
 	}
 
 	set, err := b.Build()

--- a/internal/envfactory/reconcile_helper_test.go
+++ b/internal/envfactory/reconcile_helper_test.go
@@ -220,6 +220,49 @@ func TestBuildAcceptedSet_NoMobileKey(t *testing.T) {
 	assert.Equal(t, expected, set)
 }
 
+// TestBuildAcceptedSet_MobileKeysWithoutPrimary verifies the complement of the primary-mobile-in-array
+// invariant: a non-empty mobileKeys[] with no designated primary (undefined mobKey) is rejected as a
+// *credential.MalformedCredentialSetError. Without this guard the reconcile would clear the rotator's
+// primary mobile key with no repoint, silently forwarding events under the previous (possibly revoked)
+// primary instead of loudly rejecting the payload.
+func TestBuildAcceptedSet_MobileKeysWithoutPrimary(t *testing.T) {
+	params := EnvironmentParams{
+		EnvID:           "env-abc",
+		SDKKey:          "sdk-anchor",
+		MobileKey:       "", // no primary designated...
+		AcceptedSDKKeys: []AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
+		AcceptedMobileKeys: []AcceptedMobileKey{
+			{Key: "mob-1", Value: "mob-primary"}, // ...but the array is non-empty
+		},
+	}
+	_, err := BuildAcceptedSet(params)
+
+	require.Error(t, err)
+	var malformed *credential.MalformedCredentialSetError
+	require.True(t, errors.As(err, &malformed))
+	assert.Contains(t, malformed.Error(), "no primary mobile key is designated")
+}
+
+// TestBuildAcceptedSet_EmptyMobileArrayValid verifies the boundary of the guard above: an empty
+// mobileKeys[] with an undefined mobKey (a server-side-only environment) is valid — the guard fires
+// only when the array is non-empty, so no primary mobile key is designated and nothing is rejected.
+func TestBuildAcceptedSet_EmptyMobileArrayValid(t *testing.T) {
+	params := EnvironmentParams{
+		EnvID:              "env-abc",
+		SDKKey:             "sdk-anchor",
+		MobileKey:          "", // undefined
+		AcceptedSDKKeys:    []AcceptedSDKKey{{Key: "default", Value: "sdk-anchor"}},
+		AcceptedMobileKeys: []AcceptedMobileKey{}, // empty
+	}
+	set, err := BuildAcceptedSet(params)
+
+	require.NoError(t, err)
+	expected := mustBuild(t, credential.NewAcceptedSetBuilder().
+		WithEnvironmentID("env-abc").
+		WithAnchor(credential.SDKKeyParams{Value: "sdk-anchor", Key: util.PtrOrNil("default")}))
+	assert.Equal(t, expected, set)
+}
+
 // TestBuildAcceptedSet_AnchorUndefined verifies that an undefined anchor (empty SDKKey) yields a
 // *credential.MalformedCredentialSetError: no anchor was designated, so Build rejects the set.
 func TestBuildAcceptedSet_AnchorUndefined(t *testing.T) {


### PR DESCRIPTION
## Summary

When trusted-source credentials arrive, `BuildAcceptedSet` validates them. On the SDK-key side it already rejects a payload whose anchor key is missing, or is defined but not listed in `sdkKeys[]`. The mobile side was missing the matching check: a payload that carried mobile keys (`mobileKeys[]` non-empty) but named no primary (`mobKey` undefined) was accepted.

That's a problem because the reconcile then clears the environment's primary mobile key without repointing event forwarding — so mobile analytics events keep going out under the old, possibly revoked, primary. The result is silent misattribution instead of a loud rejection.

This adds the symmetric guard: when there are mobile keys but no designated primary, `BuildAcceptedSet` rejects the payload as malformed (`NewPrimaryMobileKeyMissingError`), so it rides the existing malformed-payload path — previous credentials preserved, stream restarted. The doc comment enumerating the malformed cases is updated to cover both mobile cases (the existing "primary defined but not in the array" case and this new "no primary" case).

Two shapes stay valid, and are covered by tests:

- An environment with no mobile keys at all (empty array, undefined `mobKey`) — e.g. server-side-only environments.
- Old-format payloads, which synthesize the mobile array from `mobKey` alone, so an undefined `mobKey` just yields an empty array.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trusted-source credential validation and RAC malformed-payload handling for mobile keys; behavior is narrow, defensive, and covered by tests.
> 
> **Overview**
> **`BuildAcceptedSet`** now treats a non-empty **`mobileKeys[]`** with an undefined **`mobKey`** as malformed (via **`NewPrimaryMobileKeyMissingError`**), matching the existing SDK anchor rules. Accepting that shape would clear the primary on reconcile while event forwarding could keep using the old primary.
> 
> Malformed payloads still follow the existing path: prior credentials stay in place and the RAC stream restarts. Docs list this as a third mobile malformed case; unit tests cover reject/accept boundaries and extend stream restart tests to include this payload shape alongside undefined anchor SDK keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f8a02ef031fde3a4bfdec9eeda75eb887d47f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->