### PR TITLE
fix: Stop reporting response bytes that were never written

### DIFF
--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -34,5 +34,4 @@ const (
 	StoreKeyKey      = attribute.Key("relay.store.key")
 	PayloadEventsKey = attribute.Key("relay.payload.events")
 	PayloadBytesKey  = attribute.Key("relay.payload.bytes")
-	ResponseBytesKey = attribute.Key("relay.response.bytes")
 )

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 func getClientSideContextProperties(
@@ -321,12 +322,9 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	func() {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
-		defer span.End()
-		span.SetAttributes(tracing.ResponseBytesKey.Int(len(payloadJSON)))
-		writeCacheableJSONResponse(w, req, clientCtx.Env, payloadJSON, selector.State())
-	}()
+	traceWriteResponse(req, func() (int, error) {
+		return writeCacheableJSONResponse(w, req, clientCtx.Env, payloadJSON, selector.State())
+	})
 }
 
 // FDv2 client-side polling endpoint that evaluates flags against a context.
@@ -491,12 +489,9 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 		return
 	}
 
-	func() {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
-		defer span.End()
-		span.SetAttributes(tracing.ResponseBytesKey.Int(len(jsonData)))
-		writeCacheableJSONResponse(w, req, clientCtx.Env, jsonData, selector.State())
-	}()
+	traceWriteResponse(req, func() (int, error) {
+		return writeCacheableJSONResponse(w, req, clientCtx.Env, jsonData, selector.State())
+	})
 }
 
 // PHP SDK polling endpoint for all flags: app.ld.com/sdk/flags
@@ -535,12 +530,9 @@ func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 		return respData, etag
 	}()
 
-	func() {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
-		defer span.End()
-		span.SetAttributes(tracing.ResponseBytesKey.Int(len(respData)))
-		writeCacheableJSONResponse(w, req, clientCtx.Env, respData, etag)
-	}()
+	traceWriteResponse(req, func() (int, error) {
+		return writeCacheableJSONResponse(w, req, clientCtx.Env, respData, etag)
+	})
 }
 
 // PHP SDK polling endpoint for a flag: app.ld.com/sdk/flags/{key}
@@ -756,13 +748,11 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 		return data
 	}()
 
-	func() {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
-		defer span.End()
-		span.SetAttributes(tracing.ResponseBytesKey.Int(len(result)))
+	traceWriteResponse(req, func() (int, error) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(result)
-	}()
+		_, err := w.Write(result)
+		return http.StatusOK, err
+	})
 }
 
 func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.DataKind) func(http.ResponseWriter, *http.Request) {
@@ -806,18 +796,46 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 			return
 		}
 
-		func() {
-			_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
-			defer span.End()
-			span.SetAttributes(tracing.ResponseBytesKey.Int(len(bytes)))
-			writeCacheableJSONResponse(w, req, clientContext, bytes, strconv.Itoa(item.Version))
-		}()
+		traceWriteResponse(req, func() (int, error) {
+			return writeCacheableJSONResponse(w, req, clientContext, bytes, strconv.Itoa(item.Version))
+		})
 	}
 }
 
