### PR TITLE
fix: reconcile big segment data with polling endpoint when stream is quiet

### DIFF
--- a/integrationtests/big_segments_test.go
+++ b/integrationtests/big_segments_test.go
@@ -110,7 +110,9 @@ func verifyEvaluationWithBigSegment(
 	// Poll the evaluation endpoint until we see the expected flag values. We're using a
 	// longer timeout here than we use in tests that don't involve big segments, because
 	// the user segment state caching inside the SDK makes it hard to say how soon we'll
-	// see the effect of an update.
+	// see the effect of an update. 60s also covers the case where a segment update was
+	// not delivered on the big segments stream and is only picked up by the synchronizer's
+	// periodic (30s) reconciliation poll.
 	success := assert.Eventually(t, func() bool {
 		ok := true
 		for i, env := range environments {
@@ -125,7 +127,7 @@ func verifyEvaluationWithBigSegment(
 			}
 		}
 		return ok
-	}, time.Second*20, time.Millisecond*100, "Did not see expected flag values from Relay")
+	}, time.Second*60, time.Millisecond*100, "Did not see expected flag values from Relay")
 
 	if !success {
 		manager.logger.Info("EXPLANATION OF TEST FAILURE FOLLOWS")

--- a/integrationtests/big_segments_test.go
+++ b/integrationtests/big_segments_test.go
@@ -112,7 +112,7 @@ func verifyEvaluationWithBigSegment(
 	// the user segment state caching inside the SDK makes it hard to say how soon we'll
 	// see the effect of an update. 60s also covers the case where a segment update was
 	// not delivered on the big segments stream and is only picked up by the synchronizer's
-	// periodic (30s) reconciliation poll.
+	// follow-up reconciliation poll, which happens 30s after the stream is established.
 	success := assert.Eventually(t, func() bool {
 		ok := true
 		for i, env := range environments {

--- a/internal/bigsegments/sync.go
+++ b/internal/bigsegments/sync.go
@@ -382,6 +382,7 @@ func (s *defaultBigSegmentSynchronizer) connectStream() (*es.Stream, error) {
 }
 
 func (s *defaultBigSegmentSynchronizer) consumeStream(stream *es.Stream) error {
+	reconciled := false
 	for {
 		timer := time.NewTimer(s.reconcileInterval)
 		select {
@@ -406,14 +407,18 @@ func (s *defaultBigSegmentSynchronizer) consumeStream(stream *es.Stream) error {
 				return err
 			}
 		case <-timer.C:
-			// The stream has been quiet for a while. Updates normally arrive as stream
-			// events, but an event can be missed - for example, if it was published
-			// while the upstream subscription was still being established - and a missed
-			// event is never redelivered on the stream. Reconciling against the polling
-			// endpoint (which is cheap when there are no changes, since the request
-			// carries our cursor) bounds how long such a missed update can remain
-			// unapplied.
-			if err := s.reconcile(); err != nil {
+			if !reconciled {
+				// An update published shortly after the stream request may never be
+				// delivered as a stream event if the upstream subscription was not yet
+				// fully effective, and the poll made when the stream was established
+				// cannot cover updates published after it completed. Reconcile against
+				// the polling endpoint once per connection to pick up anything from
+				// that window; from then on the stream is trusted.
+				reconciled = true
+				if err := s.reconcile(); err != nil {
+					return err
+				}
+			} else if err := s.setSynced(); err != nil {
 				return err
 			}
 		case <-s.closeChan:

--- a/internal/bigsegments/sync.go
+++ b/internal/bigsegments/sync.go
@@ -24,7 +24,7 @@ const (
 	streamReadTimeout          = 5 * time.Minute
 	revisionsPollTimeout       = 90 * time.Second
 	defaultStreamRetryInterval = 10 * time.Second
-	synchronizedOnInterval     = 30 * time.Second
+	defaultReconcileInterval   = 30 * time.Second
 
 	segmentUpdatesChannelBufferSize = 20
 )
@@ -90,6 +90,7 @@ type defaultBigSegmentSynchronizer struct {
 	envID               config.EnvironmentID
 	sdkKey              config.SDKKey
 	streamRetryInterval time.Duration
+	reconcileInterval   time.Duration
 	segmentUpdatesChan  chan UpdatesSummary
 	hasSynced           bool
 	syncedLock          sync.RWMutex
@@ -143,6 +144,7 @@ func newDefaultBigSegmentSynchronizer(
 		envID:               envID,
 		sdkKey:              sdkKey,
 		streamRetryInterval: defaultStreamRetryInterval,
+		reconcileInterval:   defaultReconcileInterval,
 		segmentUpdatesChan:  make(chan UpdatesSummary, segmentUpdatesChannelBufferSize),
 		closeChan:           make(chan struct{}),
 		logger:              logger.With("component", component),
@@ -201,11 +203,17 @@ func (s *defaultBigSegmentSynchronizer) syncSupervisor() {
 				}
 			}
 		}
-		s.logger.Warn("will retry")
-		timer := time.NewTimer(s.streamRetryInterval)
-		defer timer.Stop()
 		select {
 		case <-s.closeChan:
+			close(s.segmentUpdatesChan)
+			return
+		default:
+		}
+		s.logger.Warn("will retry")
+		timer := time.NewTimer(s.streamRetryInterval)
+		select {
+		case <-s.closeChan:
+			timer.Stop()
 			close(s.segmentUpdatesChan)
 			return
 		case <-timer.C:
@@ -375,7 +383,7 @@ func (s *defaultBigSegmentSynchronizer) connectStream() (*es.Stream, error) {
 
 func (s *defaultBigSegmentSynchronizer) consumeStream(stream *es.Stream) error {
 	for {
-		timer := time.NewTimer(synchronizedOnInterval)
+		timer := time.NewTimer(s.reconcileInterval)
 		select {
 		case event, ok := <-stream.Events:
 			timer.Stop()
@@ -398,8 +406,14 @@ func (s *defaultBigSegmentSynchronizer) consumeStream(stream *es.Stream) error {
 				return err
 			}
 		case <-timer.C:
-			err := s.setSynced()
-			if err != nil {
+			// The stream has been quiet for a while. Updates normally arrive as stream
+			// events, but an event can be missed - for example, if it was published
+			// while the upstream subscription was still being established - and a missed
+			// event is never redelivered on the stream. Reconciling against the polling
+			// endpoint (which is cheap when there are no changes, since the request
+			// carries our cursor) bounds how long such a missed update can remain
+			// unapplied.
+			if err := s.reconcile(); err != nil {
 				return err
 			}
 		case <-s.closeChan:
@@ -407,6 +421,24 @@ func (s *defaultBigSegmentSynchronizer) consumeStream(stream *es.Stream) error {
 			return nil
 		}
 	}
+}
+
+// reconcile fetches and applies any revisions that were not delivered as stream events,
+// then refreshes the store's synchronization timestamp.
+func (s *defaultBigSegmentSynchronizer) reconcile() error {
+	segmentsUpdated := make(segmentChangesSummary)
+	for {
+		done, updates, err := s.poll()
+		if err != nil {
+			return err
+		}
+		segmentsUpdated.addAll(updates)
+		if done {
+			break
+		}
+	}
+	s.notifySegmentsUpdated(segmentsUpdated)
+	return s.setSynced()
 }
 
 // Returns total number of patches, number of patches applied, raw segment IDs, error

--- a/internal/bigsegments/sync_test.go
+++ b/internal/bigsegments/sync_test.go
@@ -422,7 +422,8 @@ func TestSyncReconcilesWhenStreamIsQuiet(t *testing.T) {
 	// - The stream stays connected but delivers no events, even though another revision
 	//   (patch2) has been published upstream; this simulates a stream event that was
 	//   missed and will never be redelivered.
-	// - The periodic reconciliation poll picks up patch2, without a stream reconnection.
+	// - The one-time reconciliation poll after stream establishment picks up patch2,
+	//   without a stream reconnection - and no further polling happens after it.
 	mockLogger, mockLog := logtest.NewMockLogger()
 
 	patch1 := newPatchBuilder("segment.g1", "1", "").addIncludes("included1").build()
@@ -484,6 +485,15 @@ func TestSyncReconcilesWhenStreamIsQuiet(t *testing.T) {
 
 			pollReq5 := helpers.RequireValue(t, requestsCh, time.Second)
 			assertPollRequest(t, pollReq5, patch2.Version)
+
+			// Reconciliation happens only once per connection: no further poll requests
+			// even after several more reconcile intervals have elapsed
+			if !helpers.AssertNoMoreValues(t, requestsCh, time.Millisecond*500) {
+				t.FailNow()
+			}
+
+			// The synchronized-on timestamp is still refreshed periodically
+			helpers.RequireValue(t, storeMock.syncTimeCh, time.Second)
 
 			// The stream connection should still be in use - reconciliation is not a reconnect
 			if !helpers.AssertNoMoreValues(t, streamRequestsCh, time.Millisecond*50) {

--- a/internal/bigsegments/sync_test.go
+++ b/internal/bigsegments/sync_test.go
@@ -416,6 +416,92 @@ func TestSyncSkipsOutOfOrderUpdateFromStreamAndRestartsStream(t *testing.T) {
 	})
 }
 
+func TestSyncReconcilesWhenStreamIsQuiet(t *testing.T) {
+	// Scenario:
+	// - The initial poll+stream cycle completes with patch1.
+	// - The stream stays connected but delivers no events, even though another revision
+	//   (patch2) has been published upstream; this simulates a stream event that was
+	//   missed and will never be redelivered.
+	// - The periodic reconciliation poll picks up patch2, without a stream reconnection.
+	mockLogger, mockLog := logtest.NewMockLogger()
+
+	patch1 := newPatchBuilder("segment.g1", "1", "").addIncludes("included1").build()
+	patch2 := newPatchBuilder("segment.g1", "2", "1").addIncludes("included2").build()
+
+	pollHandler, requestsCh := httphelpers.RecordingHandler(
+		httphelpers.SequentialHandler(
+			httphelpers.HandlerWithJSONResponse([]bigSegmentPatch{patch1}, nil), // poll 1: initial connection
+			httphelpers.HandlerWithJSONResponse([]bigSegmentPatch{}, nil),       // poll 2: completion of poll 1
+			httphelpers.HandlerWithJSONResponse([]bigSegmentPatch{}, nil),       // poll 3: done in conjunction with stream
+			httphelpers.HandlerWithJSONResponse([]bigSegmentPatch{patch2}, nil), // poll 4: first reconciliation finds a missed revision
+			httphelpers.HandlerWithJSONResponse([]bigSegmentPatch{}, nil),       // poll 5 and later: nothing further
+		),
+	)
+
+	// The stream connects successfully but never sends any events
+	sseHandler, _ := httphelpers.SSEHandler(nil)
+	streamHandler, streamRequestsCh := httphelpers.RecordingHandler(sseHandler)
+
+	httphelpers.WithServer(pollHandler, func(pollServer *httptest.Server) {
+		httphelpers.WithServer(streamHandler, func(streamServer *httptest.Server) {
+			startTime := ldtime.UnixMillisNow()
+
+			storeMock := newBigSegmentStoreMock()
+			defer storeMock.Close()
+
+			segmentSync := newDefaultBigSegmentSynchronizer(sharedtest.MakeBasicHTTPConfig(), storeMock,
+				pollServer.URL, streamServer.URL, config.EnvironmentID("env-xyz"), testSDKKey, mockLogger, "")
+			segmentSync.reconcileInterval = time.Millisecond * 100
+			defer segmentSync.Close()
+			segmentSync.Start()
+
+			updatesCh := segmentSync.SegmentUpdatesCh()
+
+			pollReq1 := helpers.RequireValue(t, requestsCh, time.Second)
+			assertPollRequest(t, pollReq1, "")
+			requirePatch(t, storeMock, patch1)
+
+			pollReq2 := helpers.RequireValue(t, requestsCh, time.Second)
+			assertPollRequest(t, pollReq2, patch1.Version)
+
+			pollReq3 := helpers.RequireValue(t, requestsCh, time.Second)
+			assertPollRequest(t, pollReq3, patch1.Version)
+
+			requireUpdates(t, updatesCh, []string{"segment"})
+
+			syncTime := <-storeMock.syncTimeCh
+			assert.True(t, syncTime >= startTime)
+			assert.True(t, syncTime <= ldtime.UnixMillisNow())
+
+			streamReq1 := helpers.RequireValue(t, streamRequestsCh, time.Second)
+			assertStreamRequest(t, streamReq1)
+
+			// The reconciliation poll should find and apply the missed revision
+			pollReq4 := helpers.RequireValue(t, requestsCh, time.Second)
+			assertPollRequest(t, pollReq4, patch1.Version)
+			requirePatch(t, storeMock, patch2)
+			requireUpdates(t, updatesCh, []string{"segment"})
+
+			pollReq5 := helpers.RequireValue(t, requestsCh, time.Second)
+			assertPollRequest(t, pollReq5, patch2.Version)
+
+			// The stream connection should still be in use - reconciliation is not a reconnect
+			if !helpers.AssertNoMoreValues(t, streamRequestsCh, time.Millisecond*50) {
+				t.FailNow()
+			}
+
+			requireNoMorePatches(t, storeMock)
+
+			assert.Equal(t, []string{
+				"applied updates",
+				"applied updates",
+			}, mockLog.Messages(slog.LevelInfo))
+			assert.Len(t, mockLog.Messages(slog.LevelWarn), 0)
+			assert.Len(t, mockLog.Messages(slog.LevelError), 0)
+		})
+	})
+}
+
 func TestSyncRetryIfStreamFails(t *testing.T) {
 	// In this test, we set up a successful poll and stream. Then we force the stream to close.
 	// The synchronizer should start over with a new poll and stream.


### PR DESCRIPTION
**Ticket:** [SDK-2840](https://launchdarkly.atlassian.net/browse/SDK-2840)

## Root cause of the `big_segments` integration flake

`TestEndToEnd/big_segments/{Redis,DynamoDB}/another_big_segment_is_created_after_synchronizer_has_started` is the most frequent remaining CI flake (12+ occurrences May–July). Log forensics on two recent failures ([run 30562656155](https://github.com/launchdarkly/ld-relay/actions/runs/30562656155/attempts/1), v9, 07-30; [run 29779343829](https://github.com/launchdarkly/ld-relay/actions/runs/29779343829), v8, 07-20) show the same signature:

- The synchronizer's poll → stream → poll sequence ran as designed, including the bridging poll after the stream was established.
- The revisions that went missing were published **after** that bridging poll completed — e.g. the second half of an include list landed within ~1s of the bridging poll, and the second segment's revisions a few seconds later.
- The `/big-segments` SSE stream had connected successfully but **delivered nothing** for the entire wait (60 seconds in the v8 run, so #711's timeout bump demonstrably does not fix this), on both environments' connections.

The bridging poll closes the gap up to the moment it completes, but it treats "stream response established" as "subscribed from this instant". If the upstream subscription is not yet fully effective at that point (the CI test environments are created seconds before connecting), events published in that window are never delivered — and the protocol has no redelivery, so the data is stale until some later unrelated event for that environment arrives (heartbeats keep the connection alive, so the 5-minute read timeout doesn't rescue it).

## Changes

- `consumeStream` performs **one follow-up reconciliation poll per stream connection**, at the first quiet-stream tick (30s) after the stream is established, covering the delayed-subscription window. After that single poll the stream is trusted and the quiet-stream timer goes back to what it did before: refreshing the store's `synchronizedOn` timestamp only. Steady-state behavior is pure streaming — no periodic polling.
- Ports #711's evaluation-wait bump (20s → 60s) to the v9 integration test — it was only ever applied to v8. 60s covers the follow-up reconciliation with margin.
- The supervisor no longer logs the `will retry` warning when it is shutting down cleanly — that warning appears at the tail of every failed-test log dump and reads as a stream failure when it's actually teardown.
- New unit test `TestSyncReconcilesWhenStreamIsQuiet`: stream connects but stays silent, a missed revision exists only on the poll endpoint; the follow-up poll applies it without a stream reconnect, and no further poll requests happen after it.

## Verification

- `go test -race -count=3 ./internal/bigsegments/` green; the reconcile test passes 50 consecutive `-race` runs under full CPU load.
- `go vet -tags integrationtests ./integrationtests/` clean.

[SDK-2840]: https://launchdarkly.atlassian.net/browse/SDK-2840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