### PR TITLE
fix: End auth span before invoking the next handler

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -115,76 +115,91 @@ func Chain(middlewares ...mux.MiddlewareFunc) mux.MiddlewareFunc {
 func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayEnvironments) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			ctx, span := tracing.Tracer().Start(req.Context(), tracing.SpanAuth)
-			defer span.End()
-			span.SetAttributes(tracing.SDKKindKey.String(string(sdkKind)))
-			req = req.WithContext(ctx)
+			// Run authentication in its own scope so the span ends before we
+			// hand off to the next handler. Otherwise the deferred span.End()
+			// would fire only after the whole chain returns, and the auth span
+			// would incorrectly encompass all downstream handling time.
+			req, ok := func() (*http.Request, bool) {
+				// The request handed to the next handler must carry parentCtx, not the
+				// auth span's context: the auth span is ended when this scope exits, and
+				// a downstream handler that finds an ended span in its context cannot
+				// attach child spans or span events to the request's trace.
+				parentCtx := req.Context()
+				ctx, span := tracing.Tracer().Start(parentCtx, tracing.SpanAuth)
+				defer span.End()
+				span.SetAttributes(tracing.SDKKindKey.String(string(sdkKind)))
+				req = req.WithContext(ctx)
 
-			credential, err := sdks.GetCredential(sdkKind, req)
-			if err != nil {
-				span.SetAttributes(tracing.AuthResultKey.String("invalid_credential"))
-				span.SetStatus(codes.Error, "invalid credential")
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-
-			queryValues := req.URL.Query()
-			filterKey := config.FilterKey(queryValues.Get("filter"))
-
-			clientCtx, err := envs.GetEnvironment(sdkauth.NewScoped(filterKey, credential))
-
-			if envs.IsNotReady(err) {
-				span.SetAttributes(tracing.AuthResultKey.String("not_ready"))
-				span.SetStatus(codes.Error, "not ready")
-				w.WriteHeader(http.StatusServiceUnavailable)
-				_, _ = w.Write([]byte(httpStatusMessageNotFullyConfigured))
-				return
-			}
-
-			if envs.IsPayloadFilterNotFound(err) {
-				span.SetAttributes(tracing.AuthResultKey.String("filter_not_found"))
-				span.SetStatus(codes.Error, "filter not found")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write([]byte(httpStatusMessagePayloadFilterNotFound))
-				return
-			}
-
-			if err != nil || clientCtx.GetInitError() == ld.ErrInitializationFailed {
-				span.SetAttributes(tracing.AuthResultKey.String("not_found"))
-				span.SetStatus(codes.Error, "environment not found")
-				// ErrInitializationFailed is what the SDK returns if it got a 401 error from LD.
-				// Our error behavior here is slightly different for JS/browser clients
-				if sdkKind == basictypes.JSClientSDK {
-					w.WriteHeader(http.StatusNotFound)
-					_, _ = w.Write([]byte(httpStatusMessageMissingEnvURLParam))
-				} else {
+				credential, err := sdks.GetCredential(sdkKind, req)
+				if err != nil {
+					span.SetAttributes(tracing.AuthResultKey.String("invalid_credential"))
+					span.SetStatus(codes.Error, "invalid credential")
 					w.WriteHeader(http.StatusUnauthorized)
-					_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
+					return nil, false
 				}
+
+				queryValues := req.URL.Query()
+				filterKey := config.FilterKey(queryValues.Get("filter"))
+
+				clientCtx, err := envs.GetEnvironment(sdkauth.NewScoped(filterKey, credential))
+
+				if envs.IsNotReady(err) {
+					span.SetAttributes(tracing.AuthResultKey.String("not_ready"))
+					span.SetStatus(codes.Error, "not ready")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte(httpStatusMessageNotFullyConfigured))
+					return nil, false
+				}
+
+				if envs.IsPayloadFilterNotFound(err) {
+					span.SetAttributes(tracing.AuthResultKey.String("filter_not_found"))
+					span.SetStatus(codes.Error, "filter not found")
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(httpStatusMessagePayloadFilterNotFound))
+					return nil, false
+				}
+
+				if err != nil || clientCtx.GetInitError() == ld.ErrInitializationFailed {
+					span.SetAttributes(tracing.AuthResultKey.String("not_found"))
+					span.SetStatus(codes.Error, "environment not found")
+					// ErrInitializationFailed is what the SDK returns if it got a 401 error from LD.
+					// Our error behavior here is slightly different for JS/browser clients
+					if sdkKind == basictypes.JSClientSDK {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = w.Write([]byte(httpStatusMessageMissingEnvURLParam))
+					} else {
+						w.WriteHeader(http.StatusUnauthorized)
+						_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
+					}
+					return nil, false
+				}
+
+				if clientCtx.GetClient() == nil {
+					span.SetAttributes(tracing.AuthResultKey.String("client_not_initialized"))
+					span.SetStatus(codes.Error, "client not initialized")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte(httpStatusMessageSDKClientNotInited))
+					return nil, false
+				}
+
+				if envID := relayenv.GetEnvironmentID(clientCtx); envID != "" {
+					w.Header().Set(ldEnvIDHeader, string(envID))
+				}
+
+				span.SetAttributes(tracing.AuthResultKey.String("success"))
+
+				contextInfo := EnvContextInfo{
+					Env:        clientCtx,
+					Credential: credential,
+				}
+				downstreamCtx := WithEnvContextInfo(parentCtx, contextInfo)
+				if sdkKind == basictypes.JSClientSDK {
+					downstreamCtx = browser.WithCORSContext(downstreamCtx, clientCtx.GetJSClientContext())
+				}
+				return req.WithContext(downstreamCtx), true
+			}()
+			if !ok {
 				return
-			}
-
-			if clientCtx.GetClient() == nil {
-				span.SetAttributes(tracing.AuthResultKey.String("client_not_initialized"))
-				span.SetStatus(codes.Error, "client not initialized")
-				w.WriteHeader(http.StatusServiceUnavailable)
-				_, _ = w.Write([]byte(httpStatusMessageSDKClientNotInited))
-				return
-			}
-
-			if envID := relayenv.GetEnvironmentID(clientCtx); envID != "" {
-				w.Header().Set(ldEnvIDHeader, string(envID))
-			}
-
-			span.SetAttributes(tracing.AuthResultKey.String("success"))
-
-			contextInfo := EnvContextInfo{
-				Env:        clientCtx,
-				Credential: credential,
-			}
-			req = req.WithContext(WithEnvContextInfo(req.Context(), contextInfo))
-			if sdkKind == basictypes.JSClientSDK {
-				req = req.WithContext(browser.WithCORSContext(req.Context(), clientCtx.GetJSClientContext()))
 			}
 			next.ServeHTTP(w, req)
 		})
