### PR TITLE
perf: Encode FDv2 polling payloads in a single jwriter pass

### DIFF
--- a/relay/endpoint_tests_base_test.go
+++ b/relay/endpoint_tests_base_test.go
@@ -13,6 +13,18 @@ import (
 	m "github.com/launchdarkly/go-test-helpers/v3/matchers"
 )
 
+// pollingPayload and payloadEvent describe the FDv2 polling response document. Tests
+// unmarshal responses through them; the handlers themselves encode the document with
+// fdv2PayloadWriter, which is guaranteed to produce the JSON this structure marshals to.
+type pollingPayload struct {
+	Events []payloadEvent `json:"events"`
+}
+
+type payloadEvent struct {
+	Event     string `json:"event"`
+	EventData any    `json:"data"`
+}
+
 // Test parameters for an endpoint that we want to test. The "data" parameter is used as the request body if
 // the method is GET, and can also be included in base64 in the URL by putting "$DATA" in the URL path. Also,
 // if the credential is an environment ID, it is substituted for "$ENV" in the URL path.

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -178,15 +178,6 @@ func streamHandlerV2(streamProvider streams.StreamProvider, logMessage string) h
 	})
 }
 
-type pollingPayload struct {
-	Events []payloadEvent `json:"events"`
-}
-
-type payloadEvent struct {
-	Event     string `json:"event"`
-	EventData any    `json:"data"`
-}
-
 // Server-side SDK polling endpoint: app.ld.com/sdk/poll/
 func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 	clientCtx := middleware.GetEnvContextInfo(req.Context())
@@ -214,37 +205,22 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
-		numItems := 2
-		if len(collection) > 0 {
-			for _, keyedItems := range collection {
-				numItems += len(keyedItems)
-			}
-		}
-
-		pollingPayload := pollingPayload{
-			Events: make([]payloadEvent, 0, numItems),
-		}
+		payloadWriter := newFDv2PayloadWriter()
 
 		basis := req.URL.Query().Get("basis")
 		if selector.IsDefined() && basis != "" && selector.State() == basis {
-			pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-				Event: "server-intent",
-				EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
-					ID:     selector.State(),
-					Target: selector.Version(),
-					Code:   subsystems.IntentNone,
-					Reason: "up-to-date",
-				}},
+			payloadWriter.writeServerIntent(subsystems.Payload{
+				ID:     selector.State(),
+				Target: selector.Version(),
+				Code:   subsystems.IntentNone,
+				Reason: "up-to-date",
 			})
 		} else {
-			pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-				Event: "server-intent",
-				EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
-					ID:     selector.State(),
-					Target: selector.Version(),
-					Code:   subsystems.IntentTransferFull,
-					Reason: "cant-catchup",
-				}},
+			payloadWriter.writeServerIntent(subsystems.Payload{
+				ID:     selector.State(),
+				Target: selector.Version(),
+				Code:   subsystems.IntentTransferFull,
+				Reason: "cant-catchup",
 			})
 			for kind, keyedItems := range collection {
 				for _, keyedItem := range keyedItems {
@@ -254,18 +230,9 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 					switch kind {
 					case ldstoreimpl.Features():
 						if flag, ok := keyedItem.Item.Item.(*ldmodel.FeatureFlag); ok {
-							writer := jwriter.NewWriter()
-							ldmodel.MarshalFeatureFlagToJSONWriter(*flag, &writer)
-
-							pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-								Event: "put-object",
-								EventData: subsystems.PutObject{
-									Version: keyedItem.Item.Version,
-									Kind:    subsystems.FlagKind,
-									Key:     keyedItem.Key,
-									Object:  writer.Bytes(),
-								},
-							})
+							objectWriter := payloadWriter.beginPutObject(keyedItem.Item.Version, subsystems.FlagKind, keyedItem.Key)
+							ldmodel.MarshalFeatureFlagToJSONWriter(*flag, objectWriter)
+							payloadWriter.endPutObject()
 						} else {
 							err := errors.New("error casting keyed item to feature flag")
 							clientCtx.Env.GetLogger().Error(err.Error())
@@ -276,18 +243,9 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 						}
 					case ldstoreimpl.Segments():
 						if segment, ok := keyedItem.Item.Item.(*ldmodel.Segment); ok {
-							writer := jwriter.NewWriter()
-							ldmodel.MarshalSegmentToJSONWriter(*segment, &writer)
-
-							pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-								Event: "put-object",
-								EventData: subsystems.PutObject{
-									Version: keyedItem.Item.Version,
-									Kind:    subsystems.SegmentKind,
-									Key:     keyedItem.Key,
-									Object:  writer.Bytes(),
-								},
-							})
+							objectWriter := payloadWriter.beginPutObject(keyedItem.Item.Version, subsystems.SegmentKind, keyedItem.Key)
+							ldmodel.MarshalSegmentToJSONWriter(*segment, objectWriter)
+							payloadWriter.endPutObject()
 						} else {
 							err := errors.New("error casting keyed item to feature segment")
 							clientCtx.Env.GetLogger().Error(err.Error())
@@ -306,13 +264,10 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 					}
 				}
 			}
