### PR TITLE
test(sharedtest): make FakeLDClient.Close idempotent

### DIFF
--- a/internal/sharedtest/testclient/fake_client.go
+++ b/internal/sharedtest/testclient/fake_client.go
@@ -36,6 +36,7 @@ type FakeLDClient struct {
 	dataSourceStatus *interfaces.DataSourceStatus
 	initialized      bool
 	lock             sync.Mutex
+	closeOnce        sync.Once
 }
 
 type CapturedLDClient struct {
@@ -70,7 +71,9 @@ func (c *FakeLDClient) GetDataStoreStatus() sdks.DataStoreStatusInfo {
 
 func (c *FakeLDClient) Close() error {
 	if c.CloseCh != nil {
-		close(c.CloseCh)
+		c.closeOnce.Do(func() {
+			close(c.CloseCh)
+		})
 	}
 	return nil
 }

--- a/internal/sharedtest/testclient/fake_client.go
+++ b/internal/sharedtest/testclient/fake_client.go
@@ -69,6 +69,8 @@ func (c *FakeLDClient) GetDataStoreStatus() sdks.DataStoreStatusInfo {
 	return sdks.DataStoreStatusInfo{Available: true}
 }
 
+// Close is idempotent, matching the real SDK client: Relay may tear a client down from more than
+// one code path, and the second call must not panic.
 func (c *FakeLDClient) Close() error {
 	if c.CloseCh != nil {
 		c.closeOnce.Do(func() {

--- a/internal/sharedtest/testclient/fake_client_test.go
+++ b/internal/sharedtest/testclient/fake_client_test.go
@@ -1,0 +1,42 @@
+package testclient
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeLDClientCloseIsIdempotent(t *testing.T) {
+	c := &FakeLDClient{Key: config.SDKKey("key"), CloseCh: make(chan struct{})}
+
+	require.NoError(t, c.Close())
+	require.NoError(t, c.Close())
+
+	select {
+	case <-c.CloseCh:
+	default:
+		assert.Fail(t, "CloseCh was not closed")
+	}
+}
+
+func TestFakeLDClientCloseIsSafeForConcurrentCallers(t *testing.T) {
+	c := &FakeLDClient{Key: config.SDKKey("key"), CloseCh: make(chan struct{})}
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() {
+			assert.NoError(t, c.Close())
+		})
+	}
+	wg.Wait()
+
+	select {
+	case <-c.CloseCh:
+	default:
+		assert.Fail(t, "CloseCh was not closed")
+	}
+}


### PR DESCRIPTION
## Summary
Makes `FakeLDClient.Close()` idempotent in the shared test harness, fixing an intermittent `panic: close of closed channel` that can take down an entire `go test` run.

## Background
`Close()` closed `CloseCh` unconditionally whenever it was non-nil, with no guard against being called twice on the same instance. This was observed once as a flake in `TestConcurrentKeysRAC_ArrayPatchAddsAndRemovesNonAnchorKeys` on the `feat/concurrent-keys` branch; the affected `FakeLDClient` struct and `Close()` method are identical across `v8`, `v9`, and `feat/concurrent-keys` (the surrounding file differs on `v9`, which uses a different data-destination API, but the struct and this method are untouched).

I was not able to reproduce the panic (dozens of `-race` runs of the specific test and of the full `relay` package all passed), and I audited every production `client.Close()` call site in `internal/relayenv/env_context_impl.go` — they all delete the client from the map before closing it, or evict the previous reference before installing a new one, so I couldn't find a path that double-closes the same client reference. The actual second closer for the one observed panic remains unidentified.

Given that, this fix is intentionally defensive rather than a root-cause fix: it makes the fake tolerate a second `Close()` regardless of which caller triggers it, which also brings it in line with production semantics — the real SDK's own components (`event_processor`, `streaming_data_source`, `Broadcaster`) are already idempotent on `Close()` via the same `sync.Once`/no-op pattern this uses. If the panic recurs, the original stack trace would help pin down the actual second caller.

## Changes
- Guard the channel close with `closeOnce sync.Once`, matching the `closeOnce` idiom already used throughout this codebase (metrics, streams, autoconfig, bigsegments, filedata, events).
- Add a doc comment on `Close()` stating the idempotency contract.
- Add `fake_client_test.go` covering two sequential `Close()` calls and N concurrent callers under `-race` — this test reproduces the original panic if the guard is removed.
