### PR TITLE
refactor(concurrent-keys): remove production-dead DeprecatedCredentials accessors

### DIFF
--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -133,25 +133,6 @@ func (r *Rotator) allCredentials() []SDKCredential {
 	return creds
 }
 
-// DeprecatedCredentials returns the SDK keys being phased out — every accepted SDK key, other than the
-// anchor, that carries a future expiry. (Per-key expiry is stored as data on the accepted entry; the
-// cleanup ticker drops the key once it elapses.)
-//
-// Mobile keys are deliberately not returned even though they expire the same way SDK keys do — carried
-// as per-key expiry and dropped by the same cleanup ticker.
-func (r *Rotator) DeprecatedCredentials() []SDKCredential {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	var out []SDKCredential
-	for key, info := range r.acceptedSDKKeys {
-		if info.Expiry != nil && key != r.anchorKey {
-			out = append(out, key)
-		}
-	}
-	return out
-}
-
 // AllCredentials returns every accepted credential: every accepted SDK key, every accepted mobile
 // key (including those carrying a future expiry — they still authenticate until the cleanup ticker
 // drops them), and the environment ID.
@@ -190,7 +171,7 @@ func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expiration
 	for key, info := range r.acceptedSDKKeys {
 		if key == r.anchorKey {
 			// Never expire the current anchor, even if a stale expiry was left on its entry (a
-			// rolled-back re-anchor can). Same guard as DeprecatedCredentials.
+			// rolled-back re-anchor can).
 			continue
 		}
 		if info.Expiry != nil && now.After(*info.Expiry) {

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -15,6 +15,20 @@ func newTestRotator() *Rotator {
 	return NewRotator(ldlogtest.NewMockLog().Loggers)
 }
 
+// deprecatedSDKKeys returns the accepted SDK keys being phased out — every non-anchor server key
+// carrying a future expiry — derived from the accepted-set snapshot, the same data the /status
+// endpoint reads via AcceptedKeys.
+func deprecatedSDKKeys(r *Rotator) []SDKCredential {
+	set := r.AcceptedKeys()
+	var out []SDKCredential
+	for key, info := range set.Server {
+		if info.Expiry != nil && key != set.Anchor {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
 func TestNewRotator(t *testing.T) {
 	mockLog := ldlogtest.NewMockLog()
 	rotator := NewRotator(mockLog.Loggers)
@@ -64,7 +78,7 @@ func TestReconcileAnchorOnly(t *testing.T) {
 	assert.Empty(t, expirations)
 	assert.Equal(t, anchor, r.AnchorKey())
 	assert.ElementsMatch(t, []SDKCredential{anchor}, r.AllCredentials())
-	assert.Empty(t, r.DeprecatedCredentials())
+	assert.Empty(t, deprecatedSDKKeys(r))
 }
 
 func TestReconcileMultipleSDKKeys(t *testing.T) {
@@ -85,7 +99,7 @@ func TestReconcileMultipleSDKKeys(t *testing.T) {
 	assert.Empty(t, expirations)
 	assert.Equal(t, anchor, r.AnchorKey())
 	assert.ElementsMatch(t, []SDKCredential{anchor, other}, r.AllCredentials())
-	assert.Empty(t, r.DeprecatedCredentials())
+	assert.Empty(t, deprecatedSDKKeys(r))
 }
 
 func TestReconcileMultipleMobileKeys(t *testing.T) {
@@ -155,7 +169,7 @@ func TestReconcileAcceptsExpiringKeysAsData(t *testing.T) {
 	// ...and the non-anchor SDK key carrying an expiry is also reported as deprecated (being phased
 	// out). The expiring mobile key is not: there is no expiringMobileKey status field, so the reconcile
 	// path treats it as accepted-only.
-	assert.ElementsMatch(t, []SDKCredential{expiringSDK}, r.DeprecatedCredentials())
+	assert.ElementsMatch(t, []SDKCredential{expiringSDK}, deprecatedSDKKeys(r))
 }
 
 func TestReconcilePrimaryMobileKeyIsAlwaysAccepted(t *testing.T) {
@@ -259,7 +273,7 @@ func TestReconcileDeExpiryRestoresKey(t *testing.T) {
 			WithSDKKey(SDKKeyParams{Value: key, Expiry: util.PtrOrNil(expiry)})),
 		now)
 	r.StepTime(now)
-	require.ElementsMatch(t, []SDKCredential{key}, r.DeprecatedCredentials())
+	require.ElementsMatch(t, []SDKCredential{key}, deprecatedSDKKeys(r))
 
 	// Second reconcile: same key, no expiry (de-expiry).
 	r.Reconcile(
@@ -271,7 +285,7 @@ func TestReconcileDeExpiryRestoresKey(t *testing.T) {
 
 	// The key is still accepted and permanent: no longer deprecated, not evicted by StepTime.
 	assert.Contains(t, r.AllCredentials(), SDKCredential(key))
-	assert.Empty(t, r.DeprecatedCredentials())
+	assert.Empty(t, deprecatedSDKKeys(r))
 
 	additions, expirations := r.StepTime(expiry.Add(1 * time.Millisecond))
 	assert.Empty(t, additions)

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -68,9 +68,6 @@ type EnvContext interface {
 	// GetCredentials returns all currently enabled and non-deprecated credentials for the environment.
 	GetCredentials() []credential.SDKCredential
 
-	// GetDeprecatedCredentials returns all deprecated and not-yet-removed credentials for the environment.
-	GetDeprecatedCredentials() []credential.SDKCredential
-
 	// GetClient returns the SDK client instance for this environment. This is nil if initialization is not yet
 	// complete. Rather than providing the full client object, we use the simpler sdks.LDClientContext which
 	// includes only the operations Relay needs to do.

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -845,10 +845,6 @@ func (c *envContextImpl) GetMobileKey() config.MobileKey {
 	return c.keyRotator.MobileKey()
 }
 
-func (c *envContextImpl) GetDeprecatedCredentials() []credential.SDKCredential {
-	return c.keyRotator.DeprecatedCredentials()
-}
-
 func (c *envContextImpl) GetAcceptedKeys() credential.AcceptedKeySet {
 	return c.keyRotator.AcceptedKeys()
 }

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -58,6 +58,20 @@ func requireClientReady(t *testing.T, clientCh chan *testclient.FakeLDClient) *t
 	return helpers.RequireValue(t, clientCh, time.Second, "timed out waiting for client")
 }
 
+// deprecatedSDKKeys returns the environment's accepted SDK keys being phased out — every non-anchor
+// server key carrying a future expiry — derived from the accepted-set snapshot, the same data the
+// /status endpoint reads via GetAcceptedKeys.
+func deprecatedSDKKeys(env EnvContext) []credential.SDKCredential {
+	set := env.GetAcceptedKeys()
+	var out []credential.SDKCredential
+	for key, info := range set.Server {
+		if info.Expiry != nil && key != set.Anchor {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
 func makeBasicEnv(t *testing.T, envConfig config.EnvConfig, clientFactory sdks.ClientFactoryFunc,
 	loggers ldlog.Loggers, readyCh chan EnvContext) EnvContext {
 	return makeBasicEnvWithMapper(t, envConfig, clientFactory, loggers, readyCh, mockConnectionMapper{})
@@ -310,7 +324,7 @@ func TestChangeSDKKey(t *testing.T) {
 	// The environment should have been initialized with a single SDK key (found in the envConfig.)
 	// At this point, there's no deprecated credentials.
 	assert.Equal(t, []credential.SDKCredential{envConfig.SDKKey}, env.GetCredentials())
-	assert.Empty(t, env.GetDeprecatedCredentials())
+	assert.Empty(t, deprecatedSDKKeys(env))
 
 	// For the purposes of key rotation, we'll make time deterministic. We build an AcceptedSet
 	// with key2 as anchor and envConfig.SDKKey expiring in one hour, then drive the time-injectable
@@ -326,13 +340,14 @@ func TestChangeSDKKey(t *testing.T) {
 	envImpl.reconcileCredentials(rotationSet, start)
 
 	// In the new accepted-set model both keys are accepted (GetCredentials includes both) until
-	// the old key's expiry elapses. GetDeprecatedCredentials reports the expiring accepted key so
-	// callers like the status endpoint can surface it without distinguishing the rotation path.
+	// the old key's expiry elapses. The expiring accepted key still carries its expiry in the
+	// accepted-set snapshot (GetAcceptedKeys) so callers like the status endpoint can surface it
+	// without distinguishing the rotation path.
 	creds := env.GetCredentials()
 	assert.Len(t, creds, 2)
 	assert.Contains(t, creds, key2)
 	assert.Contains(t, creds, envConfig.SDKKey)
-	assert.Equal(t, []credential.SDKCredential{envConfig.SDKKey}, env.GetDeprecatedCredentials())
+	assert.Equal(t, []credential.SDKCredential{envConfig.SDKKey}, deprecatedSDKKeys(env))
 
 	client2 := requireClientReady(t, clientCh)
 	assert.NotEqual(t, client1, client2)
@@ -358,7 +373,7 @@ func TestChangeSDKKey(t *testing.T) {
 	// We are now an instant after the expiry. This should cause the original key to be removed.
 	envImpl.triggerCredentialChanges(start.Add(1*time.Hour + 1*time.Millisecond))
 	assert.Equal(t, []credential.SDKCredential{key2}, env.GetCredentials())
-	assert.Empty(t, env.GetDeprecatedCredentials())
+	assert.Empty(t, deprecatedSDKKeys(env))
 }
 
 // TestMobileKeyReconcileExpiry drives a mobile key carrying a per-key expiry end-to-end through the
@@ -394,7 +409,7 @@ func TestMobileKeyReconcileExpiry(t *testing.T) {
 
 	// Reconcile stores the expiry as data, so before it elapses the key is accepted (not deprecated).
 	assert.Contains(t, env.GetCredentials(), expiringMobile)
-	assert.NotContains(t, env.GetDeprecatedCredentials(), expiringMobile)
+	assert.NotContains(t, deprecatedSDKKeys(env), expiringMobile)
 
 	// Halfway through, still accepted.
 	envImpl.triggerCredentialChanges(start.Add(30 * time.Minute))

--- a/relay/autoconfig_key_change_test.go
+++ b/relay/autoconfig_key_change_test.go
@@ -124,7 +124,7 @@ func TestAutoConfigUpdateEnvironmentSDKKeyWithExpiry(t *testing.T) {
 
 		p.awaitCredentialsUpdated(env, modified.params())
 		p.assertEnvLookup(env, testAutoConfEnv1.params()) // looking up env by old key still works
-		assert.Equal(t, []credential.SDKCredential{testAutoConfEnv1.sdkKey.Value}, env.GetDeprecatedCredentials())
+		assert.Equal(t, []credential.SDKCredential{testAutoConfEnv1.sdkKey.Value}, deprecatedSDKKeys(env))
 
 		// The deprecated key stays valid for downstream auth (asserted above), but its upstream client
 		// closes as soon as the rotation commits: the new anchor owns the env's single upstream

--- a/relay/concurrent_keys_auth_test.go
+++ b/relay/concurrent_keys_auth_test.go
@@ -371,7 +371,7 @@ func TestConcurrentKeysOffline_ConnectionSurvivesWhenKeyGainsFutureExpiry(t *tes
 		})
 
 		// The key is now in the deprecated-but-accepted set (its expiry was applied) and still authenticates.
-		require.Eventually(t, func() bool { return credsContain(env.GetDeprecatedCredentials(), extraSDKKey) },
+		require.Eventually(t, func() bool { return credsContain(deprecatedSDKKeys(env), extraSDKKey) },
 			time.Second, 5*time.Millisecond, "expiry was not applied to the connected key")
 		p.assertSDKEndpointsAvailability(true, extraSDKKey, "", "")
 	})
@@ -402,7 +402,7 @@ func TestConcurrentKeysRAC_KeyWithFutureExpiryStillAuthenticates(t *testing.T) {
 
 		// Confirm the expiry was applied (the key is now deprecated-but-accepted) and, after the
 		// cleanup ticker has had time to run, the future-dated key still authenticates.
-		require.Eventually(t, func() bool { return credsContain(env.GetDeprecatedCredentials(), extraSDKKey) },
+		require.Eventually(t, func() bool { return credsContain(deprecatedSDKKeys(env), extraSDKKey) },
 			time.Second, 5*time.Millisecond, "future expiry was not applied")
 		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
 		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
@@ -535,6 +535,20 @@ func msPtr(v int64) *int64 { return &v }
 
 func credsContain(creds []credential.SDKCredential, target credential.SDKCredential) bool {
 	return slices.Contains(creds, target)
+}
+
+// deprecatedSDKKeys returns the environment's accepted SDK keys being phased out — every non-anchor
+// server key carrying a future expiry — derived from the accepted-set snapshot, the same data the
+// /status endpoint reads via GetAcceptedKeys.
+func deprecatedSDKKeys(env relayenv.EnvContext) []credential.SDKCredential {
+	set := env.GetAcceptedKeys()
+	var out []credential.SDKCredential
+	for key, info := range set.Server {
+		if info.Expiry != nil && key != set.Anchor {
+			out = append(out, key)
+		}
+	}
+	return out
 }
 
 // awaitCredentialRemoved blocks until the given credential no longer resolves to an environment.
@@ -737,13 +751,13 @@ func TestConcurrentKeysRAC_DeExpiryCancelsScheduledDrop(t *testing.T) {
 			defaultMobileKeyReps(),
 			2,
 		)))
-		require.Eventually(t, func() bool { return credsContain(env.GetDeprecatedCredentials(), extraSDKKey) },
+		require.Eventually(t, func() bool { return credsContain(deprecatedSDKKeys(env), extraSDKKey) },
 			time.Second, 5*time.Millisecond, "expiry was not applied — nothing to cancel")
 
 		// A later payload carries the key with no expiry: the scheduled drop is cancelled.
 		p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 3)))
 
-		require.Eventually(t, func() bool { return !credsContain(env.GetDeprecatedCredentials(), extraSDKKey) },
+		require.Eventually(t, func() bool { return !credsContain(deprecatedSDKKeys(env), extraSDKKey) },
 			time.Second, 5*time.Millisecond, "de-expiry did not return the key to the permanent set")
 
 		// The key is permanent again: its expiry is cleared, so the cleanup ticker has nothing to drop.

--- a/relay/filedata_actions_test.go
+++ b/relay/filedata_actions_test.go
@@ -230,7 +230,7 @@ func TestOfflineModeDeprecatedSDKKeyIsRespectedIfExpiryInFuture(t *testing.T) {
 
 		// Expiring key is in the accepted set (and thus GetCredentials) until it expires.
 		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.SDKKey, envData.Params.AcceptedSDKKeys[1].Value, envData.Params.EnvID}, env.GetCredentials())
-		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.AcceptedSDKKeys[1].Value}, env.GetDeprecatedCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{envData.Params.AcceptedSDKKeys[1].Value}, deprecatedSDKKeys(env))
 	})
 }
 
@@ -246,14 +246,14 @@ func TestOfflineModePrimarySDKKeyIsDeprecated(t *testing.T) {
 		env := p.awaitEnvironment(update1.Params.EnvID)
 
 		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.EnvID}, env.GetCredentials())
-		assert.Empty(t, env.GetDeprecatedCredentials())
+		assert.Empty(t, deprecatedSDKKeys(env))
 
 		update2 := RotateSDKKeyWithGracePeriod("key2", "key1", time.Now().Add(1*time.Hour))
 		p.updateHandler.UpdateEnvironment(update2)
 
 		// Both the new anchor and the expiring old key are accepted until key1 expires.
 		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.SDKKey, update2.Params.AcceptedSDKKeys[1].Value, update1.Params.EnvID}, env.GetCredentials())
-		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.AcceptedSDKKeys[1].Value}, env.GetDeprecatedCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{update2.Params.AcceptedSDKKeys[1].Value}, deprecatedSDKKeys(env))
 
 		update3 := RotateSDKKey("key3")
 		p.updateHandler.UpdateEnvironment(update3)
@@ -262,7 +262,7 @@ func TestOfflineModePrimarySDKKeyIsDeprecated(t *testing.T) {
 
 		// update3 carries no expiring key, so ReconcileCredentials replaces the full accepted set with
 		// just key3; key1 and key2 are removed immediately (not held in the deprecated bucket).
-		assert.Empty(t, env.GetDeprecatedCredentials())
+		assert.Empty(t, deprecatedSDKKeys(env))
 	})
 }
 
@@ -294,10 +294,10 @@ func TestOfflineModeSDKKeyCanExpire(t *testing.T) {
 		env := p.awaitEnvironmentFor(update1.Params.EnvID, time.Second)
 		// Both the primary and the expiring key are in the accepted set until the expiry fires.
 		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.AcceptedSDKKeys[1].Value, update1.Params.EnvID}, env.GetCredentials())
-		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.AcceptedSDKKeys[1].Value}, env.GetDeprecatedCredentials())
+		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.AcceptedSDKKeys[1].Value}, deprecatedSDKKeys(env))
 
 		assert.Eventually(t, func() bool {
-			return len(env.GetDeprecatedCredentials()) == 0
+			return len(deprecatedSDKKeys(env)) == 0
 		}, time.Second, 10*time.Millisecond, "deprecated credentials should be cleaned up after expiry")
 		assert.ElementsMatch(t, []credential.SDKCredential{update1.Params.SDKKey, update1.Params.EnvID}, env.GetCredentials())
 	})