-			pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-				Event:     "payload-transferred",
-				EventData: selector,
-			})
+			payloadWriter.writePayloadTransferred(selector)
 		}
 
-		data, err := json.Marshal(pollingPayload)
+		data, eventCount, err := payloadWriter.finish()
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
@@ -321,7 +276,7 @@ func pollHandlerV2(w http.ResponseWriter, req *http.Request) {
 			return nil, false
 		}
 		span.SetAttributes(
-			tracing.PayloadEventsKey.Int(len(pollingPayload.Events)),
+			tracing.PayloadEventsKey.Int(eventCount),
 			tracing.PayloadBytesKey.Int(len(data)),
 		)
 		return data, true
@@ -393,36 +348,13 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 		return
 	}
 
-	pollingPayload := pollingPayload{
-		Events: make([]payloadEvent, 0),
-	}
 	flagEvalKind := subsystems.ObjectKind("flag-eval")
 
 	basis := req.URL.Query().Get("basis")
 	upToDate := selector.IsDefined() && basis != "" && selector.State() == basis
 
 	var evalResults []flagEvalResult
-	if upToDate {
-		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-			Event: "server-intent",
-			EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
-				ID:     selector.State(),
-				Target: selector.Version(),
-				Code:   subsystems.IntentNone,
-				Reason: "up-to-date",
-			}},
-		})
-	} else {
-		pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-			Event: "server-intent",
-			EventData: subsystems.ServerIntent{Payload: subsystems.Payload{
-				ID:     selector.State(),
-				Target: selector.Version(),
-				Code:   subsystems.IntentTransferFull,
-				Reason: "cant-catchup",
-			}},
-		})
-
+	if !upToDate {
 		evaluator := clientCtx.Env.GetEvaluator()
 
 		var allItems []ldstoretypes.KeyedItemDescriptor
@@ -443,10 +375,25 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 		_, span := tr.Start(req.Context(), tracing.SpanSerializePayload)
 		defer span.End()
 
-		if !upToDate {
+		payloadWriter := newFDv2PayloadWriter()
+
+		if upToDate {
+			payloadWriter.writeServerIntent(subsystems.Payload{
+				ID:     selector.State(),
+				Target: selector.Version(),
+				Code:   subsystems.IntentNone,
+				Reason: "up-to-date",
+			})
+		} else {
+			payloadWriter.writeServerIntent(subsystems.Payload{
+				ID:     selector.State(),
+				Target: selector.Version(),
+				Code:   subsystems.IntentTransferFull,
+				Reason: "cant-catchup",
+			})
+
 			for _, er := range evalResults {
-				evalWriter := jwriter.NewWriter()
-				evalObj := evalWriter.Object()
+				evalObj := payloadWriter.beginPutObject(er.Flag.Version, flagEvalKind, er.Flag.Key).Object()
 				er.Detail.Value.WriteToJSONWriter(evalObj.Name("value"))
 				er.Detail.VariationIndex.WriteToJSONWriter(evalObj.Name("variation"))
 				evalObj.Name("flagVersion").Int(er.Flag.Version)
@@ -462,25 +409,13 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 					evalObj.Name("samplingRatio").Int(er.Flag.SamplingRatio.IntValue())
 				}
 				evalObj.End()
-
-				pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-					Event: "put-object",
-					EventData: subsystems.PutObject{
-						Version: er.Flag.Version,
-						Kind:    flagEvalKind,
-						Key:     er.Flag.Key,
-						Object:  evalWriter.Bytes(),
-					},
-				})
+				payloadWriter.endPutObject()
 			}
 
