### PR TITLE
test(concurrent-keys): close test coverage gaps throughout the feature branch

### DIFF
--- a/internal/autoconfig/stream_manager_errors_test.go
+++ b/internal/autoconfig/stream_manager_errors_test.go
@@ -168,6 +168,97 @@ func TestMalformedCredentialPayloadPreservesEnvironmentCache(t *testing.T) {
 	})
 }
 
+// malformedRecoveryTest drives the full malformed-payload recovery loop at the stream-manager level.
+// The first connection serves a malformed credential payload (via the SequentialHandler pattern from
+// errorShouldCauseReconnect); the second connection, reached after the reconnect, serves a corrected
+// put. It asserts the three parts of the story: (a) the malformed payload dispatches no add/update,
+// (b) the malformed payload triggers a reconnect, and (c) the corrected put's environment then
+// dispatches with the corrected credential set.
+//
+// correctedEnv deliberately carries the same version as the malformed payload the caller passes in.
+// Validation runs before the version is recorded, so the malformed version is never stored; a corrected
+// put at that same version must therefore still be treated as new and dispatch, not be deduplicated away.
+func malformedRecoveryTest(t *testing.T, malformedEvent httphelpers.SSEEvent, correctedEnv envfactory.EnvironmentRep) {
+	malformedHandler, malformedStream := httphelpers.SSEHandler(&malformedEvent)
+	defer malformedStream.Close()
+
+	correctedPut := makeEnvPutEvent(correctedEnv)
+	correctedHandler, correctedStream := httphelpers.SSEHandler(&correctedPut)
+	defer correctedStream.Close()
+
+	handler := httphelpers.SequentialHandler(
+		malformedHandler, // first connection serves the malformed payload
+		correctedHandler, // connection after the reconnect serves the corrected put
+	)
+
+	streamManagerTestWithStreamHandler(t, handler, correctedStream, noopTestCache{}, func(p streamManagerTestParams) {
+		p.startStream()
+		<-p.requestsCh // first connection
+
+		// (a) + (b): the malformed payload must trigger a reconnect and must not dispatch any
+		// add/update. A malformed put still reports ReceivedAllEnvironments, which we tolerate; a
+		// malformed patch reports nothing. Loop until we observe the reconnect.
+		sawReconnect := false
+		deadline := time.After(2 * time.Second)
+		for !sawReconnect {
+			select {
+			case m := <-p.messageHandler.received:
+				if m.add != nil || m.update != nil {
+					require.Failf(t, "unexpected message",
+						"must not dispatch add/update for the malformed payload, got %s", m)
+				}
+			case <-p.requestsCh: // reconnect request == stream restart
+				sawReconnect = true
+			case <-deadline:
+				require.Fail(t, "timed out waiting for stream restart")
+			}
+		}
+		p.mockLog.AssertMessageMatch(t, true, ldlog.Error, "malformed credential payload")
+
+		// (c): after the reconnect the corrected put's environment must dispatch as an add carrying the
+		// corrected credential set. Because the malformed version was never recorded, the corrected put
+		// at the same version is not deduplicated.
+		msg := p.requireMessage()
+		require.NotNil(t, msg.add, "the corrected put must dispatch an add after recovery")
+		assert.Equal(t, correctedEnv.EnvID, msg.add.EnvID)
+		assert.Equal(t, correctedEnv.SDKKey.Value, msg.add.SDKKey,
+			"the corrected put's anchor key must dispatch")
+		assert.Equal(t, []envfactory.AcceptedSDKKey{{Value: correctedEnv.SDKKey.Value}}, msg.add.AcceptedSDKKeys,
+			"the corrected put's accepted set must dispatch")
+	})
+}
+
+// TestMalformedCredentialPayloadRecoversAfterReconnect extends the malformed-payload story past the
+// reconnect: once the backend resends a corrected put on the new connection, the update must dispatch.
+// This pins that validating at the parse boundary (before the version is recorded) leaves the receiver
+// able to accept a corrected put at the same version — a validate-after-record ordering would dedup it.
+func TestMalformedCredentialPayloadRecoversAfterReconnect(t *testing.T) {
+	// The corrected env carries the same version as every malformed variant below (testEnv1.Version).
+	correctedEnv := testEnv1
+	require.Equal(t, 10, correctedEnv.Version, "guarding the same-version premise of this test")
+
+	t.Run("malformed put recovers, corrected put at same version dispatches", func(t *testing.T) {
+		malformed := testEnv1
+		malformed.SDKKey = envfactory.SDKKeyRep{Value: config.SDKKey("")} // undefined anchor
+		malformedRecoveryTest(t, makeEnvPutEvent(malformed), correctedEnv)
+	})
+
+	t.Run("malformed patch recovers, corrected put dispatches", func(t *testing.T) {
+		malformed := testEnv1
+		malformed.SDKKey = envfactory.SDKKeyRep{Value: config.SDKKey("")} // undefined anchor
+		malformedRecoveryTest(t, makePatchEnvEvent(malformed), correctedEnv)
+	})
+
+	t.Run("anchor defined but absent from sdkKeys[] is malformed and recovers", func(t *testing.T) {
+		// A defined anchor (sdkKey.value) that does not appear in the authoritative sdkKeys[] array is
+		// treated as malformed by BuildAcceptedSet, just like an undefined anchor — exercise that variant
+		// through the stream manager.
+		malformed := testEnv1
+		malformed.SDKKeys = []envfactory.ConcurrentKeyRep{{Key: "other", Value: "sdk-other-value"}}
+		malformedRecoveryTest(t, makeEnvPutEvent(malformed), correctedEnv)
+	})
+}
+
 func TestMalformedJSONInEventCausesStreamRestart(t *testing.T) {
 	t.Run("put", func(t *testing.T) {
 		event := httphelpers.SSEEvent{Event: PutEvent, Data: malformedJSON}

--- a/internal/envfactory/env_rep_test.go
+++ b/internal/envfactory/env_rep_test.go
@@ -192,3 +192,77 @@ func TestEnvironmentRepOldFormatNoArrays(t *testing.T) {
 	require.Len(t, params.AcceptedMobileKeys, 1)
 	assert.Equal(t, AcceptedMobileKey{Value: config.MobileKey("mob-default")}, params.AcceptedMobileKeys[0])
 }
+
+// TestNewFormatPayloadDecodesIntoOldFormatStruct pins the wire-format additive guarantee directly. The
+// local oldEnvironmentRep mirrors EnvironmentRep as it was before concurrent keys: only the singular
+// sdkKey (with the legacy sdkKey.expiring rotation slot) and mobKey, and none of the new sdkKeys/
+// mobileKeys arrays or per-key expiry. Decoding a full new-format payload into it must succeed and yield
+// exactly the singular values an old relay binary saw before the arrays existed — because the parse path
+// uses the default JSON decoder (never DisallowUnknownFields), so the unknown new fields are ignored.
+func TestNewFormatPayloadDecodesIntoOldFormatStruct(t *testing.T) {
+	// oldEnvironmentRep is the pre-concurrent-keys shape. Do not add sdkKeys/mobileKeys/expiry here — the
+	// whole point is that an old binary that never knew about them still decodes a new payload cleanly.
+	type oldEnvironmentRep struct {
+		EnvID    config.EnvironmentID `json:"envID"`
+		EnvKey   string               `json:"envKey"`
+		EnvName  string               `json:"envName"`
+		MobKey   config.MobileKey     `json:"mobKey"`
+		ProjKey  string               `json:"projKey"`
+		ProjName string               `json:"projName"`
+		SDKKey   struct {
+			Value    config.SDKKey `json:"value"`
+			Expiring struct {
+				Value     config.SDKKey              `json:"value"`
+				Timestamp ldtime.UnixMillisecondTime `json:"timestamp"`
+			} `json:"expiring"`
+		} `json:"sdkKey"`
+		DefaultTTL int  `json:"defaultTtl"`
+		SecureMode bool `json:"secureMode"`
+		Version    int  `json:"version"`
+	}
+
+	// A realistic full new-format payload: singular fields plus the legacy expiring slot, the new
+	// sdkKeys/mobileKeys arrays, and per-key expiry — everything a current backend can emit.
+	jsonStr := `{
+		"envID": "68e5179e8307e4099c277e2a",
+		"envKey": "production",
+		"envName": "Production",
+		"mobKey": "mob-f41c",
+		"projKey": "my-project",
+		"projName": "My Project",
+		"sdkKey": {
+			"value": "sdk-anchor",
+			"expiring": { "value": "sdk-old-anchor", "timestamp": 1699000000000 }
+		},
+		"sdkKeys": [
+			{ "key": "default-sdk", "value": "sdk-anchor" },
+			{ "key": "service-a",   "value": "sdk-service-a", "expiry": 1700000000000 }
+		],
+		"mobileKeys": [
+			{ "key": "mob-key-1", "value": "mob-f41c" },
+			{ "key": "mob-key-2", "value": "mob-second", "expiry": 1700000000000 }
+		],
+		"defaultTtl": 5,
+		"secureMode": true,
+		"version": 26
+	}`
+
+	var rep oldEnvironmentRep
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &rep))
+
+	// The singular fields an old relay relies on populate exactly as before; the arrays are ignored.
+	assert.Equal(t, config.SDKKey("sdk-anchor"), rep.SDKKey.Value)
+	assert.Equal(t, config.SDKKey("sdk-old-anchor"), rep.SDKKey.Expiring.Value)
+	assert.Equal(t, ldtime.UnixMillisecondTime(1699000000000), rep.SDKKey.Expiring.Timestamp)
+	assert.Equal(t, config.MobileKey("mob-f41c"), rep.MobKey)
+
+	// The remaining scalar fields also decode unchanged.
+	assert.Equal(t, config.EnvironmentID("68e5179e8307e4099c277e2a"), rep.EnvID)
+	assert.Equal(t, "production", rep.EnvKey)
+	assert.Equal(t, "Production", rep.EnvName)
+	assert.Equal(t, "my-project", rep.ProjKey)
+	assert.Equal(t, "My Project", rep.ProjName)
+	assert.Equal(t, 5, rep.DefaultTTL)
+	assert.True(t, rep.SecureMode)
+	assert.Equal(t, 26, rep.Version)
+}

--- a/internal/events/event_payload_regression_test.go
+++ b/internal/events/event_payload_regression_test.go
@@ -34,53 +34,6 @@ func requireUpstreamRequest(t *testing.T, requestsCh <-chan httphelpers.HTTPRequ
 	return helpers.RequireValue(t, requestsCh, time.Second)
 }
 
-// TestAnalyticsUpstreamUsesAnchorCredential verifies that analytics events are forwarded
-// upstream under the dispatcher's stored anchor credential, even when the incoming SDK
-// request carries a different Authorization header.
-func TestAnalyticsUpstreamUsesAnchorCredential(t *testing.T) {
-	eventRelayTest(t, st.EnvMain, config.EventsConfig{}, func(p eventRelayTestParams) {
-		headers := headersWithEventSchema(CurrentEventsSchemaVersion)
-		// Incoming request carries a non-anchor key — it must not reach the upstream.
-		headers.Set("Authorization", "sdk-non-anchor-key-must-not-reach-upstream")
-
-		handler := p.dispatcher.GetHandler(basictypes.ServerSDK, ldevents.AnalyticsEventDataKind)
-		require.NotNil(t, handler)
-		w := httptest.NewRecorder()
-		handler(w, st.BuildRequest("POST", "/", []byte(eventPayloadForVerbatimOnly), headers))
-		assert.Equal(t, 202, w.Result().StatusCode)
-
-		p.dispatcher.flush()
-		r := requireUpstreamRequest(t, p.requestsCh)
-
-		assert.Equal(t, string(st.EnvMain.Config.SDKKey), r.Request.Header.Get("Authorization"),
-			"analytics upstream must carry the anchor credential, not the incoming request credential")
-	})
-}
-
-// TestDiagnosticUpstreamProxiesIncomingCredential verifies that diagnostic events proxy
-// the incoming request's Authorization header verbatim to the upstream, not the anchor.
-func TestDiagnosticUpstreamProxiesIncomingCredential(t *testing.T) {
-	const sdkAuth = "sdk-original-diagnostic-client-auth"
-
-	eventRelayTest(t, st.EnvMain, config.EventsConfig{}, func(p eventRelayTestParams) {
-		headers := headersWithEventSchema(0)
-		headers.Set("Authorization", sdkAuth)
-
-		handler := p.dispatcher.GetHandler(basictypes.ServerSDK, ldevents.DiagnosticEventDataKind)
-		require.NotNil(t, handler)
-		w := httptest.NewRecorder()
-		handler(w, st.BuildRequest("POST", "/", []byte(eventPayloadForVerbatimOnly), headers))
-		assert.Equal(t, 202, w.Result().StatusCode)
-
-		r := requireUpstreamRequest(t, p.requestsCh)
-
-		assert.Equal(t, sdkAuth, r.Request.Header.Get("Authorization"),
-			"diagnostic upstream must proxy the incoming Authorization header verbatim")
-		assert.NotEqual(t, string(st.EnvMain.Config.SDKKey), r.Request.Header.Get("Authorization"),
-			"diagnostic upstream must not use the anchor credential")
-	})
-}
-
 // TestCredentialRoutingAfterReplaceCredential verifies that after ReplaceCredential is
 // called (anchor rotation), analytics events use the new anchor while diagnostic events
 // continue to proxy the original incoming authorization.

--- a/internal/events/event_payload_regression_test.go
+++ b/internal/events/event_payload_regression_test.go
@@ -11,6 +11,7 @@
 package events
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/basictypes"
 	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
 
 	ldevents "github.com/launchdarkly/go-sdk-events/v3"
 	helpers "github.com/launchdarkly/go-test-helpers/v3"
@@ -133,5 +135,138 @@ func TestCredentialRoutingAfterReplaceCredential(t *testing.T) {
 			"after rotation: diagnostic must still proxy the original incoming authorization")
 		assert.NotEqual(t, string(newAnchorKey), r.Request.Header.Get("Authorization"),
 			"after rotation: diagnostic must not use the new anchor credential")
+	})
+}
+
+// headerSet builds a set of canonicalized header names for use as an allowed-delta list.
+func headerSet(keys ...string) map[string]struct{} {
+	s := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		s[http.CanonicalHeaderKey(k)] = struct{}{}
+	}
+	return s
+}
+
+// assertProxiedHeadersMatchExcept fails if any header present on either the incoming or the upstream
+// request has a differing value, unless its (canonicalized) name is in allowedDelta. This pins that the
+// forwarder passes headers through unchanged and diverges only on the enumerated transport/credential
+// headers, catching any regression that silently drops, adds, or rewrites a header.
+func assertProxiedHeadersMatchExcept(t *testing.T, incoming, upstream http.Header, allowedDelta map[string]struct{}) {
+	t.Helper()
+	checked := make(map[string]struct{})
+	compare := func(h http.Header) {
+		for name := range h {
+			key := http.CanonicalHeaderKey(name)
+			if _, done := checked[key]; done {
+				continue
+			}
+			checked[key] = struct{}{}
+			if _, skip := allowedDelta[key]; skip {
+				continue
+			}
+			assert.Equalf(t, incoming.Get(key), upstream.Get(key),
+				"header %q must be forwarded unchanged", key)
+		}
+	}
+	compare(incoming)
+	compare(upstream)
+}
+
+// TestAnalyticsUpstreamPayloadIsByteIdentical is the payload-regression form of the analytics routing
+// test: beyond the credential decision, the forwarded body must be byte-for-byte identical to the
+// incoming one, and every header must be forwarded unchanged except Authorization (swapped to the
+// anchor) and the transport/compression headers the sender legitimately adds.
+func TestAnalyticsUpstreamPayloadIsByteIdentical(t *testing.T) {
+	eventRelayTest(t, st.EnvMain, config.EventsConfig{}, func(p eventRelayTestParams) {
+		incomingBody := []byte(eventPayloadForVerbatimOnly)
+		incomingHeaders := headersWithEventSchema(CurrentEventsSchemaVersion)
+		incomingHeaders.Set(TagsHeader, "application-id/my-app application-version/1.2.3")
+		// The incoming request carries a non-anchor credential; it must not reach the upstream.
+		incomingHeaders.Set("Authorization", "sdk-non-anchor-key-must-not-reach-upstream")
+
+		handler := p.dispatcher.GetHandler(basictypes.ServerSDK, ldevents.AnalyticsEventDataKind)
+		require.NotNil(t, handler)
+		w := httptest.NewRecorder()
+		handler(w, st.BuildRequest("POST", "/", incomingBody, incomingHeaders))
+		assert.Equal(t, 202, w.Result().StatusCode)
+
+		p.dispatcher.flush()
+		r := requireUpstreamRequest(t, p.requestsCh)
+
+		// The upstream body is gzip-compressed; once decompressed it must equal the incoming bytes exactly.
+		uncompressed, err := util.DecompressGzipData(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, incomingBody, uncompressed, "the event payload body must be forwarded byte-for-byte")
+
+		// Authorization is the one credential header the analytics path deliberately rewrites, swapping
+		// the incoming credential for the environment's anchor.
+		assert.Equal(t, string(st.EnvMain.Config.SDKKey), r.Request.Header.Get("Authorization"),
+			"analytics upstream must carry the anchor credential, not the incoming request credential")
+
+		// Headers the analytics forwarder legitimately changes or adds, excluded from the
+		// "forwarded unchanged" comparison:
+		//   Authorization             - swapped to the environment anchor (asserted separately above)
+		//   X-LaunchDarkly-Payload-ID - a fresh UUID the sender stamps on each analytics payload
+		//   Content-Encoding          - the sender gzip-compresses the payload
+		//   Content-Length            - reflects the compressed body, set by the transport
+		//   Accept-Encoding           - added by the Go HTTP transport
+		//   User-Agent                - Relay's own SDK-client User-Agent, from the base headers
+		allowedDelta := headerSet(
+			"Authorization",
+			"X-LaunchDarkly-Payload-ID",
+			"Content-Encoding",
+			"Content-Length",
+			"Accept-Encoding",
+			"User-Agent",
+		)
+		assertProxiedHeadersMatchExcept(t, incomingHeaders, r.Request.Header, allowedDelta)
+	})
+}
+
+// TestDiagnosticUpstreamPayloadIsByteIdentical is the payload-regression form of the diagnostic routing
+// test: the body must be byte-for-byte identical, and because the diagnostic path is a verbatim reverse
+// proxy, every header including Authorization must be forwarded unchanged except the transport/compression
+// headers the sender adds.
+func TestDiagnosticUpstreamPayloadIsByteIdentical(t *testing.T) {
+	const sdkAuth = "sdk-original-diagnostic-client-auth"
+
+	eventRelayTest(t, st.EnvMain, config.EventsConfig{}, func(p eventRelayTestParams) {
+		incomingBody := []byte(eventPayloadForVerbatimOnly)
+		incomingHeaders := headersWithEventSchema(0)
+		incomingHeaders.Set("Authorization", sdkAuth)
+		incomingHeaders.Set("User-Agent", "some-sdk/1.0.0")
+		// A custom header proves the diagnostic path forwards arbitrary request headers verbatim.
+		incomingHeaders.Set("X-Custom-Passthrough", "passthrough-value")
+
+		handler := p.dispatcher.GetHandler(basictypes.ServerSDK, ldevents.DiagnosticEventDataKind)
+		require.NotNil(t, handler)
+		w := httptest.NewRecorder()
+		handler(w, st.BuildRequest("POST", "/", incomingBody, incomingHeaders))
+		assert.Equal(t, 202, w.Result().StatusCode)
+
+		r := requireUpstreamRequest(t, p.requestsCh)
+
+		uncompressed, err := util.DecompressGzipData(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, incomingBody, uncompressed, "the diagnostic payload body must be forwarded byte-for-byte")
+
+		// Unlike analytics, the diagnostic path proxies the incoming credential verbatim — the anchor is
+		// never substituted.
+		assert.Equal(t, sdkAuth, r.Request.Header.Get("Authorization"),
+			"diagnostic upstream must proxy the incoming Authorization header verbatim")
+		assert.NotEqual(t, string(st.EnvMain.Config.SDKKey), r.Request.Header.Get("Authorization"),
+			"diagnostic upstream must not use the anchor credential")
+
+		// Only the transport/compression headers the sender adds may differ; everything else — including
+		// Authorization, User-Agent, and the custom header — is forwarded unchanged.
+		//   Content-Encoding - the sender gzip-compresses the payload
+		//   Content-Length   - reflects the compressed body, set by the transport
+		//   Accept-Encoding  - added by the Go HTTP transport
+		allowedDelta := headerSet(
+			"Content-Encoding",
+			"Content-Length",
+			"Accept-Encoding",
+		)
+		assertProxiedHeadersMatchExcept(t, incomingHeaders, r.Request.Header, allowedDelta)
 	})
 }

