### PR TITLE
feat: Add payload serialization and response write spans to polling endpoints

### DIFF
--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -15,19 +15,24 @@ func Tracer() trace.Tracer { return otel.Tracer(TracerName) }
 
 // Span name constants.
 const (
-	SpanAuth           = "relay.auth"
-	SpanStoreSnapshot  = "relay.store.snapshot"
-	SpanStoreGetAll    = "relay.store.get_all"
-	SpanStoreGet       = "relay.store.get"
-	SpanEvaluateFlags  = "relay.evaluate_flags"
-	SpanEventsDispatch = "relay.events.dispatch"
+	SpanAuth             = "relay.auth"
+	SpanStoreSnapshot    = "relay.store.snapshot"
+	SpanStoreGetAll      = "relay.store.get_all"
+	SpanStoreGet         = "relay.store.get"
+	SpanEvaluateFlags    = "relay.evaluate_flags"
+	SpanEventsDispatch   = "relay.events.dispatch"
+	SpanSerializePayload = "relay.payload.serialize"
+	SpanWriteResponse    = "relay.response.write"
 )
 
 // Relay-specific span attribute keys.
 const (
-	SDKKindKey    = attribute.Key("relay.sdk_kind")
-	AuthResultKey = attribute.Key("relay.auth.result")
-	FlagCountKey  = attribute.Key("relay.flags.count")
-	EventsKindKey = attribute.Key("relay.events.kind")
-	StoreKeyKey   = attribute.Key("relay.store.key")
+	SDKKindKey       = attribute.Key("relay.sdk_kind")
+	AuthResultKey    = attribute.Key("relay.auth.result")
+	FlagCountKey     = attribute.Key("relay.flags.count")
+	EventsKindKey    = attribute.Key("relay.events.kind")
+	StoreKeyKey      = attribute.Key("relay.store.key")
+	PayloadEventsKey = attribute.Key("relay.payload.events")
+	PayloadBytesKey  = attribute.Key("relay.payload.bytes")
+	ResponseBytesKey = attribute.Key("relay.response.bytes")
 )

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -207,103 +207,126 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	numItems := 2
-	if len(collection) > 0 {
-		for _, keyedItems := range collection {
-			numItems += len(keyedItems)
-		}
-	}
+	payloadJSON, ok := func() ([]byte, bool) {
+		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		defer span.End()
 
-	pollingPayload := pollingPayload{
-		Events: make([]payloadEvent, 0, numItems),
-	}
-
-	basis := req.URL.Query().Get("basis")
-	if selector.IsDefined() && basis != "" && selector.State() == basis {
-		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-			Event: "server-intent",
-			EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
-				ID:     selector.State(),
-				Target: selector.Version(),
-				Code:   subsystems.IntentNone,
-				Reason: "up-to-date",
-			}},
-		})
-	} else {
-		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-			Event: "server-intent",
-			EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
-				ID:     selector.State(),
-				Target: selector.Version(),
-				Code:   subsystems.IntentTransferFull,
-				Reason: "cant-catchup",
-			}},
-		})
-		for kind, keyedItems := range collection {
-			for _, keyedItem := range keyedItems {
-				if keyedItem.Item.Item == nil {
-					continue // this should not happen, but just in case
-				}
-				switch kind {
-				case ldstoreimpl.Features():
-					if flag, ok := keyedItem.Item.Item.(*ldmodel.FeatureFlag); ok {
-						writer := jwriter.NewWriter()
-						ldmodel.MarshalFeatureFlagToJSONWriter(*flag, &writer)
-
-						pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-							Event: "put-object",
-							EventData: subsystems.PutObject{
-								Version: keyedItem.Item.Version,
-								Kind:    subsystems.FlagKind,
-								Key:     keyedItem.Key,
-								Object:  writer.Bytes(),
-							},
-						})
-					} else {
-						clientCtx.Env.GetLogger().Error("error casting keyed item to feature flag")
-						w.WriteHeader(http.StatusInternalServerError)
-						return
-					}
-				case ldstoreimpl.Segments():
-					if segment, ok := keyedItem.Item.Item.(*ldmodel.Segment); ok {
-						writer := jwriter.NewWriter()
-						ldmodel.MarshalSegmentToJSONWriter(*segment, &writer)
-
-						pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-							Event: "put-object",
-							EventData: subsystems.PutObject{
-								Version: keyedItem.Item.Version,
-								Kind:    subsystems.SegmentKind,
-								Key:     keyedItem.Key,
-								Object:  writer.Bytes(),
-							},
-						})
-					} else {
-						clientCtx.Env.GetLogger().Error("error casting keyed item to feature segment")
-						w.WriteHeader(http.StatusInternalServerError)
-						return
-					}
-				default:
-					clientCtx.Env.GetLogger().Error("unexpected data kind in store snapshot", "kind", kind)
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
+		numItems := 2
+		if len(collection) > 0 {
+			for _, keyedItems := range collection {
+				numItems += len(keyedItems)
 			}
 		}