@@ -205,77 +220,89 @@ func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFun
 				return
 			}
 
-			ctx, span := tracing.Tracer().Start(req.Context(), tracing.SpanAuth)
-			defer span.End()
-			req = req.WithContext(ctx)
+			// Run authentication in its own scope so the span ends before we
+			// hand off to the next handler. Otherwise the deferred span.End()
+			// would fire only after the whole chain returns, and the auth span
+			// would incorrectly encompass all downstream handling time.
+			req, ok := func() (*http.Request, bool) {
+				// As above: hand parentCtx to the next handler, not the ended auth
+				// span's context.
+				parentCtx := req.Context()
+				ctx, span := tracing.Tracer().Start(parentCtx, tracing.SpanAuth)
+				defer span.End()
+				req = req.WithContext(ctx)
 
-			token, err := sdks.FetchClientSideAuthToken(req)
-			if err != nil {
-				span.SetAttributes(tracing.AuthResultKey.String("invalid_credential"))
-				span.SetStatus(codes.Error, "invalid credential")
-				w.WriteHeader(http.StatusUnauthorized)
-				_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
+				token, err := sdks.FetchClientSideAuthToken(req)
+				if err != nil {
+					span.SetAttributes(tracing.AuthResultKey.String("invalid_credential"))
+					span.SetStatus(codes.Error, "invalid credential")
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
+					return nil, false
+				}
+
+				var cred credential.SDKCredential
+				if strings.HasPrefix(token, "mob-") {
+					cred = config.MobileKey(token)
+					span.SetAttributes(tracing.SDKKindKey.String(string(basictypes.MobileSDK)))
+				} else {
+					cred = config.EnvironmentID(token)
+					span.SetAttributes(tracing.SDKKindKey.String(string(basictypes.JSClientSDK)))
+				}
+
+				queryValues := req.URL.Query()
+				filterKey := config.FilterKey(queryValues.Get("filter"))
+
+				clientCtx, err := envs.GetEnvironment(sdkauth.NewScoped(filterKey, cred))
+
+				if envs.IsNotReady(err) {
+					span.SetAttributes(tracing.AuthResultKey.String("not_ready"))
+					span.SetStatus(codes.Error, "not ready")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte(httpStatusMessageNotFullyConfigured))
+					return nil, false
+				}
+
+				if envs.IsPayloadFilterNotFound(err) {
+					span.SetAttributes(tracing.AuthResultKey.String("filter_not_found"))
+					span.SetStatus(codes.Error, "filter not found")
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(httpStatusMessagePayloadFilterNotFound))
+					return nil, false
+				}
+
+				if err != nil || clientCtx.GetInitError() == ld.ErrInitializationFailed {
+					span.SetAttributes(tracing.AuthResultKey.String("not_found"))
+					span.SetStatus(codes.Error, "environment not found")
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
+					return nil, false
+				}
+
+				if clientCtx.GetClient() == nil {
+					span.SetAttributes(tracing.AuthResultKey.String("client_not_initialized"))
+					span.SetStatus(codes.Error, "client not initialized")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte(httpStatusMessageSDKClientNotInited))
+					return nil, false
+				}
+
+				if envID := relayenv.GetEnvironmentID(clientCtx); envID != "" {
+					w.Header().Set(ldEnvIDHeader, string(envID))
+				}
+
+				span.SetAttributes(tracing.AuthResultKey.String("success"))
+
+				contextInfo := EnvContextInfo{
+					Env:        clientCtx,
+					Credential: cred,
+				}
+				downstreamCtx := browser.WithCORSContext(WithEnvContextInfo(parentCtx, contextInfo), clientCtx.GetJSClientContext())
+				return req.WithContext(downstreamCtx), true
+			}()
+			if !ok {
 				return
 			}