--- a/internal/relayenv/env_context_reanchor_behavior_test.go
+++ b/internal/relayenv/env_context_reanchor_behavior_test.go
@@ -1,0 +1,187 @@
+package relayenv
+
+// Permanent behavioral regression tests for re-anchoring. These pin three properties of the
+// upstream-client swap that no other test in this package covers:
+//
+//   - an open downstream (client-side) connection survives a re-anchor and keeps receiving events,
+//     with the re-wired big-segment synchronizer driving its invalidations;
+//   - the new anchor's initial sync re-broadcasts a full "put" downstream, so a downstream SDK sees one
+//     duplicate put per re-anchor (tolerable — SDKs apply puts idempotently — but the swap must expect it);
+//   - httpconfig carries no baked-in SDK key other than the Authorization header the SDK sets per client,
+//     so it needs no re-wiring on a re-anchor.
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/basictypes"
+	"github.com/launchdarkly/ld-relay/v8/internal/bigsegments"
+	"github.com/launchdarkly/ld-relay/v8/internal/httpconfig"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+	"github.com/launchdarkly/ld-relay/v8/internal/store"
+	"github.com/launchdarkly/ld-relay/v8/internal/streams"
+
+	"github.com/launchdarkly/eventsource"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+	helpers "github.com/launchdarkly/go-test-helpers/v3"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// putCountingStreamUpdates is a streams.EnvStreamUpdates that counts the "all data" broadcasts it
+// receives, so a test can observe how many full "put"s a sequence of store inits produces downstream.
+type putCountingStreamUpdates struct {
+	mu             sync.Mutex
+	allDataUpdates int
+}
+
+func (r *putCountingStreamUpdates) SendAllDataUpdate(_ []ldstoretypes.Collection) {
+	r.mu.Lock()
+	r.allDataUpdates++
+	r.mu.Unlock()
+}
+
+func (r *putCountingStreamUpdates) SendSingleItemUpdate(_ ldstoretypes.DataKind, _ string, _ ldstoretypes.ItemDescriptor) {
+}
+
+func (r *putCountingStreamUpdates) InvalidateClientSideState() {}
+
+func (r *putCountingStreamUpdates) allDataCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.allDataUpdates
+}
+
+// TestReanchorDownstreamConnectionSurvives verifies that an open downstream client-side connection
+// survives a re-anchor and keeps receiving events. The connection is keyed on the environment ID (a
+// scoped credential) and is independent of the upstream SDK anchor key, so swapping the anchor must not
+// disturb it. After the re-anchor the big-segment synchronizer has been rebuilt on the new anchor, so a
+// big-segment update delivered on the current (rebuilt) synchronizer still pings the connected client.
+func TestReanchorDownstreamConnectionSurvives(t *testing.T) {
+	envConfig := st.EnvClientSide.Config
+
+	fakeBigSegmentStoreFactory := func(config.EnvConfig, config.Config, ldlog.Loggers) (bigsegments.BigSegmentStore, error) {
+		return bigsegments.NewNullBigSegmentStore(), nil
+	}
+	fakeSynchronizerFactory := &mockBigSegmentSynchronizerFactory{}
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	jsClientStreams := streams.NewStreamProvider(basictypes.JSClientPingStream, time.Hour, 0)
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	sdkStartedCh := make(chan EnvContext, 10)
+	env, err := NewEnvContext(EnvContextImplParams{
+		Identifiers:                   EnvIdentifiers{ConfiguredName: st.EnvClientSide.Name},
+		EnvConfig:                     envConfig,
+		AllConfig:                     config.Config{},
+		BigSegmentStoreFactory:        fakeBigSegmentStoreFactory,
+		BigSegmentSynchronizerFactory: fakeSynchronizerFactory.create,
+		ClientFactory:                 testclient.FakeLDClientFactoryWithChannel(true, clientCh),
+		SDKBigSegmentsConfigFactory: ldcomponents.BigSegments(
+			st.ExistingInstance[subsystems.BigSegmentStore](&st.NoOpSDKBigSegmentStore{}),
+		),
+		StreamProviders:  []streams.StreamProvider{jsClientStreams},
+		ConnectionMapper: mockConnectionMapper{},
+		Loggers:          mockLog.Loggers,
+	}, sdkStartedCh)
+	require.NoError(t, err)
+	defer env.Close()
+
+	synchronizer := fakeSynchronizerFactory.synchronizer
+	require.NotNil(t, synchronizer)
+
+	// Wait for the original anchor client and initialize the store so the client-side stream is ready.
+	<-sdkStartedCh
+	require.NoError(t, env.GetStore().Init(nil))
+
+	streamHandler := env.GetStreamHandler(jsClientStreams, envConfig.EnvID)
+	req, _ := http.NewRequest("GET", "", nil)
+	st.WithStreamRequest(t, req, streamHandler, func(eventCh <-chan eventsource.Event) {
+		initEvent := helpers.RequireValue(t, eventCh, time.Minute)
+		assert.Equal(t, "ping", initEvent.Event())
+		if !helpers.AssertNoMoreValues(t, eventCh, 100*time.Millisecond) {
+			t.FailNow()
+		}
+
+		// Re-anchor while the downstream connection is open. The re-anchor runs synchronously, so the
+		// new anchor's client is built and committed and the big-segment synchronizer is rebuilt by the
+		// time this returns.
+		now := time.Unix(1000, 0)
+		reanchorViaReconcile(t, env, reanchorSyncTestKey2, envConfig.SDKKey, "", envConfig.MobileKey, envConfig.EnvID, now)
+
+		// The synchronizer was rebuilt on the new anchor, so a post-re-anchor update arrives on the
+		// current (rebuilt) synchronizer, not the retired one (whose channel is now closed).
+		current := fakeSynchronizerFactory.synchronizer
+		require.NotSame(t, synchronizer, current, "the synchronizer was rebuilt on re-anchor")
+		current.updateCh <- bigsegments.UpdatesSummary{SegmentKeysUpdated: []string{"fake-segment-key"}}
+		pingEvent := helpers.RequireValue(t, eventCh, time.Second)
+		assert.Equal(t, "ping", pingEvent.Event(), "downstream connection should survive the re-anchor")
+	})
+}
+
+// TestReanchorInitialSyncRebroadcastsPut verifies that the new anchor's client performs its own initial
+// sync when it comes up, re-broadcasting a full "put" to every connected downstream stream. From a
+// downstream SDK's perspective this is a duplicate put on each re-anchor. It is tolerable — SDKs apply
+// puts idempotently — but the re-anchor implementation must expect it; it is not a corruption.
+func TestReanchorInitialSyncRebroadcastsPut(t *testing.T) {
+	rec := &putCountingStreamUpdates{}
+	adapter := store.NewSSERelayDataStoreAdapter(ldcomponents.InMemoryDataStore(), rec)
+
+	// The original anchor client builds and performs its initial sync -> one downstream "put".
+	s1, err := adapter.Build(subsystems.BasicClientContext{})
+	require.NoError(t, err)
+	require.NoError(t, s1.Init(st.AllData))
+	require.Equal(t, 1, rec.allDataCount())
+
+	// Re-anchor: the new anchor's client performs its OWN initial sync (store handover hands it the same
+	// wrapper, but the new client still re-broadcasts a full put when it initializes).
+	s2, err := adapter.Build(subsystems.BasicClientContext{})
+	require.NoError(t, err)
+	require.NoError(t, s2.Init(st.AllData))
+
+	assert.Equal(t, 2, rec.allDataCount(), "the new anchor's initial sync re-broadcasts a full put")
+}
+
+// TestReanchorHTTPConfigIsKeyIndependent verifies that httpconfig carries no baked-in SDK key other than
+// the Authorization default header, so a re-anchor needs no httpconfig re-wire. Relay injects the SDK
+// HTTP config *builder* into the SDK config, and the SDK rebuilds the HTTP config with the new anchor key
+// when it constructs the new client, so the Authorization header is set correctly for the new anchor
+// automatically. The pre-built SDK HTTP config used for event and big-segment transport is
+// key-independent except for that Authorization header, which those components set per request from
+// their own credential rather than reading it from httpconfig.
+func TestReanchorHTTPConfigIsKeyIndependent(t *testing.T) {
+	loggers := ldlog.NewDisabledLoggers()
+	key1 := config.SDKKey("sdk-key-one")
+	key2 := config.SDKKey("sdk-key-two")
+
+	var proxy config.ProxyConfig
+	var httpC config.HTTPConfig
+
+	c1, err := httpconfig.NewHTTPConfig(proxy, httpC, key1, "user-agent", loggers)
+	require.NoError(t, err)
+	c2, err := httpconfig.NewHTTPConfig(proxy, httpC, key2, "user-agent", loggers)
+	require.NoError(t, err)
+
+	// The only key-dependent artifact is the Authorization default header on the pre-built SDK HTTP config.
+	assert.Equal(t, string(key1), c1.SDKHTTPConfig.DefaultHeaders.Get("Authorization"))
+	assert.Equal(t, string(key2), c2.SDKHTTPConfig.DefaultHeaders.Get("Authorization"))
+
+	// Everything else (proxy settings, user agent, and the rest of the default headers) is identical and
+	// key-independent.
+	h1 := c1.SDKHTTPConfig.DefaultHeaders.Clone()
+	h2 := c2.SDKHTTPConfig.DefaultHeaders.Clone()
+	h1.Del("Authorization")
+	h2.Del("Authorization")
+	assert.Equal(t, h1, h2, "non-auth default headers are key-independent")
+	assert.Equal(t, c1.ProxyConfig, c2.ProxyConfig, "proxy config is key-independent")
+}

