### PR TITLE
feat: Add init-concurrency limiter primitive and configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -141,8 +141,35 @@ type Config struct {
 	Filters     map[string]*FiltersConfig
 	Proxy       ProxyConfig
 	HTTP        HTTPConfig
+	Concurrency ConcurrencyConfig
 
 	OpenTelemetry OpenTelemetryConfig
+}
+
+// ConcurrencyConfig corresponds to the [Concurrency] section in the configuration file.
+//
+// It limits how many SDK initialization deliveries the Relay Proxy performs at the same
+// time, covering both polling and streaming. This caps the memory and egress that a burst
+// of connecting SDKs can consume. The limit is disabled unless MaxConcurrent is set.
+type ConcurrencyConfig struct {
+	// MaxConcurrent is the maximum number of initialization deliveries allowed in flight
+	// at once. A value of 0 or less disables the limit.
+	MaxConcurrent ct.OptInt `conf:"INIT_MAX_CONCURRENT"`
+
+	// MaxQueued is the maximum number of clients that may wait for a slot once
+	// MaxConcurrent is reached. A value of 0 rejects excess clients immediately instead
+	// of queueing them.
+	MaxQueued ct.OptInt `conf:"INIT_MAX_QUEUED"`
+
+	// PerEnvMaxPercent limits the share of the budget that any single environment may
+	// use, as a percentage of MaxConcurrent plus MaxQueued. This keeps one busy
+	// environment from starving the others. A value of 0 applies no per-environment
+	// limit.
+	PerEnvMaxPercent ct.OptInt `conf:"INIT_PER_ENV_MAX_PERCENT"`
+
+	// SendTimeout releases a delivery slot if a streaming initialization payload cannot
+	// make progress to its client within this duration. It defaults to 30s.
+	SendTimeout ct.OptDuration `conf:"INIT_SEND_TIMEOUT"`
 }
 
 // MainConfig contains global configuration options for Relay.

--- a/config/config_concurrency_test.go
+++ b/config/config_concurrency_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrencyConfigFromEnvironment confirms the [Concurrency] budget parses from
+// the INIT_* environment variables.
+func TestConcurrencyConfigFromEnvironment(t *testing.T) {
+	withEnvironment(map[string]string{
+		"INIT_MAX_CONCURRENT":      "200",
+		"INIT_MAX_QUEUED":          "1000",
+		"INIT_PER_ENV_MAX_PERCENT": "40",
+		"INIT_SEND_TIMEOUT":        "15s",
+	}, func() {
+		var c Config
+		require.NoError(t, LoadConfigFromEnvironment(&c, slog.Default()))
+		assert.Equal(t, 200, c.Concurrency.MaxConcurrent.GetOrElse(-1))
+		assert.Equal(t, 1000, c.Concurrency.MaxQueued.GetOrElse(-1))
+		assert.Equal(t, 40, c.Concurrency.PerEnvMaxPercent.GetOrElse(-1))
+		assert.Equal(t, 15*time.Second, c.Concurrency.SendTimeout.GetOrElse(0))
+	})
+}
+
+// TestConcurrencyMaxConcurrentZeroDisablesGracefully is a regression guard: an explicit
+// INIT_MAX_CONCURRENT=0 (a natural way to turn the feature off) must load successfully
+// and leave the limiter disabled, NOT fail config validation and crashloop the Relay.
+// It is an OptInt, not OptIntGreaterThanZero, precisely so 0 is accepted.
+func TestConcurrencyMaxConcurrentZeroDisablesGracefully(t *testing.T) {
+	withEnvironment(map[string]string{"INIT_MAX_CONCURRENT": "0"}, func() {
+		var c Config
+		require.NoError(t, LoadConfigFromEnvironment(&c, slog.Default()))
+		assert.Equal(t, 0, c.Concurrency.MaxConcurrent.GetOrElse(-1))
+	})
+}