-			pollingPayload.Events = append(pollingPayload.Events, payloadEvent{
-				Event:     "payload-transferred",
-				EventData: selector,
-			})
+			payloadWriter.writePayloadTransferred(selector)
 		}
 
-		data, err := json.Marshal(pollingPayload)
+		data, eventCount, err := payloadWriter.finish()
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
@@ -489,7 +424,7 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 			return nil, false
 		}
 		span.SetAttributes(
-			tracing.PayloadEventsKey.Int(len(pollingPayload.Events)),
+			tracing.PayloadEventsKey.Int(eventCount),
 			tracing.PayloadBytesKey.Int(len(data)),
 		)
 		return data, true

--- a/relay/relay_endpoints_fdv2_payload.go
+++ b/relay/relay_endpoints_fdv2_payload.go
@@ -1,0 +1,93 @@
+package relay
+
+import (
+	"github.com/launchdarkly/go-jsonstream/v3/jwriter"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+)
+
+// fdv2PayloadWriter builds the FDv2 polling response document, {"events":[...]}, in a single
+// jwriter pass. It produces the same JSON as marshaling a struct of subsystems event types
+// with encoding/json, but each event -- including the object bodies of put-object events --
+// is written directly into one output buffer. That avoids the per-item buffers, interface
+// boxing, and encoding/json's re-scan of embedded raw JSON that marshaling the equivalent
+// structs costs. The internal/streams package makes the same guarantee for the SSE
+// representation of these events.
+type fdv2PayloadWriter struct {
+	writer     jwriter.Writer
+	topObj     jwriter.ObjectState
+	events     jwriter.ArrayState
+	eventCount int
+
+	// putEventObj and putDataObj hold the enclosing states of a put-object event between
+	// beginPutObject and endPutObject, while the caller writes the object body.
+	putEventObj jwriter.ObjectState
+	putDataObj  jwriter.ObjectState
+}
+
+func newFDv2PayloadWriter() *fdv2PayloadWriter {
+	p := &fdv2PayloadWriter{writer: jwriter.NewWriter()}
+	p.topObj = p.writer.Object()
+	p.events = p.topObj.Name("events").Array()
+	return p
+}
+
+// writeServerIntent appends a server-intent event. The intent has a single payload, but the
+// protocol allows several, so it is written as a one-element array.
+func (p *fdv2PayloadWriter) writeServerIntent(payload subsystems.Payload) {
+	eventObj := p.events.Object()
+	eventObj.Name("event").String(string(subsystems.EventServerIntent))
+	dataObj := eventObj.Name("data").Object()
+	payloads := dataObj.Name("payloads").Array()
+	payloadObj := payloads.Object()
+	payloadObj.Name("id").String(payload.ID)
+	payloadObj.Name("target").Int(payload.Target)
+	payloadObj.Name("intentCode").String(string(payload.Code))
+	payloadObj.Name("reason").String(payload.Reason)
+	payloadObj.End()
+	payloads.End()
+	dataObj.End()
+	eventObj.End()
+	p.eventCount++
+}
+
+// beginPutObject appends a put-object event up to its "object" property and returns the
+// Writer positioned at that value. The caller writes exactly one JSON value to it and then
+// calls endPutObject.
+func (p *fdv2PayloadWriter) beginPutObject(version int, kind subsystems.ObjectKind, key string) *jwriter.Writer {
+	p.putEventObj = p.events.Object()
+	p.putEventObj.Name("event").String(string(subsystems.EventPutObject))
+	p.putDataObj = p.putEventObj.Name("data").Object()
+	p.putDataObj.Name("version").Int(version)
+	p.putDataObj.Name("kind").String(string(kind))
+	p.putDataObj.Name("key").String(key)
+	return p.putDataObj.Name("object")
+}
+
+func (p *fdv2PayloadWriter) endPutObject() {
+	p.putDataObj.End()
+	p.putEventObj.End()
+	p.eventCount++
+}
+
+// writePayloadTransferred appends a payload-transferred event carrying the selector.
+func (p *fdv2PayloadWriter) writePayloadTransferred(selector subsystems.Selector) {
+	eventObj := p.events.Object()
+	eventObj.Name("event").String(string(subsystems.EventPayloadTransferred))
+	dataObj := eventObj.Name("data").Object()
+	dataObj.Name("state").String(selector.State())
+	dataObj.Name("version").Int(selector.Version())
+	dataObj.End()
+	eventObj.End()
+	p.eventCount++
+}
+
+// finish closes the document and returns the encoded payload and the number of events it
+// contains.
+func (p *fdv2PayloadWriter) finish() ([]byte, int, error) {
+	p.events.End()
+	p.topObj.End()
+	if err := p.writer.Error(); err != nil {
+		return nil, 0, err
+	}
+	return p.writer.Bytes(), p.eventCount, nil
+}

