### PR TITLE
feat: add a progress-aware write deadline for initialization deliveries

### DIFF
--- a/internal/initwrite/initwrite.go
+++ b/internal/initwrite/initwrite.go
@@ -4,8 +4,18 @@
 // minimum-throughput floor drives a per-write deadline, and an absolute cap bounds a single
 // delivery.
 //
-// A Writer must be constructed with Wrap or WrapGated; the zero value is not usable. Two shapes
-// are supported:
+// A Writer must be constructed with Wrap or WrapGated; the zero value is not usable.
+//
+// Connection ownership. Only the goroutine running the HTTP handler may set or clear the write
+// deadline, and it does so through this Writer: arming it before each write and clearing it at
+// the end-of-delivery flush. A write deadline is a capability scoped to the handler's lifetime
+// -- after the handler returns, the underlying connection may be recycled or, on HTTP/2, gone
+// entirely, so touching it then is unsafe. For a gated stream the producer goroutine that feeds
+// events can outlive the handler (the SSE server drains it once the client leaves), so it must
+// never touch the connection; it coordinates only through Begin/End/Done/WaitAndFinish. That
+// keeps every deadline call within the handler's lifetime.
+//
+// Two shapes are supported:
 //
 //   - Poll (Wrap): a request/response delivery. The deadline is armed on every write for the
 //     lifetime of the wrapper. net/http resets the connection's write deadline when the handler
@@ -14,13 +24,14 @@
 //     not reset between the initial delivery and later delta or heartbeat traffic. The deadline
 //     is armed only between Begin and the end-of-delivery flush, and is cleared there, so live
 //     traffic and idle periods carry no deadline. This matters on HTTP/2, where a lingering
-//     deadline is a self-firing timer that would reset an otherwise idle stream.
+//     deadline is a self-firing timer that would reset an otherwise idle stream. Begin, End,
+//     Done and WaitAndFinish apply only to this shape.
 //
 // A gated delivery ends in one of two ways. On a clean finish the producer calls End and the
-// end-of-delivery flush clears the deadline, leaving the now-idle stream alone. On an abnormal
-// end -- the client goes away, or the producer errors -- the producer calls Abort (directly, or
-// via WaitAndFinish on context cancellation), which forces any in-flight write to fail rather
-// than clearing the deadline and letting a stalled send run unbounded.
+// handler's end-of-delivery flush clears the deadline, leaving the now-idle stream alone. If the
+// client goes away first, WaitAndFinish returns on context cancellation without touching the
+// connection: the per-write deadline already armed bounds anything still in flight, and the
+// connection teardown clears it.
 //
 // A client sustaining at least the throughput floor per write keeps re-arming and is not cut
 // for being slow; one that stalls or drops below the floor on a write has its write fail, which
