### PR TITLE
fix: Count serialized flags, and cover the serialize error paths

### DIFF
--- a/internal/sharedtest/testclient/fake_client.go
+++ b/internal/sharedtest/testclient/fake_client.go
@@ -107,6 +107,19 @@ func FakeLDClientFactoryWithChannel(shouldBeInitialized bool, createdCh chan<- *
 	}
 }
 
+// FakeLDClientFactoryWithStore is FakeLDClientFactory with a store of the caller's choosing
+// instead of one preloaded with the standard test data. FakeStore serves whatever collections it
+// is given, so this is how a test reaches behavior the standard fixtures cannot express: a
+// deletion placeholder, an item of the wrong type, or a data kind Relay does not recognize.
+func FakeLDClientFactoryWithStore(shouldBeInitialized bool, store *FakeStore) sdks.ClientFactoryFunc {
+	return func(sdkKey config.SDKKey, config ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		if config.LDRelayDataDestination != nil {
+			config.LDRelayDataDestination(store, nil)
+		}
+		return &FakeLDClient{Key: sdkKey, CloseCh: make(chan struct{}), initialized: shouldBeInitialized}, nil
+	}
+}
+
 func RealLDClientFactoryWithChannel(shouldBeInitialized bool, createdCh chan<- CapturedLDClient) sdks.ClientFactoryFunc {
 	return func(sdkKey config.SDKKey, config ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
 		c, err := sdks.DefaultClientFactory()(sdkKey, config, timeout)

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func getClientSideContextProperties(
@@ -189,8 +190,9 @@ type payloadEvent struct {
 // Server-side SDK polling endpoint: app.ld.com/sdk/poll/
 func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
+	tr := tracing.Tracer()
 
-	_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreSnapshot)
+	_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreSnapshot)
 	collection, selector, err := clientCtx.Env.GetStore().Snapshot()
 	if err != nil {
 		storeSpan.RecordError(err)
@@ -209,7 +211,7 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 	}
 
 	payloadJSON, ok := func() ([]byte, bool) {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
 		numItems := 2
@@ -322,7 +324,7 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	traceWriteResponse(req, func() (int, error) {
+	traceWriteResponse(tr, req, func() (int, error) {
 		return writeCacheableJSONResponse(w, req, clientCtx.Env, payloadJSON, selector.State())
 	})
 }
@@ -336,6 +338,7 @@ func pollEvalHandlerV2(maxBodySize ct.OptBase2Bytes) func(w http.ResponseWriter,
 
 func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySize ct.OptBase2Bytes) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
+	tr := tracing.Tracer()
 	client := clientCtx.Env.GetClient()
 	store := clientCtx.Env.GetStore()
 	logger := clientCtx.Env.GetLogger()
@@ -366,7 +369,7 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 		return
 	}
 
-	_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreSnapshot)
+	_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreSnapshot)
 	collection, selector, err := store.Snapshot()
 	if err != nil {
 		storeSpan.RecordError(err)
@@ -424,14 +427,14 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 			}
 		}
 
