### PR TITLE
fix(concurrent-keys): defensive hardening bundle from final review

### DIFF
--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -970,8 +970,8 @@ func (c *envContextImpl) GetFilter() config.FilterKey {
 }
 
 func (c *envContextImpl) GetInitError() error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	return c.initErr
 }

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -724,6 +724,15 @@ func (c *envContextImpl) reanchor(change *credential.AnchorChange) bool {
 // half-built client and logged a structured error. initErr is deliberately left untouched on failure:
 // it feeds the request middleware, and setting it to the new anchor's ErrInitializationFailed would 401
 // an env that is serving fine on the previous anchor.
+//
+// Factory contract (see sdks.ClientFactoryFunc): a factory whose construction builds the environment's
+// data store must return a non-nil client even on init failure, so that the client.Close() below releases
+// the store reference the build acquired (the store wrapper is refcounted — see streamUpdatesStoreWrapper).
+// When client == nil there is no handle to release, and this method cannot safely release one itself: it
+// has no signal for whether the store was built, so releasing unconditionally could double-release the
+// still-serving previous anchor's store on an early factory error. The real SDK honors the contract (a
+// failed init returns a non-nil client; an error before the store is built releases nothing); test
+// factories must uphold it too.
 func (c *envContextImpl) buildNewAnchorClient(newAnchor, previousAnchor config.SDKKey) sdks.LDClientContext {
 	client, err := c.sdkClientFactory(newAnchor, c.sdkConfig, c.sdkInitTimeout)
 	if err != nil || client == nil || !client.Initialized() {

--- a/internal/sdks/client_factory.go
+++ b/internal/sdks/client_factory.go
@@ -42,6 +42,12 @@ type DataStoreStatusInfo struct {
 
 // ClientFactoryFunc is a function that creates the LaunchDarkly client. This is normally
 // DefaultClientFactory, but it can be changed in order to make configuration changes or for testing.
+//
+// Store-release contract: a factory whose client construction builds the environment's data store must
+// return a non-nil client even when initialization fails, so that the caller's Close() releases the
+// (refcounted) store reference the build acquired. Returning (nil, err) after the store has been built
+// leaks that reference — the caller has no handle to release it. Returning (nil, err) before the store
+// is built is fine, as nothing was acquired. The default SDK factory honors this; test factories must too.
 type ClientFactoryFunc func(sdkKey config.SDKKey, config ld.Config, timeout time.Duration) (LDClientContext, error)
 
 // LDClientConstructor is the function type of the underlying SDK client constructor.


### PR DESCRIPTION
## Summary

Two small defensive-hardening changes surfaced during the final concurrent-keys review, bundled so each can be judged on its real diff. Every item is a single, independently-droppable commit with no cross-item coupling.

| # | What it does |
|---|--------------|
| 1 | Document the client-factory store-release contract on `buildNewAnchorClient` and `sdks.ClientFactoryFunc` |
| 2 | `GetInitError` takes an `RLock` instead of a full `Lock` (called per-env on `/status`) |

## Details

### 1 — Client-factory store-release contract
If a client factory returned `(nil, err)` after the SDK had already built the data store, the store's refcount would never be released, pinning it past env `Close`. The real SDK never returns that shape, but a test factory could. There's no cheap sound guard: `buildNewAnchorClient` can't tell whether the failed call acquired a store ref, so releasing one unconditionally could double-release the still-serving previous anchor's store. This documents the invariant on `buildNewAnchorClient` and `sdks.ClientFactoryFunc` rather than adding a guard.

### 2 — Read lock in GetInitError
`GetInitError` took a full write lock for a pure read that `/status` calls once per environment. It now uses `RLock`.