--- a/internal/relayenv/env_context_reanchor_behavior_test.go
+++ b/internal/relayenv/env_context_reanchor_behavior_test.go
@@ -1,7 +1,7 @@
 package relayenv
 
 // Permanent behavioral regression tests for re-anchoring. These pin three properties of the
-// upstream-client swap that no other test in this package covers:
+// upstream-client swap:
 //
 //   - an open downstream (client-side) connection survives a re-anchor and keeps receiving events,
 //     with the re-wired big-segment synchronizer driving its invalidations;

--- a/internal/relayenv/env_context_reanchor_bigsegment_test.go
+++ b/internal/relayenv/env_context_reanchor_bigsegment_test.go
@@ -326,3 +326,47 @@ func TestReanchorBigSegmentSync_ConcurrentStoreUpdateDuringReanchorIsRaceFree(t 
 	assert.Equal(t, 2, count, "the synchronizer was recreated on re-anchor")
 	assert.Equal(t, reanchorTestKey2, sdkKey, "on the new anchor key")
 }
+
+// TestReanchorBigSegmentSync_RepromoteInGraceFormerAnchorRewires re-anchors A->B, then B->A while A is
+// still accepted (an in-grace former anchor whose client was closed when its demotion committed).
+// Promoting a previously-accepted key must re-wire big segments identically to a brand-new key: a fresh
+// synchronizer bound to A is created and Started (a segment already exists), and B's synchronizer is
+// Closed. This pins that the "previously-accepted key" promotion path does not shortcut the big-segment
+// re-wire.
+func TestReanchorBigSegmentSync_RepromoteInGraceFormerAnchorRewires(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	capturing := &capturingBigSegmentSynchronizerFactory{}
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	env := newBigSegmentTestEnv(t, nullBigSegmentStoreFactory,
+		testclient.FakeLDClientFactoryWithChannel(true, clientCh), capturing, mockLog.Loggers)
+	defer env.Close()
+	envImpl := env.(*envContextImpl)
+
+	envImpl.setBigSegmentsExist()
+	syncA := capturing.latest()
+	require.True(t, syncA.isStarted(), "the synchronizer is started once a big segment exists")
+
+	// A -> B. A stays accepted in its grace period; its client is closed at commit.
+	reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, time.Unix(1000, 0))
+	syncB := capturing.latest()
+	require.NotSame(t, syncA, syncB)
+	require.True(t, syncA.isClosed(), "A's synchronizer is closed after A->B")
+	require.True(t, syncB.isStarted(), "B's synchronizer is started (a segment already existed)")
+
+	// B -> A. A is still in the accepted set (its mappings survived the demotion) but has no client, so a
+	// fresh client is built and the big-segment sync must be re-wired onto A just like a brand-new key.
+	reanchor(t, env, envConfig.SDKKey, reanchorTestKey2, time.Unix(1000, 0))
+	syncARepromoted := capturing.latest()
+	assert.NotSame(t, syncB, syncARepromoted, "re-promoting A builds a THIRD synchronizer instance")
+	assert.NotSame(t, syncA, syncARepromoted, "and a fresh instance, not the retired original A synchronizer")
+
+	count, sdkKey := capturing.snapshot()
+	assert.Equal(t, 3, count, "one synchronizer per anchor commit: A, B, A-again")
+	assert.Equal(t, envConfig.SDKKey, sdkKey, "the third synchronizer is bound to the re-promoted key A")
+	assert.True(t, syncARepromoted.isStarted(), "the re-promoted anchor's synchronizer is Started (a segment exists)")
+	assert.True(t, syncB.isClosed(), "B's synchronizer is Closed on the re-promotion")
+	assert.Equal(t, envConfig.SDKKey, envImpl.keyRotator.AnchorKey(), "the SDK anchor is back on A")
+}