-
-			var cred credential.SDKCredential
-			if strings.HasPrefix(token, "mob-") {
-				cred = config.MobileKey(token)
-				span.SetAttributes(tracing.SDKKindKey.String(string(basictypes.MobileSDK)))
-			} else {
-				cred = config.EnvironmentID(token)
-				span.SetAttributes(tracing.SDKKindKey.String(string(basictypes.JSClientSDK)))
-			}
-
-			queryValues := req.URL.Query()
-			filterKey := config.FilterKey(queryValues.Get("filter"))
-
-			clientCtx, err := envs.GetEnvironment(sdkauth.NewScoped(filterKey, cred))
-
-			if envs.IsNotReady(err) {
-				span.SetAttributes(tracing.AuthResultKey.String("not_ready"))
-				span.SetStatus(codes.Error, "not ready")
-				w.WriteHeader(http.StatusServiceUnavailable)
-				_, _ = w.Write([]byte(httpStatusMessageNotFullyConfigured))
-				return
-			}
-
-			if envs.IsPayloadFilterNotFound(err) {
-				span.SetAttributes(tracing.AuthResultKey.String("filter_not_found"))
-				span.SetStatus(codes.Error, "filter not found")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write([]byte(httpStatusMessagePayloadFilterNotFound))
-				return
-			}
-
-			if err != nil || clientCtx.GetInitError() == ld.ErrInitializationFailed {
-				span.SetAttributes(tracing.AuthResultKey.String("not_found"))
-				span.SetStatus(codes.Error, "environment not found")
-				w.WriteHeader(http.StatusUnauthorized)
-				_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
-				return
-			}
-
-			if clientCtx.GetClient() == nil {
-				span.SetAttributes(tracing.AuthResultKey.String("client_not_initialized"))
-				span.SetStatus(codes.Error, "client not initialized")
-				w.WriteHeader(http.StatusServiceUnavailable)
-				_, _ = w.Write([]byte(httpStatusMessageSDKClientNotInited))
-				return
-			}
-
-			if envID := relayenv.GetEnvironmentID(clientCtx); envID != "" {
-				w.Header().Set(ldEnvIDHeader, string(envID))
-			}
-
-			span.SetAttributes(tracing.AuthResultKey.String("success"))
-
-			contextInfo := EnvContextInfo{
-				Env:        clientCtx,
-				Credential: cred,
-			}
-			req = req.WithContext(WithEnvContextInfo(req.Context(), contextInfo))
-			req = req.WithContext(browser.WithCORSContext(req.Context(), clientCtx.GetJSClientContext()))
 			next.ServeHTTP(w, req)
 		})
 	}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -119,26 +119,24 @@ func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayE
 			// hand off to the next handler. Otherwise the deferred span.End()
 			// would fire only after the whole chain returns, and the auth span
 			// would incorrectly encompass all downstream handling time.