--- a/relay/relay_endpoints_fdv2_payload_test.go
+++ b/relay/relay_endpoints_fdv2_payload_test.go
@@ -1,0 +1,94 @@
+package relay
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/launchdarkly/go-jsonstream/v3/jwriter"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin fdv2PayloadWriter's output to the JSON that encoding/json produces for the
+// same events expressed through the subsystems types, which is what the handlers marshaled
+// before the single-pass encoder existed. Equality is structural: encoding/json HTML-escapes
+// characters like '<' and '&' that jwriter emits raw, and both spellings decode identically.
+
+func TestFDv2PayloadWriterFullTransferMatchesEncodingJSON(t *testing.T) {
+	// The key exercises characters that the two encoders escape differently.
+	flag := ldbuilders.NewFlagBuilder("flag-key-<&>").Version(3).On(true).
+		SingleVariation(ldvalue.String("value")).Build()
+	segment := ldbuilders.NewSegmentBuilder("segment-key").Version(5).Included("user1").Build()
+	selector := subsystems.NewSelector("state-1", 42)
+	intent := subsystems.Payload{
+		ID:     selector.State(),
+		Target: selector.Version(),
+		Code:   subsystems.IntentTransferFull,
+		Reason: "cant-catchup",
+	}
+
+	payloadWriter := newFDv2PayloadWriter()
+	payloadWriter.writeServerIntent(intent)
+	flagWriter := payloadWriter.beginPutObject(flag.Version, subsystems.FlagKind, flag.Key)
+	ldmodel.MarshalFeatureFlagToJSONWriter(flag, flagWriter)
+	payloadWriter.endPutObject()
+	segmentWriter := payloadWriter.beginPutObject(segment.Version, subsystems.SegmentKind, segment.Key)
+	ldmodel.MarshalSegmentToJSONWriter(segment, segmentWriter)
+	payloadWriter.endPutObject()
+	payloadWriter.writePayloadTransferred(selector)
+	data, eventCount, err := payloadWriter.finish()
+	require.NoError(t, err)
+	assert.Equal(t, 4, eventCount)
+
+	flagJSONWriter := jwriter.NewWriter()
+	ldmodel.MarshalFeatureFlagToJSONWriter(flag, &flagJSONWriter)
+	segmentJSONWriter := jwriter.NewWriter()
+	ldmodel.MarshalSegmentToJSONWriter(segment, &segmentJSONWriter)
+	expected, err := json.Marshal(pollingPayload{Events: []payloadEvent{
+		{Event: "server-intent", EventData: subsystems.ServerIntent{Payload: intent}},
+		{Event: "put-object", EventData: subsystems.PutObject{
+			Version: flag.Version,
+			Kind:    subsystems.FlagKind,
+			Key:     flag.Key,
+			Object:  flagJSONWriter.Bytes(),
+		}},
+		{Event: "put-object", EventData: subsystems.PutObject{
+			Version: segment.Version,
+			Kind:    subsystems.SegmentKind,
+			Key:     segment.Key,
+			Object:  segmentJSONWriter.Bytes(),
+		}},
+		{Event: "payload-transferred", EventData: selector},
+	}})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(expected), string(data))
+}
+
+func TestFDv2PayloadWriterUpToDateMatchesEncodingJSON(t *testing.T) {
+	selector := subsystems.NewSelector("state-1", 42)
+	intent := subsystems.Payload{
+		ID:     selector.State(),
+		Target: selector.Version(),
+		Code:   subsystems.IntentNone,
+		Reason: "up-to-date",
+	}
+
+	payloadWriter := newFDv2PayloadWriter()
+	payloadWriter.writeServerIntent(intent)
+	data, eventCount, err := payloadWriter.finish()
+	require.NoError(t, err)
+	assert.Equal(t, 1, eventCount)
+
+	expected, err := json.Marshal(pollingPayload{Events: []payloadEvent{
+		{Event: "server-intent", EventData: subsystems.ServerIntent{Payload: intent}},
+	}})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(expected), string(data))
+}