--- a/internal/relayenv/env_context_reanchor_bigsegment_test.go
+++ b/internal/relayenv/env_context_reanchor_bigsegment_test.go
@@ -5,25 +5,20 @@ package relayenv
 // not yet started" case; these cover the started-continues, rollback, and not-configured cases.
 
 import (
-	"net/http"
 	"testing"
 	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
-	"github.com/launchdarkly/ld-relay/v8/internal/basictypes"
 	"github.com/launchdarkly/ld-relay/v8/internal/bigsegments"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
-	"github.com/launchdarkly/ld-relay/v8/internal/streams"
 
-	"github.com/launchdarkly/eventsource"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
 	ld "github.com/launchdarkly/go-server-sdk/v7"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
-	helpers "github.com/launchdarkly/go-test-helpers/v3"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -152,59 +147,6 @@ func TestReanchorBigSegmentSync_NotConfiguredIsNoOp(t *testing.T) {
 	count, _ := capturing.snapshot()
 	assert.Equal(t, 0, count, "no synchronizer is created when big segments are not configured")
 	assert.Equal(t, reanchorTestKey2, env.(*envContextImpl).keyRotator.AnchorKey(), "the SDK re-anchor still committed")
-}
-
-// TestReanchorBigSegmentSync_NewSyncDrivesClientSideInvalidation is the end-to-end integration case
-// (SDK-2543 AC): with a client-side stream connected across a re-anchor, a big-segment update delivered
-// on the NEW synchronizer must still ping the connected client -- proving the re-wired synchronizer's
-// update consumer is active and drives client-side invalidation.
-func TestReanchorBigSegmentSync_NewSyncDrivesClientSideInvalidation(t *testing.T) {
-	envConfig := st.EnvClientSide.Config
-	capturing := &capturingBigSegmentSynchronizerFactory{}
-	mockLog := ldlogtest.NewMockLog()
-	defer mockLog.DumpIfTestFailed(t)
-
-	jsClientStreams := streams.NewStreamProvider(basictypes.JSClientPingStream, time.Hour, 0)
-	sdkStartedCh := make(chan EnvContext, 1)
-	clientCh := make(chan *testclient.FakeLDClient, 10)
-	env, err := NewEnvContext(EnvContextImplParams{
-		Identifiers:                   EnvIdentifiers{ConfiguredName: st.EnvMain.Name},
-		EnvConfig:                     envConfig,
-		AllConfig:                     config.Config{},
-		BigSegmentStoreFactory:        nullBigSegmentStoreFactory,
-		BigSegmentSynchronizerFactory: capturing.create,
-		ClientFactory:                 testclient.FakeLDClientFactoryWithChannel(true, clientCh),
-		SDKBigSegmentsConfigFactory: ldcomponents.BigSegments(
-			st.ExistingInstance[subsystems.BigSegmentStore](&st.NoOpSDKBigSegmentStore{}),
-		),
-		StreamProviders:  []streams.StreamProvider{jsClientStreams},
-		ConnectionMapper: mockConnectionMapper{},
-		Loggers:          mockLog.Loggers,
-	}, sdkStartedCh)
-	require.NoError(t, err)
-	defer env.Close()
-
-	<-sdkStartedCh
-	_ = env.GetStore().Init(nil) // client-side endpoint only pings once the store is initialized
-	oldSync := capturing.latest()
-
-	streamHandler := env.GetStreamHandler(jsClientStreams, envConfig.EnvID)
-	req, _ := http.NewRequest("GET", "", nil)
-	st.WithStreamRequest(t, req, streamHandler, func(eventCh <-chan eventsource.Event) {
-		initEvent := helpers.RequireValue(t, eventCh, time.Minute)
-		require.Equal(t, "ping", initEvent.Event())
-		helpers.AssertNoMoreValues(t, eventCh, 100*time.Millisecond)
-
-		// Re-anchor mid-subscription; the synchronizer is rebuilt on the new anchor.
-		reanchor(t, env, reanchorTestKey2, envConfig.SDKKey, time.Unix(1000, 0))
-		newSync := capturing.latest()
-		require.NotSame(t, oldSync, newSync, "the synchronizer was rebuilt on re-anchor")
-
-		// A big-segment update on the NEW synchronizer pings the still-connected client-side stream.
-		newSync.updateCh <- bigsegments.UpdatesSummary{SegmentKeysUpdated: []string{"seg"}}
-		pingEvent := helpers.RequireValue(t, eventCh, time.Second)
-		assert.Equal(t, "ping", pingEvent.Event())
-	})
 }
 
 // reanchorTestKey3 is a third anchor SDK key, used to drive A->B->C sequential re-anchors.

--- a/internal/relayenv/env_context_reanchor_close_test.go
+++ b/internal/relayenv/env_context_reanchor_close_test.go
@@ -1,0 +1,109 @@
+package relayenv
+
+// Regression test for tearing down an environment while a re-anchor's client build is in flight. The
+// re-anchor releases c.mu around the (potentially slow, SDK-init-timeout-bounded) client build, so a
+// concurrent Close() can run its teardown during that window. When the build then completes, the
+// re-anchor must observe that the env is closed, discard and close the freshly-built client rather than
+// installing it, and leave no client behind.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+	"github.com/launchdarkly/ld-relay/v8/internal/util"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const reanchorCloseNewAnchor = config.SDKKey("reanchor-close-new-anchor")
+
+// TestReanchorClosedDuringInFlightBuild wedges the new anchor's synchronous client build, calls Close()
+// from another goroutine, and then releases the build. Close must return within a generous deadline
+// (it does not block on the wedged build — the build runs without c.mu held). The late-built client is
+// discarded and closed rather than installed, no client remains, and a subsequent GetClient() returns
+// nil without panicking.
+//
+// The build is bounded by the SDK init timeout in production; here the gate release unblocks it
+// deterministically. This test is run under -race to catch any unsynchronized access between the
+// Close teardown and the re-anchor's post-build lock re-acquisition.
+func TestReanchorClosedDuringInFlightBuild(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	inner := testclient.FakeLDClientFactoryWithChannel(true, clientCh)
+
+	// The new anchor's build blocks on gate; entered signals the build has reached the factory (the
+	// re-anchor is mid-flight, pre-commit, and holds no c.mu while it waits here).
+	gate := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	gatedFactory := func(sdkKey config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		if sdkKey == reanchorCloseNewAnchor {
+			entered <- struct{}{}
+			<-gate
+		}
+		return inner(sdkKey, cfg, timeout)
+	}
+
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, envConfig, gatedFactory, mockLog.Loggers, readyCh)
+	defer env.Close() // idempotent; the test closes explicitly below, this guards early failures
+
+	require.Equal(t, env, requireEnvReady(t, readyCh))
+	originalClient := requireClientReady(t, clientCh)
+	require.Eventually(t, func() bool { return env.GetClient() == originalClient }, time.Second, 10*time.Millisecond)
+
+	// Drive the re-anchor on a background goroutine; it blocks in the gated build.
+	start := time.Unix(2000, 0)
+	set, err := credential.NewAcceptedSetBuilder().
+		WithAnchor(credential.SDKKeyParams{Value: reanchorCloseNewAnchor}).
+		WithSDKKey(credential.SDKKeyParams{Value: envConfig.SDKKey, Expiry: util.PtrOrNil(start.Add(time.Hour))}).
+		Build()
+	require.NoError(t, err)
+	reconcileDone := make(chan struct{})
+	go func() {
+		defer close(reconcileDone)
+		env.(*envContextImpl).reconcileCredentials(set, start)
+	}()
+
+	<-entered // the build is wedged: the re-anchor is mid-flight, pre-commit.
+
+	// Close from another goroutine. It does not hold reconcileMu, and the re-anchor released c.mu around
+	// the build, so Close can proceed to tear down the env while the build is still blocked.
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- env.Close() }()
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return while the re-anchor build was wedged")
+	}
+
+	// Release the wedged build. The late client is built and returned to the re-anchor, which finds the
+	// env closed and discards + closes it rather than installing it.
+	close(gate)
+	<-reconcileDone
+
+	// The late-built client was closed (its close channel fires) and never installed.
+	lateClient := requireClientReady(t, clientCh)
+	lateClient.AwaitClose(t, time.Second)
+
+	envImpl := env.(*envContextImpl)
+	envImpl.mu.RLock()
+	remaining := len(envImpl.clients)
+	envImpl.mu.RUnlock()
+	assert.Equal(t, 0, remaining, "no client remains installed after Close during an in-flight re-anchor")
+
+	// GetClient after Close returns nil without panicking.
+	assert.Nil(t, env.GetClient(), "GetClient returns nil after Close, with no panic")
+}