-			req, ok := func() (*http.Request, bool) {
-				// The request handed to the next handler must carry parentCtx, not the
-				// auth span's context: the auth span is ended when this scope exits, and
-				// a downstream handler that finds an ended span in its context cannot
-				// attach child spans or span events to the request's trace.
-				parentCtx := req.Context()
-				ctx, span := tracing.Tracer().Start(parentCtx, tracing.SpanAuth)
+			//
+			// If authentication succeeds, the incoming request context is modified
+			// to include environment information.
+			ok := func() bool {
+				ctx, span := tracing.Tracer().Start(req.Context(), tracing.SpanAuth)
 				defer span.End()
 				span.SetAttributes(tracing.SDKKindKey.String(string(sdkKind)))
-				req = req.WithContext(ctx)
+				authScopedReq := req.WithContext(ctx)
 
-				credential, err := sdks.GetCredential(sdkKind, req)
+				credential, err := sdks.GetCredential(sdkKind, authScopedReq)
 				if err != nil {
 					span.SetAttributes(tracing.AuthResultKey.String("invalid_credential"))
 					span.SetStatus(codes.Error, "invalid credential")
 					w.WriteHeader(http.StatusUnauthorized)
-					return nil, false
+					return false
 				}
 
-				queryValues := req.URL.Query()
+				queryValues := authScopedReq.URL.Query()
 				filterKey := config.FilterKey(queryValues.Get("filter"))
 
 				clientCtx, err := envs.GetEnvironment(sdkauth.NewScoped(filterKey, credential))
@@ -148,7 +146,7 @@ func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayE
 					span.SetStatus(codes.Error, "not ready")
 					w.WriteHeader(http.StatusServiceUnavailable)
 					_, _ = w.Write([]byte(httpStatusMessageNotFullyConfigured))
-					return nil, false
+					return false
 				}
 
 				if envs.IsPayloadFilterNotFound(err) {
@@ -156,7 +154,7 @@ func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayE
 					span.SetStatus(codes.Error, "filter not found")
 					w.WriteHeader(http.StatusNotFound)
 					_, _ = w.Write([]byte(httpStatusMessagePayloadFilterNotFound))
-					return nil, false
+					return false
 				}
 
 				if err != nil || clientCtx.GetInitError() == ld.ErrInitializationFailed {
@@ -171,7 +169,7 @@ func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayE
 						w.WriteHeader(http.StatusUnauthorized)
 						_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
 					}
-					return nil, false
+					return false
 				}
 
 				if clientCtx.GetClient() == nil {
@@ -179,7 +177,7 @@ func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayE
 					span.SetStatus(codes.Error, "client not initialized")
 					w.WriteHeader(http.StatusServiceUnavailable)
 					_, _ = w.Write([]byte(httpStatusMessageSDKClientNotInited))
-					return nil, false
+					return false
 				}
 
 				if envID := relayenv.GetEnvironmentID(clientCtx); envID != "" {
@@ -192,15 +190,18 @@ func SelectEnvironmentByAuthorizationKey(sdkKind basictypes.SDKKind, envs RelayE
 					Env:        clientCtx,
 					Credential: credential,
 				}
-				downstreamCtx := WithEnvContextInfo(parentCtx, contextInfo)
+				downstreamCtx := WithEnvContextInfo(req.Context(), contextInfo)
 				if sdkKind == basictypes.JSClientSDK {
 					downstreamCtx = browser.WithCORSContext(downstreamCtx, clientCtx.GetJSClientContext())
 				}
-				return req.WithContext(downstreamCtx), true
+
+				req = req.WithContext(downstreamCtx)
+				return true
 			}()
 			if !ok {
 				return
 			}