--- a/relay/relay_endpoints_fdv2_payload_test.go
+++ b/relay/relay_endpoints_fdv2_payload_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/launchdarkly/ld-relay/v9/internal/streams"
+
+	"github.com/launchdarkly/eventsource"
 	"github.com/launchdarkly/go-jsonstream/v3/jwriter"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
@@ -91,4 +94,91 @@ func TestFDv2PayloadWriterUpToDateMatchesEncodingJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t, string(expected), string(data))
+}
+
+// The polling and streaming paths encode the same protocol events with separate jwriter code:
+// fdv2PayloadWriter here, and internal/streams' SSE encoders. These tests hold the two
+// implementations together by running the same inputs through both and requiring identical
+// event names and data JSON, so a protocol-shape change in either place fails here until
+// both move. They also cover the intent payloads themselves: the streams package derives
+// the up-to-date and full-transfer intents from the selector internally, so the payloads the
+// polling handlers construct must match or the comparison breaks.
+
+func TestFDv2PayloadWriterFullTransferMatchesStreamingEncoders(t *testing.T) {
+	flag := ldbuilders.NewFlagBuilder("flag-key").Version(3).On(true).
+		SingleVariation(ldvalue.String("value")).Build()
+	segment := ldbuilders.NewSegmentBuilder("segment-key").Version(5).Included("user1").Build()
+	selector := subsystems.NewSelector("state-1", 42)
+
+	payloadWriter := newFDv2PayloadWriter()
+	payloadWriter.writeServerIntent(subsystems.Payload{
+		ID:     selector.State(),
+		Target: selector.Version(),
+		Code:   subsystems.IntentTransferFull,
+		Reason: "cant-catchup",
+	})
+	flagWriter := payloadWriter.beginPutObject(flag.Version, subsystems.FlagKind, flag.Key)
+	ldmodel.MarshalFeatureFlagToJSONWriter(flag, flagWriter)
+	payloadWriter.endPutObject()
+	segmentWriter := payloadWriter.beginPutObject(segment.Version, subsystems.SegmentKind, segment.Key)
+	ldmodel.MarshalSegmentToJSONWriter(segment, segmentWriter)
+	payloadWriter.endPutObject()
+	payloadWriter.writePayloadTransferred(selector)
+	doc, _, err := payloadWriter.finish()
+	require.NoError(t, err)
+
+	flagJSONWriter := jwriter.NewWriter()
+	ldmodel.MarshalFeatureFlagToJSONWriter(flag, &flagJSONWriter)
+	segmentJSONWriter := jwriter.NewWriter()
+	ldmodel.MarshalSegmentToJSONWriter(segment, &segmentJSONWriter)
+	streamEvents := streams.MakeEventsForSetBasis([]subsystems.Change{
+		{
+			Action:  subsystems.ChangeTypePut,
+			Kind:    subsystems.FlagKind,
+			Key:     flag.Key,
+			Version: flag.Version,
+			Object:  flagJSONWriter.Bytes(),
+		},
+		{
+			Action:  subsystems.ChangeTypePut,
+			Kind:    subsystems.SegmentKind,
+			Key:     segment.Key,
+			Version: segment.Version,
+			Object:  segmentJSONWriter.Bytes(),
+		},
+	}, selector)
+
+	assertPayloadMatchesStreamEvents(t, doc, streamEvents)
+}
+
+func TestFDv2PayloadWriterUpToDateMatchesStreamingEncoders(t *testing.T) {
+	selector := subsystems.NewSelector("state-1", 42)
+
+	payloadWriter := newFDv2PayloadWriter()
+	payloadWriter.writeServerIntent(subsystems.Payload{
+		ID:     selector.State(),
+		Target: selector.Version(),
+		Code:   subsystems.IntentNone,
+		Reason: "up-to-date",
+	})
+	doc, _, err := payloadWriter.finish()
+	require.NoError(t, err)
+
+	assertPayloadMatchesStreamEvents(t, doc, streams.MakeEventsForUpToDate(selector))
+}
+
+func assertPayloadMatchesStreamEvents(t *testing.T, doc []byte, streamEvents []eventsource.Event) {
+	t.Helper()
+	var payload struct {
+		Events []struct {
+			Event string          `json:"event"`
+			Data  json.RawMessage `json:"data"`
+		} `json:"events"`
+	}
+	require.NoError(t, json.Unmarshal(doc, &payload))
+	require.Len(t, payload.Events, len(streamEvents))
+	for i, streamEvent := range streamEvents {
+		assert.Equal(t, streamEvent.Event(), payload.Events[i].Event)
+		assert.JSONEq(t, streamEvent.Data(), string(payload.Events[i].Data))
+	}
 }