-		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-			Event:     "payload-transferred",
-			EventData: selector,
-		})
-	}
 
-	json, err := json.Marshal(pollingPayload)
-	if err != nil {
-		clientCtx.Env.GetLogger().Error("error marshaling polling response", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
+		pollingPayload := pollingPayload{
+			Events: make([]payloadEvent, 0, numItems),
+		}
+
+		basis := req.URL.Query().Get("basis")
+		if selector.IsDefined() && basis != "" && selector.State() == basis {
+			pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+				Event: "server-intent",
+				EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
+					ID:     selector.State(),
+					Target: selector.Version(),
+					Code:   subsystems.IntentNone,
+					Reason: "up-to-date",
+				}},
+			})
+		} else {
+			pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+				Event: "server-intent",
+				EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
+					ID:     selector.State(),
+					Target: selector.Version(),
+					Code:   subsystems.IntentTransferFull,
+					Reason: "cant-catchup",
+				}},
+			})
+			for kind, keyedItems := range collection {
+				for _, keyedItem := range keyedItems {
+					if keyedItem.Item.Item == nil {
+						continue // this should not happen, but just in case
+					}
+					switch kind {
+					case ldstoreimpl.Features():
+						if flag, ok := keyedItem.Item.Item.(*ldmodel.FeatureFlag); ok {
+							writer := jwriter.NewWriter()
+							ldmodel.MarshalFeatureFlagToJSONWriter(*flag, &writer)
+
+							pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+								Event: "put-object",
+								EventData: subsystems.PutObject{
+									Version: keyedItem.Item.Version,
+									Kind:    subsystems.FlagKind,
+									Key:     keyedItem.Key,
+									Object:  writer.Bytes(),
+								},
+							})
+						} else {
+							clientCtx.Env.GetLogger().Error("error casting keyed item to feature flag")
+							span.SetStatus(codes.Error, "error casting keyed item to feature flag")
+							w.WriteHeader(http.StatusInternalServerError)
+							return nil, false
+						}
+					case ldstoreimpl.Segments():
+						if segment, ok := keyedItem.Item.Item.(*ldmodel.Segment); ok {
+							writer := jwriter.NewWriter()
+							ldmodel.MarshalSegmentToJSONWriter(*segment, &writer)
+
+							pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+								Event: "put-object",
+								EventData: subsystems.PutObject{
+									Version: keyedItem.Item.Version,
+									Kind:    subsystems.SegmentKind,
+									Key:     keyedItem.Key,
+									Object:  writer.Bytes(),
+								},
+							})
+						} else {
+							clientCtx.Env.GetLogger().Error("error casting keyed item to feature segment")
+							span.SetStatus(codes.Error, "error casting keyed item to feature segment")
+							w.WriteHeader(http.StatusInternalServerError)
+							return nil, false
+						}
+					default:
+						clientCtx.Env.GetLogger().Error("unexpected data kind in store snapshot", "kind", kind)
+						span.SetStatus(codes.Error, "unexpected data kind in store snapshot")
+						w.WriteHeader(http.StatusInternalServerError)
+						return nil, false
+					}
+				}
+			}
+			pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+				Event:     "payload-transferred",
+				EventData: selector,
+			})
+		}
+
+		data, err := json.Marshal(pollingPayload)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			clientCtx.Env.GetLogger().Error("error marshaling polling response", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return nil, false
+		}
+		span.SetAttributes(
+			tracing.PayloadEventsKey.Int(len(pollingPayload.Events)),
+			tracing.PayloadBytesKey.Int(len(data)),
+		)
+		return data, true
+	}()
+	if !ok {
 		return
 	}
 