--- a/config/config_from_env.go
+++ b/config/config_from_env.go
@@ -60,6 +60,8 @@ func LoadConfigFromEnvironmentBase(c *Config) ct.ValidationResult {
 	reader.ReadStruct(&c.Events, false)
 	rejectObsoleteVariableName("EVENTS_SAMPLING_INTERVAL", "", reader)
 
+	reader.ReadStruct(&c.Concurrency, false)
+
 	for envName, envKey := range reader.FindPrefixedValues("LD_ENV_") {
 		var ec EnvConfig
 		if c.Environment[envName] != nil {

--- a/internal/concurrency/limiter.go
+++ b/internal/concurrency/limiter.go
@@ -1,0 +1,186 @@
+// Package concurrency provides an admission limiter that bounds how much concurrent
+// work a burst of requests or connections can impose on Relay. It uses two limits: a
+// maximum number of slots held at once, and a bounded FIFO queue of callers waiting for
+// a slot. An optional per-environment gate keeps one environment from using the whole
+// budget.
+package concurrency
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// Params configures a Limiter. A MaxConcurrent of 0 or less produces a disabled limiter
+// whose Acquire always admits and does nothing.
+type Params struct {
+	// MaxConcurrent is the number of slots that may be held at once.
+	MaxConcurrent int
+	// MaxQueued is the number of callers that may wait in FIFO order for a slot once all
+	// slots are held. A value of 0 rejects callers immediately instead of waiting.
+	MaxQueued int
+	// PerEnvMax limits how many of a single environment's callers may participate,
+	// counting both held and waiting, at once. A value of 0 applies no per-environment
+	// limit. The per-environment gate never blocks; it only rejects.
+	PerEnvMax int
+}
+
+// Stats is a point-in-time snapshot of a Limiter's counters, for logging/metrics.
+type Stats struct {
+	Enabled       bool
+	MaxConcurrent int
+	MaxQueued     int
+	Held          int
+	Waiting       int
+	Admitted      int64
+	Rejected      int64
+}
+
+// Limiter bounds concurrency with two limits plus an optional per-environment gate that
+// never blocks and only rejects. The zero value is not usable; construct one with New.
+type Limiter struct {
+	name    string
+	enabled bool
+
+	tokens    chan struct{} // holds MaxConcurrent slots; receive to acquire, send to release
+	maxQueued int64
+	waiting   int64
+	shutdown  chan struct{}
+	closeOnce sync.Once
+
+	perEnvMax int
+	perEnv    sync.Map // envKey -> *envGate
+
+	admitted atomic.Int64
+	rejected atomic.Int64
+}
+
+type envGate struct {
+	slots chan struct{} // cap = perEnvMax; try-receive to enter, send to leave
+}
+
+// New builds a Limiter. name is used only for logging/metrics identification.
+func New(name string, p Params) *Limiter {
+	l := &Limiter{name: name}
+	if p.MaxConcurrent <= 0 {
+		return l // disabled
+	}
+	l.enabled = true
+	l.tokens = make(chan struct{}, p.MaxConcurrent)
+	for i := 0; i < p.MaxConcurrent; i++ {
+		l.tokens <- struct{}{}
+	}
+	l.maxQueued = int64(p.MaxQueued)
+	l.shutdown = make(chan struct{})
+	if p.PerEnvMax > 0 {
+		l.perEnvMax = p.PerEnvMax
+	}
+	return l
+}
+
+// Name returns the limiter's identifier.
+func (l *Limiter) Name() string { return l.name }
+
+// Enabled reports whether the limiter is enforcing a limit.
+func (l *Limiter) Enabled() bool { return l != nil && l.enabled }
+
+// Acquire attempts to admit one unit of work for the given environment key.
+// On success it returns a release func (call exactly once) and ok=true. If the
+// per-env gate or the global backlog is full, or ctx is cancelled, or the
+// limiter is shut down, it returns a no-op release and ok=false. A disabled or
+// nil limiter always admits immediately.
+func (l *Limiter) Acquire(ctx context.Context, envKey string) (release func(), ok bool) {
+	if !l.Enabled() {
+		return func() {}, true
+	}
+
+	// Per-environment gate. It never blocks; it rejects when the environment is over its share.
+	var releaseEnv func()
+	if l.perEnvMax > 0 {
+		g := l.gateFor(envKey)
+		select {
+		case g.slots <- struct{}{}:
+			releaseEnv = func() { <-g.slots }
+		default:
+			l.rejected.Add(1)
+			return func() {}, false
+		}
+	}
+
+	reject := func() (func(), bool) {
+		if releaseEnv != nil {
+			releaseEnv()
+		}
+		l.rejected.Add(1)
+		return func() {}, false
+	}
+
+	// Fast path: a token is immediately available.
+	select {
+	case <-l.tokens:
+		return l.admit(releaseEnv), true
+	default:
+	}
+
+	// No token free: enter the bounded FIFO backlog, or reject.
+	if atomic.AddInt64(&l.waiting, 1) > l.maxQueued {
+		atomic.AddInt64(&l.waiting, -1)
+		return reject()
+	}
+	defer atomic.AddInt64(&l.waiting, -1)
+
+	select {
+	case <-l.tokens:
+		return l.admit(releaseEnv), true
+	case <-ctx.Done():
+		return reject()
+	case <-l.shutdown:
+		return reject()
+	}
+}
+
+func (l *Limiter) admit(releaseEnv func()) func() {
+	l.admitted.Add(1)
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			l.tokens <- struct{}{}
+			if releaseEnv != nil {
+				releaseEnv()
+			}
+		})
+	}
+}
+
+func (l *Limiter) gateFor(envKey string) *envGate {
+	if g, ok := l.perEnv.Load(envKey); ok {
+		return g.(*envGate)
+	}
+	g := &envGate{slots: make(chan struct{}, l.perEnvMax)}
+	actual, _ := l.perEnv.LoadOrStore(envKey, g)
+	return actual.(*envGate)
+}
+
+// Close unblocks all waiters (they receive ok=false). Idempotent.
+func (l *Limiter) Close() {
+	if !l.Enabled() {
+		return
+	}
+	l.closeOnce.Do(func() { close(l.shutdown) })
+}
+
+// Stats snapshots the limiter's counters.
+func (l *Limiter) Stats() Stats {
+	if !l.Enabled() {
+		return Stats{Enabled: false}
+	}
+	return Stats{
+		Enabled:       true,
+		MaxConcurrent: cap(l.tokens),
+		MaxQueued:     int(l.maxQueued),
+		Held:          cap(l.tokens) - len(l.tokens),
+		Waiting:       int(atomic.LoadInt64(&l.waiting)),
+		Admitted:      l.admitted.Load(),
+		Rejected:      l.rejected.Load(),
+	}
+}