+// traceWriteResponse runs a response write inside a relay.response.write span, recording the
+// status code that was sent and whatever the write itself reported.
+//
+// Recording the error matters: a write that fails once the header is out -- a client that
+// disconnected, a body that was truncated -- cannot change the status code the request span
+// reports, so this span is the only place such a failure surfaces.
+//
+// The span deliberately carries no byte count. relay.payload.bytes on the serialize span
+// reports what was built, and http.response.body.size on the request span reports what
+// actually went out; the latter is counted outside the compression middleware, which is the
+// only place the wire size is observable. A count taken here could only ever repeat the
+// payload size.
+//
+// Note also that the span measures the time to hand the payload to the ResponseWriter, not
+// time on the socket: a response small enough to fit net/http's output buffer is flushed after
+// the handler returns.
+func traceWriteResponse(req *http.Request, write func() (int, error)) {
+	_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
+	defer span.End()
+
+	status, err := write()
+	span.SetAttributes(semconv.HTTPResponseStatusCode(status))
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+}
+
+// writeCacheableJSONResponse sends bytes as a JSON response with this environment's cache
+// headers, or an empty 304 when the caller's If-None-Match matches the current Etag. It
+// returns the status code that was sent and the error from writing the body, if any.
 func writeCacheableJSONResponse(w http.ResponseWriter, req *http.Request, clientContext relayenv.EnvContext,
 	bytes []byte, etagValue string,
-) {
+) (int, error) {
 	ttl := clientContext.GetTTL()
 	if ttl > 0 {
 		w.Header().Set("Vary", "Authorization")
@@ -831,14 +849,15 @@ func writeCacheableJSONResponse(w http.ResponseWriter, req *http.Request, client
 	etag := fmt.Sprintf("W/\"%s\"", etagValue)
 	if cachedEtag := req.Header.Get("If-None-Match"); cachedEtag == etag {
 		w.WriteHeader(http.StatusNotModified)
-		return
+		return http.StatusNotModified, nil
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Etag", etag)
 	w.WriteHeader(http.StatusOK)
 
-	_, _ = w.Write(bytes)
+	_, err := w.Write(bytes)
+	return http.StatusOK, err
 }
 
 func serializeFlagsAsMap(coll []ldstoretypes.KeyedItemDescriptor) []byte {

--- a/relay/relay_endpoints_spans_test.go
+++ b/relay/relay_endpoints_spans_test.go
@@ -17,6 +17,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
@@ -193,10 +194,16 @@ func TestPollingEndpointSpansAreRecorded(t *testing.T) {
 				require.True(t, ok, "serialize span is missing the payload bytes attribute")
 				assert.Positive(t, payloadBytes.AsInt64())
 
-				responseBytes, ok := writeAttrs[tracing.ResponseBytesKey]
-				require.True(t, ok, "write span is missing the response bytes attribute")
-				assert.Equal(t, payloadBytes.AsInt64(), responseBytes.AsInt64(),
-					"response bytes should equal the serialized payload size")
+				status, ok := writeAttrs[httpStatusCodeKey]
+				require.True(t, ok, "write span is missing the response status code attribute")
+				assert.Equal(t, int64(http.StatusOK), status.AsInt64())
+				assert.Equal(t, codes.Unset, write.Status().Code,
+					"a successful write should leave the span status unset")
+
+				// The write span carries no byte count of its own: what was built is on the
+				// serialize span, and what went out is on the request span.
+				_, hasResponseBytes := writeAttrs[attribute.Key("relay.response.bytes")]
+				assert.False(t, hasResponseBytes, "the write span should record no byte count")
 
 				if tc.countKey != "" {
 					count, ok := serializeAttrs[tc.countKey]

--- a/relay/relay_endpoints_write_span_test.go
+++ b/relay/relay_endpoints_write_span_test.go
@@ -1,0 +1,147 @@
+package relay
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
+
+	c "github.com/launchdarkly/ld-relay/v9/config"
+	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// httpStatusCodeKey and httpBodySizeKey are the semantic-convention attributes recorded by the
+// HTTP tracing middleware on the request span, and by traceWriteResponse on the write span.
+const (
+	httpStatusCodeKey = attribute.Key("http.response.status_code")
+	httpBodySizeKey   = attribute.Key("http.response.body.size")
+)
+
+// writeErrorResponseWriter fails every body write, standing in for a client that disconnected
+// mid-response. The header still goes out, which is what makes this case interesting: the
+// status code the request span reports cannot change afterwards.
+type writeErrorResponseWriter struct {
+	*httptest.ResponseRecorder
+	err error
+}
+
+func (w *writeErrorResponseWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+// TestWriteSpanReportsNotModified covers the ordinary SDK polling path, a conditional request
+// whose Etag still matches. No body is written, and the write span says so through its status
+// code rather than through a byte count that would have reported the whole payload.
+func TestWriteSpanReportsNotModified(t *testing.T) {
+	recorder := installSpanRecorder(t)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		first := httptest.NewRecorder()
+		p.relay.Handler.ServeHTTP(first, st.BuildRequestWithAuth("GET", "/sdk/flags", st.EnvMain.Config.SDKKey, nil))
+		require.Equal(t, http.StatusOK, first.Code)
+		etag := first.Header().Get("Etag")
+		require.NotEmpty(t, etag)
+
+		recorder.Reset()
+		conditional := st.BuildRequestWithAuth("GET", "/sdk/flags", st.EnvMain.Config.SDKKey, nil)
+		conditional.Header.Set("If-None-Match", etag)
+		second := httptest.NewRecorder()
+
+		p.relay.Handler.ServeHTTP(second, conditional)
+
+		require.Equal(t, http.StatusNotModified, second.Code)
+		require.Zero(t, second.Body.Len())
+
+		spans := recorder.Ended()
+		write := requireSpan(t, spans, tracing.SpanWriteResponse)
+		serialize := requireSpan(t, spans, tracing.SpanSerializePayload)
+
+		assert.Equal(t, int64(http.StatusNotModified), spanAttrs(write)[httpStatusCodeKey].AsInt64())
+		assert.Equal(t, codes.Unset, write.Status().Code, "a 304 is not an error")
+
+		// The payload was built even though it was not sent, and the serialize span still
+		// reports its size. The request span reports no body size at all, since nothing was
+		// written.
+		assert.Positive(t, spanAttrs(serialize)[tracing.PayloadBytesKey].AsInt64())
+		_, hasBodySize := spanAttrs(rootSpan(t, spans))[httpBodySizeKey]
+		assert.False(t, hasBodySize, "a 304 writes no body, so no body size should be recorded")
+	})
+}
+
+// TestWriteSpanUnderCompression pins down the division of labour that replaced the old
+// relay.response.bytes attribute: the serialize span reports the payload as built, and the
+// request span reports the compressed body that actually went out. Relay's own handlers cannot
+// observe the latter, because the ResponseWriter they are handed is the compressing one.
+func TestWriteSpanUnderCompression(t *testing.T) {
+	recorder := installSpanRecorder(t)
+
+	var config c.Config
+	config.HTTP.EnableCompression = true
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		req := st.BuildRequestWithAuth("GET", "/sdk/flags", st.EnvMain.Config.SDKKey, nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		w := httptest.NewRecorder()
+
+		p.relay.Handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "gzip", w.Header().Get("Content-Encoding"))
+
+		spans := recorder.Ended()
+		payloadBytes := spanAttrs(requireSpan(t, spans, tracing.SpanSerializePayload))[tracing.PayloadBytesKey].AsInt64()
+		bodySize := spanAttrs(rootSpan(t, spans))[httpBodySizeKey].AsInt64()
+
+		assert.Equal(t, int64(w.Body.Len()), bodySize,
+			"the request span should report the compressed body that was actually sent")
+		assert.Less(t, bodySize, payloadBytes,
+			"the compressed body should be smaller than the serialized payload")
+	})
+}
+
+// TestWriteSpanRecordsWriteFailure covers a write that fails after the header has gone out. The
+// response is truncated, but the status line still says 200, so the request span cannot show
+// the failure -- the write span is the only place it appears.
+func TestWriteSpanRecordsWriteFailure(t *testing.T) {
+	recorder := installSpanRecorder(t)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		writeErr := errors.New("connection reset by peer")
+		w := &writeErrorResponseWriter{ResponseRecorder: httptest.NewRecorder(), err: writeErr}
+
+		p.relay.Handler.ServeHTTP(w, st.BuildRequestWithAuth("GET", "/sdk/flags", st.EnvMain.Config.SDKKey, nil))
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Zero(t, w.Body.Len(), "the body write failed, so nothing was recorded")
+
+		spans := recorder.Ended()
+		write := requireSpan(t, spans, tracing.SpanWriteResponse)
+
+		assert.Equal(t, codes.Error, write.Status().Code, "a failed write should fail the span")
+		assert.Contains(t, write.Status().Description, writeErr.Error())
+		require.Len(t, write.Events(), 1, "the write error should be recorded on the span")
+		assert.Equal(t, "exception", write.Events()[0].Name)
+
+		// The status code attribute still reports what was sent in the header.
+		assert.Equal(t, int64(http.StatusOK), spanAttrs(write)[httpStatusCodeKey].AsInt64())
+
+		// The request span's status is driven by the status code, so it stays unset: this is
+		// exactly why the failure has to be recorded on the write span.
+		assert.Equal(t, codes.Unset, rootSpan(t, spans).Status().Code)
+	})
+}


### PR DESCRIPTION
## Summary

`relay.response.bytes` on the `relay.response.write` span was set *before* the write, from `len(payload)`, in all five polling handlers, and the write's result was discarded. It reported the payload size under the name of the response.

Measured against a real relay, `GET /sdk/flags`, 3310-byte payload:

| Scenario | `relay.payload.bytes` (serialize span) | `relay.response.bytes` (write span) | `http.response.body.size` (request span) | actual wire body |
|---|---|---|---|---|
| 200, no compression | 3310 | 3310 | 3310 | 3310 |
| 200, compression on | 3310 | **3310** | 532 | 532 |
| 304 (If-None-Match hit) | 3310 | **3310** | *absent* | 0 |

The 304 row is the ordinary SDK polling path. A short write or client disconnect was the third divergence: the partial count never appeared and the span status stayed OK, so the span named `relay.response.write` could not tell a complete response from a truncated one.

Taking the count from `w.Write` would not have fixed the compressed case. The handler's `ResponseWriter` *is* the gzip writer -- the compression middleware is registered outside the handler -- and `gzhttp.Write` returns input bytes consumed, not compressed output. The truthful count already exists on the request span as `http.response.body.size`, recorded by the HTTP tracing middleware from a counter outside the compression middleware, which is the only place wire bytes are observable; it is correct in every row above, and correctly absent rather than zero on the 304.

So this drops `relay.response.bytes` and `tracing.ResponseBytesKey`. The division of labour is now:

- **serialize span** -- `relay.payload.bytes`: what was built.
- **request span** -- `http.response.body.size`: what actually went out, after compression.
- **write span** -- duration, plus two things it was missing:
  - `http.response.status_code`, so a body-less 304 explains itself instead of looking like a lost payload.
  - `RecordError` and an error span status when the write fails. This is the load-bearing part: a write that fails once the header is out cannot change the status code, so the request span's status stays unset and the write span is the only place that failure can surface.

The five near-identical write-span closures collapse into one `traceWriteResponse` helper, which also removes the `dupl` lint exposure flagged during the review of #784. `writeCacheableJSONResponse` now returns `(status, error)`.

Tests: the previous `payloadBytes == responseBytes` assertion was a tautology -- both sides were `len()` of the same slice -- and goes away with the attribute it compared. New `relay_endpoints_write_span_test.go` covers the three divergences directly: the 304 path, the compressed path, and a write that fails after the header is out. Mutation-checked -- dropping `RecordError`, returning 200 on the etag path, or reporting a wrong status code each fail tests.

Also documented in the helper, since it is the same confusion one level down: the span measures the time to hand the payload to the `ResponseWriter`, not time on the socket -- a response small enough for net/http's output buffer is flushed after the handler returns.

Found by a multi-agent review of #784 (finding #3), which introduced these spans.

Independent of #791 (also open, also off `v9`): no overlapping files, not stacked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes to polling handlers with added tests; no auth, data, or API behavior changes beyond more accurate tracing.
> 
> **Overview**
> Fixes **misleading `relay.response.bytes`** on `relay.response.write` spans, which were set from `len(payload)` before the write and could disagree with what actually went on the wire (gzip, 304, truncated responses).
> 
> **Removes** `tracing.ResponseBytesKey` and stops attributing byte counts on the write span. **Payload size** stays on the serialize span (`relay.payload.bytes`); **wire size** is left to the request span (`http.response.body.size` from HTTP middleware, outside compression).
> 
> Polling handlers now share **`traceWriteResponse`**, which records **`http.response.status_code`** on the write span and **`RecordError` / error status** when `Write` fails after headers are sent—cases the request span cannot reflect. **`writeCacheableJSONResponse`** returns `(status, error)` so failures are observable.
> 
> Tests drop the tautological payload-vs-response bytes check and add coverage for 304, compression, and post-header write failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c99115c553a018501d3716fe10e145592cee0776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->