--- a/internal/sharedtest/configsource/rac_mock.go
+++ b/internal/sharedtest/configsource/rac_mock.go
@@ -40,6 +40,28 @@ func NewRACMock(t testing.TB, initialEvent *httphelpers.SSEEvent) *RACMock {
 	return m
 }
 
+// NewRACMockWithReconnect creates a RACMock that serves firstEvent to the first client that connects
+// and reconnectEvent to the next client — modeling a stream that a client restarts and reconnects to.
+// This supports the design's malformed-payload recovery (§9): a rejected patch forces Relay to restart
+// its config stream, and the backend serves a fresh, corrected put on the reconnection.
+//
+// Send delivers to the first connection; use it to push the event that forces the restart (e.g. the
+// malformed patch). initialEvent replay applies per handler, so the first connection sees firstEvent
+// and the reconnection sees reconnectEvent. Cleanup is registered with t.Cleanup.
+func NewRACMockWithReconnect(t testing.TB, firstEvent, reconnectEvent *httphelpers.SSEEvent) *RACMock {
+	firstHandler, firstStream := httphelpers.SSEHandler(firstEvent)
+	reconnectHandler, _ := httphelpers.SSEHandler(reconnectEvent)
+	handler := httphelpers.SequentialHandler(firstHandler, reconnectHandler)
+	server := httptest.NewServer(handler)
+	m := &RACMock{
+		URL:    server.URL,
+		server: server,
+		stream: firstStream,
+	}
+	t.Cleanup(m.Close)
+	return m
+}
+
 // Enqueue queues an event to be delivered to the next client that connects. Use this before Relay
 // has connected to ensure the event is not dropped.
 func (m *RACMock) Enqueue(event httphelpers.SSEEvent) {

--- a/relay/autoconfig_actions_test.go
+++ b/relay/autoconfig_actions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"
 
 	c "github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
 
 	"github.com/launchdarkly/go-configtypes"
@@ -44,6 +45,24 @@ func autoConfTest(
 	initialEvent *httphelpers.SSEEvent,
 	action func(p autoConfTestParams),
 ) {
+	autoConfTestWithClientFactory(t, config, initialEvent,
+		func(createdCh chan<- *testclient.FakeLDClient) sdks.ClientFactoryFunc {
+			return testclient.FakeLDClientFactoryWithChannel(true, createdCh)
+		}, action)
+}
+
+// autoConfTestWithClientFactory is autoConfTest with a caller-supplied SDK client factory, so a test
+// can inject a factory that fails or hangs for specific keys (e.g. to exercise the re-anchor
+// init-failure rollback through the real RAC handler). makeClientFactory receives the channel that
+// created clients are reported on; the usual body wraps testclient.FakeLDClientFactoryWithChannel and
+// special-cases only the keys it wants to treat differently, forwarding the rest to the healthy factory.
+func autoConfTestWithClientFactory(
+	t *testing.T,
+	config c.Config,
+	initialEvent *httphelpers.SSEEvent,
+	makeClientFactory func(createdCh chan<- *testclient.FakeLDClient) sdks.ClientFactoryFunc,
+	action func(p autoConfTestParams),
+) {
 	mockLog := ldlogtest.NewMockLog()
 	defer mockLog.DumpIfTestFailed(t)
 
@@ -78,7 +97,7 @@ func autoConfTest(
 
 			relay, err := newRelayInternal(config, relayInternalOptions{
 				loggers:       mockLog.Loggers,
-				clientFactory: testclient.FakeLDClientFactoryWithChannel(true, clientsCreatedCh),
+				clientFactory: makeClientFactory(clientsCreatedCh),
 			})
 			if err != nil {
 				panic(err)

--- a/relay/concurrent_keys_defensive_test.go
+++ b/relay/concurrent_keys_defensive_test.go
@@ -1,0 +1,94 @@
+package relay
+
+// Defensive-behavior integration tests for the RAC config stream: a malformed credential payload must
+// preserve the previous accepted set and force a stream restart, and the fresh state the backend
+// serves on the reconnection must then be applied. This is the relay-level twin of the unit-level
+// reconnect coverage in internal/autoconfig; it verifies the whole loop end-to-end through Relay's
+// downstream auth surface.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/configsource"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+
+	"github.com/launchdarkly/go-configtypes"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A malformed patch (anchor absent from sdkKeys[]) is rejected without being applied: the previously
+// accepted credentials keep authenticating and no new key leaks in. The rejection forces the config
+// stream to restart, and on the reconnection the backend serves a corrected put whose new key then
+// authenticates — completing the preserve-then-recover loop from the design's malformed-payload policy.
+func TestConcurrentKeysRAC_MalformedPayloadRecoversAfterReconnect(t *testing.T) {
+	firstPut := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
+
+	// The corrected state the backend serves on the reconnection: the original two keys plus a new one.
+	correctedPut := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(
+		[]envfactory.ConcurrentKeyRep{
+			{Key: "anchor-sdk", Value: string(anchorSDKKey)},
+			{Key: "extra-sdk", Value: string(extraSDKKey)},
+			{Key: "added-sdk", Value: string(addedSDKKey)},
+		},
+		defaultMobileKeyReps(),
+		3,
+	))
+
+	racMock := configsource.NewRACMockWithReconnect(t, &firstPut, &correctedPut)
+
+	cfg := config.Config{AutoConfig: config.AutoConfigConfig{Key: testAutoConfKey}}
+	cfg.Main.StreamURI, _ = configtypes.NewOptURLAbsoluteFromString(racMock.URL)
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	relay, err := newRelayInternal(cfg, relayInternalOptions{
+		loggers:       mockLog.Loggers,
+		clientFactory: testclient.FakeLDClientFactory(true),
+	})
+	require.NoError(t, err)
+	defer relay.Close()
+
+	h := relayTestHelper{t: t, relay: relay}
+	env := h.awaitEnvironment(multiKeyEnvID)
+	require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+	// Baseline: the two original keys authenticate; the corrected-put key is not accepted yet.
+	h.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+	h.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
+	h.assertSDKEndpointsAvailability(false, addedSDKKey, "", "")
+
+	// Send a structurally malformed patch: the anchor (anchorSDKKey) is absent from sdkKeys[]. Building
+	// the raw rep this way makes credential-set validation fail at the stream parse boundary.
+	malformed := multiKeyEnvRep(
+		[]envfactory.ConcurrentKeyRep{{Key: "extra-sdk", Value: string(extraSDKKey)}},
+		defaultMobileKeyReps(),
+		2,
+	)
+	racMock.Send(configsource.MakeAutoConfigPatchEvent(malformed))
+
+	// The malformed payload is rejected and logged; the previous accepted set is preserved (unchanged).
+	require.Eventually(t, func() bool {
+		return mockLog.HasMessageMatch(ldlog.Error, "[Mm]alformed credential payload")
+	}, 5*time.Second, 10*time.Millisecond, "malformed payload was not rejected with a structured error")
+	h.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+	h.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
+
+	// Recovery: the rejection restarted the stream, and on the reconnection the backend's corrected put
+	// applies — the new key now authenticates.
+	require.Eventually(t, func() bool {
+		_, err := relay.getEnvironment(sdkauth.New(addedSDKKey))
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond, "corrected put was not applied after the reconnect")
+
+	h.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+	h.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
+	h.assertSDKEndpointsAvailability(true, addedSDKKey, "", "")
+}

--- a/relay/concurrent_keys_lifecycle_test.go
+++ b/relay/concurrent_keys_lifecycle_test.go
@@ -166,3 +166,47 @@ func TestConcurrentKeysOffline_ConnectedStreamClosedWhenKeyRevokedByOmission(t *
 		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
 	})
 }
+
+// When one key expires, the disconnect must be targeted: only that key's downstream SDKs drop. A stream
+// held on the anchor stays connected throughout the expiry window while a concurrently-open stream on
+// the expiring non-anchor key is torn down. Uses the offline harness (real client that serves stream
+// data) with two simultaneous downstream connections on the same environment.
+func TestConcurrentKeysOffline_SiblingStreamSurvivesWhileExpiringKeyDisconnects(t *testing.T) {
+	cfg := config.Config{}
+	cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
+	offlineModeTest(t, cfg, func(p offlineModeTestParams) {
+		p.updateHandler.AddEnvironment(multiKeyArchiveEnv(defaultAcceptedSDKKeys(), defaultAcceptedMobileKeys()))
+		_ = p.awaitClient()
+		env := p.awaitEnvironment(multiKeyEnvID)
+		require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+		// Open a stream on the anchor — the sibling that must stay connected.
+		anchorReq := sharedtest.BuildRequestWithAuth("GET", "/all", anchorSDKKey, nil)
+		sharedtest.WithStreamRequest(t, anchorReq, p.relay, func(anchorCh <-chan eventsource.Event) {
+			sharedtest.AwaitEventOfType(t, anchorCh, "put", 5*time.Second)
+
+			// Concurrently open a second stream on the non-anchor key that we will expire.
+			expiringReq := sharedtest.BuildRequestWithAuth("GET", "/all", extraSDKKey, nil)
+			sharedtest.WithStreamRequest(t, expiringReq, p.relay, func(expiringCh <-chan eventsource.Event) {
+				sharedtest.AwaitEventOfType(t, expiringCh, "put", 5*time.Second)
+
+				// Give the non-anchor key a near-future expiry; the anchor stays permanent.
+				expiry := time.Now().Add(100 * time.Millisecond)
+				p.updateHandler.UpdateEnvironment(multiKeyArchiveEnv(
+					[]envfactory.AcceptedSDKKey{{Value: anchorSDKKey}, {Value: extraSDKKey, Expiry: expiry}},
+					defaultAcceptedMobileKeys(),
+				))
+
+				// Across the expiry window the anchor sibling's stream stays open (the expiring key's
+				// stream is being torn down on its own channel during this same window)...
+				assertStreamStaysOpen(t, anchorCh, 300*time.Millisecond)
+				// ...and the expiring key's stream is confirmed disconnected.
+				awaitStreamClosed(t, expiringCh, 5*time.Second)
+			})
+		})
+
+		// After the expiry: the dropped key no longer authenticates; the anchor sibling still does.
+		p.assertSDKEndpointsAvailability(false, extraSDKKey, "", "")
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+	})
+}

--- a/relay/concurrent_keys_lifecycle_test.go
+++ b/relay/concurrent_keys_lifecycle_test.go
@@ -1,0 +1,88 @@
+package relay
+
+// Key-lifecycle integration tests that observe live downstream SSE streams (real SDK clients via the
+// offline harness, or a dummy client + RAC mock) rather than just the auth layer: mixed reconcile
+// updates, revocation by omission, and sibling-stream continuity during a targeted disconnect.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"
+	"github.com/launchdarkly/ld-relay/v8/internal/filedata"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+
+	"github.com/launchdarkly/eventsource"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// base64 of {"key":"userkey","kind":"user"} — a valid mobile-eval context path.
+const mobileEvalContextPath = "/meval/eyJrZXkiOiJ1c2Vya2V5Iiwia2luZCI6InVzZXIifQ=="
+
+// reanchoredArchiveEnv builds an offline ArchiveEnvironment whose anchor is newAnchor and whose
+// accepted SDK key set is exactly sdkKeys, keeping the standard mobile keys. Used to model an offline
+// reload that re-anchors and rewrites the server-key set in one step.
+func reanchoredArchiveEnv(newAnchor config.SDKKey, sdkKeys []envfactory.AcceptedSDKKey) filedata.ArchiveEnvironment {
+	return filedata.ArchiveEnvironment{
+		Params: envfactory.EnvironmentParams{
+			EnvID:              multiKeyEnvID,
+			SDKKey:             newAnchor,
+			MobileKey:          anchorMobileKey,
+			AcceptedSDKKeys:    sdkKeys,
+			AcceptedMobileKeys: defaultAcceptedMobileKeys(),
+			Identifiers:        multiKeyIdentifiers,
+		},
+		SDKData: multiKeySDKData(),
+	}
+}
+
+// A single offline reload that adds a key, re-anchors to a brand-new key, and removes the old extra
+// key all at once. The end state is deterministic (add -> re-anchor -> remove): the added key, the new
+// anchor, and the retained mobile keys authenticate; the old anchor and the removed key do not. In
+// offline mode the re-anchor builds no new upstream client (the single file-data client keeps serving),
+// and a downstream stream open on a retained credential survives the reload undisturbed.
+func TestConcurrentKeysOffline_MixedUpdateAddsReanchorsAndRemovesInOneReload(t *testing.T) {
+	offlineModeTest(t, config.Config{}, func(p offlineModeTestParams) {
+		p.updateHandler.AddEnvironment(multiKeyArchiveEnv(defaultAcceptedSDKKeys(), defaultAcceptedMobileKeys()))
+
+		initialClient := p.awaitClient()
+		assert.Equal(t, anchorSDKKey, initialClient.Key)
+		env := p.awaitEnvironment(multiKeyEnvID)
+		require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+		// Baseline: anchor, extra SDK key, and both mobile keys authenticate.
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
+
+		// Hold a downstream stream on a retained credential (a mobile key, unaffected by the SDK
+		// re-anchor) across the reload.
+		req := sharedtest.BuildRequestWithAuth("GET", mobileEvalContextPath, anchorMobileKey, nil)
+		sharedtest.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+			sharedtest.AwaitEventOfType(t, eventCh, "ping", 5*time.Second)
+
+			// One reload doing three things at once: add addedSDKKey, re-anchor to the brand-new
+			// rotatedAnchorSDKKey, and drop the old anchor and extraSDKKey (omitted from the new set).
+			p.updateHandler.UpdateEnvironment(reanchoredArchiveEnv(rotatedAnchorSDKKey,
+				[]envfactory.AcceptedSDKKey{{Value: rotatedAnchorSDKKey}, {Value: addedSDKKey}}))
+
+			// The retained mobile-key stream is not disconnected by the reload.
+			assertStreamStaysOpen(t, eventCh, 300*time.Millisecond)
+		})
+
+		// Offline re-anchor stands up no new upstream client.
+		p.shouldNotCreateClient(200 * time.Millisecond)
+
+		// End state: old anchor and removed extra key are gone; the new anchor, the added key, and the
+		// retained mobile keys authenticate.
+		awaitCredentialRemoved(t, p.relay, anchorSDKKey)
+		awaitCredentialRemoved(t, p.relay, extraSDKKey)
+		p.assertSDKEndpointsAvailability(true, rotatedAnchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, addedSDKKey, "", "")
+		p.assertSDKEndpointsAvailability(true, "", extraMobileKey, "")
+		p.assertSDKEndpointsAvailability(false, anchorSDKKey, "", "")
+		p.assertSDKEndpointsAvailability(false, extraSDKKey, "", "")
+	})
+}