@@ -65,8 +76,8 @@ type Writer struct {
 	ending       bool
 	msgStart     time.Time
 	lastDeadline time.Time
-	// gen identifies the current gated delivery. Begin bumps it so a teardown (a flush or Abort)
-	// that observed an earlier delivery cannot clear the deadline of a newer one.
+	// gen identifies the current gated delivery. Begin bumps it so a teardown (the end-of-batch
+	// flush) that observed an earlier delivery cannot clear the deadline of a newer one.
 	gen uint64
 	// done is closed once the current gated delivery ends. It is never nil: outside a delivery
 	// it is a closed channel, so a producer waiting on it releases its slot immediately rather
@@ -81,8 +92,8 @@ func Wrap(w http.ResponseWriter, maxHold time.Duration) *Writer {
 	return newWriter(w, maxHold, true)
 }
 
-// WrapGated returns a Writer for a persistent stream: it arms nothing until Begin, and ends a
-// delivery either at the End-triggered flush (clearing the deadline) or via Abort.
+// WrapGated returns a Writer for a persistent stream: it arms nothing until Begin, and clears
+// the deadline at the End-triggered end-of-delivery flush.
 func WrapGated(w http.ResponseWriter, maxHold time.Duration) *Writer {
 	return newWriter(w, maxHold, false)
 }
@@ -141,37 +152,31 @@ func (w *Writer) End() {
 	w.mu.Unlock()
 }
 
-// Abort ends the current gated delivery abnormally. Unlike a clean finish -- where the
-// end-of-delivery flush clears the deadline so the now-idle stream is left alone -- Abort moves
-// the deadline to now, forcing any in-flight or subsequent write to fail at once. It is the
-// right call when a delivery is given up on (the client went away, or the producer errored): a
-// stalled send is torn down immediately rather than left running unbounded, and the Done waiter
-// is released so the budget slot frees. It is safe to call on any exit path, including while a
-// write is in flight, and more than once; it has no effect if no delivery is active.
-func (w *Writer) Abort() {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if w.active {
-		w.active = false
-		w.ending = false
-		_ = w.rc.SetWriteDeadline(w.now()) // force any pending write to fail now
-	}
-	if !w.doneClosed {
-		close(w.done) // release the waiter only after the deadline is set
-		w.doneClosed = true
-	}
-}
-
 // WaitAndFinish holds until the current gated delivery's last byte has been flushed to the
-// client (Done closes, with the deadline already cleared by that flush) or ctx is done (the
-// client went away). On cancellation it aborts, so a stalled send cannot hold the slot or the
-// connection past the client's departure. The caller releases its budget slot once this
-// returns. Call it after Begin.
+// client (Done closes, the handler having cleared the deadline) or ctx is done (the client went
+// away). The caller releases its budget slot once this returns. It never touches the connection
+// -- on cancellation the already-armed per-write deadline bounds anything still in flight and the
+// connection teardown clears it -- so it is safe on the producer goroutine even after the handler
+// has returned. Call it after Begin. It must be given the request's context (or another that is
+// cancelled when the client disconnects); a never-cancelled context would block the producer,
+// and its slot, until the delivery flushes.
 func (w *Writer) WaitAndFinish(ctx context.Context) {
+	w.mu.Lock()
+	done := w.done
+	w.mu.Unlock()
+
 	select {
-	case <-w.Done():
+	case <-done:
+		// Delivered: the handler's end-of-delivery flush closed done and cleared the deadline.
 	case <-ctx.Done():
-		w.Abort()
+		// The client went away before the delivery finished. Release the waiter, but do not
+		// touch the connection: it belongs to the handler, which may already have returned.
+		w.mu.Lock()
+		if w.done == done && !w.doneClosed { // still this delivery, and not already closed
+			close(w.done)
+			w.doneClosed = true
+		}
+		w.mu.Unlock()
 	}
 }
 
@@ -226,7 +231,8 @@ func (w *Writer) WriteString(s string) (int, error) {
 // Flush flushes buffered bytes and, at the end-of-delivery flush (after End), clears the
 // deadline so later traffic on a persistent stream is not governed by it. The clear runs under
 // the lock and only for the delivery that was active when Flush was entered, so it cannot wipe
-// the deadline of a newer delivery that began in the meantime.
+// the deadline of a newer delivery that began in the meantime. Flush runs on the handler
+// goroutine, within the connection's lifetime.
 func (w *Writer) Flush() {
 	f, ok := w.ResponseWriter.(http.Flusher)
 	if !ok {
@@ -247,11 +253,11 @@ func (w *Writer) Flush() {
 		return // a newer delivery began, or this one was already ended
 	}
 	w.active = false
+	_ = w.rc.SetWriteDeadline(time.Time{})
 	if !w.doneClosed {
-		close(w.done) // the basis is fully written; let the producer release the slot
+		close(w.done) // release the producer only after the deadline is cleared
 		w.doneClosed = true
 	}
-	_ = w.rc.SetWriteDeadline(time.Time{})
 }
 
 func (w *Writer) isActive() bool {

--- a/internal/initwrite/initwrite.go
+++ b/internal/initwrite/initwrite.go
@@ -27,11 +27,24 @@
 //     deadline is a self-firing timer that would reset an otherwise idle stream. Begin, End,
 //     Done and WaitAndFinish apply only to this shape.
 //
-// A gated delivery ends in one of two ways. On a clean finish the producer calls End and the
-// handler's end-of-delivery flush clears the deadline, leaving the now-idle stream alone. If the
-// client goes away first, WaitAndFinish returns on context cancellation without touching the
-// connection: the per-write deadline already armed bounds anything still in flight, and the
-// connection teardown clears it.
+// Ending a gated delivery. The producer must call End on EVERY exit after Begin -- whether it
+// wrote the whole basis, or is abandoning the delivery after an error -- and before it closes
+// the batch channel. End marks the delivery finished; the handler's end-of-delivery flush then
+// clears the deadline and releases the waiter. There are three ways a delivery ends, and End is
+// what makes the first two safe:
+//
+//   - Clean finish: the producer wrote everything, calls End, and the flush clears the deadline,
+//     leaving the now-idle stream alone.
+//   - Producer error with the client still healthy: the producer calls End on the error path too,
+//     so the same flush clears the deadline. Skipping End here is a bug -- the armed deadline is
+//     never cleared and the handler eventually cuts even this healthy stream at maxHold (on
+//     HTTP/2, an idle-stream timer fires with no write needed).
+//   - Client goes away first: WaitAndFinish returns on context cancellation without touching the
+//     connection; the per-write deadline already armed bounds anything still in flight, and the
+//     connection teardown clears it.
+//
+// The producer waits via WaitAndFinish, which frees the budget slot once the delivery has been
+// flushed or the client has gone.
 //
 // A client sustaining at least the throughput floor per write keeps re-arming and is not cut
 // for being slow; one that stalls or drops below the floor on a write has its write fail, which
@@ -143,9 +156,12 @@ func (w *Writer) Done() <-chan struct{} {
 	return w.done
 }
 
-// End signals that the producer has handed off the whole delivery. The deadline is cleared at
-// the next flush -- the eventsource server flushes exactly once at end-of-batch -- so it is
-// called before the producer closes the batch channel, guaranteeing that flush observes it.
+// End marks the delivery finished so the next flush tears it down. Call it exactly once on every
+// exit after Begin -- a completed delivery AND an abandoned one (a serialization or store error) --
+// and before closing the batch channel, so the handler's single end-of-batch flush observes it and
+// clears the deadline. Omitting it on an error path leaves the armed deadline in place, which
+// eventually cuts even a healthy client at maxHold; releasing the slot without it is not enough,
+// because only the handler goroutine can clear the connection's deadline.
 func (w *Writer) End() {
 	w.mu.Lock()
 	w.ending = true
@@ -157,9 +173,11 @@ func (w *Writer) End() {
 // away). The caller releases its budget slot once this returns. It never touches the connection
 // -- on cancellation the already-armed per-write deadline bounds anything still in flight and the
 // connection teardown clears it -- so it is safe on the producer goroutine even after the handler
-// has returned. Call it after Begin. It must be given the request's context (or another that is
-// cancelled when the client disconnects); a never-cancelled context would block the producer,
-// and its slot, until the delivery flushes.
+// has returned. Call it after Begin. It must be given the request's context, or another that is
+// cancelled when the client disconnects: a never-cancelled context would block the producer, and
+// its slot, until the delivery flushes, and a context cancelled while the handler is still live
+// (a shutdown or producer-error signal, say) would return early without ending the delivery --
+// use End for that.
 func (w *Writer) WaitAndFinish(ctx context.Context) {
 	w.mu.Lock()
 	done := w.done
@@ -232,17 +250,14 @@ func (w *Writer) WriteString(s string) (int, error) {
 // deadline so later traffic on a persistent stream is not governed by it. The clear runs under
 // the lock and only for the delivery that was active when Flush was entered, so it cannot wipe
 // the deadline of a newer delivery that began in the meantime. Flush runs on the handler
-// goroutine, within the connection's lifetime.
+// goroutine, within the connection's lifetime. The teardown happens even if the underlying
+// writer cannot flush, so a non-flushing chain cannot strand the deadline or pin the slot.
 func (w *Writer) Flush() {
-	f, ok := w.ResponseWriter.(http.Flusher)
-	if !ok {
-		return
-	}
 	w.mu.Lock()
 	active, ending, gen := w.active, w.ending, w.gen
 	w.mu.Unlock()
 
-	f.Flush()
+	_ = w.rc.Flush() // best-effort; reaches the underlying Flusher through the Unwrap chain
 
 	if !(active && ending) {
 		return
@@ -255,7 +270,9 @@ func (w *Writer) Flush() {
 	w.active = false
 	_ = w.rc.SetWriteDeadline(time.Time{})
 	if !w.doneClosed {
-		close(w.done) // release the producer only after the deadline is cleared
+		// WaitAndFinish's ctx branch may have closed done first (the client left as the delivery
+		// completed); the guard keeps this from double-closing.
+		close(w.done)
 		w.doneClosed = true
 	}
 }

--- a/internal/initwrite/initwrite.go
+++ b/internal/initwrite/initwrite.go
@@ -7,21 +7,23 @@
 // Two shapes are supported:
 //
 //   - Poll (Wrap): a request/response delivery. The deadline is armed on every write for the
-//     lifetime of the wrapper. The caller (the poll middleware) clears the connection's write
-//     deadline when the handler returns, so it cannot linger on a kept-alive connection and
-//     fire during a later request.
-//   - Stream (WrapGated): a persistent SSE connection, where net/http does NOT clear the
-//     deadline between the initial delivery and later delta/heartbeat traffic. The deadline is
-//     armed only between Begin and the end-of-delivery flush, and is cleared there, so live
-//     traffic and idle periods carry no deadline (important on HTTP/2, where a lingering
-//     deadline is a self-firing timer that would reset an idle stream).
+//     lifetime of the wrapper. net/http resets the connection's write deadline when the handler
+//     returns, so it does not linger onto a later request on a kept-alive connection.
+//   - Stream (WrapGated): a persistent SSE connection, where the connection's write deadline is
+//     not reset between the initial delivery and later delta or heartbeat traffic. The deadline
+//     is armed only between Begin and the end-of-delivery flush, and is cleared there, so live
+//     traffic and idle periods carry no deadline. This matters on HTTP/2, where a lingering
+//     deadline is a self-firing timer that would reset an otherwise idle stream. A producer that
+//     ends a delivery on an error or cancellation path -- without a final flush -- must call
+//     Finish so the deadline never outlives the delivery.
 //
 // A client sustaining at least the throughput floor per write keeps re-arming and is not cut
-// for being slow; one that stalls or drops below the floor on a write has its write fail,
-// which the HTTP server turns into a closed connection. The absolute cap (maxHold) backstops
-// a client that stays at the floor on a very large payload: because the cap governs once a
-// delivery would exceed maxHold at the floor (~7.5 MiB at the 64 KiB/s floor and the 2m
-// default), such a client is cut at maxHold. See docs/configuration.md.
+// for being slow; one that stalls or drops below the floor on a write has its write fail, which
+// the HTTP server turns into a closed connection. The absolute cap (maxHold, supplied by the
+// caller) backstops a client that stays right at the floor on a very large payload: once a
+// delivery would exceed maxHold at the floor, the cap governs and the client is cut. A maxHold
+// of zero or less disables the cap, leaving only the per-write floor; callers that want the
+// backstop must pass a positive value.
 package initwrite
 
 import (
@@ -36,7 +38,7 @@ const (
 	minBytesPerSec = 64 * 1024
 	// chunkSize bounds how much is written under a single deadline. Large writes are sliced
 	// only to re-arm the deadline mid-write; the string path copies at most one chunk at a
-	// time rather than the whole payload.
+	// time rather than the whole payload at once.
 	chunkSize = 1 << 20 // 1 MiB
 	// slack is added to each per-write deadline to tolerate a brief stall.
 	slack = 5 * time.Second
@@ -50,44 +52,70 @@ type Writer struct {
 	http.ResponseWriter
 	rc      *http.ResponseController
 	maxHold time.Duration
+	now     func() time.Time // time source; overridable in tests
 
 	mu           sync.Mutex
 	active       bool
 	ending       bool
 	msgStart     time.Time
 	lastDeadline time.Time
-	done         chan struct{} // closed at the end-of-delivery flush; nil outside a gated delivery
+	// done is closed once the current gated delivery's last byte has been flushed. It is never
+	// nil: outside a delivery it is a closed channel, so a producer waiting on it releases its
+	// slot immediately rather than blocking forever. doneClosed guards against a double close.
+	done       chan struct{}
+	doneClosed bool
 }
 
 // Wrap returns a Writer for a poll (request/response) delivery: the deadline is armed on every
-// write. net/http clears the connection deadline when the handler returns.
+// write. net/http resets the connection deadline when the handler returns.
 func Wrap(w http.ResponseWriter, maxHold time.Duration) *Writer {
-	return &Writer{ResponseWriter: w, rc: http.NewResponseController(w), maxHold: maxHold, active: true}
+	return newWriter(w, maxHold, true)
 }
 
 // WrapGated returns a Writer for a persistent stream: it arms nothing until Begin, and clears
-// the deadline at the end-of-delivery flush after End.
+// the deadline at the end-of-delivery flush after End (or when Finish is called).
 func WrapGated(w http.ResponseWriter, maxHold time.Duration) *Writer {
-	return &Writer{ResponseWriter: w, rc: http.NewResponseController(w), maxHold: maxHold}
+	return newWriter(w, maxHold, false)
+}
+
+func newWriter(w http.ResponseWriter, maxHold time.Duration, active bool) *Writer {
+	// done starts closed so that, with no delivery in progress, a producer that waits on Done
+	// is released at once instead of pinning its slot.
+	d := make(chan struct{})
+	close(d)
+	return &Writer{
+		ResponseWriter: w,
+		rc:             http.NewResponseController(w),
+		maxHold:        maxHold,
+		now:            time.Now,
+		active:         active,
+		done:           d,
+		doneClosed:     true,
+	}
 }
 
 // Begin marks the start of a gated delivery; writes from here on arm the deadline. It is
-// called from the producer before it starts producing events.
+// called from the producer before it starts producing events. If a previous delivery never
+// completed, its Done channel is closed here so any waiter is released rather than orphaned.
 func (w *Writer) Begin() {
 	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.active = true
 	w.ending = false
 	w.msgStart = time.Time{}
 	w.lastDeadline = time.Time{}
+	if !w.doneClosed {
+		close(w.done)
+	}
 	w.done = make(chan struct{})
-	w.mu.Unlock()
+	w.doneClosed = false
 }
 
 // Done returns a channel closed once the gated delivery's last byte has been flushed to the
 // client. The producer waits on it (or on the request context) before releasing the budget
 // slot, so the slot is held for the actual send rather than only until the channel handoff.
-// It returns a nil channel if no delivery is in progress (a nil channel never fires, so a
-// caller that also selects on ctx.Done is unaffected).
+// The channel is never nil: with no delivery in progress it is already closed, so a producer
+// that waits on it is not left blocked.
 func (w *Writer) Done() <-chan struct{} {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -101,6 +129,27 @@ func (w *Writer) End() {
 	w.mu.Lock()
 	w.ending = true
 	w.mu.Unlock()
+}
+
+// Finish ends the current gated delivery unconditionally: it clears any armed write deadline
+// and closes the Done channel. It is idempotent and safe to call on any producer exit path,
+// and is the backstop for a delivery that ends without a final flush (an error or a cancelled
+// context). On the normal path the end-of-delivery flush has already done this, so Finish is a
+// no-op. Because it clears the deadline, a producer must call it only once the delivery is
+// truly over, not mid-send.
+func (w *Writer) Finish() {
+	w.mu.Lock()
+	wasActive := w.active
+	w.active = false
+	w.ending = false
+	if !w.doneClosed {
+		close(w.done)
+		w.doneClosed = true
+	}
+	w.mu.Unlock()
+	if wasActive {
+		_ = w.rc.SetWriteDeadline(time.Time{})
+	}
 }
 
 // Unwrap exposes the wrapped ResponseWriter so http.NewResponseController and other wrappers
@@ -125,9 +174,9 @@ func (w *Writer) Write(p []byte) (int, error) {
 	return total, nil
 }
 
-// WriteString satisfies io.StringWriter so eventsource's io.WriteString does not allocate a
-// []byte copy of the entire payload per connection. It slices the string and copies at most
-// one chunk at a time.
+// WriteString satisfies io.StringWriter so that when the wrapped writer also implements it,
+// eventsource's io.WriteString does not allocate a []byte copy of the whole payload; it slices
+// the string and, at worst, copies at most one chunk at a time.
 func (w *Writer) WriteString(s string) (int, error) {
 	if !w.isActive() || len(s) == 0 {
 		return io.WriteString(w.ResponseWriter, s)
@@ -162,13 +211,12 @@ func (w *Writer) Flush() {
 	if active && ending {
 		w.mu.Lock()
 		w.active = false
-		done := w.done
-		w.done = nil
+		if !w.doneClosed {
+			close(w.done) // the basis is fully written; let the producer release the slot
+			w.doneClosed = true
+		}
 		w.mu.Unlock()
 		_ = w.rc.SetWriteDeadline(time.Time{})
-		if done != nil {
-			close(done) // the basis is fully written; let the producer release the slot
-		}
 	}
 }
 
@@ -180,14 +228,16 @@ func (w *Writer) isActive() bool {
 
 // arm sets the write deadline for the next chunk to now + (time to send n bytes at the
 // throughput floor) + slack, capped by the delivery's absolute deadline (msgStart + maxHold).
-// It never shortens an existing deadline within a delivery and skips trivial changes.
+// It never shortens an existing deadline within a delivery and skips trivial changes. The
+// deadline is recorded as current only when the underlying SetWriteDeadline succeeds, so a
+// transient failure does not leave the writer thinking it has armed a deadline it has not.
 func (w *Writer) arm(n int) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if !w.active {
 		return
 	}
-	now := time.Now()
+	now := w.now()
 	if w.msgStart.IsZero() {
 		w.msgStart = now
 	}
@@ -199,8 +249,9 @@ func (w *Writer) arm(n int) {
 		}
 	}
 	if dl.After(w.lastDeadline) && dl.Sub(w.lastDeadline) >= minExtension {
-		_ = w.rc.SetWriteDeadline(dl)
-		w.lastDeadline = dl
+		if err := w.rc.SetWriteDeadline(dl); err == nil {
+			w.lastDeadline = dl
+		}
 	}
 }
 

--- a/internal/initwrite/initwrite.go
+++ b/internal/initwrite/initwrite.go
@@ -35,10 +35,13 @@
 //
 //   - Clean finish: the producer wrote everything, calls End, and the flush clears the deadline,
 //     leaving the now-idle stream alone.
-//   - Producer error with the client still healthy: the producer calls End on the error path too,
-//     so the same flush clears the deadline. Skipping End here is a bug -- the armed deadline is
-//     never cleared and the handler eventually cuts even this healthy stream at maxHold (on
-//     HTTP/2, an idle-stream timer fires with no write needed).
+//   - Producer error with the client still healthy: the producer calls End on the error path too
+//     -- even an exit that wrote nothing, since the delivery stays active and a later heartbeat
+//     write would arm a deadline that then fires with nothing left to finish it. Skipping End is
+//     a bug: the deadline is never cleared, and the healthy stream is killed anyway -- on
+//     HTTP/1.1 when the absolute cap expires, and on HTTP/2 within a few seconds (the write
+//     slack) of the last write, because a deadline there is a self-firing timer. Disabling the
+//     cap does not avoid this; it only removes the later of the two bounds.
 //   - Client goes away first: WaitAndFinish returns on context cancellation without touching the
 //     connection; the per-write deadline already armed bounds anything still in flight, and the
 //     connection teardown clears it.
@@ -156,12 +159,14 @@ func (w *Writer) Done() <-chan struct{} {
 	return w.done
 }
 
-// End marks the delivery finished so the next flush tears it down. Call it exactly once on every
-// exit after Begin -- a completed delivery AND an abandoned one (a serialization or store error) --
-// and before closing the batch channel, so the handler's single end-of-batch flush observes it and
-// clears the deadline. Omitting it on an error path leaves the armed deadline in place, which
-// eventually cuts even a healthy client at maxHold; releasing the slot without it is not enough,
-// because only the handler goroutine can clear the connection's deadline.
+// End marks the delivery finished so the next flush tears it down. Call it on every exit after
+// Begin -- a completed delivery AND an abandoned one (a serialization or store error), even one
+// that wrote nothing -- and before closing the batch channel, so the handler's single end-of-batch
+// flush observes it and clears the deadline. It is idempotent. When using defers, register the
+// batch-channel close before this one (defer close(out), then defer w.End()), so End runs first.
+// Omitting it on an error path leaves the armed deadline in place, which eventually cuts even a
+// healthy client; releasing the slot without it is not enough, because only the handler goroutine
+// can clear the connection's deadline.
 func (w *Writer) End() {
 	w.mu.Lock()
 	w.ending = true
@@ -176,8 +181,8 @@ func (w *Writer) End() {
 // has returned. Call it after Begin. It must be given the request's context, or another that is
 // cancelled when the client disconnects: a never-cancelled context would block the producer, and
 // its slot, until the delivery flushes, and a context cancelled while the handler is still live
-// (a shutdown or producer-error signal, say) would return early without ending the delivery --
-// use End for that.
+// (a shutdown or producer-error signal, say) would return early without ending the delivery,
+// leaving the missed-End failure described in the package comment -- use End for that.
 func (w *Writer) WaitAndFinish(ctx context.Context) {
 	w.mu.Lock()
 	done := w.done
@@ -248,20 +253,24 @@ func (w *Writer) WriteString(s string) (int, error) {
 
 // Flush flushes buffered bytes and, at the end-of-delivery flush (after End), clears the
 // deadline so later traffic on a persistent stream is not governed by it. The clear runs under
-// the lock and only for the delivery that was active when Flush was entered, so it cannot wipe
-// the deadline of a newer delivery that began in the meantime. Flush runs on the handler
-// goroutine, within the connection's lifetime. The teardown happens even if the underlying
-// writer cannot flush, so a non-flushing chain cannot strand the deadline or pin the slot.
+// the lock and only for the delivery that was active when Flush was entered -- the state is
+// sampled BEFORE flushing, so a delivery that begins during the flush is untouched, and a stale
+// flush cannot wipe a newer delivery's deadline. Flush runs on the handler goroutine, within
+// the connection's lifetime. The teardown is deferred, so it frees the slot and clears the
+// deadline even if the flush itself is unsupported, fails, or panics.
 func (w *Writer) Flush() {
 	w.mu.Lock()
 	active, ending, gen := w.active, w.ending, w.gen
 	w.mu.Unlock()
 
-	_ = w.rc.Flush() // best-effort; reaches the underlying Flusher through the Unwrap chain
-
-	if !(active && ending) {
-		return
+	if active && ending {
+		defer w.teardown(gen)
 	}
+	_ = w.rc.Flush() // best-effort; dispatches to the first Flusher in the Unwrap chain
+}
+
+// teardown ends the delivery identified by gen: it clears the deadline and releases the waiter.
+func (w *Writer) teardown(gen uint64) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.gen != gen || !w.active {

--- a/internal/initwrite/initwrite.go
+++ b/internal/initwrite/initwrite.go
@@ -4,7 +4,8 @@
 // minimum-throughput floor drives a per-write deadline, and an absolute cap bounds a single
 // delivery.
 //
-// Two shapes are supported:
+// A Writer must be constructed with Wrap or WrapGated; the zero value is not usable. Two shapes
+// are supported:
 //
 //   - Poll (Wrap): a request/response delivery. The deadline is armed on every write for the
 //     lifetime of the wrapper. net/http resets the connection's write deadline when the handler
@@ -13,9 +14,13 @@
 //     not reset between the initial delivery and later delta or heartbeat traffic. The deadline
 //     is armed only between Begin and the end-of-delivery flush, and is cleared there, so live
 //     traffic and idle periods carry no deadline. This matters on HTTP/2, where a lingering
-//     deadline is a self-firing timer that would reset an otherwise idle stream. A producer that
-//     ends a delivery on an error or cancellation path -- without a final flush -- must call
-//     Finish so the deadline never outlives the delivery.
+//     deadline is a self-firing timer that would reset an otherwise idle stream.
+//
+// A gated delivery ends in one of two ways. On a clean finish the producer calls End and the
+// end-of-delivery flush clears the deadline, leaving the now-idle stream alone. On an abnormal
+// end -- the client goes away, or the producer errors -- the producer calls Abort (directly, or
+// via WaitAndFinish on context cancellation), which forces any in-flight write to fail rather
+// than clearing the deadline and letting a stalled send run unbounded.
 //
 // A client sustaining at least the throughput floor per write keeps re-arming and is not cut
 // for being slow; one that stalls or drops below the floor on a write has its write fail, which
@@ -27,6 +32,7 @@
 package initwrite
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"sync"
@@ -47,7 +53,7 @@ const (
 )
 
 // Writer wraps an http.ResponseWriter and arms a progress-aware write deadline on the
-// underlying connection while a delivery is active.
+// underlying connection while a delivery is active. Construct it with Wrap or WrapGated.
 type Writer struct {
 	http.ResponseWriter
 	rc      *http.ResponseController
@@ -59,9 +65,12 @@ type Writer struct {
 	ending       bool
 	msgStart     time.Time
 	lastDeadline time.Time
-	// done is closed once the current gated delivery's last byte has been flushed. It is never
-	// nil: outside a delivery it is a closed channel, so a producer waiting on it releases its
-	// slot immediately rather than blocking forever. doneClosed guards against a double close.
+	// gen identifies the current gated delivery. Begin bumps it so a teardown (a flush or Abort)
+	// that observed an earlier delivery cannot clear the deadline of a newer one.
+	gen uint64
+	// done is closed once the current gated delivery ends. It is never nil: outside a delivery
+	// it is a closed channel, so a producer waiting on it releases its slot immediately rather
+	// than blocking forever. doneClosed guards against a double close.
 	done       chan struct{}
 	doneClosed bool
 }
@@ -72,8 +81,8 @@ func Wrap(w http.ResponseWriter, maxHold time.Duration) *Writer {
 	return newWriter(w, maxHold, true)
 }
 
-// WrapGated returns a Writer for a persistent stream: it arms nothing until Begin, and clears
-// the deadline at the end-of-delivery flush after End (or when Finish is called).
+// WrapGated returns a Writer for a persistent stream: it arms nothing until Begin, and ends a
+// delivery either at the End-triggered flush (clearing the deadline) or via Abort.
 func WrapGated(w http.ResponseWriter, maxHold time.Duration) *Writer {
 	return newWriter(w, maxHold, false)
 }
@@ -104,6 +113,7 @@ func (w *Writer) Begin() {
 	w.ending = false
 	w.msgStart = time.Time{}
 	w.lastDeadline = time.Time{}
+	w.gen++
 	if !w.doneClosed {
 		close(w.done)
 	}
@@ -111,11 +121,11 @@ func (w *Writer) Begin() {
 	w.doneClosed = false
 }
 
-// Done returns a channel closed once the gated delivery's last byte has been flushed to the
-// client. The producer waits on it (or on the request context) before releasing the budget
-// slot, so the slot is held for the actual send rather than only until the channel handoff.
-// The channel is never nil: with no delivery in progress it is already closed, so a producer
-// that waits on it is not left blocked.
+// Done returns a channel closed once the current gated delivery has ended. The channel is never
+// nil: with no delivery in progress it is already closed, so a producer that waits on it is not
+// left blocked. Call it only after Begin -- capturing it earlier returns the closed idle channel
+// and would release the slot while the delivery is still in flight. Prefer WaitAndFinish, which
+// reads it at the right time.
 func (w *Writer) Done() <-chan struct{} {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -131,24 +141,37 @@ func (w *Writer) End() {
 	w.mu.Unlock()
 }
 
-// Finish ends the current gated delivery unconditionally: it clears any armed write deadline
-// and closes the Done channel. It is idempotent and safe to call on any producer exit path,
-// and is the backstop for a delivery that ends without a final flush (an error or a cancelled
-// context). On the normal path the end-of-delivery flush has already done this, so Finish is a
-// no-op. Because it clears the deadline, a producer must call it only once the delivery is
-// truly over, not mid-send.
-func (w *Writer) Finish() {
+// Abort ends the current gated delivery abnormally. Unlike a clean finish -- where the
+// end-of-delivery flush clears the deadline so the now-idle stream is left alone -- Abort moves
+// the deadline to now, forcing any in-flight or subsequent write to fail at once. It is the
+// right call when a delivery is given up on (the client went away, or the producer errored): a
+// stalled send is torn down immediately rather than left running unbounded, and the Done waiter
+// is released so the budget slot frees. It is safe to call on any exit path, including while a
+// write is in flight, and more than once; it has no effect if no delivery is active.
+func (w *Writer) Abort() {
 	w.mu.Lock()
-	wasActive := w.active
-	w.active = false
-	w.ending = false
+	defer w.mu.Unlock()
+	if w.active {
+		w.active = false
+		w.ending = false
+		_ = w.rc.SetWriteDeadline(w.now()) // force any pending write to fail now
+	}
 	if !w.doneClosed {
-		close(w.done)
+		close(w.done) // release the waiter only after the deadline is set
 		w.doneClosed = true
 	}
-	w.mu.Unlock()
-	if wasActive {
-		_ = w.rc.SetWriteDeadline(time.Time{})
+}
+
+// WaitAndFinish holds until the current gated delivery's last byte has been flushed to the
+// client (Done closes, with the deadline already cleared by that flush) or ctx is done (the
+// client went away). On cancellation it aborts, so a stalled send cannot hold the slot or the
+// connection past the client's departure. The caller releases its budget slot once this
+// returns. Call it after Begin.
+func (w *Writer) WaitAndFinish(ctx context.Context) {
+	select {
+	case <-w.Done():
+	case <-ctx.Done():
+		w.Abort()
 	}
 }
 
@@ -170,6 +193,9 @@ func (w *Writer) Write(p []byte) (int, error) {
 		if err != nil {
 			return total, err
 		}
+		if n == 0 {
+			return total, io.ErrShortWrite // a (0, nil) writer would otherwise spin forever
+		}
 	}
 	return total, nil
 }
@@ -190,34 +216,42 @@ func (w *Writer) WriteString(s string) (int, error) {
 		if err != nil {
 			return total, err
 		}
+		if n == 0 {
+			return total, io.ErrShortWrite
+		}
 	}
 	return total, nil
 }
 
-// Flush bounds the flush under the deadline and, at the end-of-delivery flush, clears the
-// deadline so later traffic on a persistent stream is not governed by it.
+// Flush flushes buffered bytes and, at the end-of-delivery flush (after End), clears the
+// deadline so later traffic on a persistent stream is not governed by it. The clear runs under
+// the lock and only for the delivery that was active when Flush was entered, so it cannot wipe
+// the deadline of a newer delivery that began in the meantime.
 func (w *Writer) Flush() {
 	f, ok := w.ResponseWriter.(http.Flusher)
 	if !ok {
 		return
 	}
 	w.mu.Lock()
-	active, ending := w.active, w.ending
+	active, ending, gen := w.active, w.ending, w.gen
 	w.mu.Unlock()
-	if active {
-		w.arm(0)
-	}
+
 	f.Flush()
-	if active && ending {
-		w.mu.Lock()
-		w.active = false
-		if !w.doneClosed {
-			close(w.done) // the basis is fully written; let the producer release the slot
-			w.doneClosed = true
-		}
-		w.mu.Unlock()
-		_ = w.rc.SetWriteDeadline(time.Time{})
+
+	if !(active && ending) {
+		return
 	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.gen != gen || !w.active {
+		return // a newer delivery began, or this one was already ended
+	}
+	w.active = false
+	if !w.doneClosed {
+		close(w.done) // the basis is fully written; let the producer release the slot
+		w.doneClosed = true
+	}
+	_ = w.rc.SetWriteDeadline(time.Time{})
 }
 
 func (w *Writer) isActive() bool {
@@ -230,7 +264,7 @@ func (w *Writer) isActive() bool {
 // throughput floor) + slack, capped by the delivery's absolute deadline (msgStart + maxHold).
 // It never shortens an existing deadline within a delivery and skips trivial changes. The
 // deadline is recorded as current only when the underlying SetWriteDeadline succeeds, so a
-// transient failure does not leave the writer thinking it has armed a deadline it has not.
+// transient failure does not leave the writer believing it has armed a deadline it has not.
 func (w *Writer) arm(n int) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/internal/initwrite/initwrite.go
+++ b/internal/initwrite/initwrite.go
@@ -39,9 +39,12 @@
 //     -- even an exit that wrote nothing, since the delivery stays active and a later heartbeat
 //     write would arm a deadline that then fires with nothing left to finish it. Skipping End is
 //     a bug: the deadline is never cleared, and the healthy stream is killed anyway -- on
-//     HTTP/1.1 when the absolute cap expires, and on HTTP/2 within a few seconds (the write
-//     slack) of the last write, because a deadline there is a self-firing timer. Disabling the
-//     cap does not avoid this; it only removes the later of the two bounds.
+//     HTTP/1.1 at the first write after the absolute cap expires, and on HTTP/2 within a few
+//     seconds (the write slack) of the last write, because a deadline there is a self-firing
+//     timer. (A heartbeat interval shorter than the slack keeps postponing the HTTP/2 fire, so
+//     the bug can be invisible under fast test heartbeats yet fatal at a production interval.)
+//     Disabling the cap does not make the omission safe: HTTP/2 still dies on the slack timer,
+//     while on HTTP/1.1 nothing fires at all and the budget slot is pinned permanently instead.
 //   - Client goes away first: WaitAndFinish returns on context cancellation without touching the
 //     connection; the per-write deadline already armed bounds anything still in flight, and the
 //     connection teardown clears it.
@@ -187,7 +190,12 @@ func (w *Writer) WaitAndFinish(ctx context.Context) {
 	w.mu.Lock()
 	done := w.done
 	w.mu.Unlock()
+	w.waitAndFinish(ctx, done)
+}
 
+// waitAndFinish is WaitAndFinish after the channel capture, split out so a test can drive the
+// cancellation branch with a stale captured channel.
+func (w *Writer) waitAndFinish(ctx context.Context, done <-chan struct{}) {
 	select {
 	case <-done:
 		// Delivered: the handler's end-of-delivery flush closed done and cleared the deadline.
@@ -277,13 +285,16 @@ func (w *Writer) teardown(gen uint64) {
 		return // a newer delivery began, or this one was already ended
 	}
 	w.active = false
+	// The close is deferred so the waiter is released even if the deadline clear panics. The
+	// doneClosed guard keeps this from double-closing when WaitAndFinish's ctx branch closed
+	// done first (the client left as the delivery completed).
+	defer func() {
+		if !w.doneClosed {
+			close(w.done)
+			w.doneClosed = true
+		}
+	}()
 	_ = w.rc.SetWriteDeadline(time.Time{})
-	if !w.doneClosed {
-		// WaitAndFinish's ctx branch may have closed done first (the client left as the delivery
-		// completed); the guard keeps this from double-closing.
-		close(w.done)
-		w.doneClosed = true
-	}
 }
 
 func (w *Writer) isActive() bool {

--- a/internal/initwrite/initwrite.go
+++ b/internal/initwrite/initwrite.go
@@ -1,0 +1,211 @@
+// Package initwrite provides a progress-aware write deadline for initialization-delivery
+// responses -- SSE stream replays and poll responses. It bounds how long a slow or stalled
+// client can hold a budget slot without false-killing a slow-but-steady client: a
+// minimum-throughput floor drives a per-write deadline, and an absolute cap bounds a single
+// delivery.
+//
+// Two shapes are supported:
+//
+//   - Poll (Wrap): a request/response delivery. The deadline is armed on every write for the
+//     lifetime of the wrapper. The caller (the poll middleware) clears the connection's write
+//     deadline when the handler returns, so it cannot linger on a kept-alive connection and
+//     fire during a later request.
+//   - Stream (WrapGated): a persistent SSE connection, where net/http does NOT clear the
+//     deadline between the initial delivery and later delta/heartbeat traffic. The deadline is
+//     armed only between Begin and the end-of-delivery flush, and is cleared there, so live
+//     traffic and idle periods carry no deadline (important on HTTP/2, where a lingering
+//     deadline is a self-firing timer that would reset an idle stream).
+//
+// A client sustaining at least the throughput floor per write keeps re-arming and is not cut
+// for being slow; one that stalls or drops below the floor on a write has its write fail,
+// which the HTTP server turns into a closed connection. The absolute cap (maxHold) backstops
+// a client that stays at the floor on a very large payload: because the cap governs once a
+// delivery would exceed maxHold at the floor (~7.5 MiB at the 64 KiB/s floor and the 2m
+// default), such a client is cut at maxHold. See docs/configuration.md.
+package initwrite
+
+import (
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// minBytesPerSec is the throughput floor a full-size chunk must sustain.
+	minBytesPerSec = 64 * 1024
+	// chunkSize bounds how much is written under a single deadline. Large writes are sliced
+	// only to re-arm the deadline mid-write; the string path copies at most one chunk at a
+	// time rather than the whole payload.
+	chunkSize = 1 << 20 // 1 MiB
+	// slack is added to each per-write deadline to tolerate a brief stall.
+	slack = 5 * time.Second
+	// minExtension avoids a SetWriteDeadline syscall for a trivially small change.
+	minExtension = 100 * time.Millisecond
+)
+
+// Writer wraps an http.ResponseWriter and arms a progress-aware write deadline on the
+// underlying connection while a delivery is active.
+type Writer struct {
+	http.ResponseWriter
+	rc      *http.ResponseController
+	maxHold time.Duration
+
+	mu           sync.Mutex
+	active       bool
+	ending       bool
+	msgStart     time.Time
+	lastDeadline time.Time
+	done         chan struct{} // closed at the end-of-delivery flush; nil outside a gated delivery
+}
+
+// Wrap returns a Writer for a poll (request/response) delivery: the deadline is armed on every
+// write. net/http clears the connection deadline when the handler returns.
+func Wrap(w http.ResponseWriter, maxHold time.Duration) *Writer {
+	return &Writer{ResponseWriter: w, rc: http.NewResponseController(w), maxHold: maxHold, active: true}
+}
+
+// WrapGated returns a Writer for a persistent stream: it arms nothing until Begin, and clears
+// the deadline at the end-of-delivery flush after End.
+func WrapGated(w http.ResponseWriter, maxHold time.Duration) *Writer {
+	return &Writer{ResponseWriter: w, rc: http.NewResponseController(w), maxHold: maxHold}
+}
+
+// Begin marks the start of a gated delivery; writes from here on arm the deadline. It is
+// called from the producer before it starts producing events.
+func (w *Writer) Begin() {
+	w.mu.Lock()
+	w.active = true
+	w.ending = false
+	w.msgStart = time.Time{}
+	w.lastDeadline = time.Time{}
+	w.done = make(chan struct{})
+	w.mu.Unlock()
+}
+
+// Done returns a channel closed once the gated delivery's last byte has been flushed to the
+// client. The producer waits on it (or on the request context) before releasing the budget
+// slot, so the slot is held for the actual send rather than only until the channel handoff.
+// It returns a nil channel if no delivery is in progress (a nil channel never fires, so a
+// caller that also selects on ctx.Done is unaffected).
+func (w *Writer) Done() <-chan struct{} {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.done
+}
+
+// End signals that the producer has handed off the whole delivery. The deadline is cleared at
+// the next flush -- the eventsource server flushes exactly once at end-of-batch -- so it is
+// called before the producer closes the batch channel, guaranteeing that flush observes it.
+func (w *Writer) End() {
+	w.mu.Lock()
+	w.ending = true
+	w.mu.Unlock()
+}
+
+// Unwrap exposes the wrapped ResponseWriter so http.NewResponseController and other wrappers
+// can reach the underlying connection through this one.
+func (w *Writer) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+// Write slices p into chunks and arms the per-chunk deadline before each.
+func (w *Writer) Write(p []byte) (int, error) {
+	if !w.isActive() || len(p) == 0 {
+		return w.ResponseWriter.Write(p)
+	}
+	total := 0
+	for total < len(p) {
+		end := min(total+chunkSize, len(p))
+		w.arm(end - total)
+		n, err := w.ResponseWriter.Write(p[total:end])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+// WriteString satisfies io.StringWriter so eventsource's io.WriteString does not allocate a
+// []byte copy of the entire payload per connection. It slices the string and copies at most
+// one chunk at a time.
+func (w *Writer) WriteString(s string) (int, error) {
+	if !w.isActive() || len(s) == 0 {
+		return io.WriteString(w.ResponseWriter, s)
+	}
+	total := 0
+	for total < len(s) {
+		end := min(total+chunkSize, len(s))
+		w.arm(end - total)
+		n, err := io.WriteString(w.ResponseWriter, s[total:end])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+// Flush bounds the flush under the deadline and, at the end-of-delivery flush, clears the
+// deadline so later traffic on a persistent stream is not governed by it.
+func (w *Writer) Flush() {
+	f, ok := w.ResponseWriter.(http.Flusher)
+	if !ok {
+		return
+	}
+	w.mu.Lock()
+	active, ending := w.active, w.ending
+	w.mu.Unlock()
+	if active {
+		w.arm(0)
+	}
+	f.Flush()
+	if active && ending {
+		w.mu.Lock()
+		w.active = false
+		done := w.done
+		w.done = nil
+		w.mu.Unlock()
+		_ = w.rc.SetWriteDeadline(time.Time{})
+		if done != nil {
+			close(done) // the basis is fully written; let the producer release the slot
+		}
+	}
+}
+
+func (w *Writer) isActive() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.active
+}
+
+// arm sets the write deadline for the next chunk to now + (time to send n bytes at the
+// throughput floor) + slack, capped by the delivery's absolute deadline (msgStart + maxHold).
+// It never shortens an existing deadline within a delivery and skips trivial changes.
+func (w *Writer) arm(n int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.active {
+		return
+	}
+	now := time.Now()
+	if w.msgStart.IsZero() {
+		w.msgStart = now
+	}
+	budget := time.Duration(n)*time.Second/time.Duration(minBytesPerSec) + slack
+	dl := now.Add(budget)
+	if w.maxHold > 0 {
+		if capDL := w.msgStart.Add(w.maxHold); dl.After(capDL) {
+			dl = capDL
+		}
+	}
+	if dl.After(w.lastDeadline) && dl.Sub(w.lastDeadline) >= minExtension {
+		_ = w.rc.SetWriteDeadline(dl)
+		w.lastDeadline = dl
+	}
+}
+
+var (
+	_ http.ResponseWriter = (*Writer)(nil)
+	_ http.Flusher        = (*Writer)(nil)
+	_ io.StringWriter     = (*Writer)(nil)
+)

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -443,20 +443,25 @@ func TestWaitAndFinishNeverSetsDeadline(t *testing.T) {
 
 func TestWaitAndFinishAfterHandlerReturnDoesNotCrashHTTP2(t *testing.T) {
 	// Reproduce the producer-outlives-handler pattern on a real HTTP/2 connection: a goroutine
-	// holds the Writer and calls WaitAndFinish after the handler has returned and its context is
-	// cancelled. Touching the connection here nil-panics inside net/http and crashes the process;
-	// WaitAndFinish must not. (A panic in that goroutine would take the whole test binary down.)
+	// holds the Writer and calls WaitAndFinish only after the handler has returned and net/http
+	// has torn its responseWriter down. Touching the connection there nil-panics inside net/http
+	// and crashes the process; WaitAndFinish must not. The handlerReturned signal plus a short
+	// settle makes the ordering deterministic, so a reintroduced connection touch crashes reliably
+	// (a panic in that goroutine takes the whole test binary down) rather than flaking green.
 	finished := make(chan struct{})
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		handlerReturned := make(chan struct{})
 		w := WrapGated(rw, 2*time.Minute)
 		w.Begin()
 		_, _ = w.Write([]byte("data: hi\n\n"))
 		w.Flush()
 		go func() {
 			defer close(finished)
-			w.WaitAndFinish(r.Context()) // fires on ctx.Done after the handler returns
+			<-handlerReturned
+			time.Sleep(2 * time.Millisecond) // let net/http reclaim the responseWriter
+			w.WaitAndFinish(r.Context())
 		}()
-		// handler returns here, completing the stream and cancelling r.Context()
+		defer close(handlerReturned) // fires as the handler returns
 	}))
 	srv.EnableHTTP2 = true
 	srv.StartTLS()
@@ -472,6 +477,103 @@ func TestWaitAndFinishAfterHandlerReturnDoesNotCrashHTTP2(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("producer goroutine did not return")
 	}
+}
+
+func TestFlushWithoutEndDoesNotTeardown(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize)) // arms one deadline
+	require.NoError(t, err)
+	require.Len(t, base.armed(), 1)
+
+	// A flush without End -- a mid-delivery/jitter flush, or a producer that errored and skipped
+	// End -- must not tear down: the deadline stays armed and the waiter stays parked. (This is
+	// the mechanism by which skipping End on an error path would eventually kill a healthy stream.)
+	w.Flush()
+	assert.Len(t, base.armed(), 1, "flush without End must not clear the deadline")
+	assertOpen(t, w.Done(), "done must stay open without End")
+}
+
+func TestEndThenFlushTearsDownAnyPartialDelivery(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write([]byte("event: put\n\n")) // only a partial "basis" before abandoning
+	require.NoError(t, err)
+
+	// End on the abandon path lets the flush clear the deadline regardless of how much was written.
+	w.End()
+	w.Flush()
+	armed := base.armed()
+	require.NotEmpty(t, armed)
+	assert.True(t, armed[len(armed)-1].IsZero(), "End+flush clears the deadline even for a partial delivery")
+	assertClosed(t, w.Done(), "End+flush releases the waiter")
+}
+
+func TestWaitAndFinishCancelAfterDeliveredDoesNotDoubleClose(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	w.End()
+	w.Flush() // clean teardown already closed done
+
+	// The client leaving after a clean delivery must not double-close done (the ctx branch's
+	// doneClosed guard).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.NotPanics(t, func() { w.WaitAndFinish(ctx) })
+}
+
+// zeroWriteConn is a contract-violating writer that always reports (0, nil); the chunk loop must
+// not spin on it.
+type zeroWriteConn struct{ *httptest.ResponseRecorder }
+
+func (zeroWriteConn) Write([]byte) (int, error)        { return 0, nil }
+func (zeroWriteConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestWriteZeroNilWriterReturnsShortWrite(t *testing.T) {
+	w := Wrap(zeroWriteConn{httptest.NewRecorder()}, 2*time.Minute)
+	n, err := w.Write(make([]byte, chunkSize))
+	assert.ErrorIs(t, err, io.ErrShortWrite)
+	assert.Zero(t, n)
+}
+
+// noFlushConn is a minimal ResponseWriter that records deadlines but cannot flush.
+type noFlushConn struct {
+	hdr       http.Header
+	deadlines []time.Time
+}
+
+func (c *noFlushConn) Header() http.Header {
+	if c.hdr == nil {
+		c.hdr = http.Header{}
+	}
+	return c.hdr
+}
+func (c *noFlushConn) Write(p []byte) (int, error) { return len(p), nil }
+func (c *noFlushConn) WriteHeader(int)             {}
+func (c *noFlushConn) SetWriteDeadline(t time.Time) error {
+	c.deadlines = append(c.deadlines, t)
+	return nil
+}
+
+func TestFlushTearsDownOnNonFlusherChain(t *testing.T) {
+	base := &noFlushConn{}
+	w := WrapGated(base, 2*time.Minute)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize)) // arms
+	require.NoError(t, err)
+	w.End()
+
+	// Even though the underlying writer cannot flush, the end-of-delivery teardown must still
+	// clear the deadline and release the waiter, so a non-flushing chain cannot strand either.
+	w.Flush()
+	require.NotEmpty(t, base.deadlines)
+	assert.True(t, base.deadlines[len(base.deadlines)-1].IsZero(), "teardown must clear the deadline without a Flusher")
+	assertClosed(t, w.Done(), "teardown must release the waiter without a Flusher")
 }
 
 func TestReBeginReleasesPriorWaiter(t *testing.T) {

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -1,8 +1,11 @@
 package initwrite
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,48 +13,295 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// deadlineConn is a ResponseWriter that records every write deadline armed on it, so tests
-// can assert the progress-aware arming logic without a real socket.
+// fakeClock is a deterministic time source so deadline math can be asserted exactly rather
+// than within a wall-clock tolerance.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Unix(1_700_000_000, 0).UTC()} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+// deadlineConn is a ResponseWriter that records every write deadline armed on it, so tests can
+// assert the progress-aware arming logic without a real socket. It forwards Flush to the
+// embedded recorder (so Flushed stays observable) and guards its recorded state with a mutex.
+// If a clock is attached it advances by advancePerWrite on each Write, so a multi-chunk write
+// can exercise per-chunk re-arming deterministically.
 type deadlineConn struct {
 	*httptest.ResponseRecorder
-	deadlines []time.Time
+
+	mu              sync.Mutex
+	deadlines       []time.Time
+	setErr          error // returned from SetWriteDeadline when non-nil, to simulate a failing syscall
+	setCalls        int
+	flushes         int
+	clock           *fakeClock
+	advancePerWrite time.Duration
 }
 
 func newDeadlineConn() *deadlineConn { return &deadlineConn{ResponseRecorder: httptest.NewRecorder()} }
 
 func (d *deadlineConn) SetWriteDeadline(t time.Time) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.setCalls++
+	if d.setErr != nil {
+		return d.setErr
+	}
 	d.deadlines = append(d.deadlines, t)
 	return nil
 }
-func (d *deadlineConn) Flush() {}
 
-func TestWriteArmsPerChunkDeadlineUnderCap(t *testing.T) {
-	base := newDeadlineConn()
-	w := Wrap(base, 2*time.Minute)
-
-	// A payload spanning several chunks should arm a deadline at least once, and every armed
-	// deadline must sit within [now+perChunk-ish, msgStart+maxHold].
-	start := time.Now()
-	n, err := w.Write(make([]byte, 3*chunkSize+1234))
-	require.NoError(t, err)
-	assert.Equal(t, 3*chunkSize+1234, n)
-	require.NotEmpty(t, base.deadlines, "expected at least one write deadline to be armed")
-	for _, dl := range base.deadlines {
-		assert.False(t, dl.Before(start), "deadline must be in the future")
-		assert.False(t, dl.After(start.Add(2*time.Minute+time.Second)), "deadline must be capped by maxHold")
+func (d *deadlineConn) Write(p []byte) (int, error) {
+	if d.clock != nil && d.advancePerWrite > 0 {
+		d.clock.advance(d.advancePerWrite)
 	}
+	return d.ResponseRecorder.Write(p)
+}
+
+// WriteString mirrors Write so the string and byte paths advance the fake clock identically;
+// without it, io.WriteString would reach the embedded recorder's own WriteString and skip the
+// clock advance, making the two paths incomparable.
+func (d *deadlineConn) WriteString(s string) (int, error) {
+	if d.clock != nil && d.advancePerWrite > 0 {
+		d.clock.advance(d.advancePerWrite)
+	}
+	return d.ResponseRecorder.WriteString(s)
+}
+
+func (d *deadlineConn) Flush() {
+	d.mu.Lock()
+	d.flushes++
+	d.mu.Unlock()
+	d.ResponseRecorder.Flush()
+}
+
+func (d *deadlineConn) armed() []time.Time {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return slices.Clone(d.deadlines)
+}
+
+func (d *deadlineConn) calls() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setCalls
+}
+
+// wrapClocked builds a Writer driven by a deterministic clock shared with base.
+func wrapClocked(base *deadlineConn, maxHold time.Duration, gated bool) (*Writer, *fakeClock) {
+	c := newFakeClock()
+	base.clock = c
+	w := Wrap(base, maxHold)
+	if gated {
+		w = WrapGated(base, maxHold)
+	}
+	w.now = c.now
+	return w, c
+}
+
+// perChunkBudget is the deadline a full 1 MiB chunk should arm: time to send it at the floor
+// plus slack. Tests assert against this exact value so a weaker/stronger floor or slack fails.
+var perChunkBudget = time.Duration(chunkSize)*time.Second/time.Duration(minBytesPerSec) + slack
+
+func TestWriteArmsFullChunkAtFloorPlusSlack(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 2*time.Minute, false)
+
+	start := c.now()
+	n, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	assert.Equal(t, chunkSize, n)
+
+	armed := base.armed()
+	require.Len(t, armed, 1, "a single full chunk should arm exactly one deadline")
+	assert.Equal(t, perChunkBudget, armed[0].Sub(start)) // 16s at 64 KiB/s + 5s slack = 21s
+}
+
+func TestWriteSmallPayloadArmsSlackOnly(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 2*time.Minute, false)
+
+	start := c.now()
+	_, err := w.Write(make([]byte, 4096))
+	require.NoError(t, err)
+
+	armed := base.armed()
+	require.Len(t, armed, 1)
+	// A tiny payload's time-at-floor rounds to ~0, so the deadline is essentially just slack.
+	assert.Equal(t, slack+time.Duration(4096)*time.Second/time.Duration(minBytesPerSec), armed[0].Sub(start))
+}
+
+func TestWriteReArmsEachChunk(t *testing.T) {
+	base := newDeadlineConn()
+	base.advancePerWrite = minExtension // enough progress between chunks to re-arm
+	w, _ := wrapClocked(base, 5*time.Minute, false)
+
+	// A multi-chunk write must arm once per full chunk, not once for the whole payload: that is
+	// what keeps a client that stalls partway through from holding a slot past the floor.
+	_, err := w.Write(make([]byte, 3*chunkSize))
+	require.NoError(t, err)
+	assert.Len(t, base.armed(), 3, "expected one arm per 1 MiB chunk")
 }
 
 func TestWriteCapsDeadlineAtMaxHold(t *testing.T) {
 	base := newDeadlineConn()
 	// A tiny cap (well under the per-chunk budget) must clamp the armed deadline to the cap.
-	w := Wrap(base, 500*time.Millisecond)
-	start := time.Now()
+	w, c := wrapClocked(base, 500*time.Millisecond, false)
+	start := c.now()
 	_, err := w.Write(make([]byte, chunkSize))
 	require.NoError(t, err)
-	require.NotEmpty(t, base.deadlines)
-	last := base.deadlines[len(base.deadlines)-1]
-	assert.False(t, last.After(start.Add(600*time.Millisecond)), "deadline should be clamped near msgStart+maxHold")
+
+	armed := base.armed()
+	require.Len(t, armed, 1)
+	assert.Equal(t, 500*time.Millisecond, armed[0].Sub(start), "deadline should be clamped to msgStart+maxHold")
+}
+
+func TestZeroMaxHoldDisablesCap(t *testing.T) {
+	base := newDeadlineConn()
+	// A non-positive maxHold leaves only the per-write floor; the deadline is not clamped.
+	w, c := wrapClocked(base, 0, false)
+	start := c.now()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+
+	armed := base.armed()
+	require.Len(t, armed, 1)
+	assert.Equal(t, perChunkBudget, armed[0].Sub(start))
+}
+
+func TestArmDoesNotAdvanceOnSetDeadlineFailure(t *testing.T) {
+	base := newDeadlineConn()
+	base.setErr = errors.New("deadline not supported")
+	base.advancePerWrite = minExtension
+	w, _ := wrapClocked(base, 2*time.Minute, false)
+
+	// If SetWriteDeadline keeps failing, the writer must keep attempting it on later chunks
+	// rather than recording a deadline it never set and going silently inert.
+	_, err := w.Write(make([]byte, 3*chunkSize))
+	require.NoError(t, err)
+	assert.Equal(t, 3, base.calls(), "each chunk should retry SetWriteDeadline after a failure")
+}
+
+func TestGatedArmsOnlyBetweenBeginAndEndFlush(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 2*time.Minute, true)
+
+	// Before Begin: writes pass through unarmed (the stream's headers/initial bytes carry no
+	// deadline until a delivery starts).
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	require.Empty(t, base.armed(), "no deadline should be armed before Begin")
+
+	// During the delivery: writes arm.
+	w.Begin()
+	start := c.now()
+	_, err = w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	armed := base.armed()
+	require.Len(t, armed, 1)
+	assert.Equal(t, perChunkBudget, armed[0].Sub(start))
+
+	// End + the single end-of-batch flush clears the deadline exactly once.
+	w.End()
+	w.Flush()
+	armed = base.armed()
+	require.Len(t, armed, 2, "end-of-delivery flush should clear the deadline")
+	assert.True(t, armed[1].IsZero(), "the clearing call must set the zero time")
+
+	// After the delivery: writes pass through unarmed again.
+	_, err = w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	assert.Len(t, base.armed(), 2, "no new deadline should be armed after the delivery ends")
+}
+
+func TestDoneIsFailSafeClosedOutsideDelivery(t *testing.T) {
+	base := newDeadlineConn()
+	w := WrapGated(base, time.Minute)
+
+	// With no delivery in progress, Done must already be closed so a waiting producer releases
+	// its slot immediately instead of pinning it forever.
+	assertClosed(t, w.Done(), "Done before Begin")
+
+	w.Begin()
+	assertOpen(t, w.Done(), "Done during delivery")
+
+	w.End()
+	w.Flush()
+	assertClosed(t, w.Done(), "Done after end-of-delivery flush")
+}
+
+func TestFinishClearsDeadlineAndClosesDone(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	done := w.Done()
+
+	// Finish is the backstop for a delivery that ends without a final flush: it clears the
+	// deadline and releases the waiter.
+	w.Finish()
+	armed := base.armed()
+	require.NotEmpty(t, armed)
+	assert.True(t, armed[len(armed)-1].IsZero(), "Finish should clear the write deadline")
+	assertClosed(t, done, "Done after Finish")
+
+	// Idempotent: a second Finish neither panics nor re-clears.
+	before := len(base.armed())
+	w.Finish()
+	assert.Len(t, base.armed(), before, "a second Finish should be a no-op")
+
+	// Inert afterwards: writes pass through unarmed.
+	_, err = w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	assert.Len(t, base.armed(), before, "no deadline should arm after Finish")
+}
+
+func TestReBeginReleasesPriorWaiter(t *testing.T) {
+	base := newDeadlineConn()
+	w := WrapGated(base, time.Minute)
+	w.Begin()
+	first := w.Done()
+	assertOpen(t, first, "first delivery's Done")
+
+	// A second Begin (a defensive case) must release the prior delivery's waiter rather than
+	// orphan it, and hand out a fresh open channel.
+	w.Begin()
+	assertClosed(t, first, "prior Done after re-Begin")
+	assertOpen(t, w.Done(), "new delivery's Done")
+}
+
+func TestWriteStringMatchesWrite(t *testing.T) {
+	payload := make([]byte, 3*chunkSize+777)
+
+	byteConn := newDeadlineConn()
+	byteConn.advancePerWrite = minExtension
+	bw, _ := wrapClocked(byteConn, 2*time.Minute, false)
+	nBytes, err := bw.Write(payload)
+	require.NoError(t, err)
+
+	strConn := newDeadlineConn()
+	strConn.advancePerWrite = minExtension
+	sw, _ := wrapClocked(strConn, 2*time.Minute, false)
+	nStr, err := sw.WriteString(string(payload))
+	require.NoError(t, err)
+
+	assert.Equal(t, nBytes, nStr, "byte and string paths should write the same count")
+	assert.Len(t, strConn.armed(), len(byteConn.armed()), "both paths should arm the same number of deadlines")
+	assert.Equal(t, byteConn.Body.Bytes(), strConn.Body.Bytes(), "both paths should emit identical bytes")
 }
 
 func TestUnwrapReachesBase(t *testing.T) {
@@ -60,7 +310,7 @@ func TestUnwrapReachesBase(t *testing.T) {
 	// The deadline set through the controller must reach the base connection.
 	err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(time.Second))
 	assert.NoError(t, err)
-	assert.NotEmpty(t, base.deadlines, "SetWriteDeadline did not reach base through initwrite.Writer.Unwrap")
+	assert.NotEmpty(t, base.armed(), "SetWriteDeadline did not reach base through initwrite.Writer.Unwrap")
 }
 
 func TestEmptyWriteNoDeadline(t *testing.T) {
@@ -68,5 +318,23 @@ func TestEmptyWriteNoDeadline(t *testing.T) {
 	w := Wrap(base, time.Minute)
 	_, err := w.Write(nil)
 	require.NoError(t, err)
-	assert.Empty(t, base.deadlines, "an empty write should not arm a deadline")
+	assert.Empty(t, base.armed(), "an empty write should not arm a deadline")
+}
+
+func assertClosed(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("%s: expected a closed channel, but it blocked", what)
+	}
+}
+
+func assertOpen(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatalf("%s: expected an open channel, but it was closed", what)
+	case <-time.After(20 * time.Millisecond):
+	}
 }

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -513,31 +513,158 @@ func TestEndThenFlushTearsDownAnyPartialDelivery(t *testing.T) {
 }
 
 func TestWaitAndFinishCancelAfterDeliveredDoesNotDoubleClose(t *testing.T) {
+	// After a clean delivery both select arms are ready, so which branch runs is a coin flip;
+	// loop so the ctx branch -- the only one that can double-close -- is certainly exercised.
+	for range 200 {
+		base := newDeadlineConn()
+		w, _ := wrapClocked(base, 2*time.Minute, true)
+		w.Begin()
+		_, err := w.Write(make([]byte, chunkSize))
+		require.NoError(t, err)
+		w.End()
+		w.Flush() // clean teardown already closed done
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		assert.NotPanics(t, func() { w.WaitAndFinish(ctx) })
+	}
+}
+
+func TestConcurrentAbandonedWaitersDoNotDoubleClose(t *testing.T) {
+	// Two waiters parked on the same open done, both released by cancellation: the ctx branch is
+	// the only ready arm for both, so both reach the close deterministically and the doneClosed
+	// guard is what stops the second from panicking.
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w.WaitAndFinish(ctx)
+		}()
+	}
+	time.Sleep(20 * time.Millisecond) // let both park on the open done
+	cancel()
+
+	finished := make(chan struct{})
+	go func() { wg.Wait(); close(finished) }()
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiters did not return")
+	}
+}
+
+func TestEndOfBatchFlushAfterClientGoneDoesNotDoubleClose(t *testing.T) {
 	base := newDeadlineConn()
 	w, _ := wrapClocked(base, 2*time.Minute, true)
 	w.Begin()
 	_, err := w.Write(make([]byte, chunkSize))
 	require.NoError(t, err)
 	w.End()
-	w.Flush() // clean teardown already closed done
 
-	// The client leaving after a clean delivery must not double-close done (the ctx branch's
-	// doneClosed guard).
+	// The client leaves after End but before the end-of-batch flush: WaitAndFinish's ctx branch
+	// closes done first, then the pending flush reaches the teardown on an already-closed
+	// channel. The teardown's own guard must keep that from double-closing (a panic here would
+	// land on the handler goroutine), and it must still clear the deadline.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	assert.NotPanics(t, func() { w.WaitAndFinish(ctx) })
+	w.WaitAndFinish(ctx)
+
+	assert.NotPanics(t, func() { w.Flush() })
+	armed := base.armed()
+	require.NotEmpty(t, armed)
+	assert.True(t, armed[len(armed)-1].IsZero(), "the flush teardown must still clear the deadline")
 }
 
-// zeroWriteConn is a contract-violating writer that always reports (0, nil); the chunk loop must
-// not spin on it.
+func TestFlushSamplesStateBeforeFlushing(t *testing.T) {
+	// The (active, ending) sample must be taken BEFORE the flush: a delivery that begins (and
+	// ends) while the flush is in progress -- the subscribe-time flush racing the producer --
+	// belongs to the NEXT flush. A sample taken afterwards would tear it down before its basis
+	// is written, freeing the slot and leaving the whole send deadline-less.
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	base.onFlush = func() {
+		base.onFlush = nil // once
+		w.Begin()
+		w.End()
+	}
+	w.Flush() // entered with no delivery active
+
+	assertOpen(t, w.Done(), "a delivery begun during the flush must not be torn down by it")
+	// The delivery is finished by the next flush, as usual.
+	w.Flush()
+	assertClosed(t, w.Done(), "the next flush finishes the delivery")
+}
+
+func TestConcurrentLifecycleIsRaceFree(t *testing.T) {
+	// Drives Begin/End/Flush/Done/WaitAndFinish/Write concurrently so the race detector pins the
+	// lock discipline (an unlocked read of done or the state fields fails under -race).
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			w.Begin()
+			_, _ = w.Write([]byte("data: x\n\n"))
+			w.End()
+			w.Flush()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			select {
+			case <-w.Done():
+			default:
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		for range 200 {
+			w.WaitAndFinish(ctx)
+		}
+	}()
+	wg.Wait()
+}
+
+// zeroWriteConn is a contract-violating writer that always reports (0, nil) from both write
+// paths; the chunk loops must not spin on it.
 type zeroWriteConn struct{ *httptest.ResponseRecorder }
 
 func (zeroWriteConn) Write([]byte) (int, error)        { return 0, nil }
+func (zeroWriteConn) WriteString(string) (int, error)  { return 0, nil }
 func (zeroWriteConn) SetWriteDeadline(time.Time) error { return nil }
 
 func TestWriteZeroNilWriterReturnsShortWrite(t *testing.T) {
 	w := Wrap(zeroWriteConn{httptest.NewRecorder()}, 2*time.Minute)
-	n, err := w.Write(make([]byte, chunkSize))
+	var n int
+	var err error
+	// The timeout makes a removed guard fail the test rather than hang the binary.
+	runWithTimeout(t, "Write on a (0, nil) writer must return", func() {
+		n, err = w.Write(make([]byte, chunkSize))
+	})
+	assert.ErrorIs(t, err, io.ErrShortWrite)
+	assert.Zero(t, n)
+}
+
+func TestWriteStringZeroNilWriterReturnsShortWrite(t *testing.T) {
+	w := Wrap(zeroWriteConn{httptest.NewRecorder()}, 2*time.Minute)
+	var n int
+	var err error
+	runWithTimeout(t, "WriteString on a (0, nil) writer must return", func() {
+		n, err = w.WriteString(string(make([]byte, chunkSize)))
+	})
 	assert.ErrorIs(t, err, io.ErrShortWrite)
 	assert.Zero(t, n)
 }
@@ -587,6 +714,113 @@ func TestReBeginReleasesPriorWaiter(t *testing.T) {
 	w.Begin()
 	assertClosed(t, first, "prior Done after re-Begin")
 	assertOpen(t, w.Done(), "new delivery's Done")
+}
+
+func TestReBeginResetsEnding(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	w.End() // delivery 1 abandoned after End
+
+	// Delivery 2 must not inherit delivery 1's ending flag: the first flush after re-Begin would
+	// otherwise tear delivery 2 down before its basis is written.
+	w.Begin()
+	w.Flush()
+	assertOpen(t, w.Done(), "a flush right after re-Begin must not tear down the new delivery")
+}
+
+func TestReBeginResetsCapAnchor(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 30*time.Second, true)
+
+	w.Begin()
+	start1 := c.now()
+	_, err := w.Write(make([]byte, chunkSize)) // anchors delivery 1's cap at start1
+	require.NoError(t, err)
+	require.Equal(t, 21*time.Second, base.armed()[0].Sub(start1))
+	w.End()
+	w.Flush()
+
+	// Delivery 2 starts 25s later; its cap must be anchored to its own start, not delivery 1's
+	// (which would clamp it to start1+30s = 5s from now).
+	c.advance(25 * time.Second)
+	w.Begin()
+	start2 := c.now()
+	_, err = w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	armed := base.armed()
+	assert.Equal(t, 21*time.Second, armed[len(armed)-1].Sub(start2), "delivery 2's budget must use its own cap anchor")
+}
+
+func TestReBeginResetsDeadlineRatchet(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 2*time.Minute, true)
+
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize)) // arms start+21s
+	require.NoError(t, err)
+	w.End()
+	w.Flush()
+	armedBefore := len(base.armed()) // includes the clearing zero
+
+	// Delivery 2's small write computes a deadline (~slack) well below delivery 1's high-water
+	// mark; a ratchet that survived re-Begin would suppress it, leaving the write deadline-less.
+	w.Begin()
+	start2 := c.now()
+	_, err = w.Write(make([]byte, 4096))
+	require.NoError(t, err)
+	armed := base.armed()
+	require.Len(t, armed, armedBefore+1, "delivery 2's first write must arm despite delivery 1's higher deadline")
+	assert.Equal(t, slack+time.Duration(4096)*time.Second/time.Duration(minBytesPerSec), armed[len(armed)-1].Sub(start2))
+}
+
+func TestMaxHoldAnchoredToDeliveryStartNotPerWrite(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 30*time.Second, false)
+
+	start := c.now()
+	_, err := w.Write(make([]byte, chunkSize)) // arms start+21s
+	require.NoError(t, err)
+
+	// 25s into the delivery, another chunk's floor budget (now+21s = start+46s) exceeds the cap.
+	// The cap must clamp to the DELIVERY's start (start+30s); a per-write anchor (now+30s) would
+	// mean no absolute backstop at all.
+	c.advance(25 * time.Second)
+	_, err = w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	armed := base.armed()
+	require.Len(t, armed, 2)
+	assert.Equal(t, 30*time.Second, armed[1].Sub(start), "the cap must be anchored to the delivery start")
+}
+
+func TestMinExtensionSkipsTrivialReArms(t *testing.T) {
+	base := newDeadlineConn()
+	base.advancePerWrite = 50 * time.Millisecond // half of minExtension per chunk
+	w, c := wrapClocked(base, 5*time.Minute, false)
+
+	// Chunk 1 arms start+21s. Chunk 2's deadline is only 50ms later -- below minExtension, so it
+	// is skipped. Chunk 3's is 100ms later than the armed one -- at the threshold, so it arms.
+	start := c.now()
+	_, err := w.Write(make([]byte, 3*chunkSize))
+	require.NoError(t, err)
+	armed := base.armed()
+	require.Len(t, armed, 2, "sub-minExtension re-arms must be skipped")
+	assert.Equal(t, 21*time.Second, armed[0].Sub(start))
+	assert.Equal(t, 21*time.Second+100*time.Millisecond, armed[1].Sub(start))
+}
+
+func TestArmIsNoOpAfterDeliveryEnds(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	w.End()
+	w.Flush()
+	calls := base.calls()
+
+	// arm's own active check covers the window between a Write's activity check and the arm; an
+	// arm that slips through after teardown would put a stray deadline on a delivered stream.
+	w.arm(4096)
+	assert.Equal(t, calls, base.calls(), "arm after the delivery ended must not set a deadline")
 }
 
 func TestFlushDoesNotClearNewerDeliveryDeadline(t *testing.T) {

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -1,0 +1,72 @@
+package initwrite
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadlineConn is a ResponseWriter that records every write deadline armed on it, so tests
+// can assert the progress-aware arming logic without a real socket.
+type deadlineConn struct {
+	*httptest.ResponseRecorder
+	deadlines []time.Time
+}
+
+func newDeadlineConn() *deadlineConn { return &deadlineConn{ResponseRecorder: httptest.NewRecorder()} }
+
+func (d *deadlineConn) SetWriteDeadline(t time.Time) error {
+	d.deadlines = append(d.deadlines, t)
+	return nil
+}
+func (d *deadlineConn) Flush() {}
+
+func TestWriteArmsPerChunkDeadlineUnderCap(t *testing.T) {
+	base := newDeadlineConn()
+	w := Wrap(base, 2*time.Minute)
+
+	// A payload spanning several chunks should arm a deadline at least once, and every armed
+	// deadline must sit within [now+perChunk-ish, msgStart+maxHold].
+	start := time.Now()
+	n, err := w.Write(make([]byte, 3*chunkSize+1234))
+	require.NoError(t, err)
+	assert.Equal(t, 3*chunkSize+1234, n)
+	require.NotEmpty(t, base.deadlines, "expected at least one write deadline to be armed")
+	for _, dl := range base.deadlines {
+		assert.False(t, dl.Before(start), "deadline must be in the future")
+		assert.False(t, dl.After(start.Add(2*time.Minute+time.Second)), "deadline must be capped by maxHold")
+	}
+}
+
+func TestWriteCapsDeadlineAtMaxHold(t *testing.T) {
+	base := newDeadlineConn()
+	// A tiny cap (well under the per-chunk budget) must clamp the armed deadline to the cap.
+	w := Wrap(base, 500*time.Millisecond)
+	start := time.Now()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	require.NotEmpty(t, base.deadlines)
+	last := base.deadlines[len(base.deadlines)-1]
+	assert.False(t, last.After(start.Add(600*time.Millisecond)), "deadline should be clamped near msgStart+maxHold")
+}
+
+func TestUnwrapReachesBase(t *testing.T) {
+	base := newDeadlineConn()
+	w := Wrap(base, time.Minute)
+	// The deadline set through the controller must reach the base connection.
+	err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(time.Second))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, base.deadlines, "SetWriteDeadline did not reach base through initwrite.Writer.Unwrap")
+}
+
+func TestEmptyWriteNoDeadline(t *testing.T) {
+	base := newDeadlineConn()
+	w := Wrap(base, time.Minute)
+	_, err := w.Write(nil)
+	require.NoError(t, err)
+	assert.Empty(t, base.deadlines, "an empty write should not arm a deadline")
+}

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -101,6 +102,7 @@ func (d *deadlineConn) WriteString(s string) (int, error) {
 
 func (d *deadlineConn) Flush() {
 	d.mu.Lock()
+	d.events = append(d.events, "flush")
 	d.flushes++
 	hook := d.onFlush
 	d.mu.Unlock()
@@ -601,9 +603,90 @@ func TestFlushSamplesStateBeforeFlushing(t *testing.T) {
 	assertClosed(t, w.Done(), "the next flush finishes the delivery")
 }
 
+func TestFlushPanicStillTearsDown(t *testing.T) {
+	base := &noFlushConn{}
+	w := WrapGated(panicFlushConn{base}, 2*time.Minute)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize)) // arms
+	require.NoError(t, err)
+	w.End()
+
+	// The teardown is deferred precisely so a panicking flush cannot strand the delivery: the
+	// deadline must be cleared and the waiter released during unwinding, and the panic must
+	// still propagate (net/http's per-connection recovery handles it in production).
+	assert.Panics(t, func() { w.Flush() }, "the flush panic must propagate")
+	require.NotEmpty(t, base.deadlines)
+	assert.True(t, base.deadlines[len(base.deadlines)-1].IsZero(), "teardown must clear the deadline during unwinding")
+	assertClosed(t, w.Done(), "teardown must release the waiter during unwinding")
+}
+
+func TestEndOfDeliveryClearRunsAfterFinalFlush(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	w.End()
+	w.Flush()
+
+	// The final flush is the syscall pushing the delivery's last bytes; it must still run under
+	// the armed deadline, with the clear strictly after it. Clearing first would let a stalled
+	// client block the handler in that flush with no bound.
+	assert.Equal(t, []string{"arm", "write", "flush", "arm"}, base.eventLog(),
+		"the clearing SetWriteDeadline must come after the final flush")
+	armed := base.armed()
+	assert.True(t, armed[len(armed)-1].IsZero())
+}
+
+func TestStaleWaitDoesNotReleaseNewerDelivery(t *testing.T) {
+	base := newDeadlineConn()
+	w := WrapGated(base, time.Minute)
+	w.Begin()
+	stale := w.Done() // delivery 1's channel
+	w.Begin()         // delivery 2 begins; delivery 1's channel is closed here
+
+	// Drive the cancellation branch with the stale capture repeatedly (which select arm runs is
+	// random, since both are ready): the identity guard must keep a stale waiter from closing
+	// delivery 2's done and releasing its slot early.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	for range 200 {
+		w.waitAndFinish(ctx, stale)
+	}
+	assertOpen(t, w.Done(), "a stale waiter must not release the newer delivery")
+}
+
+func TestProducerHandlerSplitIsRaceFree(t *testing.T) {
+	// The real shape: the producer goroutine drives Begin/End/WaitAndFinish while the handler
+	// goroutine drives Write/Flush. Under -race this pins the lock discipline on the state
+	// fields that Flush samples and Begin/End mutate (a single-goroutine lifecycle test cannot).
+	w := WrapGated(&syncConn{}, 2*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { // producer
+		defer wg.Done()
+		for range 300 {
+			w.Begin()
+			w.End()
+			w.WaitAndFinish(ctx)
+		}
+	}()
+	go func() { // handler
+		defer wg.Done()
+		for range 300 {
+			_, _ = w.Write([]byte("data: x\n\n"))
+			w.Flush()
+		}
+	}()
+	wg.Wait()
+}
+
 func TestConcurrentLifecycleIsRaceFree(t *testing.T) {
-	// Drives Begin/End/Flush/Done/WaitAndFinish/Write concurrently so the race detector pins the
-	// lock discipline (an unlocked read of done or the state fields fails under -race).
+	// Drives Done/WaitAndFinish concurrently against a Begin/End/Flush loop so the race detector
+	// pins the lock discipline on the done channel. (The write-path split lives in
+	// TestProducerHandlerSplitIsRaceFree, which runs Flush and Begin/End on different goroutines.)
 	base := newDeadlineConn()
 	w, _ := wrapClocked(base, 2*time.Minute, true)
 
@@ -670,6 +753,32 @@ func TestWriteStringZeroNilWriterReturnsShortWrite(t *testing.T) {
 }
 
 // noFlushConn is a minimal ResponseWriter that records deadlines but cannot flush.
+// panicFlushConn is a noFlushConn whose Flush panics, to prove the teardown still runs during
+// unwinding.
+type panicFlushConn struct{ *noFlushConn }
+
+func (panicFlushConn) Flush() { panic("flush exploded") }
+
+// syncConn is a minimal ResponseWriter whose every method is safe for concurrent use, so
+// producer/handler-split race tests exercise the Writer's own locking rather than the fake's.
+type syncConn struct {
+	mu  sync.Mutex
+	hdr http.Header
+}
+
+func (c *syncConn) Header() http.Header {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.hdr == nil {
+		c.hdr = http.Header{}
+	}
+	return c.hdr
+}
+func (c *syncConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (c *syncConn) WriteHeader(int)                  {}
+func (c *syncConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *syncConn) Flush()                           {}
+
 type noFlushConn struct {
 	hdr       http.Header
 	deadlines []time.Time
@@ -882,8 +991,14 @@ func TestPollWrapDeadlineDoesNotLingerOntoNextKeepAliveRequest(t *testing.T) {
 	require.Zero(t, srv.Config.WriteTimeout, "test assumes no server WriteTimeout, matching relay")
 
 	client := srv.Client() // keep-alive transport, reuses the connection
+	var reused atomic.Bool
 	get := func() (string, error) {
-		resp, err := client.Get(srv.URL)
+		req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+		if err != nil {
+			return "", err
+		}
+		trace := &httptrace.ClientTrace{GotConn: func(ci httptrace.GotConnInfo) { reused.Store(ci.Reused) }}
+		resp, err := client.Do(req.WithContext(httptrace.WithClientTrace(req.Context(), trace)))
 		if err != nil {
 			return "", err
 		}
@@ -900,6 +1015,10 @@ func TestPollWrapDeadlineDoesNotLingerOntoNextKeepAliveRequest(t *testing.T) {
 	b, err = get()
 	require.NoError(t, err, "armed deadline lingered onto the reused connection")
 	assert.Equal(t, "resp-2", b)
+	// The reuse assertion is what gives this test teeth: if the deadline lingered and killed
+	// the pooled connection, the transport would silently retry the idempotent GET on a fresh
+	// connection and the body assertions above would still pass.
+	assert.True(t, reused.Load(), "request 2 must run on the SAME keep-alive connection")
 }
 
 func TestUnwrapReachesBase(t *testing.T) {

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -623,6 +624,48 @@ func TestFlushAfterCompletionDoesNotPanic(t *testing.T) {
 	// A second flush of an already-completed delivery (the doneClosed guard) must not double-close.
 	assert.NotPanics(t, func() { w.Flush() })
 	assertClosed(t, w.Done(), "Done stays closed after a redundant flush")
+}
+
+func TestPollWrapDeadlineDoesNotLingerOntoNextKeepAliveRequest(t *testing.T) {
+	// A poll (Wrap) delivery arms a per-write deadline and relies on net/http to reset the
+	// connection's write deadline when the handler returns -- this server sets no WriteTimeout.
+	// Pin that reliance: net/http clears it unconditionally, so an armed deadline from one request
+	// cannot linger onto the next request on a reused HTTP/1.1 keep-alive connection. (If a future
+	// Go release changed this, Wrap would need to clear the deadline itself.)
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		i := n.Add(1)
+		if i == 1 {
+			// A tiny maxHold makes the armed deadline expire well before request 2's write, so a
+			// failure to clear would surface as a failed second request rather than passing by luck.
+			pw := Wrap(w, 50*time.Millisecond)
+			_, _ = pw.Write([]byte("resp-1"))
+			return
+		}
+		_, _ = io.WriteString(w, "resp-2")
+	}))
+	defer srv.Close()
+	require.Zero(t, srv.Config.WriteTimeout, "test assumes no server WriteTimeout, matching relay")
+
+	client := srv.Client() // keep-alive transport, reuses the connection
+	get := func() (string, error) {
+		resp, err := client.Get(srv.URL)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		return string(b), err
+	}
+
+	b, err := get()
+	require.NoError(t, err)
+	require.Equal(t, "resp-1", b)
+
+	time.Sleep(150 * time.Millisecond) // past the 50ms deadline armed in request 1
+	b, err = get()
+	require.NoError(t, err, "armed deadline lingered onto the reused connection")
+	assert.Equal(t, "resp-2", b)
 }
 
 func TestUnwrapReachesBase(t *testing.T) {

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -50,7 +50,7 @@ type deadlineConn struct {
 	setCalls        int
 	flushes         int
 	written         int
-	failAfter       int // if >0, Write fails once this many bytes have been written
+	failAfter       int // if >0, a write fails once this many bytes have been written
 	clock           *fakeClock
 	advancePerWrite time.Duration
 	onFlush         func() // invoked inside Flush, to interleave a concurrent state change
@@ -70,29 +70,31 @@ func (d *deadlineConn) SetWriteDeadline(t time.Time) error {
 	return nil
 }
 
-func (d *deadlineConn) Write(p []byte) (int, error) {
+func (d *deadlineConn) recordWrite(n int) (bool, int) {
 	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.events = append(d.events, "write")
 	if d.clock != nil && d.advancePerWrite > 0 {
 		d.clock.advance(d.advancePerWrite)
 	}
 	if d.failAfter > 0 && d.written >= d.failAfter {
-		d.mu.Unlock()
+		return true, 0
+	}
+	d.written += n
+	return false, n
+}
+
+func (d *deadlineConn) Write(p []byte) (int, error) {
+	if fail, _ := d.recordWrite(len(p)); fail {
 		return 0, io.ErrClosedPipe
 	}
-	d.written += len(p)
-	d.mu.Unlock()
 	return d.ResponseRecorder.Write(p)
 }
 
 func (d *deadlineConn) WriteString(s string) (int, error) {
-	d.mu.Lock()
-	d.events = append(d.events, "write")
-	if d.clock != nil && d.advancePerWrite > 0 {
-		d.clock.advance(d.advancePerWrite)
+	if fail, _ := d.recordWrite(len(s)); fail {
+		return 0, io.ErrClosedPipe
 	}
-	d.written += len(s)
-	d.mu.Unlock()
 	return d.ResponseRecorder.WriteString(s)
 }
 
@@ -179,6 +181,18 @@ func TestWriteArmsBeforeEachWrite(t *testing.T) {
 	assert.Equal(t, []string{"arm", "write", "arm", "write"}, base.eventLog())
 }
 
+func TestWriteStringArmsBeforeEachWrite(t *testing.T) {
+	// eventsource writes event data with io.WriteString, so the string path is the production
+	// path and must arm before each write just like the byte path.
+	base := newDeadlineConn()
+	base.advancePerWrite = minExtension
+	w, _ := wrapClocked(base, 5*time.Minute, false)
+
+	_, err := w.WriteString(string(make([]byte, 2*chunkSize)))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"arm", "write", "arm", "write"}, base.eventLog())
+}
+
 func TestWriteReArmsEachChunk(t *testing.T) {
 	base := newDeadlineConn()
 	base.advancePerWrite = minExtension
@@ -187,6 +201,17 @@ func TestWriteReArmsEachChunk(t *testing.T) {
 	_, err := w.Write(make([]byte, 3*chunkSize))
 	require.NoError(t, err)
 	assert.Len(t, base.armed(), 3, "expected one arm per 1 MiB chunk")
+}
+
+func TestWriteRatchetSuppressesSameValueReArm(t *testing.T) {
+	base := newDeadlineConn()
+	// No clock advance: every chunk computes the same deadline, so the ratchet should arm once
+	// and suppress the rest. (A removed ratchet would arm on every chunk.)
+	w, _ := wrapClocked(base, 5*time.Minute, false)
+
+	_, err := w.Write(make([]byte, 3*chunkSize))
+	require.NoError(t, err)
+	assert.Len(t, base.armed(), 1, "identical deadlines must not be re-armed")
 }
 
 func TestWriteCapsDeadlineAtMaxHold(t *testing.T) {
@@ -233,6 +258,36 @@ func TestWriteErrorPropagatesAndStops(t *testing.T) {
 	n, err := w.Write(make([]byte, 3*chunkSize))
 	assert.ErrorIs(t, err, io.ErrClosedPipe, "a failed write must propagate")
 	assert.Equal(t, chunkSize, n, "the count reflects only the bytes written before the failure")
+}
+
+func TestWriteStringErrorPropagatesAndStops(t *testing.T) {
+	base := newDeadlineConn()
+	base.failAfter = chunkSize
+	w := Wrap(base, 2*time.Minute)
+
+	n, err := w.WriteString(string(make([]byte, 3*chunkSize)))
+	assert.ErrorIs(t, err, io.ErrClosedPipe)
+	assert.Equal(t, chunkSize, n)
+}
+
+func TestWriteStringMatchesWrite(t *testing.T) {
+	payload := make([]byte, 3*chunkSize+777)
+
+	byteConn := newDeadlineConn()
+	byteConn.advancePerWrite = minExtension
+	bw, _ := wrapClocked(byteConn, 2*time.Minute, false)
+	nBytes, err := bw.Write(payload)
+	require.NoError(t, err)
+
+	strConn := newDeadlineConn()
+	strConn.advancePerWrite = minExtension
+	sw, _ := wrapClocked(strConn, 2*time.Minute, false)
+	nStr, err := sw.WriteString(string(payload))
+	require.NoError(t, err)
+
+	assert.Equal(t, nBytes, nStr, "byte and string paths should write the same count")
+	assert.Len(t, strConn.armed(), len(byteConn.armed()), "both paths should arm the same number of deadlines")
+	assert.Equal(t, byteConn.Body.Bytes(), strConn.Body.Bytes(), "both paths should emit identical bytes")
 }
 
 func TestGatedArmsOnlyBetweenBeginAndEndFlush(t *testing.T) {
@@ -329,30 +384,6 @@ func TestDoneIsFailSafeClosedOutsideDelivery(t *testing.T) {
 	assertClosed(t, w.Done(), "Done after end-of-delivery flush")
 }
 
-func TestAbortForceFiresDeadlineNotClears(t *testing.T) {
-	base := newDeadlineConn()
-	w, c := wrapClocked(base, 2*time.Minute, true)
-	w.Begin()
-	_, err := w.Write(make([]byte, chunkSize))
-	require.NoError(t, err)
-	done := w.Done()
-
-	// Abort must move the deadline to now (forcing a stalled in-flight write to fail), NOT clear
-	// it -- clearing would leave the remaining send unbounded.
-	w.Abort()
-	armed := base.armed()
-	require.NotEmpty(t, armed)
-	last := armed[len(armed)-1]
-	assert.False(t, last.IsZero(), "Abort must not clear the deadline")
-	assert.Equal(t, c.now(), last, "Abort should force the deadline to now")
-	assertClosed(t, done, "Done after Abort")
-
-	// Inert afterwards.
-	_, err = w.Write(make([]byte, chunkSize))
-	require.NoError(t, err)
-	assert.Len(t, base.armed(), len(armed), "no arming after Abort")
-}
-
 func TestWaitAndFinishReturnsWhenDelivered(t *testing.T) {
 	base := newDeadlineConn()
 	w, _ := wrapClocked(base, 2*time.Minute, true)
@@ -363,26 +394,84 @@ func TestWaitAndFinishReturnsWhenDelivered(t *testing.T) {
 
 	go w.Flush() // the handler goroutine's end-of-batch flush closes Done
 
-	w.WaitAndFinish(context.Background())
+	runWithTimeout(t, "WaitAndFinish should return once delivered", func() {
+		w.WaitAndFinish(context.Background())
+	})
 	armed := base.armed()
 	require.NotEmpty(t, armed)
-	assert.True(t, armed[len(armed)-1].IsZero(), "a delivered stream should have its deadline cleared, not force-fired")
+	assert.True(t, armed[len(armed)-1].IsZero(), "a delivered stream should have its deadline cleared")
 }
 
-func TestWaitAndFinishAbortsOnCancel(t *testing.T) {
+func TestWaitAndFinishOnCancelReleasesWithoutTouchingConnection(t *testing.T) {
 	base := newDeadlineConn()
-	w, c := wrapClocked(base, 2*time.Minute, true)
+	w, _ := wrapClocked(base, 2*time.Minute, true)
 	w.Begin()
-	_, err := w.Write(make([]byte, chunkSize))
+	_, err := w.Write(make([]byte, chunkSize)) // arms once (setCalls == 1)
 	require.NoError(t, err)
+	require.Equal(t, 1, base.calls())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	w.WaitAndFinish(ctx) // client gone: must abort (force-fire), not hang
+	runWithTimeout(t, "WaitAndFinish should return on cancel", func() {
+		w.WaitAndFinish(ctx)
+	})
 
-	armed := base.armed()
-	require.NotEmpty(t, armed)
-	assert.Equal(t, c.now(), armed[len(armed)-1], "cancellation should force-fire the deadline")
+	// The cancel path must not touch the connection: no additional SetWriteDeadline, and the
+	// waiter is released so the slot frees.
+	assert.Equal(t, 1, base.calls(), "cancellation must not set the write deadline")
+	assertClosed(t, w.Done(), "Done after cancel")
+}
+
+// panicDeadlineConn panics if the write deadline is set, to prove the producer-side path never
+// touches the connection (which, after the handler returns, would crash inside net/http).
+type panicDeadlineConn struct{ *httptest.ResponseRecorder }
+
+func (panicDeadlineConn) SetWriteDeadline(time.Time) error {
+	panic("SetWriteDeadline must not be called from the producer path")
+}
+
+func TestWaitAndFinishNeverSetsDeadline(t *testing.T) {
+	base := panicDeadlineConn{httptest.NewRecorder()}
+	w := WrapGated(base, 2*time.Minute)
+	w.Begin() // no writes, so no legitimate handler-side arm
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.NotPanics(t, func() { w.WaitAndFinish(ctx) },
+		"WaitAndFinish must never set the connection deadline")
+}
+
+func TestWaitAndFinishAfterHandlerReturnDoesNotCrashHTTP2(t *testing.T) {
+	// Reproduce the producer-outlives-handler pattern on a real HTTP/2 connection: a goroutine
+	// holds the Writer and calls WaitAndFinish after the handler has returned and its context is
+	// cancelled. Touching the connection here nil-panics inside net/http and crashes the process;
+	// WaitAndFinish must not. (A panic in that goroutine would take the whole test binary down.)
+	finished := make(chan struct{})
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		w := WrapGated(rw, 2*time.Minute)
+		w.Begin()
+		_, _ = w.Write([]byte("data: hi\n\n"))
+		w.Flush()
+		go func() {
+			defer close(finished)
+			w.WaitAndFinish(r.Context()) // fires on ctx.Done after the handler returns
+		}()
+		// handler returns here, completing the stream and cancelling r.Context()
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("producer goroutine did not return")
+	}
 }
 
 func TestReBeginReleasesPriorWaiter(t *testing.T) {
@@ -420,6 +509,20 @@ func TestFlushDoesNotClearNewerDeliveryDeadline(t *testing.T) {
 	assert.False(t, last.IsZero(), "a stale flush must not clear the newer delivery's deadline")
 }
 
+func TestFlushAfterCompletionDoesNotPanic(t *testing.T) {
+	base := newDeadlineConn()
+	w := WrapGated(base, 2*time.Minute)
+	w.Begin()
+	_, err := w.Write([]byte("event: put\n\n"))
+	require.NoError(t, err)
+	w.End()
+	w.Flush() // clears and closes done
+
+	// A second flush of an already-completed delivery (the doneClosed guard) must not double-close.
+	assert.NotPanics(t, func() { w.Flush() })
+	assertClosed(t, w.Done(), "Done stays closed after a redundant flush")
+}
+
 func TestUnwrapReachesBase(t *testing.T) {
 	base := newDeadlineConn()
 	w := Wrap(base, time.Minute)
@@ -434,6 +537,20 @@ func TestEmptyWriteNoDeadline(t *testing.T) {
 	_, err := w.Write(nil)
 	require.NoError(t, err)
 	assert.Empty(t, base.armed(), "an empty write should not arm a deadline")
+}
+
+func runWithTimeout(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s: did not return within the timeout", what)
+	}
 }
 
 func assertClosed(t *testing.T, ch <-chan struct{}, what string) {

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -1,7 +1,9 @@
 package initwrite
 
 import (
+	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -34,21 +36,24 @@ func (c *fakeClock) advance(d time.Duration) {
 	c.mu.Unlock()
 }
 
-// deadlineConn is a ResponseWriter that records every write deadline armed on it, so tests can
-// assert the progress-aware arming logic without a real socket. It forwards Flush to the
-// embedded recorder (so Flushed stays observable) and guards its recorded state with a mutex.
-// If a clock is attached it advances by advancePerWrite on each Write, so a multi-chunk write
-// can exercise per-chunk re-arming deterministically.
+// deadlineConn is a ResponseWriter that records the write deadlines armed on it and the order
+// of arm-vs-write calls, so tests can assert the arming logic without a real socket. It
+// forwards Flush to the embedded recorder (so Flushed stays observable) and guards its state
+// with a mutex.
 type deadlineConn struct {
 	*httptest.ResponseRecorder
 
 	mu              sync.Mutex
 	deadlines       []time.Time
-	setErr          error // returned from SetWriteDeadline when non-nil, to simulate a failing syscall
+	events          []string // "arm" / "write" in call order
+	setErr          error    // returned from SetWriteDeadline when non-nil
 	setCalls        int
 	flushes         int
+	written         int
+	failAfter       int // if >0, Write fails once this many bytes have been written
 	clock           *fakeClock
 	advancePerWrite time.Duration
+	onFlush         func() // invoked inside Flush, to interleave a concurrent state change
 }
 
 func newDeadlineConn() *deadlineConn { return &deadlineConn{ResponseRecorder: httptest.NewRecorder()} }
@@ -60,31 +65,45 @@ func (d *deadlineConn) SetWriteDeadline(t time.Time) error {
 	if d.setErr != nil {
 		return d.setErr
 	}
+	d.events = append(d.events, "arm")
 	d.deadlines = append(d.deadlines, t)
 	return nil
 }
 
 func (d *deadlineConn) Write(p []byte) (int, error) {
+	d.mu.Lock()
+	d.events = append(d.events, "write")
 	if d.clock != nil && d.advancePerWrite > 0 {
 		d.clock.advance(d.advancePerWrite)
 	}
+	if d.failAfter > 0 && d.written >= d.failAfter {
+		d.mu.Unlock()
+		return 0, io.ErrClosedPipe
+	}
+	d.written += len(p)
+	d.mu.Unlock()
 	return d.ResponseRecorder.Write(p)
 }
 
-// WriteString mirrors Write so the string and byte paths advance the fake clock identically;
-// without it, io.WriteString would reach the embedded recorder's own WriteString and skip the
-// clock advance, making the two paths incomparable.
 func (d *deadlineConn) WriteString(s string) (int, error) {
+	d.mu.Lock()
+	d.events = append(d.events, "write")
 	if d.clock != nil && d.advancePerWrite > 0 {
 		d.clock.advance(d.advancePerWrite)
 	}
+	d.written += len(s)
+	d.mu.Unlock()
 	return d.ResponseRecorder.WriteString(s)
 }
 
 func (d *deadlineConn) Flush() {
 	d.mu.Lock()
 	d.flushes++
+	hook := d.onFlush
 	d.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
 	d.ResponseRecorder.Flush()
 }
 
@@ -94,27 +113,30 @@ func (d *deadlineConn) armed() []time.Time {
 	return slices.Clone(d.deadlines)
 }
 
+func (d *deadlineConn) eventLog() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return slices.Clone(d.events)
+}
+
 func (d *deadlineConn) calls() int {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.setCalls
 }
 
-// wrapClocked builds a Writer driven by a deterministic clock shared with base.
 func wrapClocked(base *deadlineConn, maxHold time.Duration, gated bool) (*Writer, *fakeClock) {
 	c := newFakeClock()
 	base.clock = c
-	w := Wrap(base, maxHold)
+	var w *Writer
 	if gated {
 		w = WrapGated(base, maxHold)
+	} else {
+		w = Wrap(base, maxHold)
 	}
 	w.now = c.now
 	return w, c
 }
-
-// perChunkBudget is the deadline a full 1 MiB chunk should arm: time to send it at the floor
-// plus slack. Tests assert against this exact value so a weaker/stronger floor or slack fails.
-var perChunkBudget = time.Duration(chunkSize)*time.Second/time.Duration(minBytesPerSec) + slack
 
 func TestWriteArmsFullChunkAtFloorPlusSlack(t *testing.T) {
 	base := newDeadlineConn()
@@ -127,30 +149,41 @@ func TestWriteArmsFullChunkAtFloorPlusSlack(t *testing.T) {
 
 	armed := base.armed()
 	require.Len(t, armed, 1, "a single full chunk should arm exactly one deadline")
-	assert.Equal(t, perChunkBudget, armed[0].Sub(start)) // 16s at 64 KiB/s + 5s slack = 21s
+	// 1 MiB at 64 KiB/s is 16s; plus 5s slack = 21s. Literal so a weaker/stronger floor or slack fails.
+	assert.Equal(t, 21*time.Second, armed[0].Sub(start))
 }
 
-func TestWriteSmallPayloadArmsSlackOnly(t *testing.T) {
+func TestWriteSubChunkArmsFloorPlusSlack(t *testing.T) {
 	base := newDeadlineConn()
 	w, c := wrapClocked(base, 2*time.Minute, false)
 
 	start := c.now()
-	_, err := w.Write(make([]byte, 4096))
+	_, err := w.Write(make([]byte, 64*1024)) // exactly one second's worth at the floor
 	require.NoError(t, err)
 
 	armed := base.armed()
 	require.Len(t, armed, 1)
-	// A tiny payload's time-at-floor rounds to ~0, so the deadline is essentially just slack.
-	assert.Equal(t, slack+time.Duration(4096)*time.Second/time.Duration(minBytesPerSec), armed[0].Sub(start))
+	// 64 KiB at 64 KiB/s is 1s; plus 5s slack = 6s. Pins the floor and slack independently.
+	assert.Equal(t, 6*time.Second, armed[0].Sub(start))
+}
+
+func TestWriteArmsBeforeEachWrite(t *testing.T) {
+	base := newDeadlineConn()
+	base.advancePerWrite = minExtension // ensure each chunk re-arms
+	w, _ := wrapClocked(base, 5*time.Minute, false)
+
+	_, err := w.Write(make([]byte, 2*chunkSize))
+	require.NoError(t, err)
+	// The deadline for a chunk must be set before that chunk is written, or the first chunk --
+	// the one that can block forever -- would carry no deadline.
+	assert.Equal(t, []string{"arm", "write", "arm", "write"}, base.eventLog())
 }
 
 func TestWriteReArmsEachChunk(t *testing.T) {
 	base := newDeadlineConn()
-	base.advancePerWrite = minExtension // enough progress between chunks to re-arm
+	base.advancePerWrite = minExtension
 	w, _ := wrapClocked(base, 5*time.Minute, false)
 
-	// A multi-chunk write must arm once per full chunk, not once for the whole payload: that is
-	// what keeps a client that stalls partway through from holding a slot past the floor.
 	_, err := w.Write(make([]byte, 3*chunkSize))
 	require.NoError(t, err)
 	assert.Len(t, base.armed(), 3, "expected one arm per 1 MiB chunk")
@@ -158,7 +191,6 @@ func TestWriteReArmsEachChunk(t *testing.T) {
 
 func TestWriteCapsDeadlineAtMaxHold(t *testing.T) {
 	base := newDeadlineConn()
-	// A tiny cap (well under the per-chunk budget) must clamp the armed deadline to the cap.
 	w, c := wrapClocked(base, 500*time.Millisecond, false)
 	start := c.now()
 	_, err := w.Write(make([]byte, chunkSize))
@@ -171,7 +203,6 @@ func TestWriteCapsDeadlineAtMaxHold(t *testing.T) {
 
 func TestZeroMaxHoldDisablesCap(t *testing.T) {
 	base := newDeadlineConn()
-	// A non-positive maxHold leaves only the per-write floor; the deadline is not clamped.
 	w, c := wrapClocked(base, 0, false)
 	start := c.now()
 	_, err := w.Write(make([]byte, chunkSize))
@@ -179,28 +210,36 @@ func TestZeroMaxHoldDisablesCap(t *testing.T) {
 
 	armed := base.armed()
 	require.Len(t, armed, 1)
-	assert.Equal(t, perChunkBudget, armed[0].Sub(start))
+	assert.Equal(t, 21*time.Second, armed[0].Sub(start), "with no cap the per-chunk floor governs")
 }
 
 func TestArmDoesNotAdvanceOnSetDeadlineFailure(t *testing.T) {
 	base := newDeadlineConn()
 	base.setErr = errors.New("deadline not supported")
-	base.advancePerWrite = minExtension
+	// No clock advance: with the fix, lastDeadline stays unset on failure, so every chunk retries;
+	// with the bug (advance on failure), the ratchet suppresses all but the first attempt.
 	w, _ := wrapClocked(base, 2*time.Minute, false)
 
-	// If SetWriteDeadline keeps failing, the writer must keep attempting it on later chunks
-	// rather than recording a deadline it never set and going silently inert.
 	_, err := w.Write(make([]byte, 3*chunkSize))
 	require.NoError(t, err)
 	assert.Equal(t, 3, base.calls(), "each chunk should retry SetWriteDeadline after a failure")
+}
+
+func TestWriteErrorPropagatesAndStops(t *testing.T) {
+	base := newDeadlineConn()
+	base.failAfter = chunkSize // fail on the second chunk
+	w := Wrap(base, 2*time.Minute)
+
+	n, err := w.Write(make([]byte, 3*chunkSize))
+	assert.ErrorIs(t, err, io.ErrClosedPipe, "a failed write must propagate")
+	assert.Equal(t, chunkSize, n, "the count reflects only the bytes written before the failure")
 }
 
 func TestGatedArmsOnlyBetweenBeginAndEndFlush(t *testing.T) {
 	base := newDeadlineConn()
 	w, c := wrapClocked(base, 2*time.Minute, true)
 
-	// Before Begin: writes pass through unarmed (the stream's headers/initial bytes carry no
-	// deadline until a delivery starts).
+	// Before Begin: writes pass through unarmed.
 	_, err := w.Write(make([]byte, chunkSize))
 	require.NoError(t, err)
 	require.Empty(t, base.armed(), "no deadline should be armed before Begin")
@@ -212,7 +251,7 @@ func TestGatedArmsOnlyBetweenBeginAndEndFlush(t *testing.T) {
 	require.NoError(t, err)
 	armed := base.armed()
 	require.Len(t, armed, 1)
-	assert.Equal(t, perChunkBudget, armed[0].Sub(start))
+	assert.Equal(t, 21*time.Second, armed[0].Sub(start))
 
 	// End + the single end-of-batch flush clears the deadline exactly once.
 	w.End()
@@ -225,6 +264,53 @@ func TestGatedArmsOnlyBetweenBeginAndEndFlush(t *testing.T) {
 	_, err = w.Write(make([]byte, chunkSize))
 	require.NoError(t, err)
 	assert.Len(t, base.armed(), 2, "no new deadline should be armed after the delivery ends")
+}
+
+func TestGatedWriteStringLifecycle(t *testing.T) {
+	// eventsource writes event data via io.WriteString, so the string path is the production SSE
+	// path and must behave like Write under gating.
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 2*time.Minute, true)
+
+	_, err := io.WriteString(w, "before begin")
+	require.NoError(t, err)
+	require.Empty(t, base.armed(), "no deadline before Begin on the string path")
+
+	w.Begin()
+	start := c.now()
+	_, err = io.WriteString(w, string(make([]byte, chunkSize)))
+	require.NoError(t, err)
+	require.Len(t, base.armed(), 1)
+	assert.Equal(t, 21*time.Second, base.armed()[0].Sub(start))
+
+	w.End()
+	w.Flush()
+	require.Len(t, base.armed(), 2)
+	assert.True(t, base.armed()[1].IsZero(), "string-path delivery should clear at end")
+	assert.GreaterOrEqual(t, base.flushes, 1)
+}
+
+func TestGatedInertAfterDeliveryAcrossHeartbeats(t *testing.T) {
+	base := newDeadlineConn()
+	base.advancePerWrite = time.Second
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	w.End()
+	w.Flush()
+	armedAtEnd := len(base.armed())
+
+	// Simulate later heartbeat traffic on the persistent stream: with the clock advancing, a
+	// writer that failed to deactivate at end-of-delivery would re-arm here and fire on an idle
+	// HTTP/2 stream. It must not.
+	for range 3 {
+		_, err = w.Write([]byte(": keep-alive\n\n"))
+		require.NoError(t, err)
+		w.Flush()
+	}
+	assert.Len(t, base.armed(), armedAtEnd, "heartbeats after the delivery must not re-arm the deadline")
 }
 
 func TestDoneIsFailSafeClosedOutsideDelivery(t *testing.T) {
@@ -243,31 +329,60 @@ func TestDoneIsFailSafeClosedOutsideDelivery(t *testing.T) {
 	assertClosed(t, w.Done(), "Done after end-of-delivery flush")
 }
 
-func TestFinishClearsDeadlineAndClosesDone(t *testing.T) {
+func TestAbortForceFiresDeadlineNotClears(t *testing.T) {
 	base := newDeadlineConn()
-	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w, c := wrapClocked(base, 2*time.Minute, true)
 	w.Begin()
 	_, err := w.Write(make([]byte, chunkSize))
 	require.NoError(t, err)
 	done := w.Done()
 
-	// Finish is the backstop for a delivery that ends without a final flush: it clears the
-	// deadline and releases the waiter.
-	w.Finish()
+	// Abort must move the deadline to now (forcing a stalled in-flight write to fail), NOT clear
+	// it -- clearing would leave the remaining send unbounded.
+	w.Abort()
 	armed := base.armed()
 	require.NotEmpty(t, armed)
-	assert.True(t, armed[len(armed)-1].IsZero(), "Finish should clear the write deadline")
-	assertClosed(t, done, "Done after Finish")
+	last := armed[len(armed)-1]
+	assert.False(t, last.IsZero(), "Abort must not clear the deadline")
+	assert.Equal(t, c.now(), last, "Abort should force the deadline to now")
+	assertClosed(t, done, "Done after Abort")
 
-	// Idempotent: a second Finish neither panics nor re-clears.
-	before := len(base.armed())
-	w.Finish()
-	assert.Len(t, base.armed(), before, "a second Finish should be a no-op")
-
-	// Inert afterwards: writes pass through unarmed.
+	// Inert afterwards.
 	_, err = w.Write(make([]byte, chunkSize))
 	require.NoError(t, err)
-	assert.Len(t, base.armed(), before, "no deadline should arm after Finish")
+	assert.Len(t, base.armed(), len(armed), "no arming after Abort")
+}
+
+func TestWaitAndFinishReturnsWhenDelivered(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	w.End()
+
+	go w.Flush() // the handler goroutine's end-of-batch flush closes Done
+
+	w.WaitAndFinish(context.Background())
+	armed := base.armed()
+	require.NotEmpty(t, armed)
+	assert.True(t, armed[len(armed)-1].IsZero(), "a delivered stream should have its deadline cleared, not force-fired")
+}
+
+func TestWaitAndFinishAbortsOnCancel(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	w.WaitAndFinish(ctx) // client gone: must abort (force-fire), not hang
+
+	armed := base.armed()
+	require.NotEmpty(t, armed)
+	assert.Equal(t, c.now(), armed[len(armed)-1], "cancellation should force-fire the deadline")
 }
 
 func TestReBeginReleasesPriorWaiter(t *testing.T) {
@@ -277,37 +392,37 @@ func TestReBeginReleasesPriorWaiter(t *testing.T) {
 	first := w.Done()
 	assertOpen(t, first, "first delivery's Done")
 
-	// A second Begin (a defensive case) must release the prior delivery's waiter rather than
-	// orphan it, and hand out a fresh open channel.
 	w.Begin()
 	assertClosed(t, first, "prior Done after re-Begin")
 	assertOpen(t, w.Done(), "new delivery's Done")
 }
 
-func TestWriteStringMatchesWrite(t *testing.T) {
-	payload := make([]byte, 3*chunkSize+777)
-
-	byteConn := newDeadlineConn()
-	byteConn.advancePerWrite = minExtension
-	bw, _ := wrapClocked(byteConn, 2*time.Minute, false)
-	nBytes, err := bw.Write(payload)
+func TestFlushDoesNotClearNewerDeliveryDeadline(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize)) // delivery 1 armed
 	require.NoError(t, err)
+	w.End()
 
-	strConn := newDeadlineConn()
-	strConn.advancePerWrite = minExtension
-	sw, _ := wrapClocked(strConn, 2*time.Minute, false)
-	nStr, err := sw.WriteString(string(payload))
-	require.NoError(t, err)
+	// A newer delivery begins during delivery 1's end-of-batch flush (modeling the producer
+	// racing the handler's flush). The stale flush must not tear down the newer delivery.
+	base.onFlush = func() {
+		base.onFlush = nil // once
+		w.Begin()
+		c.advance(time.Second)
+		_, _ = w.Write(make([]byte, chunkSize)) // delivery 2 armed
+	}
+	w.Flush()
 
-	assert.Equal(t, nBytes, nStr, "byte and string paths should write the same count")
-	assert.Len(t, strConn.armed(), len(byteConn.armed()), "both paths should arm the same number of deadlines")
-	assert.Equal(t, byteConn.Body.Bytes(), strConn.Body.Bytes(), "both paths should emit identical bytes")
+	armed := base.armed()
+	last := armed[len(armed)-1]
+	assert.False(t, last.IsZero(), "a stale flush must not clear the newer delivery's deadline")
 }
 
 func TestUnwrapReachesBase(t *testing.T) {
 	base := newDeadlineConn()
 	w := Wrap(base, time.Minute)
-	// The deadline set through the controller must reach the base connection.
 	err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(time.Second))
 	assert.NoError(t, err)
 	assert.NotEmpty(t, base.armed(), "SetWriteDeadline did not reach base through initwrite.Writer.Unwrap")

--- a/internal/logging/request_logging.go
+++ b/internal/logging/request_logging.go
@@ -93,3 +93,9 @@ func (w *loggingHTTPResponseWriter) Flush() {
 		f.Flush()
 	}
 }
+
+// Unwrap exposes the wrapped ResponseWriter so that http.NewResponseController can reach the
+// underlying connection (e.g. to set read/write deadlines) through this logging wrapper.
+func (w *loggingHTTPResponseWriter) Unwrap() http.ResponseWriter {
+	return w.writer
+}

--- a/internal/logging/request_logging.go
+++ b/internal/logging/request_logging.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -36,6 +37,16 @@ func (w *loggingHTTPResponseWriter) Write(data []byte) (int, error) {
 	}
 	w.bytesWritten += uint64(len(data))
 	return w.writer.Write(data)
+}
+
+// WriteString preserves the underlying writer's io.StringWriter fast path: without it,
+// io.WriteString would copy a string payload into a fresh []byte at this hop.
+func (w *loggingHTTPResponseWriter) WriteString(s string) (int, error) {
+	if w.statusCode == 0 {
+		w.WriteHeader(200)
+	}
+	w.bytesWritten += uint64(len(s))
+	return io.WriteString(w.writer, s)
 }
 
 func (w *loggingHTTPResponseWriter) WriteHeader(statusCode int) {

--- a/internal/logging/request_logging_test.go
+++ b/internal/logging/request_logging_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -137,4 +138,35 @@ func TestLoggingResponseWriterUnwrapExposesConnectionDeadline(t *testing.T) {
 	err := http.NewResponseController(lw).SetWriteDeadline(time.Now().Add(time.Second))
 	assert.NoError(t, err, "controller could not set a deadline through loggingHTTPResponseWriter")
 	assert.True(t, base.gotWriteDeadline, "SetWriteDeadline did not reach the base writer through loggingHTTPResponseWriter")
+}
+
+// stringWriterProbe records whether a write reached it through the io.StringWriter fast
+// path rather than being copied to a []byte for Write.
+type stringWriterProbe struct {
+	*httptest.ResponseRecorder
+	gotWriteString bool
+}
+
+func (p *stringWriterProbe) WriteString(s string) (int, error) {
+	p.gotWriteString = true
+	return p.ResponseRecorder.WriteString(s)
+}
+
+// TestLoggingWriterPreservesStringWriterFastPath guards the WriteString forwarding that
+// keeps a large string payload (an initialization delivery) from being copied into a
+// fresh []byte at this hop, while keeping the same status and byte-count bookkeeping as
+// the Write path.
+func TestLoggingWriterPreservesStringWriterFastPath(t *testing.T) {
+	logger, _ := logtest.NewMockLogger()
+	probe := &stringWriterProbe{ResponseRecorder: httptest.NewRecorder()}
+	req, _ := http.NewRequest("GET", "/url", nil)
+	w := &loggingHTTPResponseWriter{logger: logger, writer: probe, request: req}
+
+	n, err := io.WriteString(w, "payload")
+	require.NoError(t, err)
+	assert.Equal(t, len("payload"), n)
+	assert.True(t, probe.gotWriteString, "WriteString did not reach the underlying writer; the payload was copied at this hop")
+	assert.Equal(t, "payload", probe.Body.String())
+	assert.Equal(t, 200, w.statusCode)
+	assert.Equal(t, uint64(len("payload")), w.bytesWritten)
 }

--- a/internal/logging/request_logging_test.go
+++ b/internal/logging/request_logging_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,4 +114,27 @@ func TestRequestLoggerMiddlewareAuth(t *testing.T) {
 	}
 	assert.True(t, foundRedacted, "expected to find log entry with redacted auth '*fghij'")
 	assert.True(t, foundShort, "expected to find log entry with short auth 'abcd'")
+}
+
+// deadlineProbeWriter records whether SetWriteDeadline reached it through a wrapper chain.
+type deadlineProbeWriter struct {
+	http.ResponseWriter
+	gotWriteDeadline bool
+}
+
+func (d *deadlineProbeWriter) SetWriteDeadline(time.Time) error {
+	d.gotWriteDeadline = true
+	return nil
+}
+
+// TestLoggingResponseWriterUnwrapExposesConnectionDeadline guards that the request-logging
+// wrapper implements Unwrap, so http.NewResponseController can reach the underlying
+// connection through it. Without this, deadlines set downstream (e.g. by the init-delivery
+// limiter) would silently become no-ops for every request while request logging is enabled.
+func TestLoggingResponseWriterUnwrapExposesConnectionDeadline(t *testing.T) {
+	base := &deadlineProbeWriter{ResponseWriter: httptest.NewRecorder()}
+	lw := &loggingHTTPResponseWriter{logger: slog.Default(), writer: base}
+	err := http.NewResponseController(lw).SetWriteDeadline(time.Now().Add(time.Second))
+	assert.NoError(t, err, "controller could not set a deadline through loggingHTTPResponseWriter")
+	assert.True(t, base.gotWriteDeadline, "SetWriteDeadline did not reach the base writer through loggingHTTPResponseWriter")
 }

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -39,6 +39,16 @@ func (sr *statusRecorder) Write(b []byte) (int, error) {
 	return sr.ResponseWriter.Write(b)
 }
 
+// WriteString preserves the underlying writer's io.StringWriter fast path: without it,
+// io.WriteString would copy a string payload into a fresh []byte at this hop.
+func (sr *statusRecorder) WriteString(s string) (int, error) {
+	if !sr.written {
+		sr.statusCode = 200
+		sr.written = true
+	}
+	return io.WriteString(sr.ResponseWriter, s)
+}
+
 func (sr *statusRecorder) Flush() {
 	if f, ok := sr.ResponseWriter.(http.Flusher); ok {
 		f.Flush()

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -45,6 +45,13 @@ func (sr *statusRecorder) Flush() {
 	}
 }
 
+// Unwrap exposes the wrapped ResponseWriter so that http.NewResponseController can reach
+// the underlying connection (e.g. to set read/write deadlines). Without this, a controller
+// built on top of this recorder silently loses those capabilities.
+func (sr *statusRecorder) Unwrap() http.ResponseWriter {
+	return sr.ResponseWriter
+}
+
 // countingReader wraps an io.ReadCloser and counts the bytes read.
 type countingReader struct {
 	reader    io.ReadCloser

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -200,3 +200,28 @@ func assertMetricHasValue(t *testing.T, m *metricdata.Metrics, envName, platform
 	}
 	assert.True(t, found, "no data point found for %s with platform=%s, env=%s", m.Name, platform, envName)
 }
+
+// deadlineProbeWriter is a ResponseWriter that records whether SetWriteDeadline reached it
+// through a wrapper chain.
+type deadlineProbeWriter struct {
+	http.ResponseWriter
+	gotWriteDeadline bool
+}
+
+func (d *deadlineProbeWriter) SetWriteDeadline(time.Time) error {
+	d.gotWriteDeadline = true
+	return nil
+}
+
+// TestStatusRecorderUnwrapExposesConnectionDeadline guards the Unwrap contract that the
+// init-delivery limiter relies on: if statusRecorder does not implement Unwrap,
+// http.NewResponseController cannot reach the underlying connection, and the limiter's
+// read/write deadlines silently become no-ops (a slow client would then park a budget slot
+// indefinitely).
+func TestStatusRecorderUnwrapExposesConnectionDeadline(t *testing.T) {
+	base := &deadlineProbeWriter{ResponseWriter: httptest.NewRecorder()}
+	sr := &statusRecorder{ResponseWriter: base, statusCode: 200}
+	err := http.NewResponseController(sr).SetWriteDeadline(time.Now().Add(time.Second))
+	assert.NoError(t, err, "controller could not set a deadline through statusRecorder")
+	assert.True(t, base.gotWriteDeadline, "SetWriteDeadline did not reach the base writer through statusRecorder")
+}

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -225,3 +225,31 @@ func TestStatusRecorderUnwrapExposesConnectionDeadline(t *testing.T) {
 	assert.NoError(t, err, "controller could not set a deadline through statusRecorder")
 	assert.True(t, base.gotWriteDeadline, "SetWriteDeadline did not reach the base writer through statusRecorder")
 }
+
+// stringWriterProbe records whether a write reached it through the io.StringWriter fast
+// path rather than being copied to a []byte for Write.
+type stringWriterProbe struct {
+	*httptest.ResponseRecorder
+	gotWriteString bool
+}
+
+func (p *stringWriterProbe) WriteString(s string) (int, error) {
+	p.gotWriteString = true
+	return p.ResponseRecorder.WriteString(s)
+}
+
+// TestStatusRecorderPreservesStringWriterFastPath guards the WriteString forwarding that
+// keeps a large string payload (an initialization delivery) from being copied into a
+// fresh []byte at this hop, while keeping the same implicit-200 bookkeeping as Write.
+func TestStatusRecorderPreservesStringWriterFastPath(t *testing.T) {
+	probe := &stringWriterProbe{ResponseRecorder: httptest.NewRecorder()}
+	sr := &statusRecorder{ResponseWriter: probe}
+
+	n, err := io.WriteString(sr, "payload")
+	require.NoError(t, err)
+	assert.Equal(t, len("payload"), n)
+	assert.True(t, probe.gotWriteString, "WriteString did not reach the underlying writer; the payload was copied at this hop")
+	assert.Equal(t, "payload", probe.Body.String())
+	assert.Equal(t, 200, sr.statusCode)
+	assert.True(t, sr.written)
+}


### PR DESCRIPTION
Adds the write-deadline primitive that the init-concurrency wiring will use to reclaim a slot from a client that cannot keep up, without disturbing a healthy client mid-delivery.

## What changes
- **New `internal/initwrite` package.** A `ResponseWriter` wrapper that, for each initialization delivery, arms a write deadline sized to the payload: a throughput floor (so a stalled or too-slow client is cut promptly) combined with an absolute cap (so a client stuck right at the floor on a very large payload is still bounded). It writes strings directly to avoid copying the payload once per connection, and implements `Unwrap` so `http.NewResponseController` can reach the underlying connection to set the deadline.
- **`Unwrap` on the logging and metrics `ResponseWriter` wrappers.** These wrap the connection for their own purposes and otherwise hide it, which would stop a `ResponseController` from reaching the real connection. Each now returns its inner writer.

## No behavior change
Nothing wraps a connection with `initwrite` yet, so this is inert at runtime. It builds, vets, and passes `-race` on `./internal/initwrite/`, `./internal/logging/`, and `./internal/middleware/`.

---
Second of the PRs splitting #782. Builds on #785 (the config + limiter refinement); the wiring PR will follow and depend on both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated package plus small middleware forwarding; no init-delivery wiring in this PR, so runtime behavior is unchanged.
> 
> **Overview**
> Introduces **`internal/initwrite`**, a `ResponseWriter` wrapper for upcoming init-concurrency limits. It arms **per-chunk write deadlines** from a 64 KiB/s throughput floor plus slack, with an optional **`maxHold`** cap, and supports **poll** (`Wrap`) vs **gated SSE** (`WrapGated` with `Begin`/`End`/`WaitAndFinish`) so idle streams are not left with HTTP/2 self-firing deadlines. It implements **`WriteString`**, **`Flush`**, and **`Unwrap`** for large SSE payloads and `http.NewResponseController`.
> 
> **Logging and metrics middleware** gain matching **`WriteString`** and **`Unwrap`** so deadline control and string writes are not broken or copied at those hops; tests lock in both behaviors.
> 
> **No production wiring yet** — the package is inert until a follow-up PR wraps init deliveries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7372afb9a9f9c3256bc6cada1f1bf403934055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->