### PR DESCRIPTION
## Summary

Removes the production-dead `DeprecatedCredentials` accessor trio and rewrites its test callers to read expiry data from the accepted-set snapshot instead.

- Jira: [SDK-2702](https://launchdarkly.atlassian.net/browse/SDK-2702)
- Stacked on #760 (base branch `aaronz/SDK-2702/dead-code-removal`).

## Background

The trio — `Rotator.DeprecatedCredentials`, `envContextImpl.GetDeprecatedCredentials`, and the `EnvContext.GetDeprecatedCredentials` interface entry — had no remaining production consumers. Their last caller, the `/status` endpoint, now reads `GetAcceptedKeys`, which exposes strictly more: the full accepted set with per-key expiry plus the anchor designation. "Which keys are being phased out" is derivable from that snapshot (non-anchor server keys carrying a future expiry), so the dedicated accessors are pure surface area.

They were deliberately kept during development because the test rewrites looked like they'd cost more than the accessors were worth. This PR is the actual diff, so that call can be made against something concrete rather than a guess.

## Decision requested

These accessors were kept on purpose — the worry was that the test-side rewrite would be messier than just leaving three thin methods in place. Here's the honest accounting now that it's done:

| Metric | Value |
| --- | --- |
| Production lines | +1 / −27 (net **−26**); comment reword is the only addition |
| Production items removed | 3 accessors across 3 files |
| Test lines | +65 / −22 (net **+43**) across 5 files |
| Test call sites rewritten | 19 sites across 5 files |
| Shared helper cost | ~36 of the added test lines are the helper (one ~11-line `deprecatedSDKKeys` per package) |
| Net overall | +66 / −49 (net **+17**) |

A small `deprecatedSDKKeys` helper per test package (`credential`, `relayenv`, `relay`) sources the expiring keys from `AcceptedKeys().Server` / `GetAcceptedKeys()`, filtered to non-anchor server keys with a non-nil expiry — exactly what the removed methods computed. With the helper in place, every call site became a 1:1 swap (`r.DeprecatedCredentials()` → `deprecatedSDKKeys(r)`, `env.GetDeprecatedCredentials()` → `deprecatedSDKKeys(env)`); no inline map-filtering leaked into any assertion, and every behavioral assertion is preserved unchanged.

The one honest wart: the helper is duplicated across three packages because each operates on a different type (`*Rotator` vs `EnvContext`), and sharing it would mean adding non-test production API — which defeats the point of removing production API. So it's three ~11-line test-local functions.

My read: the rewrite came out clean, and the original worry was mostly unfounded once the helper absorbed the filtering. But it is your call. If the test-side cost still outweighs the cleanup, close this PR — no hard feelings.


[SDK-2702]: https://launchdarkly.atlassian.net/browse/SDK-2702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