--- a/internal/concurrency/limiter_test.go
+++ b/internal/concurrency/limiter_test.go
@@ -1,0 +1,173 @@
+package concurrency
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDisabledLimiterAlwaysAdmits(t *testing.T) {
+	l := New("t", Params{MaxConcurrent: 0})
+	if l.Enabled() {
+		t.Fatal("expected disabled")
+	}
+	for i := 0; i < 100; i++ {
+		release, ok := l.Acquire(context.Background(), "env")
+		if !ok {
+			t.Fatal("disabled limiter must always admit")
+		}
+		release()
+	}
+}
+
+func TestNilLimiterAdmits(t *testing.T) {
+	var l *Limiter
+	release, ok := l.Acquire(context.Background(), "env")
+	if !ok {
+		t.Fatal("nil limiter must admit")
+	}
+	release()
+}
+
+func TestRejectWhenNoBacklog(t *testing.T) {
+	l := New("t", Params{MaxConcurrent: 2, MaxQueued: 0})
+	r1, ok1 := l.Acquire(context.Background(), "e")
+	r2, ok2 := l.Acquire(context.Background(), "e")
+	_, ok3 := l.Acquire(context.Background(), "e")
+	if !ok1 || !ok2 {
+		t.Fatal("first two should be admitted")
+	}
+	if ok3 {
+		t.Fatal("third should be rejected (no backlog)")
+	}
+	r1()
+	r2()
+	if s := l.Stats(); s.Admitted != 2 || s.Rejected != 1 {
+		t.Fatalf("unexpected stats: %+v", s)
+	}
+}
+
+func TestQueueThenAdmitOnRelease(t *testing.T) {
+	l := New("t", Params{MaxConcurrent: 1, MaxQueued: 1})
+	r1, ok1 := l.Acquire(context.Background(), "e")
+	if !ok1 {
+		t.Fatal("first should be admitted")
+	}
+	admitted := make(chan struct{})
+	go func() {
+		r2, ok2 := l.Acquire(context.Background(), "e") // must queue, then admit when r1 releases
+		if ok2 {
+			close(admitted)
+			r2()
+		}
+	}()
+	// Give the goroutine time to enter the backlog.
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-admitted:
+		t.Fatal("queued caller admitted before release")
+	default:
+	}
+	r1()
+	select {
+	case <-admitted:
+	case <-time.After(time.Second):
+		t.Fatal("queued caller not admitted after release")
+	}
+}
+
+func TestBacklogFullRejects(t *testing.T) {
+	l := New("t", Params{MaxConcurrent: 1, MaxQueued: 1})
+	r1, _ := l.Acquire(context.Background(), "e") // holds the only token
+	defer r1()
+	go l.Acquire(context.Background(), "e") // fills the single backlog slot
+	time.Sleep(50 * time.Millisecond)
+	if _, ok := l.Acquire(context.Background(), "e"); ok {
+		t.Fatal("expected rejection when backlog is full")
+	}
+}
+
+func TestPerEnvGateIsolatesEnvironments(t *testing.T) {
+	// Global room for 10, but each env may hold at most 1 (participant cap).
+	l := New("t", Params{MaxConcurrent: 10, MaxQueued: 10, PerEnvMax: 1})
+	rA, okA := l.Acquire(context.Background(), "A")
+	_, okA2 := l.Acquire(context.Background(), "A") // second A rejected by per-env gate
+	rB, okB := l.Acquire(context.Background(), "B") // different env still admitted
+	if !okA || okA2 || !okB {
+		t.Fatalf("per-env gate failed: okA=%v okA2=%v okB=%v", okA, okA2, okB)
+	}
+	rA()
+	rB()
+}
+
+func TestContextCancelUnblocksWaiter(t *testing.T) {
+	l := New("t", Params{MaxConcurrent: 1, MaxQueued: 5})
+	r1, _ := l.Acquire(context.Background(), "e")
+	defer r1()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan bool)
+	go func() {
+		_, ok := l.Acquire(ctx, "e")
+		done <- ok
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("expected rejection on context cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waiter not unblocked by context cancel")
+	}
+}
+
+func TestReleaseIsIdempotent(t *testing.T) {
+	l := New("t", Params{MaxConcurrent: 1, MaxQueued: 0})
+	r, _ := l.Acquire(context.Background(), "e")
+	r()
+	r() // must not release a second token
+	// Two acquires should now succeed sequentially, proving only one token exists.
+	r1, ok1 := l.Acquire(context.Background(), "e")
+	if !ok1 {
+		t.Fatal("expected admit after release")
+	}
+	if _, ok2 := l.Acquire(context.Background(), "e"); ok2 {
+		t.Fatal("double release leaked a token")
+	}
+	r1()
+}
+
+func TestConcurrentAcquireBoundsHeld(t *testing.T) {
+	const maxC = 4
+	l := New("t", Params{MaxConcurrent: maxC, MaxQueued: 1000})
+	var mu sync.Mutex
+	held, maxObserved := 0, 0
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, ok := l.Acquire(context.Background(), "e")
+			if !ok {
+				return
+			}
+			mu.Lock()
+			held++
+			if held > maxObserved {
+				maxObserved = held
+			}
+			mu.Unlock()
+			time.Sleep(time.Millisecond)
+			mu.Lock()
+			held--
+			mu.Unlock()
+			release()
+		}()
+	}
+	wg.Wait()
+	if maxObserved > maxC {
+		t.Fatalf("held %d exceeded MaxConcurrent %d", maxObserved, maxC)
+	}
+}