-	writeCacheableJSONResponse(w, req, clientCtx.Env, json, selector.State())
+	func() {
+		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
+		defer span.End()
+		span.SetAttributes(tracing.ResponseBytesKey.Int(len(payloadJSON)))
+		writeCacheableJSONResponse(w, req, clientCtx.Env, payloadJSON, selector.State())
+	}()
 }
 
 // FDv2 client-side polling endpoint that evaluates flags against a context.
@@ -366,9 +389,13 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 	pollingPayload := pollingPayload{
 		Events: make([]payloadEvent, 0),
 	}
+	flagEvalKind := subsystems.ObjectKind("flag-eval")
 
 	basis := req.URL.Query().Get("basis")
-	if selector.IsDefined() && basis != "" && selector.State() == basis {
+	upToDate := selector.IsDefined() && basis != "" && selector.State() == basis
+
+	var evalResults []flagEvalResult
+	if upToDate {
 		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
 			Event: "server-intent",
 			EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
@@ -390,7 +417,6 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 		})
 
 		evaluator := clientCtx.Env.GetEvaluator()
-		flagEvalKind := subsystems.ObjectKind("flag-eval")
 
 		var allItems []ldstoretypes.KeyedItemDescriptor
 		for kind, keyedItems := range collection {
@@ -401,54 +427,76 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 		}
 
 		_, evalSpan := tracing.Tracer().Start(req.Context(), tracing.SpanEvaluateFlags)
-		evalResults := evaluateFlags(evaluator, allItems, sdkKind, ldContext)
+		evalResults = evaluateFlags(evaluator, allItems, sdkKind, ldContext)
 		evalSpan.SetAttributes(tracing.FlagCountKey.Int(len(evalResults)))
 		evalSpan.End()
+	}
 
-		for _, er := range evalResults {
-			evalWriter := jwriter.NewWriter()
-			evalObj := evalWriter.Object()
-			er.Detail.Value.WriteToJSONWriter(evalObj.Name("value"))
-			er.Detail.VariationIndex.WriteToJSONWriter(evalObj.Name("variation"))
-			evalObj.Name("flagVersion").Int(er.Flag.Version)
-			writePrerequisites(&evalObj, er.Prerequisites)
-			evalObj.Maybe("trackEvents", er.Flag.TrackEvents || er.IsExperiment).Bool(true)
-			evalObj.Maybe("trackReason", er.IsExperiment).Bool(true)
-			if withReasons || er.IsExperiment {
-				er.Detail.Reason.WriteToJSONWriter(evalObj.Name("reason"))
+	jsonData, ok := func() ([]byte, bool) {
+		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		defer span.End()
+
+		if !upToDate {
+			for _, er := range evalResults {
+				evalWriter := jwriter.NewWriter()
+				evalObj := evalWriter.Object()
+				er.Detail.Value.WriteToJSONWriter(evalObj.Name("value"))
+				er.Detail.VariationIndex.WriteToJSONWriter(evalObj.Name("variation"))
+				evalObj.Name("flagVersion").Int(er.Flag.Version)
+				writePrerequisites(&evalObj, er.Prerequisites)
+				evalObj.Maybe("trackEvents", er.Flag.TrackEvents || er.IsExperiment).Bool(true)
+				evalObj.Maybe("trackReason", er.IsExperiment).Bool(true)
+				if withReasons || er.IsExperiment {
+					er.Detail.Reason.WriteToJSONWriter(evalObj.Name("reason"))
+				}
+				evalObj.Maybe("debugEventsUntilDate", er.Flag.DebugEventsUntilDate != 0).
+					Float64(float64(er.Flag.DebugEventsUntilDate))
+				if er.Flag.SamplingRatio.IsDefined() {
+					evalObj.Name("samplingRatio").Int(er.Flag.SamplingRatio.IntValue())
+				}
+				evalObj.End()
+
+				pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
+					Event: "put-object",
+					EventData: subsystems.PutObject{
+						Version: er.Flag.Version,
+						Kind:    flagEvalKind,
+						Key:     er.Flag.Key,
+						Object:  evalWriter.Bytes(),
+					},
+				})
 			}
-			evalObj.Maybe("debugEventsUntilDate", er.Flag.DebugEventsUntilDate != 0).
-				Float64(float64(er.Flag.DebugEventsUntilDate))
-			if er.Flag.SamplingRatio.IsDefined() {
-				evalObj.Name("samplingRatio").Int(er.Flag.SamplingRatio.IntValue())
-			}
-			evalObj.End()
 
 			pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-				Event: "put-object",
-				EventData: subsystems.PutObject{
-					Version: er.Flag.Version,
-					Kind:    flagEvalKind,
-					Key:     er.Flag.Key,
-					Object:  evalWriter.Bytes(),
-				},
+				Event:     "payload-transferred",
+				EventData: selector,
 			})
 		}
 