--- a/relay/concurrent_keys_lifecycle_test.go
+++ b/relay/concurrent_keys_lifecycle_test.go
@@ -12,8 +12,12 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"
 	"github.com/launchdarkly/ld-relay/v8/internal/filedata"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/configsource"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
 
 	"github.com/launchdarkly/eventsource"
+	"github.com/launchdarkly/go-configtypes"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,5 +88,81 @@ func TestConcurrentKeysOffline_MixedUpdateAddsReanchorsAndRemovesInOneReload(t *
 		p.assertSDKEndpointsAvailability(true, "", extraMobileKey, "")
 		p.assertSDKEndpointsAvailability(false, anchorSDKKey, "", "")
 		p.assertSDKEndpointsAvailability(false, extraSDKKey, "", "")
+	})
+}
+
+// A non-anchor key omitted from the next RAC patch is revoked immediately (not on a grace timer), and
+// a downstream SDK connected on that key is disconnected as part of the revocation. The anchor, which
+// the patch retains, keeps authenticating. Uses a real (dummy) client + RAC mock so there is a live
+// stream to observe being torn down.
+func TestConcurrentKeysRAC_ConnectedStreamClosedWhenKeyRevokedByOmission(t *testing.T) {
+	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
+	racMock := configsource.NewRACMock(t, &putEvent)
+
+	cfg := config.Config{AutoConfig: config.AutoConfigConfig{Key: testAutoConfKey}}
+	cfg.Main.StreamURI, _ = configtypes.NewOptURLAbsoluteFromString(racMock.URL)
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	relay, err := newRelayInternal(cfg, relayInternalOptions{
+		loggers:       mockLog.Loggers,
+		clientFactory: testclient.CreateDummyClient,
+	})
+	require.NoError(t, err)
+	defer relay.Close()
+
+	h := relayTestHelper{t: t, relay: relay}
+	env := h.awaitEnvironment(multiKeyEnvID)
+	require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+	// Connect a downstream SDK on the non-anchor key that the next patch will omit.
+	req := sharedtest.BuildRequestWithAuth("GET", "/all", extraSDKKey, nil)
+	sharedtest.WithStreamRequest(t, req, relay, func(eventCh <-chan eventsource.Event) {
+		sharedtest.AwaitEventOfType(t, eventCh, "put", 5*time.Second)
+
+		// Revoke by omission: a patch that carries only the anchor SDK key (extraSDKKey dropped), keeping
+		// the mobile keys. The reconcile revokes the omitted key now rather than on a grace timer.
+		racMock.Send(configsource.MakeAutoConfigPatchEvent(multiKeyEnvRep(
+			[]envfactory.ConcurrentKeyRep{{Key: "anchor-sdk", Value: string(anchorSDKKey)}},
+			defaultMobileKeyReps(),
+			2,
+		)))
+
+		// The revoked key's open stream is disconnected.
+		awaitStreamClosed(t, eventCh, 5*time.Second)
+	})
+
+	awaitCredentialRemoved(t, relay, extraSDKKey)
+	h.assertSDKEndpointsAvailability(false, extraSDKKey, "", "")
+	h.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+}
+
+// The offline-reload twin of the RAC revocation-by-omission case: a key dropped from the reloaded
+// archive is revoked immediately and its connected downstream SDK is disconnected, while the retained
+// anchor keeps authenticating.
+func TestConcurrentKeysOffline_ConnectedStreamClosedWhenKeyRevokedByOmission(t *testing.T) {
+	offlineModeTest(t, config.Config{}, func(p offlineModeTestParams) {
+		p.updateHandler.AddEnvironment(multiKeyArchiveEnv(defaultAcceptedSDKKeys(), defaultAcceptedMobileKeys()))
+		_ = p.awaitClient()
+		env := p.awaitEnvironment(multiKeyEnvID)
+		require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+		req := sharedtest.BuildRequestWithAuth("GET", "/all", extraSDKKey, nil)
+		sharedtest.WithStreamRequest(t, req, p.relay, func(eventCh <-chan eventsource.Event) {
+			sharedtest.AwaitEventOfType(t, eventCh, "put", 5*time.Second)
+
+			// Reload with the non-anchor key omitted: it is revoked immediately.
+			p.updateHandler.UpdateEnvironment(multiKeyArchiveEnv(
+				[]envfactory.AcceptedSDKKey{{Value: anchorSDKKey}},
+				defaultAcceptedMobileKeys(),
+			))
+
+			awaitStreamClosed(t, eventCh, 5*time.Second)
+		})
+
+		awaitCredentialRemoved(t, p.relay, extraSDKKey)
+		p.assertSDKEndpointsAvailability(false, extraSDKKey, "", "")
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
 	})
 }