### PR DESCRIPTION
Adds the foundation for bounding **initialization-delivery concurrency** in the Relay Proxy: an admission-control limiter and a `[Concurrency]` configuration section. The limiter caps how many SDK *initialization deliveries* — the full-dataset payloads Relay materializes and sends when an SDK first receives its data — may be in flight at once, across both polling and streaming, so a reconnect storm can't drive unbounded resident-payload memory or egress.

This change adds **only** the limiter primitive and its configuration surface. Wiring it into the initialization paths is a follow-up; nothing consumes the limiter yet, so **behavior is unchanged** and the feature stays off unless configured.

## Limiter (`internal/concurrency`)
A two-limit keyed semaphore:
- `MaxConcurrent` — units of work held at once (in-flight deliveries).
- `MaxQueued` — bounded FIFO of waiters once concurrency is saturated; `0` sheds immediately.
- optional per-environment try-only gate, so one environment can't consume the whole budget and starve the others.
- `MaxConcurrent <= 0` ⇒ disabled (zero-overhead pass-through); nil-safe; `Acquire(ctx, envKey) (release, ok)`; `Close()` unblocks all waiters. Unit-tested under `-race`.

## Configuration (`[Concurrency]`)
| File key | Env var | Meaning |
|---|---|---|
| `maxConcurrent` | `INIT_MAX_CONCURRENT` | max in-flight deliveries; unset/`≤0` disables |
| `maxQueued` | `INIT_MAX_QUEUED` | bounded FIFO backlog; `0` = shed when full |
| `perEnvMaxPercent` | `INIT_PER_ENV_MAX_PERCENT` | one env's max share of the budget; `0` = global-only |
| `sendTimeout` | `INIT_SEND_TIMEOUT` | backstop to reclaim a slot from a stalled delivery (default 30s) |