-		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-			Event:     "payload-transferred",
-			EventData: selector,
-		})
-	}
-
-	jsonData, err := json.Marshal(pollingPayload)
-	if err != nil {
-		logger.Error("error marshaling polling response", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
+		data, err := json.Marshal(pollingPayload)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			logger.Error("error marshaling polling response", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return nil, false
+		}
+		span.SetAttributes(
+			tracing.PayloadEventsKey.Int(len(pollingPayload.Events)),
+			tracing.PayloadBytesKey.Int(len(data)),
+		)
+		return data, true
+	}()
+	if !ok {
 		return
 	}
 
-	writeCacheableJSONResponse(w, req, clientCtx.Env, jsonData, selector.State())
+	func() {
+		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
+		defer span.End()
+		span.SetAttributes(tracing.ResponseBytesKey.Int(len(jsonData)))
+		writeCacheableJSONResponse(w, req, clientCtx.Env, jsonData, selector.State())
+	}()
 }
 
 // PHP SDK polling endpoint for all flags: app.ld.com/sdk/flags
@@ -468,15 +516,31 @@ func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	respData := serializeFlagsAsMap(data)
-	// Compute an overall Etag for the data set by hashing flag keys and versions
-	hash := sha1.New()                                                         //nolint:gosec // just used for insecure hashing
-	sort.Slice(data, func(i, j int) bool { return data[i].Key < data[j].Key }) // makes the hash deterministic
-	for _, item := range data {
-		_, _ = io.WriteString(hash, fmt.Sprintf("%s:%d", item.Key, item.Item.Version))
-	}
-	etag := hex.EncodeToString(hash.Sum(nil))[:15]
-	writeCacheableJSONResponse(w, req, clientCtx.Env, respData, etag)
+	respData, etag := func() ([]byte, string) {
+		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		defer span.End()
+
+		respData := serializeFlagsAsMap(data)
+		// Compute an overall Etag for the data set by hashing flag keys and versions
+		hash := sha1.New()                                                         //nolint:gosec // just used for insecure hashing
+		sort.Slice(data, func(i, j int) bool { return data[i].Key < data[j].Key }) // makes the hash deterministic
+		for _, item := range data {
+			_, _ = io.WriteString(hash, fmt.Sprintf("%s:%d", item.Key, item.Item.Version))
+		}
+		etag := hex.EncodeToString(hash.Sum(nil))[:15]
+		span.SetAttributes(
+			tracing.FlagCountKey.Int(len(data)),
+			tracing.PayloadBytesKey.Int(len(respData)),
+		)
+		return respData, etag
+	}()
+
+	func() {
+		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
+		defer span.End()
+		span.SetAttributes(tracing.ResponseBytesKey.Int(len(respData)))
+		writeCacheableJSONResponse(w, req, clientCtx.Env, respData, etag)
+	}()
 }
 
 // PHP SDK polling endpoint for a flag: app.ld.com/sdk/flags/{key}
@@ -662,28 +726,43 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 	evalSpan.SetAttributes(tracing.FlagCountKey.Int(len(evalResults)))
 	evalSpan.End()
 
