### PR TITLE
feat: Add an OTel bridge for eventsource ServerTrace hooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/kardianos/minwinsvc v1.0.2
-	github.com/launchdarkly/eventsource v1.11.2
+	github.com/launchdarkly/eventsource v1.12.0
 	github.com/launchdarkly/go-configtypes v1.2.2
 	github.com/launchdarkly/go-jsonstream/v3 v3.1.1
 	github.com/launchdarkly/go-sdk-common/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/launchdarkly/api-client-go/v13 v13.0.1-0.20230420175109-f5469391a13e 
 github.com/launchdarkly/api-client-go/v13 v13.0.1-0.20230420175109-f5469391a13e/go.mod h1:cQRkOAs0LGcfIs6RSsHNqwhzItUZooyhpqPv0hgiQZM=
 github.com/launchdarkly/ccache v1.1.0 h1:voD1M+ZJXR3MREOKtBwgTF9hYHl1jg+vFKS/+VAkR2k=
 github.com/launchdarkly/ccache v1.1.0/go.mod h1:TlxzrlnzvYeXiLHmesMuvoZetu4Z97cV1SsdqqBJi1Q=
-github.com/launchdarkly/eventsource v1.11.2 h1:RwQcuYEQ7Gtz/f78AysiHpFLwDEHGRUduWs/+k+V2vs=
-github.com/launchdarkly/eventsource v1.11.2/go.mod h1:dU+rZxkPOlGPsyJPpiDqiepAcFwIITDUClY9+A6RrMw=
+github.com/launchdarkly/eventsource v1.12.0 h1:4A4UBFj+uwoPMfkTOVDBCgxVpBcqFdszrCjytbYWzug=
+github.com/launchdarkly/eventsource v1.12.0/go.mod h1:dU+rZxkPOlGPsyJPpiDqiepAcFwIITDUClY9+A6RrMw=
 github.com/launchdarkly/go-configtypes v1.2.2 h1:IXfC7puQpUSctkNfd0L3t6kvlVIQwszBDWpnoiYxk8g=
 github.com/launchdarkly/go-configtypes v1.2.2/go.mod h1:KAwNI0N8ZuAZecfBga9sAv/LwlChEA1RDJ6+pxbxwhk=
 github.com/launchdarkly/go-jsonstream/v3 v3.1.1 h1:ugupp2eNtwVbr69KCdeUrm1vUf1/3ju4Wdliaob95uY=

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -30,6 +30,7 @@ const (
 	streamEventsDiscardedMeasureName     = "launchdarkly.relay.stream.events.discarded"
 	streamWriteErrorsMeasureName         = "launchdarkly.relay.stream.write.errors"
 	streamReplayEventsMeasureName        = "launchdarkly.relay.stream.replay.events"
+	streamReplayDataSizeMeasureName      = "launchdarkly.relay.stream.replay.data.size"
 	streamReplayDrainDurationMeasureName = "launchdarkly.relay.stream.replay.drain.duration"
 
 	defaultFlushInterval = time.Minute

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -19,6 +19,19 @@ const (
 	eventsDroppedMeasureName    = "launchdarkly.relay.events.dropped"
 	eventsPendingMeasureName    = "launchdarkly.relay.events.pending"
 
+	// Instrument names for the eventsource server SSE streams. These are recorded by the
+	// otelbridge package from eventsource ServerTrace callbacks.
+	streamSubscribersActiveMeasureName   = "launchdarkly.relay.stream.subscribers.active"
+	streamConnectionDurationMeasureName  = "launchdarkly.relay.stream.connection.duration"
+	streamSubscribersDroppedMeasureName  = "launchdarkly.relay.stream.subscribers.dropped"
+	streamEventsSentMeasureName          = "launchdarkly.relay.stream.events.sent"
+	streamEventsSentSizeMeasureName      = "launchdarkly.relay.stream.events.sent.size"
+	streamCommentsSentMeasureName        = "launchdarkly.relay.stream.comments.sent"
+	streamEventsDiscardedMeasureName     = "launchdarkly.relay.stream.events.discarded"
+	streamWriteErrorsMeasureName         = "launchdarkly.relay.stream.write.errors"
+	streamReplayEventsMeasureName        = "launchdarkly.relay.stream.replay.events"
+	streamReplayDrainDurationMeasureName = "launchdarkly.relay.stream.replay.drain.duration"
+
 	defaultFlushInterval = time.Minute
 
 	BrowserPlatformCategory = "browser"

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -19,6 +19,109 @@ type Instruments struct {
 	eventsFailedSend    metric.Int64Counter       // cumulative count of events that failed to send
 	eventsBytesSent     metric.Int64Counter       // cumulative bytes of event payloads successfully sent
 	pendingEvents       metric.Int64Gauge         // current number of events pending delivery
+	stream              StreamInstruments
+}
+
+// StreamInstruments holds the OTel instruments for the eventsource server SSE streams. They are
+// recorded by the otelbridge package from eventsource ServerTrace callbacks. The fields are
+// exported because the bridge lives in another package and assembles the per-channel attributes
+// itself; instrument creation still happens once in NewManager, as with all other instruments.
+type StreamInstruments struct {
+	SubscribersActive   metric.Int64UpDownCounter // active SSE subscribers (+1/-1)
+	ConnectionDuration  metric.Float64Histogram   // SSE connection lifetime in seconds
+	SubscribersDropped  metric.Int64Counter       // subscribers force-dropped for buffer overflow
+	EventsSent          metric.Int64Counter       // events written to subscribers
+	EventsSentSize      metric.Int64Histogram     // size in bytes of event payloads written
+	CommentsSent        metric.Int64Counter       // comments (heartbeats) written to subscribers
+	EventsDiscarded     metric.Int64Counter       // events discarded before delivery (jitter coalescing)
+	WriteErrors         metric.Int64Counter       // encode/write failures to a subscriber
+	ReplayEvents        metric.Int64Histogram     // events drained per replay
+	ReplayDrainDuration metric.Float64Histogram   // time to drain a replay batch, in seconds
+}
+
+// StreamInstruments returns the eventsource stream instruments for use by the otelbridge package.
+func (i *Instruments) StreamInstruments() StreamInstruments {
+	return i.stream
+}
+
+// newStreamInstruments creates the eventsource stream instruments from the given meter. The
+// subscribers.active description calls out that it counts SSE subscriptions inside the eventsource
+// server, which is a finer granularity than the http.server.active_requests metric emitted by the
+// HTTP middleware.
+func newStreamInstruments(meter metric.Meter) (StreamInstruments, error) {
+	subscribersActive, err := meter.Int64UpDownCounter(streamSubscribersActiveMeasureName,
+		metric.WithDescription("Number of active SSE subscriptions inside the eventsource server; "+
+			"finer-grained than http.server.active_requests, which counts HTTP requests"),
+		metric.WithUnit("{subscriber}"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	connectionDuration, err := meter.Float64Histogram(streamConnectionDurationMeasureName,
+		metric.WithDescription("Lifetime of an SSE subscription connection"),
+		metric.WithUnit("s"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	subscribersDropped, err := meter.Int64Counter(streamSubscribersDroppedMeasureName,
+		metric.WithDescription("SSE subscribers force-disconnected after falling behind the buffer"),
+		metric.WithUnit("{subscriber}"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	eventsSent, err := meter.Int64Counter(streamEventsSentMeasureName,
+		metric.WithDescription("Events written to SSE subscribers"),
+		metric.WithUnit("{event}"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	eventsSentSize, err := meter.Int64Histogram(streamEventsSentSizeMeasureName,
+		metric.WithDescription("Size of event payloads written to SSE subscribers"),
+		metric.WithUnit("By"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	commentsSent, err := meter.Int64Counter(streamCommentsSentMeasureName,
+		metric.WithDescription("Comments written to SSE subscribers"),
+		metric.WithUnit("{comment}"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	eventsDiscarded, err := meter.Int64Counter(streamEventsDiscardedMeasureName,
+		metric.WithDescription("Events discarded before delivery, such as by jitter coalescing"),
+		metric.WithUnit("{event}"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	writeErrors, err := meter.Int64Counter(streamWriteErrorsMeasureName,
+		metric.WithDescription("Failures encoding or writing an event to a subscriber"),
+		metric.WithUnit("{error}"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	replayEvents, err := meter.Int64Histogram(streamReplayEventsMeasureName,
+		metric.WithDescription("Events drained to a subscriber per replay"),
+		metric.WithUnit("{event}"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	replayDrainDuration, err := meter.Float64Histogram(streamReplayDrainDurationMeasureName,
+		metric.WithDescription("Time to drain a replay batch to a subscriber"),
+		metric.WithUnit("s"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
+	return StreamInstruments{
+		SubscribersActive:   subscribersActive,
+		ConnectionDuration:  connectionDuration,
+		SubscribersDropped:  subscribersDropped,
+		EventsSent:          eventsSent,
+		EventsSentSize:      eventsSentSize,
+		CommentsSent:        commentsSent,
+		EventsDiscarded:     eventsDiscarded,
+		WriteErrors:         writeErrors,
+		ReplayEvents:        replayEvents,
+		ReplayDrainDuration: replayDrainDuration,
+	}, nil
 }
 
 // Measure identifies what to record. Each pre-defined Measure var specifies which
@@ -96,6 +199,10 @@ func NewInstrumentsForTest(meter metric.Meter) (*Instruments, error) {
 	if err != nil {
 		return nil, err
 	}
+	stream, err := newStreamInstruments(meter)
+	if err != nil {
+		return nil, err
+	}
 	return &Instruments{
 		connections:         connections,
 		requestDuration:     requestDuration,
@@ -105,6 +212,7 @@ func NewInstrumentsForTest(meter metric.Meter) (*Instruments, error) {
 		eventsFailedSend:    eventsFailedSend,
 		eventsBytesSent:     eventsBytesSent,
 		pendingEvents:       pendingEvents,
+		stream:              stream,
 	}, nil
 }
 

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -36,6 +36,7 @@ type StreamInstruments struct {
 	EventsDiscarded     metric.Int64Counter       // events discarded before delivery (jitter coalescing)
 	WriteErrors         metric.Int64Counter       // encode/write failures to a subscriber
 	ReplayEvents        metric.Int64Histogram     // events drained per replay
+	ReplayDataSize      metric.Int64Histogram     // summed payload bytes drained per replay batch
 	ReplayDrainDuration metric.Float64Histogram   // time to drain a replay batch, in seconds
 }
 
@@ -104,6 +105,13 @@ func newStreamInstruments(meter metric.Meter) (StreamInstruments, error) {
 	if err != nil {
 		return StreamInstruments{}, err
 	}
+	replayDataSize, err := meter.Int64Histogram(streamReplayDataSizeMeasureName,
+		metric.WithDescription("Summed size of replayed event payloads written to a subscriber per batch; "+
+			"replayed events are not counted in events.sent.size"),
+		metric.WithUnit("By"))
+	if err != nil {
+		return StreamInstruments{}, err
+	}
 	replayDrainDuration, err := meter.Float64Histogram(streamReplayDrainDurationMeasureName,
 		metric.WithDescription("Time to drain a replay batch to a subscriber"),
 		metric.WithUnit("s"))
@@ -120,6 +128,7 @@ func newStreamInstruments(meter metric.Meter) (StreamInstruments, error) {
 		EventsDiscarded:     eventsDiscarded,
 		WriteErrors:         writeErrors,
 		ReplayEvents:        replayEvents,
+		ReplayDataSize:      replayDataSize,
 		ReplayDrainDuration: replayDrainDuration,
 	}, nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -115,6 +115,8 @@ func NewManager(
 		otelmetric.WithDescription("Events buffered in the queue"),
 		otelmetric.WithUnit("{event}"))
 
+	stream, _ := newStreamInstruments(meter)
+
 	instruments := &Instruments{
 		connections:         connections,
 		requestDuration:     requestDuration,
@@ -124,6 +126,7 @@ func NewManager(
 		eventsFailedSend:    eventsFailedSend,
 		eventsBytesSent:     eventsBytesSent,
 		pendingEvents:       pendingEvents,
+		stream:              stream,
 	}
 
 	usageChan := make(chan any, 256)
@@ -148,6 +151,13 @@ func NewManager(
 // GetInstruments returns the OTel instruments for recording metrics.
 func (m *Manager) GetInstruments() *Instruments {
 	return m.instruments
+}
+
+// BaseAttributes returns the process-level attributes shared by every metric this Manager records,
+// currently just relay.id. It is used as the fallback attribute set for stream metrics whose channel
+// cannot be mapped to an environment.
+func (m *Manager) BaseAttributes() []attribute.KeyValue {
+	return []attribute.KeyValue{relayIDAttrKey.String(m.metricsRelayID)}
 }
 
 // SetInstrumentsForTest replaces the instruments on this Manager. Intended for testing only.

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -23,6 +23,8 @@ import (
 	"github.com/launchdarkly/ld-relay/v9/internal/streams"
 	"github.com/launchdarkly/ld-relay/v9/internal/util"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	ldeval "github.com/launchdarkly/go-server-sdk-evaluation/v3"
 	ld "github.com/launchdarkly/go-server-sdk/v7"
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
@@ -65,6 +67,15 @@ type ConnectionMapper interface {
 	RemoveConnectionMapping(scopedCredential sdkauth.ScopedCredential)
 }
 
+// StreamChannelRegistry maps SSE channel strings to the metric attributes for this environment, for
+// the eventsource OTel bridge. The environment registers a channel when it registers a credential
+// with the SSE servers and unregisters it when the credential is removed. It is implemented by the
+// otelbridge.Bridge and is nil when OTLP metrics are disabled.
+type StreamChannelRegistry interface {
+	RegisterChannel(channel string, attrs attribute.Set)
+	UnregisterChannel(channel string)
+}
+
 // EnvContextImplParams contains the constructor parameters for NewEnvContextImpl. These have their
 // own type because there are a lot of them, and many are irrelevant in tests.
 type EnvContextImplParams struct {
@@ -84,6 +95,7 @@ type EnvContextImplParams struct {
 	LogNameMode                      LogNameMode
 	Logger                           *slog.Logger
 	ConnectionMapper                 ConnectionMapper
+	StreamChannelRegistry            StreamChannelRegistry
 	ExpiredCredentialCleanupInterval time.Duration
 }
 
@@ -121,6 +133,8 @@ type envContextImpl struct {
 	stopMonitoringCredentials chan struct{}
 	doneMonitoringCredentials chan struct{}
 	connectionMapper          ConnectionMapper
+	streamChannelRegistry     StreamChannelRegistry
+	streamChannels            map[string]struct{} // channel strings registered with streamChannelRegistry
 	offline                   bool
 	closed                    bool
 }
@@ -188,6 +202,8 @@ func NewEnvContext(
 		stopMonitoringCredentials: make(chan struct{}),
 		doneMonitoringCredentials: make(chan struct{}),
 		connectionMapper:          params.ConnectionMapper,
+		streamChannelRegistry:     params.StreamChannelRegistry,
+		streamChannels:            make(map[string]struct{}),
 		offline:                   envConfig.Offline,
 	}
 
@@ -315,6 +331,11 @@ func NewEnvContext(
 	}
 
 	envContext.metricsEnv = em
+
+	// Register the SSE channel strings for the initial credentials with the stream metrics bridge,
+	// now that the environment's metric attributes (em) exist. envStreams.AddCredential above already
+	// registered the same channels with the eventsource servers.
+	envContext.registerInitialStreamChannels(allCreds)
 
 	// Create an EventMetrics recorder for the event dispatchers to use when reporting
 	// internal metrics like dropped events. This must be done after the EnvironmentManager
@@ -449,10 +470,43 @@ func (c *envContextImpl) cleanupExpiredCredentials(interval time.Duration) {
 	}
 }
 
+// registerInitialStreamChannels registers the SSE channels for the environment's initial set of
+// credentials. It runs during construction before any credential-mutating goroutine has started, so
+// it needs no lock.
+func (c *envContextImpl) registerInitialStreamChannels(creds []credential.SDKCredential) {
+	for _, cred := range creds {
+		c.registerStreamChannel(cred)
+	}
+}
+
+// registerStreamChannel registers the SSE channel for a credential with the stream metrics bridge,
+// using this environment's metric attributes. It is a no-op when OTLP metrics are disabled. Callers
+// must hold c.mu, except during construction before any credential-mutating goroutine has started.
+func (c *envContextImpl) registerStreamChannel(cred credential.SDKCredential) {
+	if c.streamChannelRegistry == nil || c.metricsEnv == nil || !cred.Defined() {
+		return
+	}
+	channel := sdkauth.NewScoped(c.filterKey, cred).String()
+	c.streamChannelRegistry.RegisterChannel(channel, c.metricsEnv.GetAttributes())
+	c.streamChannels[channel] = struct{}{}
+}
+
+// unregisterStreamChannel removes the SSE channel for a credential from the stream metrics bridge.
+// Callers must hold c.mu.
+func (c *envContextImpl) unregisterStreamChannel(cred credential.SDKCredential) {
+	if c.streamChannelRegistry == nil || !cred.Defined() {
+		return
+	}
+	channel := sdkauth.NewScoped(c.filterKey, cred).String()
+	c.streamChannelRegistry.UnregisterChannel(channel)
+	delete(c.streamChannels, channel)
+}
+
 func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.envStreams.AddCredential(newCredential)
+	c.registerStreamChannel(newCredential)
 	for streamProvider, handlers := range c.handlersV1 {
 		if h := streamProvider.HandlerV1(sdkauth.NewScoped(c.filterKey, newCredential)); h != nil {
 			handlers[newCredential] = h
@@ -498,6 +552,7 @@ func (c *envContextImpl) removeCredential(oldCredential credential.SDKCredential
 	defer c.mu.Unlock()
 	c.connectionMapper.RemoveConnectionMapping(sdkauth.NewScoped(c.filterKey, oldCredential))
 	c.envStreams.RemoveCredential(oldCredential)
+	c.unregisterStreamChannel(oldCredential)
 	for _, handlers := range c.handlersV1 {
 		delete(handlers, oldCredential)
 	}
@@ -762,6 +817,17 @@ func (c *envContextImpl) Close() error {
 	<-c.doneMonitoringCredentials
 
 	_ = c.envStreams.Close()
+
+	// Unregister any channels still in the bridge for this environment. The credential-monitoring
+	// goroutine has already stopped (above), so no add/removeCredential can race this.
+	if c.streamChannelRegistry != nil {
+		c.mu.Lock()
+		for channel := range c.streamChannels {
+			c.streamChannelRegistry.UnregisterChannel(channel)
+		}
+		c.streamChannels = make(map[string]struct{})
+		c.mu.Unlock()
+	}
 
 	if c.metricsManager != nil && c.metricsEnv != nil {
 		c.metricsManager.RemoveEnvironment(c.metricsEnv)

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -640,7 +640,7 @@ func TestReceivingBigSegmentsUpdateCausesClientSideInvalidationEvent(t *testing.
 	}
 	fakeSynchronizerFactory := &mockBigSegmentSynchronizerFactory{}
 
-	jsClientStreams := streams.NewStreamProvider(basictypes.JSClientPingStream, time.Hour, 0)
+	jsClientStreams := streams.NewStreamProvider(basictypes.JSClientPingStream, time.Hour, 0, nil)
 	sdkStartedCh := make(chan EnvContext)
 	env, err := NewEnvContext(EnvContextImplParams{
 		Identifiers:                   EnvIdentifiers{ConfiguredName: st.EnvMain.Name},

--- a/internal/streams/otelbridge/bridge.go
+++ b/internal/streams/otelbridge/bridge.go
@@ -51,17 +51,18 @@ const (
 )
 
 var (
-	streamKindAttrKey     = attribute.Key("stream.kind")            //nolint:gochecknoglobals
-	streamProtocolAttrKey = attribute.Key("stream.protocol")        //nolint:gochecknoglobals
-	endReasonAttrKey      = attribute.Key("end.reason")             //nolint:gochecknoglobals
-	eventTypeAttrKey      = attribute.Key("event.type")             //nolint:gochecknoglobals
-	discardReasonAttrKey  = attribute.Key("reason")                 //nolint:gochecknoglobals
-	replayAbortedAttrKey  = attribute.Key("replay.aborted")         //nolint:gochecknoglobals
-	writeTypeAttrKey      = attribute.Key("write.type")             //nolint:gochecknoglobals
-	payloadSizeAttrKey    = attribute.Key("payload.size")           //nolint:gochecknoglobals
-	eventCountAttrKey     = attribute.Key("event.count")            //nolint:gochecknoglobals
-	connDurationAttrKey   = attribute.Key("connection.duration_ms") //nolint:gochecknoglobals
-	errorMessageAttrKey   = attribute.Key("error.message")          //nolint:gochecknoglobals
+	streamKindAttrKey       = attribute.Key("stream.kind")            //nolint:gochecknoglobals
+	streamProtocolAttrKey   = attribute.Key("stream.protocol")        //nolint:gochecknoglobals
+	endReasonAttrKey        = attribute.Key("end.reason")             //nolint:gochecknoglobals
+	eventTypeAttrKey        = attribute.Key("event.type")             //nolint:gochecknoglobals
+	discardReasonAttrKey    = attribute.Key("reason")                 //nolint:gochecknoglobals
+	replayAbortedAttrKey    = attribute.Key("replay.aborted")         //nolint:gochecknoglobals
+	replayClientGoneAttrKey = attribute.Key("replay.client_gone")     //nolint:gochecknoglobals
+	writeTypeAttrKey        = attribute.Key("write.type")             //nolint:gochecknoglobals
+	payloadSizeAttrKey      = attribute.Key("payload.size")           //nolint:gochecknoglobals
+	eventCountAttrKey       = attribute.Key("event.count")            //nolint:gochecknoglobals
+	connDurationAttrKey     = attribute.Key("connection.duration_ms") //nolint:gochecknoglobals
+	errorMessageAttrKey     = attribute.Key("error.message")          //nolint:gochecknoglobals
 )
 
 // knownEventTypes is the set of SSE event types that relay publishes. Anything else is bucketed as
@@ -186,7 +187,7 @@ func (t *streamTrace) writeSpan(ctx context.Context, channel, writeType string, 
 
 // replaySpan emits a short eventsource.replay span nested under the request span, back-dated by the
 // drain duration the handler observed. Same recording gate as writeSpan.
-func (t *streamTrace) replaySpan(ctx context.Context, info eventsource.ReplayFinishedInfo) {
+func (t *streamTrace) replaySpan(ctx context.Context, info eventsource.ReplayFinishedInfo, clientGone bool) {
 	if !trace.SpanFromContext(ctx).IsRecording() {
 		return
 	}
@@ -194,7 +195,8 @@ func (t *streamTrace) replaySpan(ctx context.Context, info eventsource.ReplayFin
 	attrs := t.channelAttrs(info.Channel,
 		eventCountAttrKey.Int(info.EventCount),
 		payloadSizeAttrKey.Int64(info.TotalDataSize),
-		replayAbortedAttrKey.Bool(info.Aborted))
+		replayAbortedAttrKey.Bool(info.Aborted),
+		replayClientGoneAttrKey.Bool(clientGone))
 	_, span := t.bridge.tracer.Start(ctx, spanReplay,
 		trace.WithTimestamp(end.Add(-info.DrainDuration)),
 		trace.WithAttributes(attrs...))
@@ -266,19 +268,22 @@ func (t *streamTrace) replayFinished(ctx context.Context, info eventsource.Repla
 	// aborted attribute separates partially-drained batches (the client went away mid-replay) so
 	// their smaller counts and durations do not skew the completed-drain distributions.
 	//
-	// info.Aborted only covers what eventsource observed. Relay's own repositories end their
-	// batches early when the request context is canceled, which eventsource necessarily reports
-	// as a normal completion of whatever was produced -- so a canceled request context at drain
-	// end is treated as aborted here too, keeping those truncated drains out of the completed
-	// distributions.
-	if ctx.Err() != nil {
-		info.Aborted = true
-	}
-	attrs := t.attrs(info.Channel, replayAbortedAttrKey.Bool(info.Aborted))
+	// info.Aborted only covers what eventsource observed: relay's own repositories end their
+	// batches early when the request context is canceled, and eventsource necessarily reports
+	// that as a normal completion of whatever was produced. Overriding Aborted with the context
+	// state is no better -- a fully delivered batch whose client departs immediately afterwards
+	// would then land full-size samples in the aborted distributions -- so the two facts stay
+	// separate: replay.aborted is eventsource's truncation verdict, and replay.client_gone
+	// reports whether the request context was already canceled when the drain ended. A drain
+	// truncated by cancellation shows up as aborted=false, client_gone=true.
+	clientGone := ctx.Err() != nil
+	attrs := t.attrs(info.Channel,
+		replayAbortedAttrKey.Bool(info.Aborted),
+		replayClientGoneAttrKey.Bool(clientGone))
 	t.bridge.instruments.ReplayEvents.Record(context.Background(), int64(info.EventCount), attrs)
 	t.bridge.instruments.ReplayDataSize.Record(context.Background(), info.TotalDataSize, attrs)
 	t.bridge.instruments.ReplayDrainDuration.Record(context.Background(), info.DrainDuration.Seconds(), attrs)
-	t.replaySpan(ctx, info)
+	t.replaySpan(ctx, info, clientGone)
 }
 
 // eventTypeValue maps an event type to itself if it is on the relay allowlist, otherwise to the

--- a/internal/streams/otelbridge/bridge.go
+++ b/internal/streams/otelbridge/bridge.go
@@ -1,0 +1,272 @@
+// Package otelbridge implements the eventsource ServerTrace callbacks in terms of the OTel stream
+// instruments owned by the metrics package. It is the ld-relay-side implementation of the
+// vendor-neutral hooks that the eventsource library exposes for its SSE Server.
+//
+// The bridge translates a callback's channel string (an sdkauth.ScopedCredential string form) into
+// the environment attribute set that relay uses for all of its metrics. Because the callbacks run on
+// eventsource-internal goroutines -- including the Server's single dispatch goroutine -- the lookup
+// is a lock-light read of a map that relay populates when it registers credentials with the SSE
+// servers. A channel that is not in the registry still records, using a minimal fallback attribute
+// set, so a measurement is never dropped.
+//
+// The handler-goroutine callbacks also receive the subscriber's request context. When that context
+// carries a recording span (relay's otelmux middleware holds one open for the connection's lifetime),
+// the bridge emits short child spans for event/comment writes and for replay drains, back-dated from
+// the durations the library measured, plus span events for subscribe/unsubscribe/write-error. When no
+// recording span is present -- including when OTLP is disabled and the global tracer is a noop -- no
+// spans are created, so the trace path costs one branch.
+package otelbridge
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/metrics"
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
+
+	"github.com/launchdarkly/eventsource"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// otherEventType is the bucket for any event type that is not on the relay allowlist, so a
+	// future stream kind cannot silently explode event.type cardinality.
+	otherEventType = "_other"
+
+	// writeTypeEvent and writeTypeComment label an eventsource.write span by what was written.
+	writeTypeEvent   = "event"
+	writeTypeComment = "comment"
+
+	// Span names for the short child spans the bridge nests under the request span.
+	spanWrite  = "eventsource.write"
+	spanReplay = "eventsource.replay"
+
+	// Span event names added to the request span at points in time.
+	eventSubscribed   = "eventsource.subscribed"
+	eventUnsubscribed = "eventsource.unsubscribed"
+	eventWriteError   = "eventsource.write_error"
+)
+
+var (
+	streamKindAttrKey     = attribute.Key("stream.kind")            //nolint:gochecknoglobals
+	streamProtocolAttrKey = attribute.Key("stream.protocol")        //nolint:gochecknoglobals
+	endReasonAttrKey      = attribute.Key("end.reason")             //nolint:gochecknoglobals
+	eventTypeAttrKey      = attribute.Key("event.type")             //nolint:gochecknoglobals
+	discardReasonAttrKey  = attribute.Key("reason")                 //nolint:gochecknoglobals
+	writeTypeAttrKey      = attribute.Key("write.type")             //nolint:gochecknoglobals
+	payloadSizeAttrKey    = attribute.Key("payload.size")           //nolint:gochecknoglobals
+	eventCountAttrKey     = attribute.Key("event.count")            //nolint:gochecknoglobals
+	connDurationAttrKey   = attribute.Key("connection.duration_ms") //nolint:gochecknoglobals
+	errorMessageAttrKey   = attribute.Key("error.message")          //nolint:gochecknoglobals
+)
+
+// knownEventTypes is the set of SSE event types that relay publishes. Anything else is bucketed as
+// otherEventType. The FDv1 streams publish put/patch/delete/ping; the FDv2 streams publish the
+// data-system protocol events (server-intent/put-object/delete-object/payload-transferred).
+var knownEventTypes = map[string]struct{}{ //nolint:gochecknoglobals
+	"put":                 {},
+	"patch":               {},
+	"delete":              {},
+	"ping":                {},
+	"server-intent":       {},
+	"put-object":          {},
+	"delete-object":       {},
+	"payload-transferred": {},
+}
+
+// Bridge holds the stream instruments, the tracer, and the channel-to-attributes registry shared by
+// every eventsource Server's ServerTrace. It is safe for concurrent use.
+type Bridge struct {
+	instruments metrics.StreamInstruments
+	tracer      trace.Tracer
+	baseAttrs   []attribute.KeyValue
+	mu          sync.RWMutex
+	channels    map[string][]attribute.KeyValue
+}
+
+// New creates a Bridge that records to the given stream instruments. baseAttrs is the process-level
+// attribute set (relay.id) used as the fallback for channels that are not registered. The tracer is
+// relay's shared tracer, which is a noop when OTLP is disabled.
+func New(instruments metrics.StreamInstruments, baseAttrs []attribute.KeyValue) *Bridge {
+	return &Bridge{
+		instruments: instruments,
+		tracer:      tracing.Tracer(),
+		baseAttrs:   baseAttrs,
+		channels:    make(map[string][]attribute.KeyValue),
+	}
+}
+
+// RegisterChannel associates a channel string with the environment attribute set that its metrics
+// should carry. It is called when a credential is registered with the SSE servers.
+func (b *Bridge) RegisterChannel(channel string, attrs attribute.Set) {
+	kvs := attrs.ToSlice()
+	b.mu.Lock()
+	b.channels[channel] = kvs
+	b.mu.Unlock()
+}
+
+// UnregisterChannel removes a channel from the registry. It is called when a credential is removed
+// from the SSE servers (key rotation, credential expiry, or environment teardown).
+func (b *Bridge) UnregisterChannel(channel string) {
+	b.mu.Lock()
+	delete(b.channels, channel)
+	b.mu.Unlock()
+}
+
+// TraceFor returns a ServerTrace whose callbacks record the stream instruments with the given
+// stream.kind and stream.protocol baked in, alongside the per-channel environment attributes. The
+// returned value is meant to be attached to a single eventsource.Server.
+func (b *Bridge) TraceFor(streamKind, protocol string) *eventsource.ServerTrace {
+	t := &streamTrace{
+		bridge:     b,
+		kindKV:     streamKindAttrKey.String(streamKind),
+		protocolKV: streamProtocolAttrKey.String(protocol),
+	}
+	return &eventsource.ServerTrace{
+		SubscriberAdded:   t.subscriberAdded,
+		SubscriberRemoved: t.subscriberRemoved,
+		SubscriberDropped: t.subscriberDropped,
+		EventSent:         t.eventSent,
+		CommentSent:       t.commentSent,
+		EventDiscarded:    t.eventDiscarded,
+		WriteError:        t.writeError,
+		ReplayFinished:    t.replayFinished,
+	}
+}
+
+// streamTrace holds the per-Server tracing state: the bridge and the stream.kind/stream.protocol
+// attributes for this Server. Its methods are the ServerTrace callbacks.
+type streamTrace struct {
+	bridge     *Bridge
+	kindKV     attribute.KeyValue
+	protocolKV attribute.KeyValue
+}
+
+// channelAttrs builds the attributes for a channel: the channel's environment attributes (or the
+// fallback base attributes when the channel is unknown), plus this Server's stream.kind and
+// stream.protocol, plus any call-specific attributes. The slice is used for both metric and span
+// attribution.
+func (t *streamTrace) channelAttrs(channel string, extra ...attribute.KeyValue) []attribute.KeyValue {
+	t.bridge.mu.RLock()
+	base, ok := t.bridge.channels[channel]
+	t.bridge.mu.RUnlock()
+	if !ok {
+		base = t.bridge.baseAttrs
+	}
+	kvs := make([]attribute.KeyValue, 0, len(base)+2+len(extra))
+	kvs = append(kvs, base...)
+	kvs = append(kvs, t.kindKV, t.protocolKV)
+	kvs = append(kvs, extra...)
+	return kvs
+}
+
+// attrs wraps channelAttrs as a metric measurement option.
+func (t *streamTrace) attrs(channel string, extra ...attribute.KeyValue) metric.MeasurementOption {
+	return metric.WithAttributeSet(attribute.NewSet(t.channelAttrs(channel, extra...)...))
+}
+
+// writeSpan emits a short eventsource.write span nested under the request span, back-dated so its
+// start is duration before now. It creates nothing when the request context has no recording span,
+// which is also the noop-tracer (OTLP-disabled) case.
+func (t *streamTrace) writeSpan(ctx context.Context, channel, writeType string, duration time.Duration, extra ...attribute.KeyValue) {
+	if !trace.SpanFromContext(ctx).IsRecording() {
+		return
+	}
+	end := time.Now()
+	attrs := t.channelAttrs(channel, append([]attribute.KeyValue{writeTypeAttrKey.String(writeType)}, extra...)...)
+	_, span := t.bridge.tracer.Start(ctx, spanWrite,
+		trace.WithTimestamp(end.Add(-duration)),
+		trace.WithAttributes(attrs...))
+	span.End(trace.WithTimestamp(end))
+}
+
+// replaySpan emits a short eventsource.replay span nested under the request span, back-dated by the
+// drain duration the handler observed. Same recording gate as writeSpan.
+func (t *streamTrace) replaySpan(ctx context.Context, channel string, count int, duration time.Duration) {
+	if !trace.SpanFromContext(ctx).IsRecording() {
+		return
+	}
+	end := time.Now()
+	attrs := t.channelAttrs(channel, eventCountAttrKey.Int(count))
+	_, span := t.bridge.tracer.Start(ctx, spanReplay,
+		trace.WithTimestamp(end.Add(-duration)),
+		trace.WithAttributes(attrs...))
+	span.End(trace.WithTimestamp(end))
+}
+
+// addSpanEvent records a point-in-time event on the request span, if it is recording.
+func (t *streamTrace) addSpanEvent(ctx context.Context, name string, attrs ...attribute.KeyValue) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	span.AddEvent(name, trace.WithAttributes(attrs...))
+}
+
+func (t *streamTrace) subscriberAdded(ctx context.Context, info eventsource.SubscriberAddedInfo) {
+	t.bridge.instruments.SubscribersActive.Add(context.Background(), 1, t.attrs(info.Channel))
+	t.addSpanEvent(ctx, eventSubscribed)
+}
+
+func (t *streamTrace) subscriberRemoved(ctx context.Context, info eventsource.SubscriberRemovedInfo) {
+	t.bridge.instruments.SubscribersActive.Add(context.Background(), -1, t.attrs(info.Channel))
+	t.bridge.instruments.ConnectionDuration.Record(context.Background(), info.ConnDuration.Seconds(),
+		t.attrs(info.Channel, endReasonAttrKey.String(string(info.Reason))))
+	t.addSpanEvent(ctx, eventUnsubscribed,
+		endReasonAttrKey.String(string(info.Reason)),
+		connDurationAttrKey.Int64(info.ConnDuration.Milliseconds()))
+}
+
+func (t *streamTrace) subscriberDropped(info eventsource.SubscriberDroppedInfo) {
+	// No context: this fires on the Server's dispatch goroutine, not a subscriber's handler.
+	t.bridge.instruments.SubscribersDropped.Add(context.Background(), 1, t.attrs(info.Channel))
+}
+
+func (t *streamTrace) eventSent(ctx context.Context, info eventsource.EventSentInfo) {
+	eventType := eventTypeValue(info.EventType)
+	t.bridge.instruments.EventsSent.Add(context.Background(), 1,
+		t.attrs(info.Channel, eventTypeAttrKey.String(eventType)))
+	t.bridge.instruments.EventsSentSize.Record(context.Background(), int64(info.DataSize), t.attrs(info.Channel))
+	t.writeSpan(ctx, info.Channel, writeTypeEvent, info.WriteDuration,
+		eventTypeAttrKey.String(eventType),
+		payloadSizeAttrKey.Int(info.DataSize))
+}
+
+func (t *streamTrace) commentSent(ctx context.Context, info eventsource.CommentSentInfo) {
+	t.bridge.instruments.CommentsSent.Add(context.Background(), 1, t.attrs(info.Channel))
+	t.writeSpan(ctx, info.Channel, writeTypeComment, info.WriteDuration)
+}
+
+func (t *streamTrace) eventDiscarded(_ context.Context, info eventsource.EventDiscardedInfo) {
+	t.bridge.instruments.EventsDiscarded.Add(context.Background(), 1,
+		t.attrs(info.Channel, discardReasonAttrKey.String(string(info.Reason))))
+}
+
+func (t *streamTrace) writeError(ctx context.Context, info eventsource.WriteErrorInfo) {
+	// The error value is deliberately not a metric attribute; it is unbounded and would explode
+	// cardinality. Span events do not share that constraint, so the message is attached there.
+	t.bridge.instruments.WriteErrors.Add(context.Background(), 1, t.attrs(info.Channel))
+	var attrs []attribute.KeyValue
+	if info.Err != nil {
+		attrs = append(attrs, errorMessageAttrKey.String(info.Err.Error()))
+	}
+	t.addSpanEvent(ctx, eventWriteError, attrs...)
+}
+
+func (t *streamTrace) replayFinished(ctx context.Context, info eventsource.ReplayFinishedInfo) {
+	t.bridge.instruments.ReplayEvents.Record(context.Background(), int64(info.EventCount), t.attrs(info.Channel))
+	t.bridge.instruments.ReplayDrainDuration.Record(context.Background(), info.DrainDuration.Seconds(), t.attrs(info.Channel))
+	t.replaySpan(ctx, info.Channel, info.EventCount, info.DrainDuration)
+}
+
+// eventTypeValue maps an event type to itself if it is on the relay allowlist, otherwise to the
+// otherEventType bucket. An empty type is also bucketed.
+func eventTypeValue(eventType string) string {
+	if _, ok := knownEventTypes[eventType]; ok {
+		return eventType
+	}
+	return otherEventType
+}

--- a/internal/streams/otelbridge/bridge.go
+++ b/internal/streams/otelbridge/bridge.go
@@ -265,6 +265,15 @@ func (t *streamTrace) replayFinished(ctx context.Context, info eventsource.Repla
 	// recorded; TotalDataSize carries the payload bytes that events.sent.size no longer sees. The
 	// aborted attribute separates partially-drained batches (the client went away mid-replay) so
 	// their smaller counts and durations do not skew the completed-drain distributions.
+	//
+	// info.Aborted only covers what eventsource observed. Relay's own repositories end their
+	// batches early when the request context is canceled, which eventsource necessarily reports
+	// as a normal completion of whatever was produced -- so a canceled request context at drain
+	// end is treated as aborted here too, keeping those truncated drains out of the completed
+	// distributions.
+	if ctx.Err() != nil {
+		info.Aborted = true
+	}
 	attrs := t.attrs(info.Channel, replayAbortedAttrKey.Bool(info.Aborted))
 	t.bridge.instruments.ReplayEvents.Record(context.Background(), int64(info.EventCount), attrs)
 	t.bridge.instruments.ReplayDataSize.Record(context.Background(), info.TotalDataSize, attrs)

--- a/internal/streams/otelbridge/bridge.go
+++ b/internal/streams/otelbridge/bridge.go
@@ -56,6 +56,7 @@ var (
 	endReasonAttrKey      = attribute.Key("end.reason")             //nolint:gochecknoglobals
 	eventTypeAttrKey      = attribute.Key("event.type")             //nolint:gochecknoglobals
 	discardReasonAttrKey  = attribute.Key("reason")                 //nolint:gochecknoglobals
+	replayAbortedAttrKey  = attribute.Key("replay.aborted")         //nolint:gochecknoglobals
 	writeTypeAttrKey      = attribute.Key("write.type")             //nolint:gochecknoglobals
 	payloadSizeAttrKey    = attribute.Key("payload.size")           //nolint:gochecknoglobals
 	eventCountAttrKey     = attribute.Key("event.count")            //nolint:gochecknoglobals
@@ -185,14 +186,17 @@ func (t *streamTrace) writeSpan(ctx context.Context, channel, writeType string, 
 
 // replaySpan emits a short eventsource.replay span nested under the request span, back-dated by the
 // drain duration the handler observed. Same recording gate as writeSpan.
-func (t *streamTrace) replaySpan(ctx context.Context, channel string, count int, duration time.Duration) {
+func (t *streamTrace) replaySpan(ctx context.Context, info eventsource.ReplayFinishedInfo) {
 	if !trace.SpanFromContext(ctx).IsRecording() {
 		return
 	}
 	end := time.Now()
-	attrs := t.channelAttrs(channel, eventCountAttrKey.Int(count))
+	attrs := t.channelAttrs(info.Channel,
+		eventCountAttrKey.Int(info.EventCount),
+		payloadSizeAttrKey.Int64(info.TotalDataSize),
+		replayAbortedAttrKey.Bool(info.Aborted))
 	_, span := t.bridge.tracer.Start(ctx, spanReplay,
-		trace.WithTimestamp(end.Add(-duration)),
+		trace.WithTimestamp(end.Add(-info.DrainDuration)),
 		trace.WithAttributes(attrs...))
 	span.End(trace.WithTimestamp(end))
 }
@@ -257,9 +261,15 @@ func (t *streamTrace) writeError(ctx context.Context, info eventsource.WriteErro
 }
 
 func (t *streamTrace) replayFinished(ctx context.Context, info eventsource.ReplayFinishedInfo) {
-	t.bridge.instruments.ReplayEvents.Record(context.Background(), int64(info.EventCount), t.attrs(info.Channel))
-	t.bridge.instruments.ReplayDrainDuration.Record(context.Background(), info.DrainDuration.Seconds(), t.attrs(info.Channel))
-	t.replaySpan(ctx, info.Channel, info.EventCount, info.DrainDuration)
+	// Replayed events do not fire EventSent, so this callback is the only place replay volume is
+	// recorded; TotalDataSize carries the payload bytes that events.sent.size no longer sees. The
+	// aborted attribute separates partially-drained batches (the client went away mid-replay) so
+	// their smaller counts and durations do not skew the completed-drain distributions.
+	attrs := t.attrs(info.Channel, replayAbortedAttrKey.Bool(info.Aborted))
+	t.bridge.instruments.ReplayEvents.Record(context.Background(), int64(info.EventCount), attrs)
+	t.bridge.instruments.ReplayDataSize.Record(context.Background(), info.TotalDataSize, attrs)
+	t.bridge.instruments.ReplayDrainDuration.Record(context.Background(), info.DrainDuration.Seconds(), attrs)
+	t.replaySpan(ctx, info)
 }
 
 // eventTypeValue maps an event type to itself if it is on the relay allowlist, otherwise to the

--- a/internal/streams/otelbridge/bridge_test.go
+++ b/internal/streams/otelbridge/bridge_test.go
@@ -116,6 +116,13 @@ func attrValue(t *testing.T, set attribute.Set, key attribute.Key) string {
 	return v.AsString()
 }
 
+func boolAttrValue(t *testing.T, set attribute.Set, key attribute.Key) bool {
+	t.Helper()
+	v, ok := set.Value(key)
+	require.Truef(t, ok, "attribute %q not present", key)
+	return v.AsBool()
+}
+
 // assertStreamKindAndProtocol checks that every metric carries the baked-in stream identity.
 func assertStreamKindAndProtocol(t *testing.T, set attribute.Set) {
 	t.Helper()
@@ -270,13 +277,14 @@ func TestWriteError(t *testing.T) {
 	assertStreamKindAndProtocol(t, dp.Attributes)
 }
 
-func TestReplayFinishedRecordsEventsAndDuration(t *testing.T) {
+func TestReplayFinishedRecordsEventsSizeAndDuration(t *testing.T) {
 	h := newBridgeHarness(t)
 	h.bridge.RegisterChannel(testChannel, envAttrs())
 
 	h.trace().ReplayFinished(context.Background(), eventsource.ReplayFinishedInfo{
 		Channel:       testChannel,
 		EventCount:    5,
+		TotalDataSize: 2048,
 		DrainDuration: 250 * time.Millisecond,
 	})
 
@@ -286,10 +294,42 @@ func TestReplayFinishedRecordsEventsAndDuration(t *testing.T) {
 	assert.Equal(t, uint64(1), events.Count)
 	assert.Equal(t, int64(5), events.Sum)
 	assertEnvAttrs(t, events.Attributes)
+	assert.Equal(t, false, boolAttrValue(t, events.Attributes, replayAbortedAttrKey))
+
+	// Replayed events do not fire EventSent, so replay.data.size is the only
+	// byte-volume record for the batch.
+	size := histIntPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.replay.data.size"))
+	assert.Equal(t, uint64(1), size.Count)
+	assert.Equal(t, int64(2048), size.Sum)
+	assertEnvAttrs(t, size.Attributes)
 
 	drain := histFloatPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.replay.drain.duration"))
 	assert.Equal(t, uint64(1), drain.Count)
 	assert.InDelta(t, 0.25, drain.Sum, 0.001)
+}
+
+func TestReplayFinishedAbortedIsAttributed(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	h.trace().ReplayFinished(context.Background(), eventsource.ReplayFinishedInfo{
+		Channel:       testChannel,
+		EventCount:    3,
+		TotalDataSize: 300,
+		DrainDuration: 50 * time.Millisecond,
+		Aborted:       true,
+	})
+
+	rm := h.collect(t)
+
+	events := histIntPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.replay.events"))
+	assert.Equal(t, int64(3), events.Sum)
+	assert.Equal(t, true, boolAttrValue(t, events.Attributes, replayAbortedAttrKey),
+		"a partially-drained batch must be distinguishable from a completed one")
+
+	size := histIntPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.replay.data.size"))
+	assert.Equal(t, int64(300), size.Sum)
+	assert.Equal(t, true, boolAttrValue(t, size.Attributes, replayAbortedAttrKey))
 }
 
 func TestUnknownChannelUsesFallbackAttributes(t *testing.T) {

--- a/internal/streams/otelbridge/bridge_test.go
+++ b/internal/streams/otelbridge/bridge_test.go
@@ -332,6 +332,28 @@ func TestReplayFinishedAbortedIsAttributed(t *testing.T) {
 	assert.Equal(t, true, boolAttrValue(t, size.Attributes, replayAbortedAttrKey))
 }
 
+func TestReplayFinishedOnCanceledRequestIsAborted(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	// Relay's repositories end their batch early when the request context is
+	// canceled, so eventsource reports Aborted=false for the truncated drain;
+	// the canceled context is the signal that the client was gone.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	h.trace().ReplayFinished(ctx, eventsource.ReplayFinishedInfo{
+		Channel:       testChannel,
+		EventCount:    170,
+		TotalDataSize: 1700,
+		DrainDuration: 10 * time.Millisecond,
+		Aborted:       false,
+	})
+
+	events := histIntPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.replay.events"))
+	assert.Equal(t, true, boolAttrValue(t, events.Attributes, replayAbortedAttrKey),
+		"a drain that finished on a dead request must not land in the completed distributions")
+}
+
 func TestUnknownChannelUsesFallbackAttributes(t *testing.T) {
 	h := newBridgeHarness(t)
 	// No RegisterChannel: the channel is unknown.

--- a/internal/streams/otelbridge/bridge_test.go
+++ b/internal/streams/otelbridge/bridge_test.go
@@ -295,6 +295,7 @@ func TestReplayFinishedRecordsEventsSizeAndDuration(t *testing.T) {
 	assert.Equal(t, int64(5), events.Sum)
 	assertEnvAttrs(t, events.Attributes)
 	assert.Equal(t, false, boolAttrValue(t, events.Attributes, replayAbortedAttrKey))
+	assert.Equal(t, false, boolAttrValue(t, events.Attributes, replayClientGoneAttrKey))
 
 	// Replayed events do not fire EventSent, so replay.data.size is the only
 	// byte-volume record for the batch.
@@ -332,13 +333,15 @@ func TestReplayFinishedAbortedIsAttributed(t *testing.T) {
 	assert.Equal(t, true, boolAttrValue(t, size.Attributes, replayAbortedAttrKey))
 }
 
-func TestReplayFinishedOnCanceledRequestIsAborted(t *testing.T) {
+func TestReplayFinishedOnCanceledRequestIsMarkedClientGone(t *testing.T) {
 	h := newBridgeHarness(t)
 	h.bridge.RegisterChannel(testChannel, envAttrs())
 
 	// Relay's repositories end their batch early when the request context is
-	// canceled, so eventsource reports Aborted=false for the truncated drain;
-	// the canceled context is the signal that the client was gone.
+	// canceled, which eventsource reports as a normal completion of whatever
+	// was produced. The canceled context is recorded as its own attribute --
+	// NOT folded into aborted, which would also sweep fully delivered batches
+	// whose client departed right afterwards into the aborted distributions.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	h.trace().ReplayFinished(ctx, eventsource.ReplayFinishedInfo{
@@ -350,8 +353,10 @@ func TestReplayFinishedOnCanceledRequestIsAborted(t *testing.T) {
 	})
 
 	events := histIntPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.replay.events"))
-	assert.Equal(t, true, boolAttrValue(t, events.Attributes, replayAbortedAttrKey),
-		"a drain that finished on a dead request must not land in the completed distributions")
+	assert.Equal(t, false, boolAttrValue(t, events.Attributes, replayAbortedAttrKey),
+		"eventsource's truncation verdict must pass through unmodified")
+	assert.Equal(t, true, boolAttrValue(t, events.Attributes, replayClientGoneAttrKey),
+		"the canceled request context is reported as its own dimension")
 }
 
 func TestUnknownChannelUsesFallbackAttributes(t *testing.T) {

--- a/internal/streams/otelbridge/bridge_test.go
+++ b/internal/streams/otelbridge/bridge_test.go
@@ -1,0 +1,345 @@
+package otelbridge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/metrics"
+
+	"github.com/launchdarkly/eventsource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+const (
+	testChannel  = "sdk-key-123"
+	testRelayID  = "relay-abc"
+	testEnvName  = "my-env"
+	testStreamKd = "server"
+	testProtocol = "v1"
+)
+
+var (
+	relayIDKey = attribute.Key("relay.id")
+	envNameKey = attribute.Key("environment.name")
+)
+
+// bridgeHarness bundles a bridge with the manual reader that captures what it records.
+type bridgeHarness struct {
+	bridge *Bridge
+	reader sdkmetric.Reader
+}
+
+func newBridgeHarness(t *testing.T) *bridgeHarness {
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	instruments, err := metrics.NewInstrumentsForTest(meterProvider.Meter("test"))
+	require.NoError(t, err)
+
+	baseAttrs := []attribute.KeyValue{relayIDKey.String(testRelayID)}
+	return &bridgeHarness{
+		bridge: New(instruments.StreamInstruments(), baseAttrs),
+		reader: reader,
+	}
+}
+
+// envAttrs is the attribute set relay would register for an environment's channel.
+func envAttrs() attribute.Set {
+	return attribute.NewSet(relayIDKey.String(testRelayID), envNameKey.String(testEnvName))
+}
+
+func (h *bridgeHarness) collect(t *testing.T) *metricdata.ResourceMetrics {
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, h.reader.Collect(context.Background(), &rm))
+	return &rm
+}
+
+func (h *bridgeHarness) trace() *eventsource.ServerTrace {
+	return h.bridge.TraceFor(testStreamKd, testProtocol)
+}
+
+func metricByName(t *testing.T, rm *metricdata.ResourceMetrics, name string) metricdata.Metrics {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+	require.Failf(t, "metric not found", "no metric named %q", name)
+	return metricdata.Metrics{}
+}
+
+func requireNoMetric(t *testing.T, rm *metricdata.ResourceMetrics, name string) {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			require.NotEqualf(t, name, m.Name, "expected no data for metric %q", name)
+		}
+	}
+}
+
+func sumPoint(t *testing.T, m metricdata.Metrics) metricdata.DataPoint[int64] {
+	t.Helper()
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.Truef(t, ok, "expected Sum[int64] for %s", m.Name)
+	require.Lenf(t, sum.DataPoints, 1, "expected one data point for %s", m.Name)
+	return sum.DataPoints[0]
+}
+
+func histFloatPoint(t *testing.T, m metricdata.Metrics) metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+	hist, ok := m.Data.(metricdata.Histogram[float64])
+	require.Truef(t, ok, "expected Histogram[float64] for %s", m.Name)
+	require.Lenf(t, hist.DataPoints, 1, "expected one data point for %s", m.Name)
+	return hist.DataPoints[0]
+}
+
+func histIntPoint(t *testing.T, m metricdata.Metrics) metricdata.HistogramDataPoint[int64] {
+	t.Helper()
+	hist, ok := m.Data.(metricdata.Histogram[int64])
+	require.Truef(t, ok, "expected Histogram[int64] for %s", m.Name)
+	require.Lenf(t, hist.DataPoints, 1, "expected one data point for %s", m.Name)
+	return hist.DataPoints[0]
+}
+
+func attrValue(t *testing.T, set attribute.Set, key attribute.Key) string {
+	t.Helper()
+	v, ok := set.Value(key)
+	require.Truef(t, ok, "attribute %q not present", key)
+	return v.AsString()
+}
+
+// assertStreamKindAndProtocol checks that every metric carries the baked-in stream identity.
+func assertStreamKindAndProtocol(t *testing.T, set attribute.Set) {
+	t.Helper()
+	assert.Equal(t, testStreamKd, attrValue(t, set, streamKindAttrKey))
+	assert.Equal(t, testProtocol, attrValue(t, set, streamProtocolAttrKey))
+}
+
+// assertEnvAttrs checks that a metric was attributed to the registered environment.
+func assertEnvAttrs(t *testing.T, set attribute.Set) {
+	t.Helper()
+	assert.Equal(t, testRelayID, attrValue(t, set, relayIDKey))
+	assert.Equal(t, testEnvName, attrValue(t, set, envNameKey))
+}
+
+func TestSubscriberAddedIncrementsActive(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	h.trace().SubscriberAdded(context.Background(), eventsource.SubscriberAddedInfo{Channel: testChannel})
+
+	dp := sumPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.subscribers.active"))
+	assert.Equal(t, int64(1), dp.Value)
+	assertEnvAttrs(t, dp.Attributes)
+	assertStreamKindAndProtocol(t, dp.Attributes)
+}
+
+func TestSubscriberRemovedDecrementsActiveAndRecordsDuration(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+	tr := h.trace()
+
+	tr.SubscriberAdded(context.Background(), eventsource.SubscriberAddedInfo{Channel: testChannel})
+	tr.SubscriberRemoved(context.Background(), eventsource.SubscriberRemovedInfo{
+		Channel:      testChannel,
+		Reason:       eventsource.ReasonClientClosed,
+		ConnDuration: 3 * time.Second,
+	})
+
+	rm := h.collect(t)
+
+	active := sumPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.subscribers.active"))
+	assert.Equal(t, int64(0), active.Value)
+
+	dur := histFloatPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.connection.duration"))
+	assert.Equal(t, uint64(1), dur.Count)
+	assert.InDelta(t, 3.0, dur.Sum, 0.001)
+	assert.Equal(t, "client_closed", attrValue(t, dur.Attributes, endReasonAttrKey))
+	assertEnvAttrs(t, dur.Attributes)
+	assertStreamKindAndProtocol(t, dur.Attributes)
+}
+
+func TestSubscriberDropped(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	h.trace().SubscriberDropped(eventsource.SubscriberDroppedInfo{Channel: testChannel, BufferSize: 32})
+
+	dp := sumPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.subscribers.dropped"))
+	assert.Equal(t, int64(1), dp.Value)
+	assertEnvAttrs(t, dp.Attributes)
+	assertStreamKindAndProtocol(t, dp.Attributes)
+}
+
+func TestEventSentRecordsCountWithTypeAndSize(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	h.trace().EventSent(context.Background(), eventsource.EventSentInfo{Channel: testChannel, EventType: "put", DataSize: 128})
+
+	rm := h.collect(t)
+
+	sent := sumPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.events.sent"))
+	assert.Equal(t, int64(1), sent.Value)
+	assert.Equal(t, "put", attrValue(t, sent.Attributes, eventTypeAttrKey))
+	assertEnvAttrs(t, sent.Attributes)
+	assertStreamKindAndProtocol(t, sent.Attributes)
+
+	size := histIntPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.events.sent.size"))
+	assert.Equal(t, uint64(1), size.Count)
+	assert.Equal(t, int64(128), size.Sum)
+	// The size histogram is not broken down by event type.
+	_, hasType := size.Attributes.Value(eventTypeAttrKey)
+	assert.False(t, hasType)
+}
+
+func TestEventSentBucketsUnknownAndFDv2Types(t *testing.T) {
+	cases := []struct {
+		raw      string
+		expected string
+	}{
+		{"put", "put"},
+		{"patch", "patch"},
+		{"delete", "delete"},
+		{"ping", "ping"},
+		{"server-intent", "server-intent"},
+		{"put-object", "put-object"},
+		{"delete-object", "delete-object"},
+		{"payload-transferred", "payload-transferred"},
+		{"goodbye", "_other"},
+		{"", "_other"},
+		{"some-future-type", "_other"},
+	}
+	for _, c := range cases {
+		t.Run(c.raw, func(t *testing.T) {
+			h := newBridgeHarness(t)
+			h.bridge.RegisterChannel(testChannel, envAttrs())
+
+			h.trace().EventSent(context.Background(), eventsource.EventSentInfo{Channel: testChannel, EventType: c.raw, DataSize: 1})
+
+			dp := sumPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.events.sent"))
+			assert.Equal(t, c.expected, attrValue(t, dp.Attributes, eventTypeAttrKey))
+		})
+	}
+}
+
+func TestCommentSent(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	h.trace().CommentSent(context.Background(), eventsource.CommentSentInfo{Channel: testChannel})
+
+	dp := sumPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.comments.sent"))
+	assert.Equal(t, int64(1), dp.Value)
+	assertEnvAttrs(t, dp.Attributes)
+	assertStreamKindAndProtocol(t, dp.Attributes)
+}
+
+func TestEventDiscarded(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	h.trace().EventDiscarded(context.Background(), eventsource.EventDiscardedInfo{
+		Channel: testChannel,
+		Reason:  eventsource.DiscardReasonJitterCoalesce,
+	})
+
+	dp := sumPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.events.discarded"))
+	assert.Equal(t, int64(1), dp.Value)
+	assert.Equal(t, "jitter_coalesce", attrValue(t, dp.Attributes, discardReasonAttrKey))
+	assertEnvAttrs(t, dp.Attributes)
+}
+
+func TestWriteError(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	h.trace().WriteError(context.Background(), eventsource.WriteErrorInfo{Channel: testChannel, Err: errors.New("broken pipe")})
+
+	dp := sumPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.write.errors"))
+	assert.Equal(t, int64(1), dp.Value)
+	assertEnvAttrs(t, dp.Attributes)
+	assertStreamKindAndProtocol(t, dp.Attributes)
+}
+
+func TestReplayFinishedRecordsEventsAndDuration(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	h.trace().ReplayFinished(context.Background(), eventsource.ReplayFinishedInfo{
+		Channel:       testChannel,
+		EventCount:    5,
+		DrainDuration: 250 * time.Millisecond,
+	})
+
+	rm := h.collect(t)
+
+	events := histIntPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.replay.events"))
+	assert.Equal(t, uint64(1), events.Count)
+	assert.Equal(t, int64(5), events.Sum)
+	assertEnvAttrs(t, events.Attributes)
+
+	drain := histFloatPoint(t, metricByName(t, rm, "launchdarkly.relay.stream.replay.drain.duration"))
+	assert.Equal(t, uint64(1), drain.Count)
+	assert.InDelta(t, 0.25, drain.Sum, 0.001)
+}
+
+func TestUnknownChannelUsesFallbackAttributes(t *testing.T) {
+	h := newBridgeHarness(t)
+	// No RegisterChannel: the channel is unknown.
+
+	h.trace().SubscriberAdded(context.Background(), eventsource.SubscriberAddedInfo{Channel: "never-registered"})
+
+	dp := sumPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.subscribers.active"))
+	assert.Equal(t, int64(1), dp.Value, "measurement must not be dropped for an unknown channel")
+	assert.Equal(t, testRelayID, attrValue(t, dp.Attributes, relayIDKey))
+	assertStreamKindAndProtocol(t, dp.Attributes)
+	// The fallback set has no environment name.
+	_, hasEnv := dp.Attributes.Value(envNameKey)
+	assert.False(t, hasEnv)
+}
+
+func TestUnregisterChannelRevertsToFallback(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+	h.bridge.UnregisterChannel(testChannel)
+
+	h.trace().SubscriberAdded(context.Background(), eventsource.SubscriberAddedInfo{Channel: testChannel})
+
+	dp := sumPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.subscribers.active"))
+	_, hasEnv := dp.Attributes.Value(envNameKey)
+	assert.False(t, hasEnv, "after unregister, the channel falls back to the base attributes")
+}
+
+func TestTraceForBakesInDistinctStreamIdentity(t *testing.T) {
+	h := newBridgeHarness(t)
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+
+	h.bridge.TraceFor("mobile-ping", "v2").SubscriberDropped(
+		eventsource.SubscriberDroppedInfo{Channel: testChannel})
+
+	dp := sumPoint(t, metricByName(t, h.collect(t), "launchdarkly.relay.stream.subscribers.dropped"))
+	assert.Equal(t, "mobile-ping", attrValue(t, dp.Attributes, streamKindAttrKey))
+	assert.Equal(t, "v2", attrValue(t, dp.Attributes, streamProtocolAttrKey))
+}
+
+func TestReplayStartedHookIsNotSet(t *testing.T) {
+	// The bridge records nothing on ReplayStarted; only ReplayFinished carries metrics. Leaving the
+	// hook nil keeps eventsource on its cheaper path for that call site.
+	assert.Nil(t, newBridgeHarness(t).trace().ReplayStarted)
+}
+
+func TestEventTypeValue(t *testing.T) {
+	assert.Equal(t, "put", eventTypeValue("put"))
+	assert.Equal(t, "payload-transferred", eventTypeValue("payload-transferred"))
+	assert.Equal(t, otherEventType, eventTypeValue("bogus"))
+	assert.Equal(t, otherEventType, eventTypeValue(""))
+}

--- a/internal/streams/otelbridge/span_test.go
+++ b/internal/streams/otelbridge/span_test.go
@@ -163,6 +163,7 @@ func TestReplayFinishedEmitsBackDatedReplaySpan(t *testing.T) {
 		h.trace().ReplayFinished(ctx, eventsource.ReplayFinishedInfo{
 			Channel:       testChannel,
 			EventCount:    7,
+			TotalDataSize: 4096,
 			DrainDuration: drainDuration,
 		})
 	})
@@ -171,6 +172,8 @@ func TestReplayFinishedEmitsBackDatedReplaySpan(t *testing.T) {
 	assert.Equal(t, parent.SpanContext().SpanID(), span.Parent().SpanID(), "replay span must be a child of the request span")
 	assert.Equal(t, drainDuration, span.EndTime().Sub(span.StartTime()), "replay span is back-dated by DrainDuration")
 	assert.Equal(t, int64(7), spanAttr(t, span, eventCountAttrKey).AsInt64())
+	assert.Equal(t, int64(4096), spanAttr(t, span, payloadSizeAttrKey).AsInt64())
+	assert.Equal(t, false, spanAttr(t, span, replayAbortedAttrKey).AsBool())
 	assert.Equal(t, testStreamKd, spanAttr(t, span, streamKindAttrKey).AsString())
 	assert.Equal(t, testProtocol, spanAttr(t, span, streamProtocolAttrKey).AsString())
 	assert.Equal(t, testEnvName, spanAttr(t, span, envNameKey).AsString())

--- a/internal/streams/otelbridge/span_test.go
+++ b/internal/streams/otelbridge/span_test.go
@@ -174,6 +174,7 @@ func TestReplayFinishedEmitsBackDatedReplaySpan(t *testing.T) {
 	assert.Equal(t, int64(7), spanAttr(t, span, eventCountAttrKey).AsInt64())
 	assert.Equal(t, int64(4096), spanAttr(t, span, payloadSizeAttrKey).AsInt64())
 	assert.Equal(t, false, spanAttr(t, span, replayAbortedAttrKey).AsBool())
+	assert.Equal(t, false, spanAttr(t, span, replayClientGoneAttrKey).AsBool())
 	assert.Equal(t, testStreamKd, spanAttr(t, span, streamKindAttrKey).AsString())
 	assert.Equal(t, testProtocol, spanAttr(t, span, streamProtocolAttrKey).AsString())
 	assert.Equal(t, testEnvName, spanAttr(t, span, envNameKey).AsString())

--- a/internal/streams/otelbridge/span_test.go
+++ b/internal/streams/otelbridge/span_test.go
@@ -1,0 +1,233 @@
+package otelbridge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/eventsource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// spanHarness bundles a bridge whose tracer records into an in-memory recorder, so tests can assert
+// the spans and span events the callbacks emit.
+type spanHarness struct {
+	bridge   *Bridge
+	recorder *tracetest.SpanRecorder
+	tracer   trace.Tracer
+}
+
+func newSpanHarness(t *testing.T) *spanHarness {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	tracer := tp.Tracer("test")
+
+	h := newBridgeHarness(t)
+	h.bridge.tracer = tracer
+	h.bridge.RegisterChannel(testChannel, envAttrs())
+	return &spanHarness{bridge: h.bridge, recorder: recorder, tracer: tracer}
+}
+
+func (h *spanHarness) trace() *eventsource.ServerTrace {
+	return h.bridge.TraceFor(testStreamKd, testProtocol)
+}
+
+// withRequestSpan starts a recording parent span, runs fn with its context, then ends it. It returns
+// the parent's read-only span so tests can inspect its span events.
+func (h *spanHarness) withRequestSpan(fn func(ctx context.Context)) sdktrace.ReadOnlySpan {
+	ctx, parent := h.tracer.Start(context.Background(), "request")
+	fn(ctx)
+	parent.End()
+	for _, s := range h.recorder.Ended() {
+		if s.Name() == "request" {
+			return s
+		}
+	}
+	return nil
+}
+
+func endedSpanByName(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range spans {
+		if s.Name() == name {
+			return s
+		}
+	}
+	require.Failf(t, "span not found", "no span named %q", name)
+	return nil
+}
+
+func spanAttr(t *testing.T, s sdktrace.ReadOnlySpan, key attribute.Key) attribute.Value {
+	t.Helper()
+	for _, kv := range s.Attributes() {
+		if kv.Key == key {
+			return kv.Value
+		}
+	}
+	require.Failf(t, "span attribute not found", "no attribute %q on span %q", key, s.Name())
+	return attribute.Value{}
+}
+
+func eventByName(t *testing.T, s sdktrace.ReadOnlySpan, name string) sdktrace.Event {
+	t.Helper()
+	for _, e := range s.Events() {
+		if e.Name == name {
+			return e
+		}
+	}
+	require.Failf(t, "span event not found", "no event %q on span %q", name, s.Name())
+	return sdktrace.Event{}
+}
+
+func eventAttr(t *testing.T, e sdktrace.Event, key attribute.Key) attribute.Value {
+	t.Helper()
+	for _, kv := range e.Attributes {
+		if kv.Key == key {
+			return kv.Value
+		}
+	}
+	require.Failf(t, "event attribute not found", "no attribute %q on event %q", key, e.Name)
+	return attribute.Value{}
+}
+
+func TestEventSentEmitsBackDatedWriteSpan(t *testing.T) {
+	h := newSpanHarness(t)
+	const writeDuration = 40 * time.Millisecond
+
+	parent := h.withRequestSpan(func(ctx context.Context) {
+		h.trace().EventSent(ctx, eventsource.EventSentInfo{
+			Channel:       testChannel,
+			EventType:     "put",
+			DataSize:      256,
+			WriteDuration: writeDuration,
+		})
+	})
+
+	span := endedSpanByName(t, h.recorder.Ended(), spanWrite)
+	assert.Equal(t, parent.SpanContext().SpanID(), span.Parent().SpanID(), "write span must be a child of the request span")
+	assert.Equal(t, writeDuration, span.EndTime().Sub(span.StartTime()), "write span is back-dated by WriteDuration")
+
+	assert.Equal(t, writeTypeEvent, spanAttr(t, span, writeTypeAttrKey).AsString())
+	assert.Equal(t, "put", spanAttr(t, span, eventTypeAttrKey).AsString())
+	assert.Equal(t, int64(256), spanAttr(t, span, payloadSizeAttrKey).AsInt64())
+	assert.Equal(t, testStreamKd, spanAttr(t, span, streamKindAttrKey).AsString())
+	assert.Equal(t, testProtocol, spanAttr(t, span, streamProtocolAttrKey).AsString())
+	assert.Equal(t, testEnvName, spanAttr(t, span, envNameKey).AsString())
+}
+
+func TestEventSentWriteSpanBucketsUnknownEventType(t *testing.T) {
+	h := newSpanHarness(t)
+
+	h.withRequestSpan(func(ctx context.Context) {
+		h.trace().EventSent(ctx, eventsource.EventSentInfo{
+			Channel:   testChannel,
+			EventType: "some-future-type",
+			DataSize:  1,
+		})
+	})
+
+	span := endedSpanByName(t, h.recorder.Ended(), spanWrite)
+	assert.Equal(t, otherEventType, spanAttr(t, span, eventTypeAttrKey).AsString())
+}
+
+func TestCommentSentEmitsWriteSpanWithoutEventAttrs(t *testing.T) {
+	h := newSpanHarness(t)
+	const writeDuration = 15 * time.Millisecond
+
+	h.withRequestSpan(func(ctx context.Context) {
+		h.trace().CommentSent(ctx, eventsource.CommentSentInfo{Channel: testChannel, WriteDuration: writeDuration})
+	})
+
+	span := endedSpanByName(t, h.recorder.Ended(), spanWrite)
+	assert.Equal(t, writeTypeComment, spanAttr(t, span, writeTypeAttrKey).AsString())
+	assert.Equal(t, writeDuration, span.EndTime().Sub(span.StartTime()))
+
+	// A comment carries neither an event type nor a payload size.
+	for _, kv := range span.Attributes() {
+		assert.NotEqual(t, eventTypeAttrKey, kv.Key)
+		assert.NotEqual(t, payloadSizeAttrKey, kv.Key)
+	}
+}
+
+func TestReplayFinishedEmitsBackDatedReplaySpan(t *testing.T) {
+	h := newSpanHarness(t)
+	const drainDuration = 120 * time.Millisecond
+
+	parent := h.withRequestSpan(func(ctx context.Context) {
+		h.trace().ReplayFinished(ctx, eventsource.ReplayFinishedInfo{
+			Channel:       testChannel,
+			EventCount:    7,
+			DrainDuration: drainDuration,
+		})
+	})
+
+	span := endedSpanByName(t, h.recorder.Ended(), spanReplay)
+	assert.Equal(t, parent.SpanContext().SpanID(), span.Parent().SpanID(), "replay span must be a child of the request span")
+	assert.Equal(t, drainDuration, span.EndTime().Sub(span.StartTime()), "replay span is back-dated by DrainDuration")
+	assert.Equal(t, int64(7), spanAttr(t, span, eventCountAttrKey).AsInt64())
+	assert.Equal(t, testStreamKd, spanAttr(t, span, streamKindAttrKey).AsString())
+	assert.Equal(t, testProtocol, spanAttr(t, span, streamProtocolAttrKey).AsString())
+	assert.Equal(t, testEnvName, spanAttr(t, span, envNameKey).AsString())
+}
+
+func TestSubscribeUnsubscribeEmitSpanEventsOnRequestSpan(t *testing.T) {
+	h := newSpanHarness(t)
+
+	parent := h.withRequestSpan(func(ctx context.Context) {
+		tr := h.trace()
+		tr.SubscriberAdded(ctx, eventsource.SubscriberAddedInfo{Channel: testChannel})
+		tr.SubscriberRemoved(ctx, eventsource.SubscriberRemovedInfo{
+			Channel:      testChannel,
+			Reason:       eventsource.ReasonClientClosed,
+			ConnDuration: 2500 * time.Millisecond,
+		})
+	})
+
+	// The subscribe/unsubscribe points are events on the request span, not new spans.
+	for _, s := range h.recorder.Ended() {
+		assert.NotEqual(t, spanWrite, s.Name())
+		assert.NotEqual(t, spanReplay, s.Name())
+	}
+
+	require.NotNil(t, parent)
+	eventByName(t, parent, eventSubscribed)
+
+	unsub := eventByName(t, parent, eventUnsubscribed)
+	assert.Equal(t, "client_closed", eventAttr(t, unsub, endReasonAttrKey).AsString())
+	assert.Equal(t, int64(2500), eventAttr(t, unsub, connDurationAttrKey).AsInt64())
+}
+
+func TestWriteErrorEmitsSpanEventWithMessage(t *testing.T) {
+	h := newSpanHarness(t)
+
+	parent := h.withRequestSpan(func(ctx context.Context) {
+		h.trace().WriteError(ctx, eventsource.WriteErrorInfo{Channel: testChannel, Err: errors.New("broken pipe")})
+	})
+
+	require.NotNil(t, parent)
+	ev := eventByName(t, parent, eventWriteError)
+	assert.Equal(t, "broken pipe", eventAttr(t, ev, errorMessageAttrKey).AsString())
+}
+
+func TestNoRecordingSpanProducesNoSpans(t *testing.T) {
+	h := newSpanHarness(t)
+	tr := h.trace()
+
+	// context.Background() carries no recording span, so nothing should be created and nothing panics.
+	assert.NotPanics(t, func() {
+		tr.SubscriberAdded(context.Background(), eventsource.SubscriberAddedInfo{Channel: testChannel})
+		tr.EventSent(context.Background(), eventsource.EventSentInfo{Channel: testChannel, EventType: "put", DataSize: 8, WriteDuration: time.Millisecond})
+		tr.CommentSent(context.Background(), eventsource.CommentSentInfo{Channel: testChannel, WriteDuration: time.Millisecond})
+		tr.WriteError(context.Background(), eventsource.WriteErrorInfo{Channel: testChannel, Err: errors.New("x")})
+		tr.SubscriberRemoved(context.Background(), eventsource.SubscriberRemovedInfo{Channel: testChannel, Reason: eventsource.ReasonClientClosed})
+		tr.ReplayFinished(context.Background(), eventsource.ReplayFinishedInfo{Channel: testChannel, EventCount: 1, DrainDuration: time.Millisecond})
+	})
+
+	assert.Empty(t, h.recorder.Ended(), "no spans should be created without a recording request span")
+}

--- a/internal/streams/otelbridge/wiring_test.go
+++ b/internal/streams/otelbridge/wiring_test.go
@@ -1,0 +1,141 @@
+package otelbridge
+
+import (
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/config"
+	"github.com/launchdarkly/ld-relay/v9/internal/basictypes"
+	"github.com/launchdarkly/ld-relay/v9/internal/metrics"
+	"github.com/launchdarkly/ld-relay/v9/internal/sdkauth"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v9/internal/streams"
+
+	"github.com/launchdarkly/eventsource"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+	helpers "github.com/launchdarkly/go-test-helpers/v3"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// wiringStore is a minimal EnvStoreQueries whose initialized-but-empty state makes the server-side
+// repository replay a single "put" event on connect.
+type wiringStore struct{}
+
+func (wiringStore) IsInitialized() bool { return true }
+
+func (wiringStore) Snapshot() (map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor, subsystems.Selector, error) {
+	return map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor{}, subsystems.NoSelector(), nil
+}
+
+// TestStreamProviderWiringRecordsMetrics exercises the whole path: a real StreamProvider built with
+// the bridge's TraceFor, a real eventsource Server, an HTTP subscription, and a manual reader that
+// captures what the ServerTrace callbacks record.
+func TestStreamProviderWiringRecordsMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	instruments, err := metrics.NewInstrumentsForTest(meterProvider.Meter("test"))
+	require.NoError(t, err)
+
+	bridge := New(instruments.StreamInstruments(), []attribute.KeyValue{relayIDKey.String(testRelayID)})
+
+	// Record spans into memory and point the bridge at that tracer, standing in for relay's global
+	// tracer when OTLP is enabled.
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	tracer := tracerProvider.Tracer("test")
+	bridge.tracer = tracer
+
+	sp := streams.NewStreamProvider(basictypes.ServerSideStream, 0, 0, bridge.TraceFor)
+	require.NotNil(t, sp)
+	defer sp.Close()
+
+	cred := sdkauth.New(config.SDKKey("sdk-key-wiring"))
+	esp := sp.RegisterV1(cred, wiringStore{}, slog.Default())
+	require.NotNil(t, esp)
+	defer esp.Close()
+
+	// Relay would register this channel where it registers the credential with the SSE servers.
+	bridge.RegisterChannel(cred.String(), attribute.NewSet(
+		relayIDKey.String(testRelayID), envNameKey.String(testEnvName)))
+
+	handler := sp.HandlerV1(cred)
+	require.NotNil(t, handler)
+
+	// Relay's otelmux middleware holds a request span open for the connection; stand in for it so the
+	// handler goroutine sees a recording span on its request context and the bridge emits child spans.
+	tracedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := tracer.Start(r.Context(), "request")
+		defer span.End()
+		handler.ServeHTTP(w, r.WithContext(ctx))
+	})
+
+	req, _ := http.NewRequest("GET", "", nil)
+	sharedtest.WithStreamRequest(t, req, tracedHandler, func(eventCh <-chan eventsource.Event) {
+		e := helpers.RequireValue(t, eventCh, time.Second, "timed out waiting for replayed event")
+		require.Equal(t, "put", e.Event())
+
+		// SubscriberAdded fires before the first event is written, so active is already settled.
+		active := sumPoint(t, metricByName(t, collectRM(t, reader), "launchdarkly.relay.stream.subscribers.active"))
+		assert.Equal(t, int64(1), active.Value)
+		assertEnvAttrs(t, active.Attributes)
+		assert.Equal(t, "server", attrValue(t, active.Attributes, streamKindAttrKey))
+		assert.Equal(t, "v1", attrValue(t, active.Attributes, streamProtocolAttrKey))
+
+		// The replayed "put" is delivered as a bulk batch, so under the per-batch telemetry model it
+		// surfaces through ReplayFinished (replay.events), not EventSent. ReplayFinished fires just after
+		// the client observed the batch drain, so poll for it.
+		require.Eventually(t, func() bool {
+			m := findMetricByName(collectRM(t, reader), "launchdarkly.relay.stream.replay.events")
+			return m != nil
+		}, time.Second, 5*time.Millisecond, "replay.events was never recorded")
+
+		replayed := histIntPoint(t, metricByName(t, collectRM(t, reader), "launchdarkly.relay.stream.replay.events"))
+		assert.Equal(t, uint64(1), replayed.Count)       // one replay batch drained
+		assert.GreaterOrEqual(t, replayed.Sum, int64(1)) // holding at least the replayed "put"
+		assertEnvAttrs(t, replayed.Attributes)
+
+		// The batch drain produces an eventsource.replay child span under the request span. It ends
+		// immediately, so it is exported once the drain completes; poll until it appears.
+		require.Eventually(t, func() bool {
+			return replaySpanCount(spanRecorder) >= 1
+		}, time.Second, 5*time.Millisecond, "no eventsource.replay span was recorded")
+	})
+}
+
+func replaySpanCount(recorder *tracetest.SpanRecorder) int {
+	count := 0
+	for _, s := range recorder.Ended() {
+		if s.Name() == spanReplay {
+			count++
+		}
+	}
+	return count
+}
+
+func collectRM(t *testing.T, reader sdkmetric.Reader) *metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	return &rm
+}
+
+func findMetricByName(rm *metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == name {
+				return &sm.Metrics[i]
+			}
+		}
+	}
+	return nil
+}

--- a/internal/streams/stream_provider.go
+++ b/internal/streams/stream_provider.go
@@ -63,49 +63,67 @@ type EnvStreamProvider interface {
 	Close()
 }
 
+// ServerTraceFactory produces the eventsource.ServerTrace to attach to a Server for a given stream
+// kind and wire protocol ("v1" or "v2"), or nil to leave tracing disabled. It lets the relay package
+// wire the OTel bridge into the SSE servers without the streams package depending on the bridge.
+type ServerTraceFactory func(streamKind, protocol string) *eventsource.ServerTrace
+
 // NewStreamProvider creates a StreamProvider implementation for the specified kind of stream endpoint.
-func NewStreamProvider(kind basictypes.StreamKind, maxConnTime, pingStreamJitterTime time.Duration) StreamProvider {
+// If traceFactory is non-nil, it is used to attach a ServerTrace to each of the provider's two SSE
+// servers (fdv1 and fdv2), tagged with the stream kind and protocol.
+func NewStreamProvider(kind basictypes.StreamKind, maxConnTime, pingStreamJitterTime time.Duration, traceFactory ServerTraceFactory) StreamProvider {
+	v1Trace, v2Trace := traces(kind, traceFactory)
 	switch kind {
 	case basictypes.ServerSideFlagsOnlyStream:
 		return &serverSideFlagsOnlyStreamProvider{
-			fdv1Server: newSSEServer(maxConnTime),
-			fdv2Server: newSSEServer(maxConnTime),
+			fdv1Server: newSSEServer(maxConnTime, v1Trace),
+			fdv2Server: newSSEServer(maxConnTime, v2Trace),
 		}
 	case basictypes.MobilePingStream:
 		return &clientSidePingStreamProvider{
-			fdv1Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime),
-			fdv2Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime),
+			fdv1Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime, v1Trace),
+			fdv2Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime, v2Trace),
 			isJSClient: false,
 		}
 	case basictypes.JSClientPingStream:
 		return &clientSidePingStreamProvider{
-			fdv1Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime),
-			fdv2Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime),
+			fdv1Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime, v1Trace),
+			fdv2Server: newSSEServerWithJitter(maxConnTime, pingStreamJitterTime, v2Trace),
 			isJSClient: true,
 		}
 	default:
 		return &serverSideStreamProvider{
-			fdv1Server: newSSEServer(maxConnTime),
-			fdv2Server: newSSEServer(maxConnTime),
+			fdv1Server: newSSEServer(maxConnTime, v1Trace),
+			fdv2Server: newSSEServer(maxConnTime, v2Trace),
 		}
 	}
 }
 
-func newSSEServer(maxConnTime time.Duration) *eventsource.Server {
+// traces builds the fdv1 and fdv2 ServerTraces for a stream kind, or nils if there is no factory.
+func traces(kind basictypes.StreamKind, traceFactory ServerTraceFactory) (v1Trace, v2Trace *eventsource.ServerTrace) {
+	if traceFactory == nil {
+		return nil, nil
+	}
+	return traceFactory(string(kind), "v1"), traceFactory(string(kind), "v2")
+}
+
+func newSSEServer(maxConnTime time.Duration, trace *eventsource.ServerTrace) *eventsource.Server {
 	s := eventsource.NewServer()
 	s.Gzip = false
 	s.AllowCORS = true
 	s.ReplayAll = true
 	s.MaxConnTime = maxConnTime
+	s.Trace = trace
 	return s
 }
 
-func newSSEServerWithJitter(maxConnTime time.Duration, jitter time.Duration) *eventsource.Server {
+func newSSEServerWithJitter(maxConnTime time.Duration, jitter time.Duration, trace *eventsource.ServerTrace) *eventsource.Server {
 	s := eventsource.NewServerWithJitter(jitter)
 	s.Gzip = false
 	s.AllowCORS = true
 	s.ReplayAll = true
 	s.MaxConnTime = maxConnTime
+	s.Trace = trace
 	return s
 }
 

--- a/internal/streams/stream_provider_client_side_ping_test.go
+++ b/internal/streams/stream_provider_client_side_ping_test.go
@@ -25,7 +25,7 @@ func TestStreamProviderMobilePing(t *testing.T) {
 	invalidCredential2 := sdkauth.New(testEnvID)
 
 	withStreamProvider := func(t *testing.T, maxConnTime time.Duration, action func(StreamProvider)) {
-		sp := NewStreamProvider(basictypes.MobilePingStream, maxConnTime, 0)
+		sp := NewStreamProvider(basictypes.MobilePingStream, maxConnTime, 0, nil)
 		require.NotNil(t, sp)
 		defer sp.Close()
 		action(sp)
@@ -69,7 +69,7 @@ func TestStreamProviderJSClientPing(t *testing.T) {
 	invalidCredential2 := sdkauth.New(testMobileKey)
 
 	withStreamProvider := func(t *testing.T, maxConnTime time.Duration, action func(StreamProvider)) {
-		sp := NewStreamProvider(basictypes.JSClientPingStream, maxConnTime, 0)
+		sp := NewStreamProvider(basictypes.JSClientPingStream, maxConnTime, 0, nil)
 		require.NotNil(t, sp)
 		defer sp.Close()
 		action(sp)
@@ -114,7 +114,7 @@ func TestStreamProviderAllClientSidePing(t *testing.T) {
 
 	validCredential := sdkauth.New(testMobileKey)
 	withStreamProvider := func(t *testing.T, maxConnTime time.Duration, action func(StreamProvider)) {
-		sp := NewStreamProvider(basictypes.MobilePingStream, maxConnTime, 0)
+		sp := NewStreamProvider(basictypes.MobilePingStream, maxConnTime, 0, nil)
 		require.NotNil(t, sp)
 		defer sp.Close()
 		action(sp)

--- a/internal/streams/stream_provider_ping_jitter_test.go
+++ b/internal/streams/stream_provider_ping_jitter_test.go
@@ -25,7 +25,7 @@ func TestPingStreamJitterDelaysPings(t *testing.T) {
 	validCredential := sdkauth.New(testMobileKey)
 	jitterTime := 200 * time.Millisecond
 
-	sp := NewStreamProvider(basictypes.MobilePingStream, 0, jitterTime)
+	sp := NewStreamProvider(basictypes.MobilePingStream, 0, jitterTime, nil)
 	require.NotNil(t, sp)
 	defer sp.Close()
 
@@ -80,7 +80,7 @@ func TestPingStreamJitterCoalescesMultiplePings(t *testing.T) {
 	validCredential := sdkauth.New(testMobileKey)
 	jitterTime := 200 * time.Millisecond
 
-	sp := NewStreamProvider(basictypes.MobilePingStream, 0, jitterTime)
+	sp := NewStreamProvider(basictypes.MobilePingStream, 0, jitterTime, nil)
 	require.NotNil(t, sp)
 	defer sp.Close()
 
@@ -164,7 +164,7 @@ func TestPingStreamJitterCoalescesMultiplePings(t *testing.T) {
 func TestPingStreamNoJitterSendsPingsImmediately(t *testing.T) {
 	validCredential := sdkauth.New(testMobileKey)
 
-	sp := NewStreamProvider(basictypes.MobilePingStream, 0, 0)
+	sp := NewStreamProvider(basictypes.MobilePingStream, 0, 0, nil)
 	require.NotNil(t, sp)
 	defer sp.Close()
 
@@ -212,7 +212,7 @@ func TestPingStreamNoJitterSendsPingsImmediately(t *testing.T) {
 func TestPingStreamNoJitterSendsMultiplePings(t *testing.T) {
 	validCredential := sdkauth.New(testMobileKey)
 
-	sp := NewStreamProvider(basictypes.MobilePingStream, 0, 0)
+	sp := NewStreamProvider(basictypes.MobilePingStream, 0, 0, nil)
 	require.NotNil(t, sp)
 	defer sp.Close()
 
@@ -276,7 +276,7 @@ func TestJSClientPingStreamJitter(t *testing.T) {
 	validCredential := sdkauth.New(testEnvID)
 	jitterTime := 200 * time.Millisecond
 
-	sp := NewStreamProvider(basictypes.JSClientPingStream, 0, jitterTime)
+	sp := NewStreamProvider(basictypes.JSClientPingStream, 0, jitterTime, nil)
 	require.NotNil(t, sp)
 	defer sp.Close()
 
@@ -335,7 +335,7 @@ func TestServerSideStreamNoJitter(t *testing.T) {
 	validCredential := sdkauth.New(testSDKKey)
 
 	// Server-side streams are created with jitter=0 regardless of config
-	sp := NewStreamProvider(basictypes.ServerSideStream, 0, 100*time.Millisecond)
+	sp := NewStreamProvider(basictypes.ServerSideStream, 0, 100*time.Millisecond, nil)
 	require.NotNil(t, sp)
 	defer sp.Close()
 
@@ -386,7 +386,7 @@ func TestPingStreamJitterSubsequentUpdatesAfterDelay(t *testing.T) {
 	validCredential := sdkauth.New(testMobileKey)
 	jitterTime := 150 * time.Millisecond
 
-	sp := NewStreamProvider(basictypes.MobilePingStream, 0, jitterTime)
+	sp := NewStreamProvider(basictypes.MobilePingStream, 0, jitterTime, nil)
 	require.NotNil(t, sp)
 	defer sp.Close()
 

--- a/internal/streams/stream_provider_server_side_flags_test.go
+++ b/internal/streams/stream_provider_server_side_flags_test.go
@@ -25,7 +25,7 @@ func TestStreamProviderServerSideFlagsOnly(t *testing.T) {
 	invalidCredential2 := sdkauth.New(testEnvID)
 
 	withStreamProvider := func(t *testing.T, maxConnTime time.Duration, action func(StreamProvider)) {
-		sp := NewStreamProvider(basictypes.ServerSideFlagsOnlyStream, maxConnTime, 0)
+		sp := NewStreamProvider(basictypes.ServerSideFlagsOnlyStream, maxConnTime, 0, nil)
 		require.NotNil(t, sp)
 		defer sp.Close()
 		action(sp)

--- a/internal/streams/stream_provider_server_side_test.go
+++ b/internal/streams/stream_provider_server_side_test.go
@@ -31,7 +31,7 @@ func TestStreamProviderServerSide(t *testing.T) {
 	invalidCredential2 := sdkauth.New(testEnvID)
 
 	withStreamProvider := func(t *testing.T, maxConnTime time.Duration, action func(StreamProvider)) {
-		sp := NewStreamProvider(basictypes.ServerSideStream, maxConnTime, 0)
+		sp := NewStreamProvider(basictypes.ServerSideStream, maxConnTime, 0, nil)
 		require.NotNil(t, sp)
 		defer sp.Close()
 		action(sp)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -25,6 +25,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v9/internal/relayenv"
 	"github.com/launchdarkly/ld-relay/v9/internal/sdks"
 	"github.com/launchdarkly/ld-relay/v9/internal/streams"
+	"github.com/launchdarkly/ld-relay/v9/internal/streams/otelbridge"
 	"github.com/launchdarkly/ld-relay/v9/internal/util"
 	"github.com/launchdarkly/ld-relay/v9/relay/version"
 
@@ -51,6 +52,7 @@ type Relay struct {
 	http.Handler
 	envsByCredential              *EnvironmentLookup
 	metricsManager                *metrics.Manager
+	streamMetricsBridge           *otelbridge.Bridge
 	clientFactory                 sdks.ClientFactoryFunc
 	serverSideStreamProvider      streams.StreamProvider
 	serverSideFlagsStreamProvider streams.StreamProvider
@@ -145,13 +147,24 @@ func newRelayInternal(c config.Config, options relayInternalOptions) (*Relay, er
 
 	userAgent := "LDRelay/" + version.Version
 
+	// When OTLP metrics are enabled, build the eventsource OTel bridge and attach its ServerTrace to
+	// every SSE server. When disabled, streamTraceFactory stays nil so each Server.Trace stays nil and
+	// the library takes its zero-overhead path.
+	var streamMetricsBridge *otelbridge.Bridge
+	var streamTraceFactory streams.ServerTraceFactory
+	if c.OpenTelemetry.Enabled {
+		streamMetricsBridge = otelbridge.New(metricsManager.GetInstruments().StreamInstruments(), metricsManager.BaseAttributes())
+		streamTraceFactory = streamMetricsBridge.TraceFor
+	}
+
 	r := &Relay{
 		envsByCredential:              NewEnvironmentLookup(),
-		serverSideStreamProvider:      streams.NewStreamProvider(basictypes.ServerSideStream, maxConnTime, 0),
-		serverSideFlagsStreamProvider: streams.NewStreamProvider(basictypes.ServerSideFlagsOnlyStream, maxConnTime, 0),
-		mobileStreamProvider:          streams.NewStreamProvider(basictypes.MobilePingStream, maxConnTime, pingStreamJitterTime),
-		jsClientStreamProvider:        streams.NewStreamProvider(basictypes.JSClientPingStream, maxConnTime, pingStreamJitterTime),
+		serverSideStreamProvider:      streams.NewStreamProvider(basictypes.ServerSideStream, maxConnTime, 0, streamTraceFactory),
+		serverSideFlagsStreamProvider: streams.NewStreamProvider(basictypes.ServerSideFlagsOnlyStream, maxConnTime, 0, streamTraceFactory),
+		mobileStreamProvider:          streams.NewStreamProvider(basictypes.MobilePingStream, maxConnTime, pingStreamJitterTime, streamTraceFactory),
+		jsClientStreamProvider:        streams.NewStreamProvider(basictypes.JSClientPingStream, maxConnTime, pingStreamJitterTime, streamTraceFactory),
 		metricsManager:                metricsManager,
+		streamMetricsBridge:           streamMetricsBridge,
 		clientFactory:                 clientFactory,
 		clientInitCh:                  clientInitCh,
 		version:                       version.Version,
@@ -483,7 +496,7 @@ func (r *Relay) addEnvironment(
 		}
 		return r.clientFactory(sdkKey, config, timeout)
 	}
-	clientContext, err := relayenv.NewEnvContext(relayenv.EnvContextImplParams{
+	params := relayenv.EnvContextImplParams{
 		Identifiers:                      identifiers,
 		EnvConfig:                        envConfig,
 		AllConfig:                        r.config,
@@ -498,7 +511,13 @@ func (r *Relay) addEnvironment(
 		Logger:                           r.logger,
 		ConnectionMapper:                 r,
 		ExpiredCredentialCleanupInterval: r.config.Main.ExpiredCredentialCleanupInterval.GetOrElse(0),
-	}, resultCh)
+	}
+	// Only set the registry when the bridge exists; a nil *otelbridge.Bridge stored in the interface
+	// field would be a non-nil interface value and defeat the nil checks in envContextImpl.
+	if r.streamMetricsBridge != nil {
+		params.StreamChannelRegistry = r.streamMetricsBridge
+	}
+	clientContext, err := relayenv.NewEnvContext(params, resultCh)
 	if err != nil {
 		return nil, nil, errNewClientContextFailed(identifiers.GetDisplayName(), err)
 	}


### PR DESCRIPTION
## Summary

Adds the ld-relay side of the eventsource server observability work: an OTel bridge that fills in the `ServerTrace` callbacks released in eventsource v1.12.0, recording stream metrics and emitting child spans for SSE connections.

**Instruments** live on `metrics.Instruments`, created once in `NewManager` from the Manager's private meter, so they are noop when `USE_OTLP` is disabled. All under the `launchdarkly.relay.stream.*` prefix:

| Instrument | Type | Notes |
|---|---|---|
| `subscribers.active` | Int64UpDownCounter | |
| `connection.duration` | Float64Histogram (s) | attr `end.reason` |
| `subscribers.dropped` | Int64Counter | buffer overflow |
| `events.sent` | Int64Counter | attr `event.type`; live events only |
| `events.sent.size` | Int64Histogram (By) | live events only |
| `comments.sent` | Int64Counter | heartbeats |
| `events.discarded` | Int64Counter | attr `reason` (jitter coalescing) |
| `write.errors` | Int64Counter | |
| `replay.events` | Int64Histogram | events per drain |
| `replay.data.size` | Int64Histogram (By) | payload bytes per drain |
| `replay.drain.duration` | Float64Histogram (s) | |

Replayed events are encoded in bulk and flushed once per batch, so they do not fire `EventSent`. The `events.sent*` instruments therefore count individually-flushed live traffic only, and replay volume is reported through the `replay.*` instruments. A quiet environment showing no `events.sent` is expected.

**Bridge** (`internal/streams/otelbridge`) exposes `New(instruments, baseAttrs)` and `TraceFor(kind, protocol)`, which bakes `stream.kind` and `stream.protocol` into each returned trace. A concurrency-safe `RegisterChannel`/`UnregisterChannel` registry maps channel strings to per-environment attributes. Callbacks are non-blocking: one RLock-guarded map read plus an instrument recording. Unknown channels record against a `relay.id`-only fallback set so a measurement is never dropped. `event.type` is allowlisted to the types relay publishes, with anything else bucketed as `_other`.

**Spans.** When the request context carries a recording span (relay's otelmux middleware keeps one open per SSE connection), the bridge emits short child spans back-dated from the durations the library measured: `eventsource.write` per event/comment write and `eventsource.replay` per replay drain, plus `subscribed`, `unsubscribed`, and `write_error` span events on the request span. When no recording span is present, including the OTLP-disabled noop-tracer case, nothing is created.

**Replay truncation** is reported as two separate facts rather than one, because they answer different questions:

- `replay.aborted` is eventsource's own truncation verdict from `ReplayFinishedInfo.Aborted`.
- `replay.client_gone` reports whether the request context was already canceled when the drain ended.

These are deliberately not merged. `Aborted` only covers what eventsource observed, and relay's repositories end their batches early when the request context is canceled, which eventsource necessarily reports as a normal completion of whatever was produced. Overriding `Aborted` with the context state is no better, since a fully delivered batch whose client departs immediately afterwards would then land full-size samples in the aborted distributions. A drain truncated by cancellation surfaces as `aborted=false, client_gone=true`.

**Wiring.** Relay constructs the bridge only when `USE_OTLP` is enabled and passes its `TraceFor` into `NewStreamProvider`, which attaches a per-protocol `ServerTrace` to each of the 8 eventsource servers (4 stream kinds x FDv1/FDv2). When disabled, `Server.Trace` stays nil. Each environment registers its SSE channels with the bridge where it registers credentials with the SSE servers, and unregisters them on credential removal/rotation and environment teardown.

The first commit bumps eventsource to v1.12.0, which is where the `ServerTrace` callbacks landed. Every commit in this branch builds and passes the suite on its own.

Verified against a local relay exporting to an OTLP collector, across all four stream kinds: `server` (v1/v2), `server-flags` (v1), `mobile-ping` (v1/v2), and `js-ping` (v1).

## Known limitation

The `replay.aborted=true` and `replay.client_gone=true` paths are covered by unit tests but were not reproducible against a live relay. A replay batch small enough to fit in the kernel socket buffer drains in microseconds regardless of how slowly the client reads, so there is no mid-drain window to interrupt; for FDv1 `/all` the batch is a single `put` event, so no mid-batch state exists at all. Exercising these live needs a payload large enough to exceed the socket send buffer.
