### PR TITLE
perf: Resolve the tracer once per polling handler

### DIFF
--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func getClientSideContextProperties(
@@ -189,8 +190,9 @@ type payloadEvent struct {
 // Server-side SDK polling endpoint: app.ld.com/sdk/poll/
 func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
+	tr := tracing.Tracer()
 
-	_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreSnapshot)
+	_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreSnapshot)
 	collection, selector, err := clientCtx.Env.GetStore().Snapshot()
 	if err != nil {
 		storeSpan.RecordError(err)
@@ -209,7 +211,7 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 	}
 
 	payloadJSON, ok := func() ([]byte, bool) {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
 		numItems := 2
@@ -322,7 +324,7 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	traceWriteResponse(req, func() (int, error) {
+	traceWriteResponse(tr, req, func() (int, error) {
 		return writeCacheableJSONResponse(w, req, clientCtx.Env, payloadJSON, selector.State())
 	})
 }
@@ -336,6 +338,7 @@ func pollEvalHandlerV2(maxBodySize ct.OptBase2Bytes) func(w http.ResponseWriter,
 
 func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySize ct.OptBase2Bytes) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
+	tr := tracing.Tracer()
 	client := clientCtx.Env.GetClient()
 	store := clientCtx.Env.GetStore()
 	logger := clientCtx.Env.GetLogger()
@@ -366,7 +369,7 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 		return
 	}
 
-	_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreSnapshot)
+	_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreSnapshot)
 	collection, selector, err := store.Snapshot()
 	if err != nil {
 		storeSpan.RecordError(err)
@@ -424,14 +427,14 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 			}
 		}
 