--- a/relay/relay_endpoints_fdv2_poll_benchmark_test.go
+++ b/relay/relay_endpoints_fdv2_poll_benchmark_test.go
@@ -1,0 +1,115 @@
+package relay
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/relayenv"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testclient"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testenv"
+
+	ct "github.com/launchdarkly/go-configtypes"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+)
+
+// makeLargePollingDataSet builds a data set big enough that payload serialization dominates
+// the polling handlers' cost. The flag shape mirrors the internal/streams encoding benchmarks:
+// each flag has rules and user targets, and is client-side visible so the eval endpoint
+// includes it.
+func makeLargePollingDataSet(numFlags, numSegments int) []ldstoretypes.Collection {
+	numRules := 20
+	numTargets := 2
+	numUsersInTarget := 20
+
+	allData := []ldstoretypes.Collection{
+		{Kind: ldstoreimpl.Features()},
+		{Kind: ldstoreimpl.Segments()},
+	}
+
+	for i := 0; i < numFlags; i++ {
+		fb := ldbuilders.NewFlagBuilder(fmt.Sprintf("flag%d", i)).Version(1).On(true).
+			SingleVariation(ldvalue.String(fmt.Sprintf("value%d", i))).
+			ClientSideUsingEnvironmentID(true)
+		for r := 0; r < numRules; r++ {
+			fb.AddRule(ldbuilders.NewRuleBuilder().ID(fmt.Sprintf("rule%d", r)).Variation(0))
+		}
+		for t := 0; t < numTargets; t++ {
+			var userKeys []string
+			for u := 0; u < numUsersInTarget; u++ {
+				userKeys = append(userKeys, fmt.Sprintf("user%d", u))
+			}
+			fb.AddTarget(t, userKeys...)
+		}
+		flag := fb.Build()
+		allData[0].Items = append(allData[0].Items,
+			ldstoretypes.KeyedItemDescriptor{Key: flag.Key, Item: sharedtest.FlagDesc(flag)})
+	}
+
+	for i := 0; i < numSegments; i++ {
+		var userKeys []string
+		for u := 0; u < numUsersInTarget; u++ {
+			userKeys = append(userKeys, fmt.Sprintf("user%d", u))
+		}
+		segment := ldbuilders.NewSegmentBuilder(fmt.Sprintf("segment%d", i)).Version(1).
+			Included(userKeys...).Build()
+		allData[1].Items = append(allData[1].Items,
+			ldstoretypes.KeyedItemDescriptor{Key: segment.Key, Item: sharedtest.SegmentDesc(segment)})
+	}
+
+	return allData
+}
+
+func benchmarkPollingEnv(numFlags int) relayenv.EnvContext {
+	store := testclient.NewFakeStore(makeLargePollingDataSet(numFlags, numFlags/10))
+	return testenv.NewTestEnvContextWithClientFactory("",
+		testclient.FakeLDClientFactoryWithStore(true, store), nil)
+}
+
+func BenchmarkPollHandlerV2(b *testing.B) {
+	for _, numFlags := range []int{100, 2000} {
+		b.Run(fmt.Sprintf("flags=%d", numFlags), func(b *testing.B) {
+			env := benchmarkPollingEnv(numFlags)
+			req := buildPreRoutedRequest("GET", nil, nil, nil, env)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				resp := httptest.NewRecorder()
+				pollHandlerV2(resp, req)
+				if resp.Code != http.StatusOK {
+					b.Fatalf("unexpected status %d", resp.Code)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPollEvalHandlerV2(b *testing.B) {
+	contextJSON := []byte(`{"kind": "user", "key": "user-key", "name": "name"}`)
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+
+	for _, numFlags := range []int{100, 2000} {
+		b.Run(fmt.Sprintf("flags=%d", numFlags), func(b *testing.B) {
+			env := benchmarkPollingEnv(numFlags)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				// The request must be rebuilt each iteration because the handler consumes the body.
+				req := buildPreRoutedRequest("REPORT", contextJSON, headers, nil, env)
+				resp := httptest.NewRecorder()
+				pollEvalHandlerV2Shared(resp, req, ct.OptBase2Bytes{})
+				if resp.Code != http.StatusOK {
+					b.Fatalf("unexpected status %d", resp.Code)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- **test: Add benchmarks for the FDv2 polling handlers**
- **perf: Encode FDv2 polling payloads in a single jwriter pass**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the wire format and serialization path for server- and client-side FDv2 polling, but behavior is heavily pinned to prior JSON and streaming encoders; main risk is subtle protocol or escaping differences under load.
> 
> **Overview**
> **FDv2 polling responses** (`pollHandlerV2` and client-side `pollEvalHandlerV2Shared`) no longer build `pollingPayload` structs and `json.Marshal` them. They now stream the `{"events":[...]}` document through a new **`fdv2PayloadWriter`**, writing `server-intent`, `put-object` (with flag/segment/eval bodies inlined via `beginPutObject` / `endPutObject`), and `payload-transferred` in one buffer. That cuts per-item intermediate bytes and `encoding/json` work on large snapshots.
> 
> Test helpers **`pollingPayload` / `payloadEvent`** move to `endpoint_tests_base_test.go` with a note that handlers use the writer. New tests assert the writer matches prior `encoding/json` output and **`internal/streams`** SSE event shapes; benchmarks exercise the poll handlers at 100 and 2000 flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09763407e5ef12eb5d113b3bec39470d9b7ea742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->