-	responseWriter := jwriter.NewWriter()
-	responseObj := responseWriter.Object()
-	for _, er := range evalResults {
-		valueObj := responseObj.Name(er.Flag.Key).Object()
-		er.Detail.Value.WriteToJSONWriter(valueObj.Name("value"))
-		er.Detail.VariationIndex.WriteToJSONWriter(valueObj.Name("variation"))
-		valueObj.Name("version").Int(er.Flag.Version)
-		valueObj.Maybe("trackEvents", er.Flag.TrackEvents || er.IsExperiment).Bool(true)
-		valueObj.Maybe("trackReason", er.IsExperiment).Bool(true)
-		if withReasons || er.IsExperiment {
-			er.Detail.Reason.WriteToJSONWriter(valueObj.Name("reason"))
-		}
-		valueObj.Maybe("debugEventsUntilDate", er.Flag.DebugEventsUntilDate != 0).
-			Float64(float64(er.Flag.DebugEventsUntilDate))
-		writePrerequisites(&valueObj, er.Prerequisites)
-		valueObj.End()
-	}
-	responseObj.End()
-	result := responseWriter.Bytes()
+	result := func() []byte {
+		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		defer span.End()
 
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(result)
+		responseWriter := jwriter.NewWriter()
+		responseObj := responseWriter.Object()
+		for _, er := range evalResults {
+			valueObj := responseObj.Name(er.Flag.Key).Object()
+			er.Detail.Value.WriteToJSONWriter(valueObj.Name("value"))
+			er.Detail.VariationIndex.WriteToJSONWriter(valueObj.Name("variation"))
+			valueObj.Name("version").Int(er.Flag.Version)
+			valueObj.Maybe("trackEvents", er.Flag.TrackEvents || er.IsExperiment).Bool(true)
+			valueObj.Maybe("trackReason", er.IsExperiment).Bool(true)
+			if withReasons || er.IsExperiment {
+				er.Detail.Reason.WriteToJSONWriter(valueObj.Name("reason"))
+			}
+			valueObj.Maybe("debugEventsUntilDate", er.Flag.DebugEventsUntilDate != 0).
+				Float64(float64(er.Flag.DebugEventsUntilDate))
+			writePrerequisites(&valueObj, er.Prerequisites)
+			valueObj.End()
+		}
+		responseObj.End()
+		data := responseWriter.Bytes()
+		span.SetAttributes(
+			tracing.FlagCountKey.Int(len(evalResults)),
+			tracing.PayloadBytesKey.Int(len(data)),
+		)
+		return data
+	}()
+
+	func() {
+		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
+		defer span.End()
+		span.SetAttributes(tracing.ResponseBytesKey.Int(len(result)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(result)
+	}()
 }
 
 func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.DataKind) func(http.ResponseWriter, *http.Request) {
@@ -706,15 +785,33 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 		}
 		if item.Item == nil {
 			w.WriteHeader(http.StatusNotFound)
-		} else {
-			bytes, err := json.Marshal(item.Item)
-			if err == nil {
-				writeCacheableJSONResponse(w, req, clientContext, bytes, strconv.Itoa(item.Version))
-			} else {
+			return
+		}
+
+		bytes, ok := func() ([]byte, bool) {
+			_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+			defer span.End()
+			data, err := json.Marshal(item.Item)
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
 				clientContext.GetLogger().Error("error marshaling JSON", "error", err)
 				w.WriteHeader(http.StatusInternalServerError)
+				return nil, false
 			}
+			span.SetAttributes(tracing.PayloadBytesKey.Int(len(data)))
+			return data, true
+		}()
+		if !ok {
+			return
 		}
+
+		func() {
+			_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
+			defer span.End()
+			span.SetAttributes(tracing.ResponseBytesKey.Int(len(bytes)))
+			writeCacheableJSONResponse(w, req, clientContext, bytes, strconv.Itoa(item.Version))
+		}()
 	}
 }
 