-		_, evalSpan := tracing.Tracer().Start(req.Context(), tracing.SpanEvaluateFlags)
+		_, evalSpan := tr.Start(req.Context(), tracing.SpanEvaluateFlags)
 		evalResults = evaluateFlags(evaluator, allItems, sdkKind, ldContext)
 		evalSpan.SetAttributes(tracing.FlagCountKey.Int(len(evalResults)))
 		evalSpan.End()
 	}
 
 	jsonData, ok := func() ([]byte, bool) {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
 		if !upToDate {
@@ -489,7 +492,7 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 		return
 	}
 
-	traceWriteResponse(req, func() (int, error) {
+	traceWriteResponse(tr, req, func() (int, error) {
 		return writeCacheableJSONResponse(w, req, clientCtx.Env, jsonData, selector.State())
 	})
 }
@@ -497,8 +500,9 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 // PHP SDK polling endpoint for all flags: app.ld.com/sdk/flags
 func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
+	tr := tracing.Tracer()
 
-	_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreGetAll)
+	_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreGetAll)
 	data, err := clientCtx.Env.GetStore().GetAll(ldstoreimpl.Features())
 	if err != nil {
 		storeSpan.RecordError(err)
@@ -512,7 +516,7 @@ func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	respData, etag := func() ([]byte, string) {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
 		respData := serializeFlagsAsMap(data)
@@ -530,7 +534,7 @@ func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 		return respData, etag
 	}()
 
-	traceWriteResponse(req, func() (int, error) {
+	traceWriteResponse(tr, req, func() (int, error) {
 		return writeCacheableJSONResponse(w, req, clientCtx.Env, respData, etag)
 	})
 }
@@ -664,6 +668,7 @@ func writePrerequisites(obj *jwriter.ObjectState, prerequisites []string) {
 
 func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basictypes.SDKKind, maxBodySize ct.OptBase2Bytes) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
+	tr := tracing.Tracer()
 	client := clientCtx.Env.GetClient()
 	store := clientCtx.Env.GetStore()
 	logger := clientCtx.Env.GetLogger()
@@ -696,7 +701,7 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 
 	logger.Debug("application requested client-side flags", "sdkKind", sdkKind, "contextKey", ldContext.Key())
 
-	_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreGetAll)
+	_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreGetAll)
 	items, err := store.GetAll(ldstoreimpl.Features())
 	if err != nil {
 		storeSpan.RecordError(err)
@@ -713,13 +718,13 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 
 	evaluator := clientCtx.Env.GetEvaluator()
 
-	_, evalSpan := tracing.Tracer().Start(req.Context(), tracing.SpanEvaluateFlags)
+	_, evalSpan := tr.Start(req.Context(), tracing.SpanEvaluateFlags)
 	evalResults := evaluateFlags(evaluator, items, sdkKind, ldContext)
 	evalSpan.SetAttributes(tracing.FlagCountKey.Int(len(evalResults)))
 	evalSpan.End()
 
 	result := func() []byte {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
 		responseWriter := jwriter.NewWriter()
@@ -748,7 +753,7 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 		return data
 	}()
 
-	traceWriteResponse(req, func() (int, error) {
+	traceWriteResponse(tr, req, func() (int, error) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write(result)
 		return http.StatusOK, err
@@ -758,8 +763,9 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.DataKind) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		key := mux.Vars(req)["key"]
+		tr := tracing.Tracer()
 
-		_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreGet)
+		_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreGet)
 		storeSpan.SetAttributes(tracing.StoreKeyKey.String(key))
 		item, err := clientContext.GetStore().Get(kind, key)
 		if err != nil {
@@ -779,7 +785,7 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 		}
 
 		bytes, ok := func() ([]byte, bool) {
-			_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+			_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 			defer span.End()
 			data, err := json.Marshal(item.Item)
 			if err != nil {
@@ -796,7 +802,7 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 			return
 		}
 
-		traceWriteResponse(req, func() (int, error) {
+		traceWriteResponse(tr, req, func() (int, error) {
 			return writeCacheableJSONResponse(w, req, clientContext, bytes, strconv.Itoa(item.Version))
 		})
 	}
@@ -818,8 +824,8 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 // Note also that the span measures the time to hand the payload to the ResponseWriter, not
 // time on the socket: a response small enough to fit net/http's output buffer is flushed after
 // the handler returns.
-func traceWriteResponse(req *http.Request, write func() (int, error)) {
-	_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
+func traceWriteResponse(tr trace.Tracer, req *http.Request, write func() (int, error)) {
+	_, span := tr.Start(req.Context(), tracing.SpanWriteResponse)
 	defer span.End()
 
 	status, err := write()

--- a/relay/relay_endpoints_tracer_test.go
+++ b/relay/relay_endpoints_tracer_test.go
@@ -1,0 +1,50 @@
+package relay
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
+
+	c "github.com/launchdarkly/ld-relay/v9/config"
+	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandlerTracerFollowsTheCurrentProvider pins down that the handlers resolve their tracer
+// per request rather than once per process. Each handler hoists tracing.Tracer() into a local
+// so it pays for one lookup instead of three or four, and the tempting next step -- memoizing
+// that lookup in a package-level variable -- would latch the first provider it saw and silently
+// stop recording when the provider changes. This test fails if that happens.
+func TestHandlerTracerFollowsTheCurrentProvider(t *testing.T) {
+	first := installSpanRecorder(t)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		request := func() {
+			result, _ := st.DoRequest(st.BuildRequestWithAuth("GET", "/sdk/flags", st.EnvMain.Config.SDKKey, nil), p.relay)
+			require.Equal(t, http.StatusOK, result.StatusCode)
+		}
+
+		request()
+		require.Len(t, spansNamed(first.Ended(), tracing.SpanSerializePayload), 1,
+			"the recorder installed before the relay started should see the first request's spans")
+
+		// Swap in a second provider after the relay is already running and serving.
+		second := installSpanRecorder(t)
+		first.Reset()
+
+		request()
+
+		assert.Len(t, spansNamed(second.Ended(), tracing.SpanSerializePayload), 1,
+			"the handler should have resolved its tracer from the provider current at request time")
+		assert.Len(t, spansNamed(second.Ended(), tracing.SpanWriteResponse), 1,
+			"the response-write span should follow the same tracer as the rest of the handler")
+		assert.Empty(t, spansNamed(first.Ended(), tracing.SpanSerializePayload),
+			"the replaced provider should no longer receive handler spans")
+	})
+}

--- a/relay/relay_endpoints_tracing_benchmark_test.go
+++ b/relay/relay_endpoints_tracing_benchmark_test.go
@@ -1,0 +1,75 @@
+package relay
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/basictypes"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testenv"
+
+	ct "github.com/launchdarkly/go-configtypes"
+	"github.com/launchdarkly/go-sdk-common/v3/lduser"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// BenchmarkEvaluateAllFlagsTracedConcurrent measures the evaluation endpoint with tracing
+// enabled and requests in flight concurrently, which is where tracer-lookup cost lives:
+// resolving a tracer takes the provider's exclusive mutex, so every lookup is a point where
+// concurrent requests serialize against each other.
+//
+// Be careful reading it. The handler spends microseconds between lookups, so the lock is only
+// lightly contended and a saved lookup is worth tens of nanoseconds -- around 2% here, close
+// to this benchmark's run-to-run spread. It is here to exercise the concurrent traced path,
+// not to gate on a number.
+func BenchmarkEvaluateAllFlagsTracedConcurrent(b *testing.B) {
+	numFlags := 50
+
+	allData := []ldstoretypes.Collection{
+		{Kind: ldstoreimpl.Features(), Items: []ldstoretypes.KeyedItemDescriptor{}},
+		{Kind: ldstoreimpl.Segments(), Items: []ldstoretypes.KeyedItemDescriptor{}},
+	}
+	for i := 0; i < numFlags; i++ {
+		flag := ldbuilders.NewFlagBuilder(fmt.Sprintf("flag%d", i)).Version(1).
+			SingleVariation(ldvalue.String(fmt.Sprintf("value%d", i))).
+			ClientSideUsingEnvironmentID(true).
+			Build()
+		allData[0].Items = append(allData[0].Items,
+			ldstoretypes.KeyedItemDescriptor{Key: flag.Key, Item: sharedtest.FlagDesc(flag)})
+	}
+
+	user := lduser.NewUserBuilder("user-key").Name("name").Email("email").Custom("a", ldvalue.String("b")).Build()
+
+	store := sharedtest.NewInMemoryStore()
+	store.Init(allData)
+	ctx := testenv.NewTestEnvContext("", false, store)
+	userData := []byte(user.String())
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+
+	// A real SDK tracer provider, so tracer lookups take the same lock they take in production.
+	// Spans are dropped by the sampler, isolating the lookup cost from export cost.
+	previous := otel.GetTracerProvider()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.NeverSample()))
+	otel.SetTracerProvider(provider)
+	b.Cleanup(func() { otel.SetTracerProvider(previous) })
+
+	handler := evaluateAllFeatureFlags(basictypes.JSClientSDK, ct.OptBase2Bytes{})
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req := buildPreRoutedRequest("REPORT", userData, headers, nil, ctx)
+			handler(httptest.NewRecorder(), req)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

**Stacked on #792** -- base is `mk/SDK-2842/response-write-span`, so the diff here is just the one commit. GitHub will retarget this to `v9` when #792 merges.

`tracing.Tracer()` is `otel.Tracer("ld-relay")`, and it resolves through the global provider on every call. With tracing enabled that reaches `sdktrace.TracerProvider.Tracer`, which takes an exclusive `p.mu.Lock()` and does a map lookup keyed on an `instrumentation.Scope` struct; with tracing disabled it reaches the global delegating provider, which locks as well. So the cost is paid either way. The polling handlers called it three or four times per request.

Each handler now resolves the tracer once into a local and starts every span from it, including the one in `traceWriteResponse`, which takes the tracer as its first argument. `bulkEventHandler` and the two auth-middleware sites start a single span each, so they are left alone.

### What it is actually worth

The review that raised this (#784 review, finding #5) put it at ~300-550 ns/request. That does not survive measurement: it is derived from the contended cost of a tracer lookup in a tight loop, which is not how a handler behaves.

One lookup in isolation, 8 cores:

| | serial | parallel (tight loop) |
|---|---|---|
| tracing disabled | 41.9 ns | 100.4 ns |
| tracing enabled | 49.8 ns | 119.2 ns |
| hoisted local | ~0 | ~0 |

End to end on the evaluation endpoint with 50 flags, median of 5 runs:

| Benchmark | before | after |
|---|---|---|
| `BenchmarkEvaluateAllFlags` (serial, tracing off) | 9800 ns/op | 9789 ns/op |
| `BenchmarkEvaluateAllFlagsTracedConcurrent` (parallel, tracing on) | 3717 ns/op | 3625 ns/op |

About 90 ns/request, roughly 2%, and not resolvable at all in the serial benchmark. A real handler spends microseconds between lookups, so the provider mutex is barely contended and each lookup costs closer to its uncontended ~45 ns.

**This is therefore a cleanup that removes real work, not a throughput improvement**, and it should not be described as one in a release note. Doing one lookup instead of four is strictly less work and reads better, which is the case for landing it.

### The trap this avoids

The tracer is deliberately **not** memoized in a package-level variable. Relay resolves per request, and the span-recorder test helper swaps the global provider, so a memoized tracer would latch the first provider it ever saw and silently stop recording. `TestHandlerTracerFollowsTheCurrentProvider` installs a second recorder after the relay is already serving and asserts handler spans follow the new provider; mutating `tracing.Tracer()` to memoize fails it.

The new concurrent benchmark carries a comment saying plainly that it cannot resolve a 2% change and exists to exercise the traced concurrent path rather than to gate a number.

The existing span assertions in `relay_endpoints_spans_test.go` are untouched and still pass, which is the evidence that span names, parentage and attributes did not move.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only refactor with no request semantics changes; existing span tests still cover behavior.
> 
> **Overview**
> Polling and evaluation handlers used to call `tracing.Tracer()` on every span start (often three or four times per request). Each call goes through the global OTel provider and can take a lock.
> 
> Handlers now assign `tr := tracing.Tracer()` once per request and start all spans (store, evaluate, serialize, and response write) from that local. **`traceWriteResponse`** takes the tracer as its first argument instead of resolving it internally.
> 
> Single-span paths like **`bulkEventHandler`** are unchanged. Tracers are **not** cached in a package variable so a swapped global provider still applies on the next request.
> 
> **`TestHandlerTracerFollowsTheCurrentProvider`** asserts spans follow a provider installed mid-flight. **`BenchmarkEvaluateAllFlagsTracedConcurrent`** exercises the concurrent traced evaluation path; the change is a small cleanup, not a major throughput win.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bda60314fa14370d782726fe2925a4543b21b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->