+
 			next.ServeHTTP(w, req)
 		})
 	}
@@ -224,21 +225,21 @@ func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFun
 			// hand off to the next handler. Otherwise the deferred span.End()
 			// would fire only after the whole chain returns, and the auth span
 			// would incorrectly encompass all downstream handling time.
-			req, ok := func() (*http.Request, bool) {
-				// As above: hand parentCtx to the next handler, not the ended auth
-				// span's context.
-				parentCtx := req.Context()
-				ctx, span := tracing.Tracer().Start(parentCtx, tracing.SpanAuth)
+			//
+			// If authentication succeeds, the incoming request context is modified
+			// to include environment information.
+			ok := func() bool {
+				ctx, span := tracing.Tracer().Start(req.Context(), tracing.SpanAuth)
 				defer span.End()
-				req = req.WithContext(ctx)
+				authScopedReq := req.WithContext(ctx)
 
-				token, err := sdks.FetchClientSideAuthToken(req)
+				token, err := sdks.FetchClientSideAuthToken(authScopedReq)
 				if err != nil {
 					span.SetAttributes(tracing.AuthResultKey.String("invalid_credential"))
 					span.SetStatus(codes.Error, "invalid credential")
 					w.WriteHeader(http.StatusUnauthorized)
 					_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
-					return nil, false
+					return false
 				}
 
 				var cred credential.SDKCredential
@@ -250,7 +251,7 @@ func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFun
 					span.SetAttributes(tracing.SDKKindKey.String(string(basictypes.JSClientSDK)))
 				}
 
-				queryValues := req.URL.Query()
+				queryValues := authScopedReq.URL.Query()
 				filterKey := config.FilterKey(queryValues.Get("filter"))
 
 				clientCtx, err := envs.GetEnvironment(sdkauth.NewScoped(filterKey, cred))
@@ -260,7 +261,7 @@ func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFun
 					span.SetStatus(codes.Error, "not ready")
 					w.WriteHeader(http.StatusServiceUnavailable)
 					_, _ = w.Write([]byte(httpStatusMessageNotFullyConfigured))
-					return nil, false
+					return false
 				}
 
 				if envs.IsPayloadFilterNotFound(err) {
@@ -268,7 +269,7 @@ func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFun
 					span.SetStatus(codes.Error, "filter not found")
 					w.WriteHeader(http.StatusNotFound)
 					_, _ = w.Write([]byte(httpStatusMessagePayloadFilterNotFound))
-					return nil, false
+					return false
 				}
 
 				if err != nil || clientCtx.GetInitError() == ld.ErrInitializationFailed {
@@ -276,7 +277,7 @@ func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFun
 					span.SetStatus(codes.Error, "environment not found")
 					w.WriteHeader(http.StatusUnauthorized)
 					_, _ = w.Write([]byte(httpStatusMessageInvalidEnvCredential))
-					return nil, false
+					return false
 				}
 
 				if clientCtx.GetClient() == nil {
@@ -284,7 +285,7 @@ func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFun
 					span.SetStatus(codes.Error, "client not initialized")
 					w.WriteHeader(http.StatusServiceUnavailable)
 					_, _ = w.Write([]byte(httpStatusMessageSDKClientNotInited))
-					return nil, false
+					return false
 				}
 
 				if envID := relayenv.GetEnvironmentID(clientCtx); envID != "" {
@@ -297,12 +298,16 @@ func SelectEnvironmentByClientSideAuth(envs RelayEnvironments) mux.MiddlewareFun
 					Env:        clientCtx,
 					Credential: cred,
 				}