-		_, evalSpan := tracing.Tracer().Start(req.Context(), tracing.SpanEvaluateFlags)
+		_, evalSpan := tr.Start(req.Context(), tracing.SpanEvaluateFlags)
 		evalResults = evaluateFlags(evaluator, allItems, sdkKind, ldContext)
 		evalSpan.SetAttributes(tracing.FlagCountKey.Int(len(evalResults)))
 		evalSpan.End()
 	}
 
 	jsonData, ok := func() ([]byte, bool) {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
 		if !upToDate {
@@ -489,7 +492,7 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 		return
 	}
 
-	traceWriteResponse(req, func() (int, error) {
+	traceWriteResponse(tr, req, func() (int, error) {
 		return writeCacheableJSONResponse(w, req, clientCtx.Env, jsonData, selector.State())
 	})
 }
@@ -497,8 +500,9 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 // PHP SDK polling endpoint for all flags: app.ld.com/sdk/flags
 func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
+	tr := tracing.Tracer()
 
-	_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreGetAll)
+	_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreGetAll)
 	data, err := clientCtx.Env.GetStore().GetAll(ldstoreimpl.Features())
 	if err != nil {
 		storeSpan.RecordError(err)
@@ -512,7 +516,7 @@ func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	respData, etag := func() ([]byte, string) {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
 		respData := serializeFlagsAsMap(data)
@@ -530,7 +534,7 @@ func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 		return respData, etag
 	}()
 
-	traceWriteResponse(req, func() (int, error) {
+	traceWriteResponse(tr, req, func() (int, error) {
 		return writeCacheableJSONResponse(w, req, clientCtx.Env, respData, etag)
 	})
 }
@@ -664,6 +668,7 @@ func writePrerequisites(obj *jwriter.ObjectState, prerequisites []string) {
 
 func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basictypes.SDKKind, maxBodySize ct.OptBase2Bytes) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
+	tr := tracing.Tracer()
 	client := clientCtx.Env.GetClient()
 	store := clientCtx.Env.GetStore()
 	logger := clientCtx.Env.GetLogger()
@@ -696,7 +701,7 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 
 	logger.Debug("application requested client-side flags", "sdkKind", sdkKind, "contextKey", ldContext.Key())
 
-	_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreGetAll)
+	_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreGetAll)
 	items, err := store.GetAll(ldstoreimpl.Features())
 	if err != nil {
 		storeSpan.RecordError(err)
@@ -713,13 +718,13 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 
 	evaluator := clientCtx.Env.GetEvaluator()
 
-	_, evalSpan := tracing.Tracer().Start(req.Context(), tracing.SpanEvaluateFlags)
+	_, evalSpan := tr.Start(req.Context(), tracing.SpanEvaluateFlags)
 	evalResults := evaluateFlags(evaluator, items, sdkKind, ldContext)
 	evalSpan.SetAttributes(tracing.FlagCountKey.Int(len(evalResults)))
 	evalSpan.End()
 
 	result := func() []byte {
-		_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
 		responseWriter := jwriter.NewWriter()
@@ -748,7 +753,7 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 		return data
 	}()
 
-	traceWriteResponse(req, func() (int, error) {
+	traceWriteResponse(tr, req, func() (int, error) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write(result)
 		return http.StatusOK, err
@@ -758,8 +763,9 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.DataKind) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		key := mux.Vars(req)["key"]
+		tr := tracing.Tracer()
 
-		_, storeSpan := tracing.Tracer().Start(req.Context(), tracing.SpanStoreGet)
+		_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreGet)
 		storeSpan.SetAttributes(tracing.StoreKeyKey.String(key))
 		item, err := clientContext.GetStore().Get(kind, key)
 		if err != nil {
@@ -779,7 +785,7 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 		}
 
 		bytes, ok := func() ([]byte, bool) {
-			_, span := tracing.Tracer().Start(req.Context(), tracing.SpanSerializePayload)
+			_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 			defer span.End()
 			data, err := json.Marshal(item.Item)
 			if err != nil {
@@ -796,7 +802,7 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 			return
 		}
 
-		traceWriteResponse(req, func() (int, error) {
+		traceWriteResponse(tr, req, func() (int, error) {
 			return writeCacheableJSONResponse(w, req, clientContext, bytes, strconv.Itoa(item.Version))
 		})
 	}
@@ -818,8 +824,8 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 // Note also that the span measures the time to hand the payload to the ResponseWriter, not
 // time on the socket: a response small enough to fit net/http's output buffer is flushed after
 // the handler returns.
-func traceWriteResponse(req *http.Request, write func() (int, error)) {
-	_, span := tracing.Tracer().Start(req.Context(), tracing.SpanWriteResponse)
+func traceWriteResponse(tr trace.Tracer, req *http.Request, write func() (int, error)) {
+	_, span := tr.Start(req.Context(), tracing.SpanWriteResponse)
 	defer span.End()
 
 	status, err := write()

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -267,8 +267,10 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 								},
 							})
 						} else {
-							clientCtx.Env.GetLogger().Error("error casting keyed item to feature flag")
-							span.SetStatus(codes.Error, "error casting keyed item to feature flag")
+							err := errors.New("error casting keyed item to feature flag")
+							clientCtx.Env.GetLogger().Error(err.Error())
+							span.RecordError(err)
+							span.SetStatus(codes.Error, err.Error())
 							w.WriteHeader(http.StatusInternalServerError)
 							return nil, false
 						}
@@ -287,14 +289,18 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 								},
 							})
 						} else {
-							clientCtx.Env.GetLogger().Error("error casting keyed item to feature segment")
-							span.SetStatus(codes.Error, "error casting keyed item to feature segment")
+							err := errors.New("error casting keyed item to feature segment")
+							clientCtx.Env.GetLogger().Error(err.Error())
+							span.RecordError(err)
+							span.SetStatus(codes.Error, err.Error())
 							w.WriteHeader(http.StatusInternalServerError)
 							return nil, false
 						}
 					default:
