### PR TITLE
fix: Redact end-user context from the url.path span attribute

### DIFF
--- a/internal/middleware/tracing_middleware.go
+++ b/internal/middleware/tracing_middleware.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// contextPathVar is the route variable that holds a base64-encoded evaluation context. It
+// must match the variable name used by the routes in relay_routes.go.
+const contextPathVar = "context"
+
+// RedactContextFromSpanPath replaces the url.path attribute of the current request span
+// with the matched route template, for routes that take an evaluation context in the path.
+//
+// The HTTP tracing middleware records the raw request path, which on those routes holds the
+// end user's context: keys, names, emails and custom attributes. Attributes cannot be
+// removed from a span once set, but they are deduplicated last-write-wins when they are
+// read, so overwriting the value here keeps the context out of the exported trace. Nothing
+// is lost by doing so: the same middleware records the route template as http.route.
+//
+// Routes with no context variable keep their real path.
+//
+// This must be registered after the middleware that starts the request span.
+func RedactContextFromSpanPath(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, hasContext := mux.Vars(r)[contextPathVar]; hasContext {
+			if span := trace.SpanFromContext(r.Context()); span.IsRecording() {
+				// A route that produced a path variable always has a path template.
+				template, _ := mux.CurrentRoute(r).GetPathTemplate()
+				span.SetAttributes(semconv.URLPath(template))
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/middleware/tracing_middleware_test.go
+++ b/internal/middleware/tracing_middleware_test.go
@@ -1,0 +1,139 @@
+package middleware
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// contextBase64 is a context blob of the kind the client-side SDKs put in the path: it holds
+// personal data that must never reach the tracing backend.
+var contextBase64 = base64.StdEncoding.EncodeToString(
+	[]byte(`{"kind":"user","key":"user@example.com","name":"Jane Doe","email":"jane@example.com"}`),
+)
+
+// contextRouteTemplates is every relay route template that takes an evaluation context in the
+// path. Keep in step with relay_routes.go.
+var contextRouteTemplates = []string{
+	"/sdk/evalx/{envId}/contexts/{context}",
+	"/sdk/evalx/{envId}/users/{context}",
+	"/sdk/evalx/contexts/{context}",
+	"/sdk/evalx/users/{context}",
+	"/sdk/poll/eval/{context}",
+	"/sdk/stream/eval/{context}",
+	"/msdk/evalx/contexts/{context}",
+	"/msdk/evalx/users/{context}",
+	"/meval/{context}",
+	"/eval/{envId}/{context}",
+}
+
+// tracedRouter builds a router instrumented the same way as relay's, recording its spans, and
+// registers the given templates with a handler that does nothing.
+func tracedRouter(t *testing.T, templates ...string) (*mux.Router, *tracetest.SpanRecorder) {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	router := mux.NewRouter()
+	router.Use(otelmux.Middleware("test", otelmux.WithTracerProvider(provider)))
+	router.Use(RedactContextFromSpanPath)
+	for _, template := range templates {
+		router.HandleFunc(template, func(http.ResponseWriter, *http.Request) {}).Methods("GET")
+	}
+	return router, recorder
+}
+
+func requireURLPath(t *testing.T, recorder *tracetest.SpanRecorder) string {
+	t.Helper()
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	for _, kv := range spans[0].Attributes() {
+		if kv.Key == attribute.Key("url.path") {
+			return kv.Value.AsString()
+		}
+	}
+	require.Fail(t, "span has no url.path attribute")
+	return ""
+}
+
+func TestContextIsRedactedFromSpanPath(t *testing.T) {
+	for _, template := range contextRouteTemplates {
+		t.Run(template, func(t *testing.T) {
+			router, recorder := tracedRouter(t, template)
+			// Substituting the context variable last leaves any other variable in place, so
+			// the request path differs from the template only by the redacted value.
+			path := strings.Replace(template, "{envId}", "507f1f77bcf86cd799439011", 1)
+			path = strings.Replace(path, "{context}", contextBase64, 1)
+
+			router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", path, nil))
+
+			assert.Equal(t, template, requireURLPath(t, recorder))
+		})
+	}
+}
+
+func TestPathsWithoutAContextAreLeftAlone(t *testing.T) {
+	// Routes with no context variable: their variables are flag and segment keys, environment
+	// identifiers and payload filter keys, all of which are useful in a trace.
+	for _, params := range []struct{ template, path string }{
+		{"/sdk/flags/{key}", "/sdk/flags/my-flag-key"},
+		{"/sdk/segments/{key}", "/sdk/segments/my-segment-key"},
+		{"/sdk/goals/{envId}", "/sdk/goals/507f1f77bcf86cd799439011"},
+		{"/status/{projKey}/{envKey}/filters/{filterKey}", "/status/my-proj/my-env/filters/my-filter"},
+		{"/status", "/status"},
+	} {
+		t.Run(params.template, func(t *testing.T) {
+			router, recorder := tracedRouter(t, params.template)
+
+			router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", params.path, nil))
+
+			assert.Equal(t, params.path, requireURLPath(t, recorder))
+		})
+	}
+}
+
+// TestRedactionSurvivesNestedSubrouters covers the way relay actually declares these routes:
+// the context route lives several subrouters deep, and the middleware runs on the top-level
+// router, so it must still see the full template of the innermost matched route.
+func TestRedactionSurvivesNestedSubrouters(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	router := mux.NewRouter()
+	router.Use(otelmux.Middleware("test", otelmux.WithTracerProvider(provider)))
+	router.Use(RedactContextFromSpanPath)
+	sdkRouter := router.PathPrefix("/sdk/").Subrouter()
+	pollRouter := sdkRouter.PathPrefix("/poll/eval").Subrouter()
+	pollRouter.HandleFunc("/{context}", func(http.ResponseWriter, *http.Request) {}).Methods("GET")
+
+	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/sdk/poll/eval/"+contextBase64, nil))
+
+	assert.Equal(t, "/sdk/poll/eval/{context}", requireURLPath(t, recorder))
+}
+
+// TestRedactionWithoutARecordingSpan covers a relay with tracing disabled, where the request
+// span is a noop and there is nothing to overwrite.
+func TestRedactionWithoutARecordingSpan(t *testing.T) {
+	handled := false
+	router := mux.NewRouter()
+	router.Use(RedactContextFromSpanPath)
+	router.HandleFunc("/meval/{context}", func(http.ResponseWriter, *http.Request) { handled = true }).Methods("GET")
+
+	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/meval/"+contextBase64, nil))
+
+	assert.True(t, handled)
+}

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -34,7 +34,8 @@ const (
 // IMPORTANT: The route strings that are used here, such as "/sdk/evalx/{envId}/contexts/{context}", will appear
 // in metrics data under the "route" tag if Relay is configured to export metrics. Therefore, we should use
 // variable names like {envId} consistently and make sure they correspond to how the routes are shown in
-// docs/endpoints.md.
+// docs/endpoints.md. The {context} variable name is also load-bearing for tracing: it is how
+// middleware.RedactContextFromSpanPath recognizes a route that carries end-user data in the path.
 func (r *Relay) makeRouter() *mux.Router {
 	router := mux.NewRouter()
 	router.Use(logging.ContextLoggerMiddleware(r.logger))
@@ -42,6 +43,8 @@ func (r *Relay) makeRouter() *mux.Router {
 		router.Use(logging.RequestLoggerMiddleware(r.logger))
 	}
 	router.Use(otelmux.Middleware(tracing.TracerName))
+	// Must come after the tracing middleware, which records the raw request path on the span it starts.
+	router.Use(middleware.RedactContextFromSpanPath)
 	if r.config.HTTP.EnableCompression {
 		router.Use(func(next http.Handler) http.Handler {
 			return h.GzipHandler(next)

--- a/relay/relay_tracing_privacy_test.go
+++ b/relay/relay_tracing_privacy_test.go
@@ -1,0 +1,104 @@
+package relay
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	c "github.com/launchdarkly/ld-relay/v9/config"
+	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEndUserContextIsNotExportedInSpans drives the polling routes that take an evaluation
+// context in the path through a real relay, and asserts that no span produced while handling
+// the request carries the context anywhere in its attributes. The HTTP tracing middleware
+// records the raw request path, so without middleware.RedactContextFromSpanPath the base64
+// context - keys, names, emails, custom attributes - is exported to the tracing backend.
+//
+// The streaming eval routes carry a context in the path too; they are covered by the
+// middleware's own tests, since exercising them here would mean holding connections open.
+func TestEndUserContextIsNotExportedInSpans(t *testing.T) {
+	recorder := installSpanRecorder(t)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain, st.EnvClientSide, st.EnvWithAllCredentials)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		contextJSON := `{"kind":"user","key":"user@example.com","name":"Jane Doe","email":"jane@example.com"}`
+		contextBase64 := base64.StdEncoding.EncodeToString([]byte(contextJSON))
+
+		sdkKey := st.EnvMain.Config.SDKKey
+		mobileKey := st.EnvWithAllCredentials.Config.MobileKey
+		envID := string(st.EnvClientSide.Config.EnvID)
+
+		cases := []struct {
+			route string
+			req   *http.Request
+		}{
+			{
+				route: "/sdk/evalx/contexts/{context}",
+				req:   st.BuildRequestWithAuth("GET", "/sdk/evalx/contexts/"+contextBase64, sdkKey, nil),
+			},
+			{
+				route: "/sdk/evalx/users/{context}",
+				req:   st.BuildRequestWithAuth("GET", "/sdk/evalx/users/"+contextBase64, sdkKey, nil),
+			},
+			{
+				route: "/sdk/evalx/{envId}/contexts/{context}",
+				req:   st.BuildRequest("GET", "/sdk/evalx/"+envID+"/contexts/"+contextBase64, nil, nil),
+			},
+			{
+				route: "/sdk/evalx/{envId}/users/{context}",
+				req:   st.BuildRequest("GET", "/sdk/evalx/"+envID+"/users/"+contextBase64, nil, nil),
+			},
+			{
+				route: "/sdk/poll/eval/{context}",
+				req:   st.BuildRequestWithAuth("GET", "/sdk/poll/eval/"+contextBase64, mobileKey, nil),
+			},
+			{
+				route: "/msdk/evalx/contexts/{context}",
+				req:   st.BuildRequestWithAuth("GET", "/msdk/evalx/contexts/"+contextBase64, mobileKey, nil),
+			},
+			{
+				route: "/msdk/evalx/users/{context}",
+				req:   st.BuildRequestWithAuth("GET", "/msdk/evalx/users/"+contextBase64, mobileKey, nil),
+			},
+		}
+
+		for _, params := range cases {
+			t.Run(params.route, func(t *testing.T) {
+				recorder.Reset()
+				w := httptest.NewRecorder()
+
+				p.relay.Handler.ServeHTTP(w, params.req)
+
+				// A route that did not match, or a request that was rejected before reaching
+				// the handler, would make the assertions below vacuous.
+				require.Equal(t, http.StatusOK, w.Code)
+				spans := recorder.Ended()
+				require.NotEmpty(t, spans)
+
+				for _, span := range spans {
+					for _, kv := range span.Attributes() {
+						assert.NotContains(t, kv.Value.String(), contextBase64,
+							"span %q attribute %q exports the end-user context", span.Name(), kv.Key)
+						assert.NotContains(t, kv.Value.String(), contextJSON,
+							"span %q attribute %q exports the end-user context", span.Name(), kv.Key)
+					}
+				}
+
+				// The path is reported as the route template, which is also what http.route
+				// holds, so nothing is lost by redacting it.
+				root := rootSpan(t, spans)
+				attrs := spanAttrs(root)
+				assert.Equal(t, params.route, attrs["url.path"].AsString())
+				assert.Equal(t, params.route, attrs["http.route"].AsString())
+				assert.NotContains(t, root.Name(), contextBase64)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Summary

The HTTP tracing middleware records the raw request path as the `url.path` attribute on the root request span. Several relay routes carry the base64-encoded evaluation context in the path, so end-user keys, names, emails and custom attributes were exported verbatim to the tracing backend whenever OTLP tracing is enabled:

```
url.path   = /msdk/evalx/contexts/eyJraW5kIjoidXNlciIsImtleSI6InNlY3JldC11c2VyQGV4YW1wbGUuY29tIiwibmFtZSI6IkphbmUgRG9lIiwi...
http.route = /msdk/evalx/contexts/{context}
```

Every route with a `{context}` variable is affected: the mobile and JS `evalx` routes, `/sdk/poll/eval`, `/sdk/stream/eval`, `/meval` and `/eval/{envId}`. The `REPORT` variants take the context in the body and were never affected. The JS eval routes are unauthenticated, so the exported path content was also attacker-chosen.

`middleware.RedactContextFromSpanPath` runs immediately after the tracing middleware and replaces `url.path` with the matched route template on any route that has a `{context}` variable. Nothing is lost by doing so: the same middleware already records that template as `http.route`. Routes with no context variable keep their concrete path, so flag keys, segment keys, environment IDs and status identifiers stay visible in traces.

Span attributes cannot be removed once set, but they are deduplicated last-write-wins when read, so overwriting the value at request time is enough.

Notes on the approach:

- Redaction is scoped to the `{context}` route variable on purpose. Replacing `url.path` with the route template on *every* route was considered and rejected: the concrete values on the other routes are worth having in a trace. This does mean the variable name is load-bearing -- a future route that carries a context under a different name would not be redacted -- so the `makeRouter` doc comment now records that, alongside the existing note that route variable names are load-bearing for the metrics `route` tag.
- otelmux v0.69.0 exposes no attribute hook -- its options are `WithFilter` (skip tracing the request entirely), `WithSpanNameFormatter`, `WithMetricAttributesFn` (metrics only), plus provider wiring -- and `url.path` is set unconditionally from `req.URL.Path` at span start. Overwriting downstream is the only lever.
- gorilla/mux builds the `Use` chain inside `Router.Match`, so the middleware runs only on a matched route and always has a current route and its variables. Unmatched paths never produce a span at all.
- For subrouter matches the innermost route wins, so `GetPathTemplate()` returns the full template even though the middleware is registered on the top-level router.
- It is registered before the auth and environment-selector middleware, so redaction covers rejected requests and CORS preflights too.

Not introduced by #784, but that PR hangs new spans on exactly these traces.

Out of scope: `logging.RequestLoggerMiddleware` logs the raw path at debug level (local logs only), and outbound `otelhttp` client spans record `url.full` for relay-to-LD requests, which never carry an end-user context.