`maxConcurrent` is an `OptInt` (not `OptIntGreaterThanZero`) so an explicit `0` disables gracefully instead of failing config validation.

## Testing
- Limiter unit tests under `-race`: admission, bounded-queue shed, disabled pass-through, exactly-once release, per-env gate.
- Config parse test for the `INIT_*` variables, including a regression that `INIT_MAX_CONCURRENT=0` disables rather than crashlooping.
- Existing `config` suite passes with the new section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New code is isolated; no production paths call the limiter yet, so default behavior is unchanged.
> 
> **Overview**
> Introduces a **foundation** for capping SDK initialization-delivery concurrency (polling and streaming). Runtime behavior is **unchanged** until a follow-up wires the limiter into init paths; with no config, the limiter stays disabled.
> 
> Adds `internal/concurrency` with an admission `Limiter`: global in-flight slots (`MaxConcurrent`), optional bounded wait queue (`MaxQueued`, `0` = reject when saturated), and an optional per-environment try-only gate so one env cannot take the whole budget. `Acquire(ctx, envKey)` returns a one-shot release; disabled/nil limiters admit with no overhead.
> 
> Adds `[Concurrency]` / `INIT_*` settings on `Config` (`INIT_MAX_CONCURRENT`, `INIT_MAX_QUEUED`, `INIT_PER_ENV_MAX_PERCENT`, `INIT_SEND_TIMEOUT`) and loads them from the environment. `MaxConcurrent` uses `OptInt` so `INIT_MAX_CONCURRENT=0` disables the feature without failing validation.
> 
> Unit tests cover limiter semantics (queueing, rejection, per-env isolation, context cancel, idempotent release) and config parsing including the zero-disable regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c6628bb6f80ca7d4e8dae7fb892bad2ba068cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->