--- a/relay/concurrent_keys_reanchor_test.go
+++ b/relay/concurrent_keys_reanchor_test.go
@@ -14,13 +14,17 @@ import (
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/api"
+	"github.com/launchdarkly/ld-relay/v8/internal/envfactory"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
 	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/configsource"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
 
+	"github.com/launchdarkly/eventsource"
+	"github.com/launchdarkly/go-configtypes"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
 	ld "github.com/launchdarkly/go-server-sdk/v7"
 
 	"github.com/stretchr/testify/assert"
@@ -112,4 +116,95 @@ func requireEnvStatus(t *testing.T, relay *Relay) api.EnvironmentStatusRep {
 		return envStatus
 	}
 	return api.EnvironmentStatusRep{}
+}
+
+// defaultRotationRep builds the RAC EnvironmentRep the backend emits on a default rotation: sdkKey.value
+// flips to newAnchor (permanent, no expiry) and the demoted old anchor stays in sdkKeys[] carrying a
+// grace expiry. Mobile keys are unchanged.
+func defaultRotationRep(newAnchor, demotedAnchor config.SDKKey, demotedExpiry int64, version int) envfactory.EnvironmentRep {
+	return envfactory.EnvironmentRep{
+		EnvID:    multiKeyEnvID,
+		EnvKey:   multiKeyIdentifiers.EnvKey,
+		EnvName:  multiKeyIdentifiers.EnvName,
+		ProjKey:  multiKeyIdentifiers.ProjKey,
+		ProjName: multiKeyIdentifiers.ProjName,
+		SDKKey:   envfactory.SDKKeyRep{Value: newAnchor},
+		MobKey:   anchorMobileKey,
+		SDKKeys: []envfactory.ConcurrentKeyRep{
+			{Key: "new-anchor-sdk", Value: string(newAnchor)},
+			{Key: "old-anchor-sdk", Value: string(demotedAnchor), Expiry: msPtr(demotedExpiry)},
+		},
+		MobileKeys: defaultMobileKeyReps(),
+		Version:    version,
+	}
+}
+
+// On a default rotation the backend flips sdkKey.value to a promoted key and demotes the old anchor with
+// a grace expiry, all in one patch (the array carries [new (no expiry), old (expiry)]). Relay must
+// re-anchor to the new key while keeping the demoted old anchor serving through its grace window — a
+// downstream stream opened on the old anchor before the rotation survives the swap — and then, once the
+// grace expiry passes, drop the old anchor and disconnect that stream. The new anchor authenticates
+// throughout. Uses a real (dummy) client + RAC mock so there is a live stream to observe (FakeLDClient
+// never serves a stream body).
+func TestConcurrentKeysRAC_DefaultRotationGraceDemotesOldAnchor(t *testing.T) {
+	// The initial env has a single (anchor) SDK key, so the default-rotation array is exactly
+	// [new (no expiry), old (expiry)] — the minimal shape the backend emits on a default rotation.
+	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(
+		[]envfactory.ConcurrentKeyRep{{Key: "anchor-sdk", Value: string(anchorSDKKey)}},
+		defaultMobileKeyReps(), 1))
+	racMock := configsource.NewRACMock(t, &putEvent)
+
+	cfg := config.Config{AutoConfig: config.AutoConfigConfig{Key: testAutoConfKey}}
+	cfg.Main.StreamURI, _ = configtypes.NewOptURLAbsoluteFromString(racMock.URL)
+	// A short cleanup interval so the grace expiry is reaped promptly once it passes.
+	cfg.Main.ExpiredCredentialCleanupInterval = configtypes.NewOptDuration(100 * time.Millisecond)
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	relay, err := newRelayInternal(cfg, relayInternalOptions{
+		loggers:       mockLog.Loggers,
+		clientFactory: testclient.CreateDummyClient,
+	})
+	require.NoError(t, err)
+	defer relay.Close()
+
+	h := relayTestHelper{t: t, relay: relay}
+	env := h.awaitEnvironment(multiKeyEnvID)
+	require.Eventually(t, func() bool { return env.GetClient() != nil }, 5*time.Second, 5*time.Millisecond)
+
+	// Connect a downstream SDK on the current anchor before the rotation, so this genuinely exercises
+	// demoting the anchor out from under a live connection.
+	req := sharedtest.BuildRequestWithAuth("GET", "/all", anchorSDKKey, nil)
+	sharedtest.WithStreamRequest(t, req, relay, func(eventCh <-chan eventsource.Event) {
+		sharedtest.AwaitEventOfType(t, eventCh, "put", 5*time.Second)
+
+		// Default-rotation patch: promote rotatedAnchorSDKKey to anchor (permanent), demote the old
+		// anchor with a short grace expiry. The grace window is comfortably longer than the stays-open
+		// check below so the survival assertion is not racing the expiry.
+		grace := time.Now().Add(500 * time.Millisecond)
+		racMock.Send(configsource.MakeAutoConfigPatchEvent(
+			defaultRotationRep(rotatedAnchorSDKKey, anchorSDKKey, grace.UnixMilli(), 2)))
+
+		// The swap takes effect: the promoted key becomes the environment's anchor.
+		require.Eventually(t, func() bool { return env.GetAcceptedKeys().Anchor == rotatedAnchorSDKKey },
+			5*time.Second, 5*time.Millisecond, "rotation did not re-anchor to the promoted key")
+
+		// During the grace window the demoted old anchor still authenticates and its stream is undisturbed
+		// by the swap (a duplicate put from the new anchor's store re-init is fine; only a close fails here).
+		h.assertSDKEndpointsAvailability(true, anchorSDKKey, "", "")
+		assertStreamStaysOpen(t, eventCh, 150*time.Millisecond)
+
+		// Once the grace expiry passes, the cleanup ticker drops the old anchor and disconnects its stream.
+		awaitStreamClosed(t, eventCh, 5*time.Second)
+	})
+
+	// After the grace window: the old anchor is gone; the new anchor still authenticates.
+	awaitCredentialRemoved(t, relay, anchorSDKKey)
+	h.assertSDKEndpointsAvailability(false, anchorSDKKey, "", "")
+	h.assertSDKEndpointsAvailability(true, rotatedAnchorSDKKey, anchorMobileKey, multiKeyEnvID)
+
+	// Sanity: the new anchor really is the one relay resolves for upstream.
+	_, errNew := relay.getEnvironment(sdkauth.New(rotatedAnchorSDKKey))
+	assert.NoError(t, errNew)
 }

--- a/relay/concurrent_keys_reanchor_test.go
+++ b/relay/concurrent_keys_reanchor_test.go
@@ -1,0 +1,115 @@
+package relay
+
+// Re-anchor integration tests driven through the real RAC handler (autoConfTest), covering the
+// failure and default-rotation paths that the auth-focused tests in concurrent_keys_auth_test.go do
+// not: init-failure rollback (and subsequent recovery), and the backend's default-rotation array
+// shape that grace-demotes the old anchor.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/api"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/configsource"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// When the newly-designated anchor's SDK client fails to initialize, the re-anchor rolls back: the
+// previous anchor and its siblings keep authenticating, the failed key is rejected, the environment
+// stays connected, and a structured error is logged. The rollback must also leave the environment
+// recoverable — a later payload rotating to a healthy key re-anchors cleanly. This drives the whole
+// sequence through the RAC handler with a client factory that refuses to initialize one specific key.
+func TestConcurrentKeysRAC_ReanchorInitFailureRollsBackAndRecovers(t *testing.T) {
+	// The healthy recovery anchor rotated to after the failed rotation is rolled back.
+	const recoveryAnchorSDKKey = config.SDKKey("sdk-recovery-anchor")
+
+	putEvent := configsource.MakeAutoConfigPutEvent(multiKeyEnvRep(defaultSDKKeyReps(), defaultMobileKeyReps(), 1))
+
+	// Fail to initialize only the first rotated anchor; every other key (the original anchor, the
+	// healthy recovery anchor) builds normally and is reported on the created-clients channel.
+	makeFactory := func(createdCh chan<- *testclient.FakeLDClient) sdks.ClientFactoryFunc {
+		healthy := testclient.FakeLDClientFactoryWithChannel(true, createdCh)
+		return func(key config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+			if key == rotatedAnchorSDKKey {
+				return nil, errors.New("re-anchor: new client init refused")
+			}
+			return healthy(key, cfg, timeout)
+		}
+	}
+
+	autoConfTestWithClientFactory(t, testAutoConfDefaultConfig, &putEvent, makeFactory, func(p autoConfTestParams) {
+		anchorClient := p.awaitClient()
+		assert.Equal(t, anchorSDKKey, anchorClient.Key)
+		p.shouldNotCreateClient(200 * time.Millisecond)
+		_ = p.awaitEnvironment(multiKeyEnvID)
+
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
+
+		// Rotate the anchor to the key whose client refuses to initialize. The synchronous re-anchor
+		// build fails, so the reconcile rolls back the anchor change.
+		p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(rotatedAnchorRep(rotatedAnchorSDKKey, 2)))
+
+		// Wait for the rollback to settle: the structured error is logged and the failed new anchor's
+		// briefly-registered mappings are torn down. The error is logged before the mapping teardown, so
+		// requiring both proves we observe the fully rolled-back state (not the mid-swap registration window).
+		require.Eventually(t, func() bool {
+			_, err := p.relay.getEnvironment(sdkauth.New(rotatedAnchorSDKKey))
+			return err != nil && p.mockLog.HasMessageMatch(ldlog.Error, "Re-anchor to SDK key .* failed")
+		}, 5*time.Second, 10*time.Millisecond, "re-anchor init failure did not roll back with a structured error")
+
+		// Previous anchor and its sibling still authenticate; the failed new anchor is rejected.
+		p.assertSDKEndpointsAvailability(true, anchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
+		p.assertSDKEndpointsAvailability(false, rotatedAnchorSDKKey, "", "")
+
+		// The environment is still connected — the preserved anchor's client keeps serving.
+		assert.Equal(t, "connected", requireEnvStatus(t, p.relay).Status)
+
+		// The failed rotation built nothing that stuck around.
+		p.shouldNotCreateClient(200 * time.Millisecond)
+
+		// Recovery: rotate to a healthy key. The re-anchor now commits — a new client comes up, the new
+		// anchor authenticates, and the previous anchor's client is torn down.
+		p.stream.Enqueue(configsource.MakeAutoConfigPatchEvent(rotatedAnchorRep(recoveryAnchorSDKKey, 3)))
+
+		recoveryClient := p.awaitClient()
+		assert.Equal(t, recoveryAnchorSDKKey, recoveryClient.Key)
+		anchorClient.AwaitClose(t, 5*time.Second)
+		awaitCredentialRemoved(t, p.relay, anchorSDKKey)
+
+		p.assertSDKEndpointsAvailability(true, recoveryAnchorSDKKey, anchorMobileKey, multiKeyEnvID)
+		p.assertSDKEndpointsAvailability(true, extraSDKKey, extraMobileKey, "")
+		p.assertSDKEndpointsAvailability(false, anchorSDKKey, "", "")
+		p.assertSDKEndpointsAvailability(false, rotatedAnchorSDKKey, "", "")
+	})
+}
+
+// requireEnvStatus fetches the /status endpoint and returns the single environment's status rep,
+// failing the test if the response does not describe exactly one environment.
+func requireEnvStatus(t *testing.T, relay *Relay) api.EnvironmentStatusRep {
+	t.Helper()
+	req, _ := http.NewRequest("GET", "/status", nil)
+	result, body := sharedtest.DoRequest(req, relay)
+	require.Equal(t, http.StatusOK, result.StatusCode)
+	var status api.StatusRep
+	require.NoError(t, json.Unmarshal(body, &status))
+	require.Len(t, status.Environments, 1)
+	for _, envStatus := range status.Environments {
+		return envStatus
+	}
+	return api.EnvironmentStatusRep{}
+}