-						clientCtx.Env.GetLogger().Error("unexpected data kind in store snapshot", "kind", kind)
-						span.SetStatus(codes.Error, "unexpected data kind in store snapshot")
+						err := errors.New("unexpected data kind in store snapshot")
+						clientCtx.Env.GetLogger().Error(err.Error(), "kind", kind)
+						span.RecordError(err)
+						span.SetStatus(codes.Error, err.Error())
 						w.WriteHeader(http.StatusInternalServerError)
 						return nil, false
 					}
@@ -519,7 +525,7 @@ func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
-		respData := serializeFlagsAsMap(data)
+		respData, flagCount := serializeFlagsAsMap(data)
 		// Compute an overall Etag for the data set by hashing flag keys and versions
 		hash := sha1.New()                                                         //nolint:gosec // just used for insecure hashing
 		sort.Slice(data, func(i, j int) bool { return data[i].Key < data[j].Key }) // makes the hash deterministic
@@ -528,7 +534,7 @@ func pollAllFlagsHandler(w http.ResponseWriter, req *http.Request) {
 		}
 		etag := hex.EncodeToString(hash.Sum(nil))[:15]
 		span.SetAttributes(
-			tracing.FlagCountKey.Int(len(data)),
+			tracing.FlagCountKey.Int(flagCount),
 			tracing.PayloadBytesKey.Int(len(respData)),
 		)
 		return respData, etag
@@ -866,14 +872,19 @@ func writeCacheableJSONResponse(w http.ResponseWriter, req *http.Request, client
 	return http.StatusOK, err
 }
 