--- a/relay/relay_endpoints_spans_test.go
+++ b/relay/relay_endpoints_spans_test.go
@@ -1,0 +1,280 @@
+package relay
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
+
+	c "github.com/launchdarkly/ld-relay/v9/config"
+	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testenv"
+
+	ct "github.com/launchdarkly/go-configtypes"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// installSpanRecorder registers a SpanRecorder-backed TracerProvider as the global OTel
+// provider and restores the previous provider on cleanup. Both tracing.Tracer() and the
+// otelmux middleware resolve through the global provider, so spans produced while handling
+// a request are captured by the returned recorder.
+//
+// Because the tracer provider is process-global, tests that call this must not run in
+// parallel with one another (none of the relay tests use t.Parallel).
+func installSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	previous := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previous)
+	})
+	return recorder
+}
+
+func spansNamed(spans []sdktrace.ReadOnlySpan, name string) []sdktrace.ReadOnlySpan {
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if s.Name() == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func requireSpan(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	matches := spansNamed(spans, name)
+	require.Lenf(t, matches, 1, "expected exactly one %q span, found %d", name, len(matches))
+	return matches[0]
+}
+
+// rootSpan returns the single span with no local parent. For a request driven through the
+// relay this is the otelmux request span, which parents every manual span in the handler.
+func rootSpan(t *testing.T, spans []sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
+	t.Helper()
+	var roots []sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if !s.Parent().IsValid() {
+			roots = append(roots, s)
+		}
+	}
+	require.Lenf(t, roots, 1, "expected exactly one root span, found %d", len(roots))
+	return roots[0]
+}
+
+func spanAttrs(s sdktrace.ReadOnlySpan) map[attribute.Key]attribute.Value {
+	attrs := make(map[attribute.Key]attribute.Value)
+	for _, kv := range s.Attributes() {
+		attrs[kv.Key] = kv.Value
+	}
+	return attrs
+}
+
+// assertChildOfEnded verifies that child is an ended span belonging to parent's trace and
+// pointing at parent as its parent span.
+func assertChildOfEnded(t *testing.T, child, parent sdktrace.ReadOnlySpan) {
+	t.Helper()
+	assert.Falsef(t, child.EndTime().IsZero(), "%q span was not ended", child.Name())
+	assert.Equalf(t, parent.SpanContext().TraceID(), child.SpanContext().TraceID(),
+		"%q should share a trace with %q", child.Name(), parent.Name())
+	assert.Equalf(t, parent.SpanContext().SpanID(), child.Parent().SpanID(),
+		"%q should be a child of %q", child.Name(), parent.Name())
+}
+
+// countStarted reports how many spans with the given name were started. A span that was
+// started but never ended (a leak) still appears here, so comparing against the ended
+// count detects leaks.
+func countStarted(spans []sdktrace.ReadWriteSpan, name string) int {
+	n := 0
+	for _, s := range spans {
+		if s.Name() == name {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPollingEndpointSpansAreRecorded drives each instrumented polling handler through the
+// full relay (so the otelmux request span is present as a real parent) and asserts that the
+// serialize and response-write spans exist, are ended, are children of the request span, and
+// carry plausible attribute values.
+func TestPollingEndpointSpansAreRecorded(t *testing.T) {
+	recorder := installSpanRecorder(t)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain, st.EnvWithAllCredentials)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		contextJSON := []byte(`{"kind":"user","key":"me"}`)
+		contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+		serverSDKKey := st.EnvMain.Config.SDKKey
+		mobileKey := st.EnvWithAllCredentials.Config.MobileKey
+
+		cases := []struct {
+			name     string
+			buildReq func() *http.Request
+			// countKey is the attribute expected to hold the item/event count on the
+			// serialize span, or "" when the handler records no count.
+			countKey attribute.Key
+		}{
+			{
+				name: "pollHandlerV2 GET /sdk/poll",
+				buildReq: func() *http.Request {
+					return st.BuildRequestWithAuth("GET", "/sdk/poll", serverSDKKey, nil)
+				},
+				countKey: tracing.PayloadEventsKey,
+			},
+			{
+				name: "pollEvalHandlerV2Shared GET /sdk/poll/eval",
+				buildReq: func() *http.Request {
+					return st.BuildRequestWithAuth("GET", "/sdk/poll/eval/"+contextBase64, mobileKey, nil)
+				},
+				countKey: tracing.PayloadEventsKey,
+			},
+			{
+				name: "evaluateAllShared REPORT /sdk/evalx/context",
+				buildReq: func() *http.Request {
+					h := make(http.Header)
+					h.Set("Authorization", string(serverSDKKey))
+					h.Set("Content-Type", "application/json")
+					return st.BuildRequest("REPORT", "/sdk/evalx/context", contextJSON, h)
+				},
+				countKey: tracing.FlagCountKey,
+			},
+			{
+				name: "pollAllFlagsHandler GET /sdk/flags",
+				buildReq: func() *http.Request {
+					return st.BuildRequestWithAuth("GET", "/sdk/flags", serverSDKKey, nil)
+				},
+				countKey: tracing.FlagCountKey,
+			},
+			{
+				name: "pollFlagOrSegment GET /sdk/flags/{key}",
+				buildReq: func() *http.Request {
+					return st.BuildRequestWithAuth("GET", "/sdk/flags/"+st.Flag1ServerSide.Flag.Key, serverSDKKey, nil)
+				},
+				countKey: "",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				recorder.Reset()
+
+				result, _ := st.DoRequest(tc.buildReq(), p.relay)
+				require.Equal(t, http.StatusOK, result.StatusCode)
+
+				spans := recorder.Ended()
+				root := rootSpan(t, spans)
+				serialize := requireSpan(t, spans, tracing.SpanSerializePayload)
+				write := requireSpan(t, spans, tracing.SpanWriteResponse)
+
+				assertChildOfEnded(t, serialize, root)
+				assertChildOfEnded(t, write, root)
+
+				serializeAttrs := spanAttrs(serialize)
+				writeAttrs := spanAttrs(write)
+
+				payloadBytes, ok := serializeAttrs[tracing.PayloadBytesKey]
+				require.True(t, ok, "serialize span is missing the payload bytes attribute")
+				assert.Positive(t, payloadBytes.AsInt64())
+
+				responseBytes, ok := writeAttrs[tracing.ResponseBytesKey]
+				require.True(t, ok, "write span is missing the response bytes attribute")
+				assert.Equal(t, payloadBytes.AsInt64(), responseBytes.AsInt64(),
+					"response bytes should equal the serialized payload size")
+
+				if tc.countKey != "" {
+					count, ok := serializeAttrs[tc.countKey]
+					require.Truef(t, ok, "serialize span is missing the %q attribute", tc.countKey)
+					assert.GreaterOrEqual(t, count.AsInt64(), int64(1))
+				} else {
+					_, hasEvents := serializeAttrs[tracing.PayloadEventsKey]
+					_, hasFlags := serializeAttrs[tracing.FlagCountKey]
+					assert.False(t, hasEvents, "single-item serialize span should record no event count")
+					assert.False(t, hasFlags, "single-item serialize span should record no flag count")
+				}
+
+				// No span may leak: every serialize/write span that was started must also
+				// have ended.
+				started := recorder.Started()
+				assert.Equal(t, 1, countStarted(started, tracing.SpanSerializePayload))
+				assert.Equal(t, 1, countStarted(started, tracing.SpanWriteResponse))
+			})
+		}
+	})
+}
+
+// TestPollingEndpointSpansDoNotLeakOnEarlyReturn exercises early-return paths that occur
+// before serialization and asserts that no serialize or response-write span is left
+// dangling. pollFlagOrSegment's not-found path additionally shows that a store span created
+// before the early return is properly ended.
+//
+// Note: the serialize span's own error branches (a json.Marshal failure or a store type-cast
+// failure) operate on data the store has already validated and cannot be provoked through the
+// test harness, which always serves a fixed in-memory dataset. Those branches are guarded
+// structurally by the IIFE's `defer span.End()`, so the span cannot leak regardless of which
+// return fires.
+func TestPollingEndpointSpansDoNotLeakOnEarlyReturn(t *testing.T) {
+	recorder := installSpanRecorder(t)
+
+	t.Run("pollFlagOrSegment not found ends store span and starts no serialize/write span", func(t *testing.T) {
+		recorder.Reset()
+
+		envCtx := testenv.MakeTestContextWithData()
+		req := buildPreRoutedRequest("GET", nil, nil, map[string]string{"key": "no-such-flag"}, envCtx)
+		ctx, parent := tracing.Tracer().Start(req.Context(), "test.request")
+		req = req.WithContext(ctx)
+
+		resp := httptest.NewRecorder()
+		pollFlagHandler(resp, req)
+		parent.End()
+
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+
+		ended := recorder.Ended()
+		storeSpan := requireSpan(t, ended, tracing.SpanStoreGet)
+		assertChildOfEnded(t, storeSpan, rootSpan(t, ended))
+
+		assert.Empty(t, spansNamed(ended, tracing.SpanSerializePayload))
+		assert.Empty(t, spansNamed(ended, tracing.SpanWriteResponse))
+		started := recorder.Started()
+		assert.Zero(t, countStarted(started, tracing.SpanSerializePayload))
+		assert.Zero(t, countStarted(started, tracing.SpanWriteResponse))
+	})
+
+	t.Run("pollEvalHandlerV2Shared invalid context starts no serialize/write span", func(t *testing.T) {
+		recorder.Reset()
+
+		envCtx := testenv.MakeTestContextWithData()
+		headers := make(http.Header)
+		headers.Set("Content-Type", "application/json")
+		req := buildPreRoutedRequest("REPORT", []byte(`{}`), headers, nil, envCtx)
+		ctx, parent := tracing.Tracer().Start(req.Context(), "test.request")
+		req = req.WithContext(ctx)
+
+		resp := httptest.NewRecorder()
+		pollEvalHandlerV2Shared(resp, req, ct.OptBase2Bytes{})
+		parent.End()
+
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+
+		started := recorder.Started()
+		assert.Zero(t, countStarted(started, tracing.SpanSerializePayload))
+		assert.Zero(t, countStarted(started, tracing.SpanWriteResponse))
+	})
+}