-				downstreamCtx := browser.WithCORSContext(WithEnvContextInfo(parentCtx, contextInfo), clientCtx.GetJSClientContext())
-				return req.WithContext(downstreamCtx), true
+				downstreamCtx := WithEnvContextInfo(req.Context(), contextInfo)
+				downstreamCtx = browser.WithCORSContext(downstreamCtx, clientCtx.GetJSClientContext())
+
+				req = req.WithContext(downstreamCtx)
+				return true
 			}()
 			if !ok {
 				return
 			}
+
 			next.ServeHTTP(w, req)
 		})
 	}

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 
@@ -21,12 +22,18 @@ import (
 	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
 	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testclient"
 	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testenv"
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Shortcut for building a request when we are going to be passing it directly to an endpoint handler, rather than
@@ -474,6 +481,111 @@ func TestSelectEnvironmentByClientSideAuth(t *testing.T) {
 
 		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	})
+}
+
+// installSpanRecorder installs an in-memory span recorder as the global tracer
+// provider for the duration of the test, so assertions can be made about spans
+// produced by tracing.Tracer(). Because the tracer provider is process-global,
+// tests using this must not call t.Parallel.
+func installSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return sr
+}
+
+func assertSpanHasStringAttribute(t *testing.T, span sdktrace.ReadOnlySpan, key attribute.Key, value string) {
+	t.Helper()
+	for _, kv := range span.Attributes() {
+		if kv.Key == key {
+			assert.Equal(t, value, kv.Value.AsString())
+			return
+		}
+	}
+	t.Errorf("span %q is missing attribute %q", span.Name(), key)
+}
+
+// authSpanObserver returns a handler that records, at the moment it is invoked,
+// whether the auth span has already ended and what span (if any) is active in
+// the request context. This is how we verify the auth span is closed before the
+// next handler runs, rather than encompassing downstream handling.
+func authSpanObserver(sr *tracetest.SpanRecorder, endedDuringNext *bool, activeInNext *trace.SpanContext) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		*endedDuringNext = slices.ContainsFunc(sr.Ended(), func(s sdktrace.ReadOnlySpan) bool {
+			return s.Name() == tracing.SpanAuth
+		})
+		*activeInNext = trace.SpanContextFromContext(req.Context())
+	})
+}
+
+func TestSelectEnvironmentByAuthorizationKeyEndsAuthSpanBeforeNext(t *testing.T) {
+	sr := installSpanRecorder(t)
+
+	env1 := testenv.NewTestEnvContext("env1", false, nil)
+	envs := testEnvironments{
+		envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+			sdkauth.New(st.EnvMain.Config.SDKKey): env1,
+		},
+	}
+	selector := SelectEnvironmentByAuthorizationKey(basictypes.ServerSDK, envs)
+
+	var authEndedDuringNext bool
+	var activeInNext trace.SpanContext
+	next := authSpanObserver(sr, &authEndedDuringNext, &activeInNext)
+
+	req := buildPreRoutedRequestWithAuth(st.EnvMain.Config.SDKKey)
+	resp, _ := st.DoRequest(req, selector(next))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.True(t, authEndedDuringNext, "auth span must end before the next handler runs")
+
+	ended := sr.Ended()
+	require.Len(t, ended, 1)
+	authSpan := ended[0]
+	assert.Equal(t, tracing.SpanAuth, authSpan.Name())
+	assertSpanHasStringAttribute(t, authSpan, tracing.AuthResultKey, "success")
+	assertSpanHasStringAttribute(t, authSpan, tracing.SDKKindKey, string(basictypes.ServerSDK))
+
+	// The next handler must not run scoped to the (now-ended) auth span; it
+	// should carry the original request context instead.
+	assert.NotEqual(t, authSpan.SpanContext().SpanID(), activeInNext.SpanID())
+}
+
+func TestSelectEnvironmentByClientSideAuthEndsAuthSpanBeforeNext(t *testing.T) {
+	sr := installSpanRecorder(t)
+
+	envWithAllCreds := testenv.NewTestEnvContextWithEnvConfig("env-all", st.EnvWithAllCredentials.Config, false, nil)
+	envs := testEnvironments{
+		envs: map[sdkauth.ScopedCredential]relayenv.EnvContext{
+			sdkauth.New(st.EnvWithAllCredentials.Config.MobileKey): envWithAllCreds,
+		},
+	}
+	selector := SelectEnvironmentByClientSideAuth(envs)
+
+	var authEndedDuringNext bool
+	var activeInNext trace.SpanContext
+	next := authSpanObserver(sr, &authEndedDuringNext, &activeInNext)
+
+	headers := make(http.Header)
+	headers.Set("Authorization", string(st.EnvWithAllCredentials.Config.MobileKey))
+	req := buildPreRoutedRequest("GET", nil, headers, nil, nil)
+	resp, _ := st.DoRequest(req, selector(next))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.True(t, authEndedDuringNext, "auth span must end before the next handler runs")
+
+	ended := sr.Ended()
+	require.Len(t, ended, 1)
+	authSpan := ended[0]
+	assert.Equal(t, tracing.SpanAuth, authSpan.Name())
+	assertSpanHasStringAttribute(t, authSpan, tracing.AuthResultKey, "success")
+	assertSpanHasStringAttribute(t, authSpan, tracing.SDKKindKey, string(basictypes.MobileSDK))
+
+	// The next handler must not run scoped to the (now-ended) auth span; it
+	// should carry the original request context instead.
+	assert.NotEqual(t, authSpan.SpanContext().SpanID(), activeInNext.SpanID())
 }
 
 func TestEnvIDHeader(t *testing.T) {


### PR DESCRIPTION
The auth span used a deferred span.End() that fired only after the whole
middleware chain returned, so the span incorrectly measured all downstream
handling time. Wrap the auth logic in an inner scope so the span ends before
next.ServeHTTP is called.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only structural change in auth middleware with regression tests; request auth outcomes and context values for handlers are intended to stay the same.
> 
> **Overview**
> Fixes **incorrect `relay.auth` span duration** in `SelectEnvironmentByAuthorizationKey` and `SelectEnvironmentByClientSideAuth`. Auth logic now runs in a short-lived inner scope so `defer span.End()` runs **before** `next.ServeHTTP`, so traces no longer attribute downstream handler time to authentication.
> 
> On success, environment and CORS data are merged onto the **original** request context (`downstreamCtx` from `req.Context()`), so the next handler is not left running under the ended auth span. Auth behavior and HTTP status responses are unchanged.
> 
> Adds middleware tests with an in-memory OTel span recorder to assert the auth span is finished when the next handler runs and that the active span in the next handler is not the auth span.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44030becefd7226b7a8eb2ae2fb4d68254259c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->