-func serializeFlagsAsMap(coll []ldstoretypes.KeyedItemDescriptor) []byte {
+// serializeFlagsAsMap writes the flags in coll as a JSON object keyed by flag key, and reports
+// how many it wrote. GetAll is contractually required to include placeholders for deleted items,
+// which have no flag to serialize, so the count is not len(coll).
+func serializeFlagsAsMap(coll []ldstoretypes.KeyedItemDescriptor) ([]byte, int) {
 	w := jwriter.NewWriter()
 	obj := w.Object()
+	count := 0
 	for _, item := range coll {
 		if item.Item.Item != nil {
 			ldmodel.MarshalFeatureFlagToJSONWriter(*item.Item.Item.(*ldmodel.FeatureFlag), obj.Name(item.Key))
+			count++
 		}
 	}
 	obj.End()
-	return w.Bytes()
+	return w.Bytes(), count
 }

--- a/relay/relay_endpoints_serialize_errors_test.go
+++ b/relay/relay_endpoints_serialize_errors_test.go
@@ -1,0 +1,227 @@
+package relay
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/relayenv"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testclient"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testenv"
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// headerCountingResponseWriter counts WriteHeader calls. net/http and httptest both swallow a
+// second WriteHeader (logging "superfluous response.WriteHeader call" at most), so counting is
+// the only way a test can see that a handler wrote a status twice -- which is exactly what
+// dropping one of the `if !ok { return }` guards after a failed serialization would do.
+type headerCountingResponseWriter struct {
+	*httptest.ResponseRecorder
+	headerWrites int
+}
+
+func (w *headerCountingResponseWriter) WriteHeader(code int) {
+	w.headerWrites++
+	w.ResponseRecorder.WriteHeader(code)
+}
+
+// unknownDataKind is a data kind Relay does not recognize, for the default branch of the
+// snapshot loop.
+type unknownDataKind struct{}
+
+func (unknownDataKind) GetName() string { return "unknown-kind" }
+
+func (unknownDataKind) Serialize(ldstoretypes.ItemDescriptor) []byte { return nil }
+
+func (unknownDataKind) Deserialize([]byte) (ldstoretypes.ItemDescriptor, error) {
+	return ldstoretypes.ItemDescriptor{}, nil
+}
+
+// envWithStore builds an environment context whose read-only store is the given fake store, so a
+// test can serve data the standard fixtures cannot express.
+func envWithStore(store *testclient.FakeStore) relayenv.EnvContext {
+	return testenv.NewTestEnvContextWithClientFactory("",
+		testclient.FakeLDClientFactoryWithStore(true, store), nil)
+}
+
+func liveFlag(key string) ldstoretypes.KeyedItemDescriptor {
+	flag := ldbuilders.NewFlagBuilder(key).Version(1).SingleVariation(ldvalue.String("v")).Build()
+	return ldstoretypes.KeyedItemDescriptor{
+		Key:  key,
+		Item: ldstoretypes.ItemDescriptor{Version: flag.Version, Item: &flag},
+	}
+}
+
+// tombstone is the placeholder GetAll is contractually required to return for a deleted item.
+func tombstone(key string, version int) ldstoretypes.KeyedItemDescriptor {
+	return ldstoretypes.KeyedItemDescriptor{
+		Key:  key,
+		Item: ldstoretypes.ItemDescriptor{Version: version, Item: nil},
+	}
+}
+
+// wrongTypedItem is an item stored under a kind whose Go type does not match it.
+func wrongTypedItem(key string) ldstoretypes.KeyedItemDescriptor {
+	return ldstoretypes.KeyedItemDescriptor{
+		Key:  key,
+		Item: ldstoretypes.ItemDescriptor{Version: 1, Item: "not a flag or a segment"},
+	}
+}
+
+// TestFlagCountExcludesTombstones covers the /sdk/flags count. GetAll includes placeholders for
+// deleted flags and serializeFlagsAsMap skips them, so counting the raw result reported flags
+// that were never in the response.
+func TestFlagCountExcludesTombstones(t *testing.T) {
+	recorder := installSpanRecorder(t)
+
+	store := testclient.NewFakeStore([]ldstoretypes.Collection{
+		{
+			Kind: ldstoreimpl.Features(),
+			Items: []ldstoretypes.KeyedItemDescriptor{
+				liveFlag("live-flag"),
+				tombstone("deleted-one", 7),
+				tombstone("deleted-two", 9),
+			},
+		},
+		{Kind: ldstoreimpl.Segments(), Items: []ldstoretypes.KeyedItemDescriptor{}},
+	})
+
+	req := buildPreRoutedRequest("GET", nil, make(http.Header), nil, envWithStore(store))
+	w := httptest.NewRecorder()
+
+	pollAllFlagsHandler(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Len(t, body, 1, "only the live flag should be serialized")
+
+	serialize := requireSpan(t, recorder.Ended(), tracing.SpanSerializePayload)
+	assert.Equal(t, int64(len(body)), spanAttrs(serialize)[tracing.FlagCountKey].AsInt64(),
+		"the flag count should match the flags in the response, not the raw store entries")
+}
+
+// TestSerializeErrorPathsInPollHandlerV2 reaches the three branches of the snapshot loop that
+// give up on the payload. Each must report the failure on the serialize span, send exactly one
+// 500, and start no response-write span -- the last two being what the `if !ok { return }` guard
+// after the closure is for.
+func TestSerializeErrorPathsInPollHandlerV2(t *testing.T) {
+	segment := ldbuilders.NewSegmentBuilder("a-segment").Version(1).Build()
+
+	for _, params := range []struct {
+		name        string
+		collections []ldstoretypes.Collection
+		wantStatus  string
+	}{
+		{
+			name: "item under the flag kind is not a flag",
+			collections: []ldstoretypes.Collection{
+				{Kind: ldstoreimpl.Features(), Items: []ldstoretypes.KeyedItemDescriptor{wrongTypedItem("bad")}},
+			},
+			wantStatus: "error casting keyed item to feature flag",
+		},
+		{
+			name: "item under the segment kind is not a segment",
+			collections: []ldstoretypes.Collection{
+				{Kind: ldstoreimpl.Segments(), Items: []ldstoretypes.KeyedItemDescriptor{wrongTypedItem("bad")}},
+			},
+			wantStatus: "error casting keyed item to feature segment",
+		},
+		{
+			name: "a data kind Relay does not recognize",
+			collections: []ldstoretypes.Collection{
+				{Kind: unknownDataKind{}, Items: []ldstoretypes.KeyedItemDescriptor{
+					{Key: "x", Item: ldstoretypes.ItemDescriptor{Version: 1, Item: &segment}},
+				}},
+			},
+			wantStatus: "unexpected data kind in store snapshot",
+		},
+	} {
+		t.Run(params.name, func(t *testing.T) {
+			recorder := installSpanRecorder(t)
+
+			store := testclient.NewFakeStore(params.collections)
+			req := buildPreRoutedRequest("GET", nil, make(http.Header), nil, envWithStore(store))
+			w := &headerCountingResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+
+			pollHandlerV2(w, req)
+
+			assert.Equal(t, http.StatusInternalServerError, w.Code)
+			assert.Equal(t, 1, w.headerWrites, "the handler should send exactly one status")
+			assert.Zero(t, w.Body.Len(), "a failed serialization should send no payload")
+
+			spans := recorder.Ended()
+			serialize := requireSpan(t, spans, tracing.SpanSerializePayload)
+			assert.Equal(t, codes.Error, serialize.Status().Code)
+			assert.Equal(t, params.wantStatus, serialize.Status().Description)
+			assertRecordedError(t, serialize, params.wantStatus)
+
+			assert.Empty(t, spansNamed(spans, tracing.SpanWriteResponse),
+				"no response was written, so there should be no write span")
+			assert.Zero(t, countStarted(recorder.Started(), tracing.SpanWriteResponse))
+		})
+	}
+}
+
+// TestSerializeErrorPathInPollFlagOrSegment reaches the json.Marshal failure branch by storing an
+// item that cannot be marshaled, and makes the same assertions.
+func TestSerializeErrorPathInPollFlagOrSegment(t *testing.T) {
+	recorder := installSpanRecorder(t)
+
+	// A channel has no JSON representation, so json.Marshal fails on the stored item.
+	unmarshalable := ldstoretypes.KeyedItemDescriptor{
+		Key:  "bad-flag",
+		Item: ldstoretypes.ItemDescriptor{Version: 1, Item: make(chan int)},
+	}
+	store := testclient.NewFakeStore([]ldstoretypes.Collection{
+		{Kind: ldstoreimpl.Features(), Items: []ldstoretypes.KeyedItemDescriptor{unmarshalable}},
+	})
+
+	env := envWithStore(store)
+	req := buildPreRoutedRequest("GET", nil, make(http.Header), map[string]string{"key": "bad-flag"}, env)
+	w := &headerCountingResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+
+	pollFlagOrSegment(env, ldstoreimpl.Features())(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, 1, w.headerWrites, "the handler should send exactly one status")
+	assert.Zero(t, w.Body.Len())
+
+	spans := recorder.Ended()
+	serialize := requireSpan(t, spans, tracing.SpanSerializePayload)
+	assert.Equal(t, codes.Error, serialize.Status().Code)
+	assertRecordedError(t, serialize, "json")
+
+	assert.Empty(t, spansNamed(spans, tracing.SpanWriteResponse))
+	assert.Zero(t, countStarted(recorder.Started(), tracing.SpanWriteResponse))
+}
+
+// assertRecordedError checks that RecordError was called, not just SetStatus: the error has to
+// reach the span as an exception event to show up in a trace viewer.
+func assertRecordedError(t *testing.T, span sdktrace.ReadOnlySpan, containing string) {
+	t.Helper()
+	for _, event := range span.Events() {
+		if event.Name != "exception" {
+			continue
+		}
+		for _, kv := range event.Attributes {
+			if kv.Key == "exception.message" {
+				assert.Contains(t, kv.Value.AsString(), containing)
+				return
+			}
+		}
+	}
+	assert.Failf(t, "no recorded error", "span %q has no exception event; events: %v", span.Name(), span.Events())
+}

--- a/relay/relay_endpoints_spans_test.go
+++ b/relay/relay_endpoints_spans_test.go
@@ -231,11 +231,9 @@ func TestPollingEndpointSpansAreRecorded(t *testing.T) {
 // dangling. pollFlagOrSegment's not-found path additionally shows that a store span created
 // before the early return is properly ended.
 //
-// Note: the serialize span's own error branches (a json.Marshal failure or a store type-cast
-// failure) operate on data the store has already validated and cannot be provoked through the
-// test harness, which always serves a fixed in-memory dataset. Those branches are guarded
-// structurally by the IIFE's `defer span.End()`, so the span cannot leak regardless of which
-// return fires.
+// The serialize span's own error branches -- a json.Marshal failure, a store type-cast failure,
+// an unrecognized data kind -- are covered separately in relay_endpoints_serialize_errors_test.go,
+// which serves them from a store built for the purpose.
 func TestPollingEndpointSpansDoNotLeakOnEarlyReturn(t *testing.T) {
 	recorder := installSpanRecorder(t)
 

--- a/relay/relay_endpoints_tracer_test.go
+++ b/relay/relay_endpoints_tracer_test.go
@@ -1,0 +1,50 @@
+package relay
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
+
+	c "github.com/launchdarkly/ld-relay/v9/config"
+	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandlerTracerFollowsTheCurrentProvider pins down that the handlers resolve their tracer
+// per request rather than once per process. Each handler hoists tracing.Tracer() into a local
+// so it pays for one lookup instead of three or four, and the tempting next step -- memoizing
+// that lookup in a package-level variable -- would latch the first provider it saw and silently
+// stop recording when the provider changes. This test fails if that happens.
+func TestHandlerTracerFollowsTheCurrentProvider(t *testing.T) {
+	first := installSpanRecorder(t)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		request := func() {
+			result, _ := st.DoRequest(st.BuildRequestWithAuth("GET", "/sdk/flags", st.EnvMain.Config.SDKKey, nil), p.relay)
+			require.Equal(t, http.StatusOK, result.StatusCode)
+		}
+
+		request()
+		require.Len(t, spansNamed(first.Ended(), tracing.SpanSerializePayload), 1,
+			"the recorder installed before the relay started should see the first request's spans")
+
+		// Swap in a second provider after the relay is already running and serving.
+		second := installSpanRecorder(t)
+		first.Reset()
+
+		request()
+
+		assert.Len(t, spansNamed(second.Ended(), tracing.SpanSerializePayload), 1,
+			"the handler should have resolved its tracer from the provider current at request time")
+		assert.Len(t, spansNamed(second.Ended(), tracing.SpanWriteResponse), 1,
+			"the response-write span should follow the same tracer as the rest of the handler")
+		assert.Empty(t, spansNamed(first.Ended(), tracing.SpanSerializePayload),
+			"the replaced provider should no longer receive handler spans")
+	})
+}

--- a/relay/relay_endpoints_tracing_benchmark_test.go
+++ b/relay/relay_endpoints_tracing_benchmark_test.go
@@ -1,0 +1,75 @@
+package relay
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/basictypes"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testenv"
+
+	ct "github.com/launchdarkly/go-configtypes"
+	"github.com/launchdarkly/go-sdk-common/v3/lduser"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// BenchmarkEvaluateAllFlagsTracedConcurrent measures the evaluation endpoint with tracing
+// enabled and requests in flight concurrently, which is where tracer-lookup cost lives:
+// resolving a tracer takes the provider's exclusive mutex, so every lookup is a point where
+// concurrent requests serialize against each other.
+//
+// Be careful reading it. The handler spends microseconds between lookups, so the lock is only
+// lightly contended and a saved lookup is worth tens of nanoseconds -- around 2% here, close
+// to this benchmark's run-to-run spread. It is here to exercise the concurrent traced path,
+// not to gate on a number.
+func BenchmarkEvaluateAllFlagsTracedConcurrent(b *testing.B) {
+	numFlags := 50
+
+	allData := []ldstoretypes.Collection{
+		{Kind: ldstoreimpl.Features(), Items: []ldstoretypes.KeyedItemDescriptor{}},
+		{Kind: ldstoreimpl.Segments(), Items: []ldstoretypes.KeyedItemDescriptor{}},
+	}
+	for i := 0; i < numFlags; i++ {
+		flag := ldbuilders.NewFlagBuilder(fmt.Sprintf("flag%d", i)).Version(1).
+			SingleVariation(ldvalue.String(fmt.Sprintf("value%d", i))).
+			ClientSideUsingEnvironmentID(true).
+			Build()
+		allData[0].Items = append(allData[0].Items,
+			ldstoretypes.KeyedItemDescriptor{Key: flag.Key, Item: sharedtest.FlagDesc(flag)})
+	}
+
+	user := lduser.NewUserBuilder("user-key").Name("name").Email("email").Custom("a", ldvalue.String("b")).Build()
+
+	store := sharedtest.NewInMemoryStore()
+	store.Init(allData)
+	ctx := testenv.NewTestEnvContext("", false, store)
+	userData := []byte(user.String())
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+
+	// A real SDK tracer provider, so tracer lookups take the same lock they take in production.
+	// Spans are dropped by the sampler, isolating the lookup cost from export cost.
+	previous := otel.GetTracerProvider()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.NeverSample()))
+	otel.SetTracerProvider(provider)
+	b.Cleanup(func() { otel.SetTracerProvider(previous) })
+
+	handler := evaluateAllFeatureFlags(basictypes.JSClientSDK, ct.OptBase2Bytes{})
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req := buildPreRoutedRequest("REPORT", userData, headers, nil, ctx)
+			handler(httptest.NewRecorder(), req)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Findings #6 and #7 of the #784 review, together because both needed the same missing test scaffolding.

**Stacked on #793** (which is stacked on #792). The diff here is one commit; GitHub retargets the base as the stack merges.

### #6 -- the flag count included deletion tombstones

`pollAllFlagsHandler` set `relay.flags.count` from `len(data)`, the raw `GetAll` result, while `serializeFlagsAsMap` skips entries whose item is nil. `subsystems.DataStore.GetAll` is documented to *include* placeholders for deleted items rather than filter them, and the SDK's in-memory store obeys that literally -- `GetAll` copies every map entry with no nil check. Relay's read-only store is that SDK store, handed over through `LDRelayDataDestination`, so any flag deleted while relay is running inflated the count until the next full payload transfer.

Reproduced: one live flag beside two tombstones reported `relay.flags.count = 3` against a response containing one flag.

`serializeFlagsAsMap` now reports how many flags it actually wrote. The key previously meant "flags evaluated" on the two `relay.evaluate_flags` spans and "raw store entries" here; now it means "flags in this payload" everywhere.

### #7 -- the serialize error paths had no coverage

Dropping `if !ok { return }` after a failed serialization used to survive the whole suite, even though it produces a superfluous `WriteHeader` after a 500. The branches were unreachable through the harness because `FakeLDClientFactory` hardwires `NewFakeStore(sharedtest.AllData)`, and the store parameter on `NewTestEnvContextWithClientFactory` goes to the unused DataStoreFactory path.

`FakeStore` already serves whatever collections it is given, so the scaffolding is one factory variant -- `FakeLDClientFactoryWithStore` -- that hands relay a caller-supplied store. The new tests reach all four give-up branches:

- item under the flag kind that is not a flag
- item under the segment kind that is not a segment
- a data kind relay does not recognize
- a `json.Marshal` failure in `pollFlagOrSegment` (a channel has no JSON representation)

Each asserts the failure reaches the serialize span, that the handler sends **exactly one** status, and that no response-write span is started. Counting `WriteHeader` calls is deliberate: net/http and `httptest` both swallow a second one, so a counting `ResponseWriter` is the only way a test can see the double write that a missing guard would cause.

Three of those branches called `SetStatus` but not `RecordError`, unlike the `json.Marshal` branches beside them, so the error never appeared as a span exception event. They record it now.

The note in `relay_endpoints_spans_test.go` calling these branches unprovokable is no longer true, and points at the new tests instead.

### Mutation checks

All killed:

| Mutation | Result |
|---|---|
| count `len(data)` again | flag-count test fails, 3 vs 1 |
| drop `RecordError` from the cast branches | 3 failures, one per branch |
| drop `if !ok { return }` in `pollHandlerV2` | 9 failures |
| drop `if !ok { return }` in `pollFlagOrSegment` | 3 failures |

### Not done

The `w.WriteHeader(http.StatusInternalServerError)` calls sit inside the serialize closures, so the 500 write is attributed to serialization. Moving them out to the callers touches five closures for a microsecond of misattribution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to telemetry accuracy, OpenTelemetry error recording, and test scaffolding; polling behavior for valid data is unchanged.
> 
> **Overview**
> Fixes **`relay.flags.count`** on **`GET /sdk/flags`** so it reflects flags actually serialized, not raw **`GetAll`** entries (which include deletion tombstones with nil items). **`serializeFlagsAsMap`** now returns a written count; **`pollAllFlagsHandler`** uses that for the serialize span attribute.
> 
> Adds **`FakeLDClientFactoryWithStore`** so tests can inject custom store data (tombstones, wrong types, unknown kinds). New tests in **`relay_endpoints_serialize_errors_test.go`** exercise poll serialization failures: bad flag/segment casts, unknown data kind, and **`json.Marshal`** errors—asserting a single **500**, serialize span error status, **`RecordError`** on spans (added for the three cast/default branches that only had **`SetStatus`** before), and no response-write span when serialization aborts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2998b867b92dc63d7c94b6be41034b8578813a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->