### PR DESCRIPTION
The polling handlers previously left the time after the store snapshot
unaccounted for in traces: payload construction, serialization, and the
response write were all invisible. Add two manual spans to each polling
handler with the snapshot/evaluate -> serialize -> write shape:

- relay.payload.serialize wraps payload assembly and JSON marshaling,
with relay.payload.events / relay.flags.count and relay.payload.bytes
attributes describing the serialized payload.
- relay.response.write wraps the response write, with a
relay.response.bytes attribute.

Handlers instrumented: pollHandlerV2, pollEvalHandlerV2Shared,
pollAllFlagsHandler, evaluateAllShared, and pollFlagOrSegment. Flag
evaluation keeps its existing relay.evaluate_flags span so serialize
timing stays distinct from evaluation.

Adds span-assertion tests backed by an OTel SpanRecorder: success-path
coverage for every handler (span presence, parentage under the otelmux
request span, ended state, and attribute values) plus early-return
coverage proving no serialize/write span leaks unended.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only wrapping around existing response paths; behavior unchanged aside from minor error-path span status recording.
> 
> **Overview**
> Adds OpenTelemetry breakdown for **payload build/marshal** vs **HTTP response write** on SDK polling and eval handlers, so latency can be split between serialization and I/O.
> 
> New spans **`relay.payload.serialize`** and **`relay.response.write`** (plus attributes for event/flag counts and byte sizes) wrap the former inline logic in `pollHandlerV2`, `pollEvalHandlerV2Shared`, `pollAllFlagsHandler`, `evaluateAllShared`, and `pollFlagOrSegment`. Serialize paths use IIFEs with `defer span.End()`, record errors on marshal/cast failures, and only start write spans after a successful payload. **`pollEvalHandlerV2Shared`** also refactors so flag evaluation stays outside the serialize span while the up-to-date (`basis`) path still serializes a minimal payload.
> 
> **`relay_endpoints_spans_test.go`** drives the instrumented routes through a real relay with a global span recorder, asserting parent/child relationships, attributes, and that early returns do not leak serialize/write spans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3dec0b1ea388cc4c63b0e11bcca01eae3a6565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->