--- a/relay/endpoints_status_test.go
+++ b/relay/endpoints_status_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/util"
 
 	ct "github.com/launchdarkly/go-configtypes"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
 	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	ld "github.com/launchdarkly/go-server-sdk/v7"
@@ -246,6 +247,97 @@ func TestEndpointsStatusExpiringSDKKey(t *testing.T) {
 			st.AssertJSONPathMatch(t, sdks.ObscureKey("sdk-aaa"), envStatus, "expiringSdkKey")
 		})
 	})
+}
+
+// TestEndpointsStatusDuringInFlightRotation drives the real /status handler while an SDK-key re-anchor
+// is in flight: the new anchor's client build is wedged via a gated client factory, so the rotation has
+// been reconciled but not yet committed. The status request must complete with 200, report the
+// PRE-rotation anchor (the rotator has not flipped its anchor pointer until the build is committed), and
+// expose a self-consistent accepted set (the reported anchor is present in sdkKeys[]). Once the build is
+// released and the rotation commits, /status reports the new anchor. Run under -race to catch any
+// unsynchronized read between the status handler and the concurrent re-anchor.
+func TestEndpointsStatusDuringInFlightRotation(t *testing.T) {
+	const newAnchor = c.SDKKey("sdk-status-rotation-new-anchor")
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	// Gated factory: healthy for every key except newAnchor, whose build wedges until released. This
+	// holds the re-anchor mid-flight (pre-commit) so /status observes the pre-rotation anchor.
+	buildEntered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	inner := testclient.FakeLDClientFactory(true)
+	gated := func(sdkKey c.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		if sdkKey == newAnchor {
+			buildEntered <- struct{}{}
+			<-release
+		}
+		return inner(sdkKey, cfg, timeout)
+	}
+
+	relay, err := newRelayInternal(config, relayInternalOptions{
+		loggers:       mockLog.Loggers,
+		clientFactory: gated,
+	})
+	require.NoError(t, err)
+	defer relay.Close()
+	require.NoError(t, relay.waitForAllClients(time.Second))
+
+	env, err := relay.getEnvironment(sdkauth.New(st.EnvMain.Config.SDKKey))
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	anchor := st.EnvMain.Config.SDKKey
+	graceExpiry := time.Now().Add(time.Hour)
+	set, err := credential.NewAcceptedSetBuilder().
+		WithAnchor(credential.SDKKeyParams{Value: newAnchor}).
+		WithSDKKey(credential.SDKKeyParams{Value: anchor, Expiry: util.PtrOrNil(graceExpiry)}).
+		Build()
+	require.NoError(t, err)
+
+	// Drive the re-anchor on a background goroutine; it blocks in the gated build, holding the rotation
+	// mid-flight (pre-commit).
+	reconcileDone := make(chan struct{})
+	go func() {
+		defer close(reconcileDone)
+		env.ReconcileCredentials(set)
+	}()
+	<-buildEntered // the new anchor's build is wedged: the rotation is in flight, not yet committed.
+
+	// /status must complete and report the pre-rotation anchor while the rotation is in flight.
+	r, _ := http.NewRequest("GET", "http://localhost/status", nil)
+	result, body := st.DoRequest(r, relay)
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+	envStatus := ldvalue.Parse(body).GetByKey("environments").GetByKey(st.EnvMain.Name)
+
+	// The scalar anchor is still the pre-rotation key (the anchor pointer flips only on commit).
+	assert.Equal(t, sdks.ObscureKey(string(anchor)), envStatus.GetByKey("sdkKey").StringValue(),
+		"status reports the pre-rotation anchor while the rotation is mid-flight")
+
+	// The arrays are self-consistent: the reported anchor is present in sdkKeys[].
+	sdkKeys := envStatus.GetByKey("sdkKeys")
+	require.False(t, findKeyStatusByValue(sdkKeys, sdks.ObscureKey(string(anchor))).IsNull(),
+		"the reported anchor must be present in sdkKeys[]")
+
+	// The env still serves the previous anchor's client, so it reports connected.
+	assert.Equal(t, "connected", envStatus.GetByKey("status").StringValue())
+
+	// Release the build; the rotation commits.
+	close(release)
+	<-reconcileDone
+
+	// After the commit, /status reports the new anchor, still present in a consistent sdkKeys[].
+	r2, _ := http.NewRequest("GET", "http://localhost/status", nil)
+	result2, body2 := st.DoRequest(r2, relay)
+	assert.Equal(t, http.StatusOK, result2.StatusCode)
+	envStatus2 := ldvalue.Parse(body2).GetByKey("environments").GetByKey(st.EnvMain.Name)
+	assert.Equal(t, sdks.ObscureKey(string(newAnchor)), envStatus2.GetByKey("sdkKey").StringValue(),
+		"after the commit, status reports the new anchor")
+	require.False(t, findKeyStatusByValue(envStatus2.GetByKey("sdkKeys"), sdks.ObscureKey(string(newAnchor))).IsNull(),
+		"the new anchor must be present in sdkKeys[] after the commit")
 }
 
 // TestKeyStatus verifies the helper that converts an accepted key into its status-endpoint JSON form.


### PR DESCRIPTION
## Summary

Closes every test-coverage gap identified in the final pre-merge review ([SDK-2702](https://launchdarkly.atlassian.net/browse/SDK-2702)) — one commit per gap, no production changes.

## What's covered

**Re-anchor failure and rotation paths, tested end-to-end through the real remote-auto-config (RAC) handler:**

- If the new anchor's client fails to initialize, the environment rolls back: the previous anchor and its sibling keys keep serving, the failed key returns 401, `/status` stays connected, and a later rotation to a healthy key recovers cleanly.
- A default rotation in the array format the backend actually sends (new anchor plus a grace-demoted old anchor): the old key keeps serving through its grace window, its live stream survives the swap, and the stream closes when the key finally expires.
- A malformed payload is rejected, the previous credentials are preserved, and after a reconnect the corrected payload applies. A stream-manager-level test also pins that the corrected put still dispatches even at the same version — the "validate before recording the version" contract.

**Key lifecycle, tested end-to-end:**

- An offline archive reload that adds, re-anchors, and removes keys in a single step: a retained key's stream survives, and no client is built while offline.
- A connected live stream is torn down when its key is revoked by being omitted from the payload (tested for both the RAC and offline paths).
- Sibling streams are independent: the anchor's stream stays open while an expiring key's stream is torn down.

**Concurrency and internals (relayenv):**

- Calling `Close()` during an in-flight re-anchor build is race-clean, completes in bounded time, and leaks no client.
- Re-promoting an in-grace former anchor rewires big segments correctly (a third synchronizer is created and the old one is closed).
- A `/status` request during a wedged rotation consistently reports the pre-rotation anchor.

**Contracts:**

- Event forwarding: the analytics and diagnostic payloads sent upstream are byte-for-byte identical to what came in, except for an explicitly listed set of headers (only analytics rewrites `Authorization`).
- Wire-format compatibility: a full new-format payload still decodes cleanly into a struct that mirrors the pre-concurrent-keys representation.

## Rehomed proof-of-concept assertions

The re-anchor proof-of-concept file (`env_context_reanchor_test.go`) is slated for deletion before the v8 merge, but two behaviors were pinned only there: downstream connections surviving a re-anchor (plus the duplicate-put rebroadcast count), and httpconfig being key-independent. The first commit copies those into a permanent home (`env_context_reanchor_behavior_test.go`) rebuilt on durable helpers, so the proof-of-concept file can later be deleted wholesale.

[SDK-2702]: https://launchdarkly.atlassian.net/browse/SDK-2702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior modifications; risk is limited to CI time and test maintenance.
> 
> **Overview**
> This PR **adds tests only** to close pre-merge coverage gaps for concurrent SDK keys and re-anchoring; there are **no production code changes**.
> 
> **End-to-end RAC / relay behavior:** New integration tests cover re-anchor init failure (rollback, then recovery), default rotation with grace-demoted old anchor (live stream survives grace, then closes), malformed config payload (preserve credentials → stream restart → corrected put applies), and key lifecycle (mixed offline reload, revocation-by-omission disconnecting streams, sibling streams when one key expires).
> 
> **Stream manager / autoconfig:** `malformedRecoveryTest` and `TestMalformedCredentialPayloadRecoversAfterReconnect` assert reconnect after malformed put/patch, no add/update on bad payload, and that a corrected put at the **same version** still dispatches (validate-before-record contract).
> 
> **relayenv:** Permanent re-anchor behavior tests (downstream connection survives, duplicate put on new anchor init, httpconfig key-independence); close-during-in-flight-build; re-promote in-grace former anchor rewires big segments; duplicate client-side invalidation test removed from bigsegment file in favor of behavior test file.
> 
> **Events / wire format:** Byte-identical upstream analytics/diagnostic payloads with header allowlists; old-format struct still decodes new-format JSON. **`autoConfTestWithClientFactory`** and **`NewRACMockWithReconnect`** support the new scenarios.
> 
> **Status:** `/status` during wedged in-flight rotation reports pre-commit anchor and consistent `sdkKeys[]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eed8ba5224c932ae57fc0ef3c09a1574ce7fc6ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->