### PR TITLE
feat: Count active requests for every endpoint, not just streams

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,7 +8,7 @@ The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://o
 
 | Metric | Type | Unit | Description |
 |--------|------|------|-------------|
-| `http.server.active_requests` | UpDownCounter | `{request}` | The number of currently active stream connections from SDKs to the Relay Proxy. |
+| `http.server.active_requests` | UpDownCounter | `{request}` | The number of requests currently in flight, across every endpoint the Relay Proxy serves. Use the `relay.endpoint.type` attribute to narrow this to a single kind of endpoint -- for example, filtering to `stream` gives the number of open SSE connections from SDKs. |
 | `http.server.request.duration` | Histogram | `s` | The duration of requests to the Relay Proxy's service endpoints, in seconds. |
 | `launchdarkly.relay.events.received.size` | Counter | `By` | The cumulative number of event bytes received by the Relay Proxy (measured after decompression). |
 | `launchdarkly.relay.events.sent` | Counter | `{event}` | The cumulative number of events successfully sent to LaunchDarkly. |
@@ -34,6 +34,11 @@ All metrics include the following attributes:
 | `application.id` | The application identifier, extracted from the `application-id` field of the `X-LaunchDarkly-Tags` header. |
 | `application.version` | The application version, extracted from the `application-version` field of the `X-LaunchDarkly-Tags` header. |
 | `instance.id` | The SDK instance identifier from the `X-LaunchDarkly-Instance-Id` header. |
+| `relay.endpoint.type` | The kind of endpoint that served the request: `stream`, `poll`, `events`, `goals`, or `status`. Requests that matched no route report `not-provided`. |
+
+Attribute values that are absent are reported as `not-provided` rather than being omitted. The status
+endpoints and requests that matched no route are not associated with an SDK or an LD environment, so
+they report `not-provided` for `environment.name`, `platform.category`, and the other SDK attributes.
 
 ## Backend-specific notes
 

--- a/internal/metrics/active_requests_benchmark_test.go
+++ b/internal/metrics/active_requests_benchmark_test.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// A request-shaped RequestInfo, with every attribute populated the way a real SDK request would
+// populate it, so the attribute set being built is representative in size.
+func benchRequestInfo() RequestInfo {
+	return RequestInfo{
+		UserAgent:          "GoClient/7.15.4",
+		SDKWrapper:         "flutter-client/2.0.0",
+		Route:              "/sdk/evalx/{envId}/contexts/{context}",
+		Method:             "GET",
+		ApplicationID:      "my-app",
+		ApplicationVersion: "1.2.3",
+		InstanceID:         "instance-abc",
+		EndpointType:       EndpointTypePoll,
+		URLScheme:          "https",
+		ProtocolVersion:    "1.1",
+	}
+}
+
+func benchEnvironmentManager(b *testing.B) *EnvironmentManager {
+	b.Helper()
+	return &EnvironmentManager{
+		envKVs: []attribute.KeyValue{
+			relayIDAttrKey.String("bench-relay-id"),
+			envNameAttrKey.String("bench-env"),
+		},
+	}
+}
+
+// BenchmarkStartActiveRequest measures the work this change adds to every non-streaming request:
+// one attribute set built and one increment/decrement pair on the UpDownCounter. Duration recording
+// already built a comparable set before this change, so this is the marginal cost, not the total.
+//
+// The noop case matters as much as the real one: an operator with OpenTelemetry disabled still pays
+// for the attribute set, because the instruments are noop but the attributes are built before the
+// instrument is touched.
+func BenchmarkStartActiveRequest(b *testing.B) {
+	ri := benchRequestInfo()
+	em := benchEnvironmentManager(b)
+
+	b.Run("real meter", func(b *testing.B) {
+		reader := sdkmetric.NewManualReader()
+		provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		instruments, err := NewInstrumentsForTest(provider.Meter("ld-relay"))
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			StartActiveRequest(instruments, em, ServerPlatformCategory, ri)()
+		}
+	})
+
+	b.Run("noop meter", func(b *testing.B) {
+		instruments, err := NewInstrumentsForTest(noop.Meter{})
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			StartActiveRequest(instruments, em, ServerPlatformCategory, ri)()
+		}
+	})
+}
+
+// BenchmarkBuildRequestAttributes isolates the attribute set construction -- the allocation and sort
+// of ~12 attributes that dominates the cost above.
+func BenchmarkBuildRequestAttributes(b *testing.B) {
+	ri := benchRequestInfo()
+	em := benchEnvironmentManager(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = buildRequestAttributes(em.envKVs, ServerPlatformCategory, ri)
+	}
+}

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -3,7 +3,8 @@ package metrics
 import (
 	"strings"
 	"time"
-	"unicode/utf8"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/util"
 
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -124,18 +125,12 @@ func requestKVs(platform string, ri RequestInfo) []attribute.KeyValue {
 // Empty values are replaced with descriptive defaults, and slashes are replaced with underscores.
 // This is appropriate for user agent strings and SDK wrapper names, but not for routes.
 //
-// Invalid UTF-8 is stripped, which matters more than it looks. Attribute values end up in OTLP
-// protobuf string fields, and proto3 requires those to be valid UTF-8: a single bad byte fails the
-// marshal for the entire export batch, not just the offending data point. Because these series are
-// cumulative, the poisoned series is re-collected every interval, so exports keep failing until the
-// process restarts. Header values are not restricted to ASCII -- RFC 7230 permits obs-text, and Go's
-// HTTP parser passes those bytes through unchanged -- so any caller can supply one, including an
-// unauthenticated caller via the status and not-found handlers.
+// Invalid UTF-8 is stripped via util.SanitizeUTF8, which matters more than it looks: a single bad byte
+// fails the OTLP marshal for the entire export batch, and these series are cumulative, so exports keep
+// failing until the process restarts. Header values are not restricted to ASCII, so an unauthenticated
+// caller can supply one via the status and not-found handlers.
 func sanitizeTagValue(v string) string {
-	v = strings.ReplaceAll(v, "/", "_")
-	if !utf8.ValidString(v) {
-		v = strings.ToValidUTF8(v, "")
-	}
+	v = util.SanitizeUTF8(strings.ReplaceAll(v, "/", "_"))
 	if strings.TrimSpace(v) == "" {
 		return notProvidedValue
 	}

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -122,11 +123,23 @@ func requestKVs(platform string, ri RequestInfo) []attribute.KeyValue {
 // sanitizeTagValue ensures attribute values are valid.
 // Empty values are replaced with descriptive defaults, and slashes are replaced with underscores.
 // This is appropriate for user agent strings and SDK wrapper names, but not for routes.
+//
+// Invalid UTF-8 is stripped, which matters more than it looks. Attribute values end up in OTLP
+// protobuf string fields, and proto3 requires those to be valid UTF-8: a single bad byte fails the
+// marshal for the entire export batch, not just the offending data point. Because these series are
+// cumulative, the poisoned series is re-collected every interval, so exports keep failing until the
+// process restarts. Header values are not restricted to ASCII -- RFC 7230 permits obs-text, and Go's
+// HTTP parser passes those bytes through unchanged -- so any caller can supply one, including an
+// unauthenticated caller via the status and not-found handlers.
 func sanitizeTagValue(v string) string {
+	v = strings.ReplaceAll(v, "/", "_")
+	if !utf8.ValidString(v) {
+		v = strings.ToValidUTF8(v, "")
+	}
 	if strings.TrimSpace(v) == "" {
 		return notProvidedValue
 	}
-	return strings.ReplaceAll(v, "/", "_")
+	return v
 }
 
 // sanitizeRouteValue ensures route attribute values are valid.

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -21,9 +21,38 @@ const (
 
 	defaultFlushInterval = time.Minute
 
+	// notProvidedValue is the sentinel reported for an attribute whose value is absent.
+	notProvidedValue = "not-provided"
+
 	BrowserPlatformCategory = "browser"
 	MobilePlatformCategory  = "mobile"
 	ServerPlatformCategory  = "server"
+)
+
+// EndpointType identifies the kind of Relay endpoint that served a request. It is reported on
+// request-scoped metrics as the relay.endpoint.type attribute, so that a metric covering all
+// requests can still be broken down by the delivery mode the request belongs to.
+type EndpointType string
+
+const (
+	// EndpointTypeStream is an SSE endpoint that holds the connection open.
+	EndpointTypeStream EndpointType = "stream"
+
+	// EndpointTypePoll is a request/response flag delivery endpoint.
+	EndpointTypePoll EndpointType = "poll"
+
+	// EndpointTypeEvents is an analytics or diagnostic event ingestion endpoint.
+	EndpointTypeEvents EndpointType = "events"
+
+	// EndpointTypeStatus is a Relay status endpoint. These are not associated with an SDK or an
+	// LD environment.
+	EndpointTypeStatus EndpointType = "status"
+
+	// EndpointTypeGoals is the experimentation goals endpoint used by the JS SDK.
+	EndpointTypeGoals EndpointType = "goals"
+
+	// EndpointTypeNotProvided is used for requests that did not match any route Relay serves.
+	EndpointTypeNotProvided EndpointType = notProvidedValue
 )
 
 var (
@@ -35,6 +64,7 @@ var (
 	applicationIDAttrKey      = attribute.Key("application.id")      //nolint:gochecknoglobals
 	applicationVersionAttrKey = attribute.Key("application.version") //nolint:gochecknoglobals
 	instanceIDAttrKey         = attribute.Key("instance.id")         //nolint:gochecknoglobals
+	endpointTypeAttrKey       = attribute.Key("relay.endpoint.type") //nolint:gochecknoglobals
 
 	// OTEL HTTP semantic convention attribute keys (from semconv package)
 	httpRouteAttrKey           = semconv.HTTPRouteKey              //nolint:gochecknoglobals
@@ -47,50 +77,46 @@ var (
 )
 
 // buildRequestAttributes creates an OTel attribute set for request metrics using semconv attribute names
-// where applicable. All string values should be pre-sanitized via sanitizeTagValue before calling this function.
-func buildRequestAttributes(baseKVs []attribute.KeyValue, platform, userAgent, sdkWrapper, route, method, urlScheme, applicationID, applicationVersion, instanceID string) attribute.Set {
-	attrs := make([]attribute.KeyValue, len(baseKVs), len(baseKVs)+9)
+// where applicable. Values from the RequestInfo are sanitized here, so callers pass it through as-is.
+func buildRequestAttributes(baseKVs []attribute.KeyValue, platform string, ri RequestInfo) attribute.Set {
+	attrs := make([]attribute.KeyValue, len(baseKVs), len(baseKVs)+10)
 	copy(attrs, baseKVs)
-	attrs = append(attrs,
-		platformCategoryAttrKey.String(platform),
-		userAgentAttrKey.String(userAgent),
-		sdkWrapperAttrKey.String(sdkWrapper),
-		httpRouteAttrKey.String(route),
-		httpRequestMethodAttrKey.String(method),
-		urlSchemeAttrKey.String(urlScheme),
-		applicationIDAttrKey.String(applicationID),
-		applicationVersionAttrKey.String(applicationVersion),
-		instanceIDAttrKey.String(instanceID),
-	)
+	attrs = append(attrs, requestKVs(platform, ri)...)
 	return attribute.NewSet(attrs...)
 }
 
 // buildDurationAttributes creates an OTel attribute set for the http.server.request.duration histogram,
 // including all semconv required/conditionally-required attributes.
-func buildDurationAttributes(baseKVs []attribute.KeyValue, platform, userAgent, sdkWrapper, route, method, applicationID, applicationVersion, instanceID, urlScheme, protocolVersion, errorType string, statusCode int) attribute.Set {
-	attrs := make([]attribute.KeyValue, len(baseKVs), len(baseKVs)+14)
+func buildDurationAttributes(baseKVs []attribute.KeyValue, platform string, ri RequestInfo) attribute.Set {
+	attrs := make([]attribute.KeyValue, len(baseKVs), len(baseKVs)+13)
 	copy(attrs, baseKVs)
-	attrs = append(attrs,
-		platformCategoryAttrKey.String(platform),
-		userAgentAttrKey.String(userAgent),
-		sdkWrapperAttrKey.String(sdkWrapper),
-		httpRouteAttrKey.String(route),
-		httpRequestMethodAttrKey.String(method),
-		urlSchemeAttrKey.String(urlScheme),
-		applicationIDAttrKey.String(applicationID),
-		applicationVersionAttrKey.String(applicationVersion),
-		instanceIDAttrKey.String(instanceID),
-	)
-	if protocolVersion != "" {
-		attrs = append(attrs, networkProtoVersionAttrKey.String(protocolVersion))
+	attrs = append(attrs, requestKVs(platform, ri)...)
+	if ri.ProtocolVersion != "" {
+		attrs = append(attrs, networkProtoVersionAttrKey.String(ri.ProtocolVersion))
 	}
-	if statusCode > 0 {
-		attrs = append(attrs, httpResponseStatusAttrKey.Int(statusCode))
+	if ri.StatusCode > 0 {
+		attrs = append(attrs, httpResponseStatusAttrKey.Int(ri.StatusCode))
 	}
-	if errorType != "" {
-		attrs = append(attrs, errorTypeAttrKey.String(errorType))
+	if ri.ErrorType != "" {
+		attrs = append(attrs, errorTypeAttrKey.String(ri.ErrorType))
 	}
 	return attribute.NewSet(attrs...)
+}
+
+// requestKVs returns the attributes that every request-scoped metric carries.
+func requestKVs(platform string, ri RequestInfo) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		platformCategoryAttrKey.String(sanitizeTagValue(platform)),
+		userAgentAttrKey.String(sanitizeTagValue(ri.UserAgent)),
+		sdkWrapperAttrKey.String(sanitizeTagValue(ri.SDKWrapper)),
+		httpRouteAttrKey.String(sanitizeRouteValue(ri.Route)),
+		httpRequestMethodAttrKey.String(sanitizeTagValue(ri.Method)),
+		urlSchemeAttrKey.String(ri.URLScheme),
+		applicationIDAttrKey.String(sanitizeTagValue(ri.ApplicationID)),
+		applicationVersionAttrKey.String(sanitizeTagValue(ri.ApplicationVersion)),
+		instanceIDAttrKey.String(sanitizeTagValue(ri.InstanceID)),
+		endpointTypeAttrKey.String(sanitizeTagValue(string(ri.EndpointType))),
+	}
 }
 
 // sanitizeTagValue ensures attribute values are valid.
@@ -98,7 +124,7 @@ func buildDurationAttributes(baseKVs []attribute.KeyValue, platform, userAgent, 
 // This is appropriate for user agent strings and SDK wrapper names, but not for routes.
 func sanitizeTagValue(v string) string {
 	if strings.TrimSpace(v) == "" {
-		return "not-provided"
+		return notProvidedValue
 	}
 	return strings.ReplaceAll(v, "/", "_")
 }
@@ -108,7 +134,7 @@ func sanitizeTagValue(v string) string {
 // slashes are preserved since they are meaningful in route paths.
 func sanitizeRouteValue(v string) string {
 	if strings.TrimSpace(v) == "" {
-		return "not-provided"
+		return notProvidedValue
 	}
 	return v
 }

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -30,6 +30,11 @@ type Measure struct {
 	platformCategory  string
 }
 
+// PlatformCategory returns the SDK platform category that this Measure reports under.
+func (m Measure) PlatformCategory() string {
+	return m.platformCategory
+}
+
 // To avoid having to put nolint:gochecknoglobals on everything here, that linter is excluded
 // specifically for this file in .golangci-lint.yml.
 var (
@@ -117,6 +122,7 @@ type RequestInfo struct {
 	ApplicationID      string
 	ApplicationVersion string
 	InstanceID         string
+	EndpointType       EndpointType
 	// Semconv fields populated after handler execution
 	StatusCode      int
 	URLScheme       string
@@ -124,36 +130,40 @@ type RequestInfo struct {
 	ErrorType       string
 }
 
-func (ri RequestInfo) sanitized() (ua, wrapper, route, method, appID, appVersion, instanceID string) {
-	return sanitizeTagValue(ri.UserAgent),
-		sanitizeTagValue(ri.SDKWrapper),
-		sanitizeRouteValue(ri.Route),
-		sanitizeTagValue(ri.Method),
-		sanitizeTagValue(ri.ApplicationID),
-		sanitizeTagValue(ri.ApplicationVersion),
-		sanitizeTagValue(ri.InstanceID)
+// StartActiveRequest increments http.server.active_requests and returns a function that decrements it
+// again. The returned function must be called exactly once, when the request is finished.
+//
+// The attribute set is computed once, up front, and reused for the decrement. Anything only known after
+// the handler runs (status code, error type) therefore cannot be reported on this metric: a mismatched
+// attribute set between the increment and the decrement would leak a permanently non-zero series.
+func StartActiveRequest(instruments *Instruments, em *EnvironmentManager, platformCategory string, ri RequestInfo) func() {
+	if instruments == nil || em == nil {
+		return func() {}
+	}
+
+	// Built once and shared by both calls, so that the two can't drift apart.
+	attrs := metric.WithAttributeSet(buildRequestAttributes(em.envKVs, platformCategory, ri))
+	instruments.connections.Add(context.Background(), 1, attrs)
+	return func() {
+		instruments.connections.Add(context.Background(), -1, attrs)
+	}
 }
 
-// WithGauge increments the specified metric before running the function and then decrements it (for use with
-// the active connection metrics).
-func WithGauge(em *EnvironmentManager, instruments *Instruments, ri RequestInfo, f func(), measure Measure) {
-	if em == nil || !measure.recordConnections {
+// WithStreamConnection runs a function while counting it as an active stream connection in the data
+// that Relay reports back to LaunchDarkly.
+//
+// This is deliberately limited to streaming endpoints, unlike the http.server.active_requests
+// instrument, which covers every request Relay serves. LaunchDarkly's notion of a "connection" is a
+// held-open stream, so counting polls or event posts here would misreport usage.
+func WithStreamConnection(em *EnvironmentManager, ri RequestInfo, f func(), measure Measure) {
+	if em == nil || !measure.recordConnections || em.collector == nil {
 		f()
 		return
 	}
 
-	ua, wrapper, route, method, appID, appVersion, instanceID := ri.sanitized()
-	attrs := buildRequestAttributes(em.envKVs, measure.platformCategory, ua, wrapper, route, method, ri.URLScheme, appID, appVersion, instanceID)
-
-	if instruments != nil {
-		instruments.connections.Add(context.Background(), 1, metric.WithAttributeSet(attrs))
-		defer instruments.connections.Add(context.Background(), -1, metric.WithAttributeSet(attrs))
-	}
-
-	if em.collector != nil {
-		em.collector.RecordConnectionChange(measure.platformCategory, ua, wrapper, 1)
-		defer em.collector.RecordConnectionChange(measure.platformCategory, ua, wrapper, -1)
-	}
+	ua, wrapper := sanitizeTagValue(ri.UserAgent), sanitizeTagValue(ri.SDKWrapper)
+	em.collector.RecordConnectionChange(measure.platformCategory, ua, wrapper, 1)
+	defer em.collector.RecordConnectionChange(measure.platformCategory, ua, wrapper, -1)
 
 	f()
 }
@@ -161,8 +171,7 @@ func WithGauge(em *EnvironmentManager, instruments *Instruments, ri RequestInfo,
 // WithCount runs a function and records polling metrics if applicable.
 func WithCount(em *EnvironmentManager, ri RequestInfo, f func(), measure Measure) {
 	if em != nil && measure.recordPolling && em.collector != nil {
-		ua, wrapper, _, _, _, _, _ := ri.sanitized()
-		em.collector.RecordPollingRequest(measure.platformCategory, ua, wrapper)
+		em.collector.RecordPollingRequest(measure.platformCategory, sanitizeTagValue(ri.UserAgent), sanitizeTagValue(ri.SDKWrapper))
 	}
 
 	f()
@@ -173,8 +182,7 @@ func RecordEventsReceivedBytes(ctx context.Context, instruments *Instruments, em
 	if em == nil || instruments == nil || bytes <= 0 {
 		return
 	}
-	ua, wrapper, route, method, appID, appVersion, instanceID := ri.sanitized()
-	attrs := buildRequestAttributes(em.envKVs, platformCategory, ua, wrapper, route, method, ri.URLScheme, appID, appVersion, instanceID)
+	attrs := buildRequestAttributes(em.envKVs, platformCategory, ri)
 	instruments.eventsReceivedBytes.Add(ctx, bytes, metric.WithAttributeSet(attrs))
 }
 
@@ -184,8 +192,7 @@ func RecordRequestDuration(ctx context.Context, instruments *Instruments, em *En
 	if em == nil || instruments == nil || !measure.recordDuration {
 		return
 	}
-	ua, wrapper, route, method, appID, appVersion, instanceID := ri.sanitized()
-	attrs := buildDurationAttributes(em.envKVs, measure.platformCategory, ua, wrapper, route, method, appID, appVersion, instanceID, ri.URLScheme, ri.ProtocolVersion, ri.ErrorType, ri.StatusCode)
+	attrs := buildDurationAttributes(em.envKVs, measure.platformCategory, ri)
 	instruments.requestDuration.Record(ctx, duration.Seconds(), metric.WithAttributeSet(attrs))
 }
 

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -69,35 +69,56 @@ var (
 // NewInstrumentsForTest creates Instruments backed by the given OTel meter.
 // This is intended for use by tests outside the metrics package.
 func NewInstrumentsForTest(meter metric.Meter) (*Instruments, error) {
-	connections, err := meter.Int64UpDownCounter(connMeasureName)
+	return newInstruments(meter)
+}
+
+// newInstruments creates every instrument Relay records against, from the given meter.
+func newInstruments(meter metric.Meter) (*Instruments, error) {
+	connections, err := meter.Int64UpDownCounter(connMeasureName,
+		metric.WithDescription("Number of active HTTP server requests"),
+		metric.WithUnit("{request}"))
 	if err != nil {
 		return nil, err
 	}
-	requestDuration, err := meter.Float64Histogram(requestDurationMeasureName)
+	requestDuration, err := meter.Float64Histogram(requestDurationMeasureName,
+		metric.WithDescription("Duration of HTTP server requests"),
+		metric.WithUnit("s"))
 	if err != nil {
 		return nil, err
 	}
-	eventsReceivedBytes, err := meter.Int64Counter(eventsReceivedMeasureName)
+	eventsReceivedBytes, err := meter.Int64Counter(eventsReceivedMeasureName,
+		metric.WithDescription("Bytes of event data received"),
+		metric.WithUnit("By"))
 	if err != nil {
 		return nil, err
 	}
-	eventsDropped, err := meter.Int64Counter(eventsDroppedMeasureName)
+	eventsDropped, err := meter.Int64Counter(eventsDroppedMeasureName,
+		metric.WithDescription("Events dropped due to capacity overflow"),
+		metric.WithUnit("{event}"))
 	if err != nil {
 		return nil, err
 	}
-	eventsSent, err := meter.Int64Counter(eventsSentMeasureName)
+	eventsSent, err := meter.Int64Counter(eventsSentMeasureName,
+		metric.WithDescription("Events successfully sent"),
+		metric.WithUnit("{event}"))
 	if err != nil {
 		return nil, err
 	}
-	eventsFailedSend, err := meter.Int64Counter(eventsSendErrorsMeasureName)
+	eventsFailedSend, err := meter.Int64Counter(eventsSendErrorsMeasureName,
+		metric.WithDescription("Events that failed to send after all retries"),
+		metric.WithUnit("{event}"))
 	if err != nil {
 		return nil, err
 	}
-	eventsBytesSent, err := meter.Int64Counter(eventsSentSizeMeasureName)
+	eventsBytesSent, err := meter.Int64Counter(eventsSentSizeMeasureName,
+		metric.WithDescription("Bytes of event payloads successfully sent"),
+		metric.WithUnit("By"))
 	if err != nil {
 		return nil, err
 	}
-	pendingEvents, err := meter.Int64Gauge(eventsPendingMeasureName)
+	pendingEvents, err := meter.Int64Gauge(eventsPendingMeasureName,
+		metric.WithDescription("Events buffered in the queue"),
+		metric.WithUnit("{event}"))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -14,8 +14,6 @@ import (
 	"github.com/pborman/uuid"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel/attribute"
-	otelmetric "go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
@@ -69,8 +67,12 @@ func NewManager(
 
 	res := tracing.NewResource(logger)
 
+	// instruments is deliberately left nil when OpenTelemetry is disabled. Every recording path
+	// no-ops on nil instruments, and checking that first is what lets them skip building attribute
+	// sets: with a noop meter the attributes were still assembled per request, at roughly 2 us and
+	// 3.5 KB each, only to be handed to an instrument that discards them.
 	var meterProvider *sdkmetric.MeterProvider
-	var meter otelmetric.Meter
+	var instruments *Instruments
 	if otlpConfig.Enabled {
 		opts, err := newOTLPExporters(otlpConfig, logger)
 		if err != nil {
@@ -82,49 +84,13 @@ func NewManager(
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationBase2ExponentialHistogram{MaxSize: 160, MaxScale: 20}},
 		)))
 		meterProvider = sdkmetric.NewMeterProvider(opts...)
-		meter = meterProvider.Meter("ld-relay")
 		if err := runtime.Start(runtime.WithMeterProvider(meterProvider)); err != nil {
 			logger.Warn("failed to start Go runtime metrics", "error", err)
 		}
-	} else {
-		meter = noop.Meter{}
-	}
-
-	connections, _ := meter.Int64UpDownCounter(connMeasureName,
-		otelmetric.WithDescription("Number of active HTTP server requests"),
-		otelmetric.WithUnit("{request}"))
-	requestDuration, _ := meter.Float64Histogram(requestDurationMeasureName,
-		otelmetric.WithDescription("Duration of HTTP server requests"),
-		otelmetric.WithUnit("s"))
-	eventsReceivedBytes, _ := meter.Int64Counter(eventsReceivedMeasureName,
-		otelmetric.WithDescription("Bytes of event data received"),
-		otelmetric.WithUnit("By"))
-
-	eventsDropped, _ := meter.Int64Counter(eventsDroppedMeasureName,
-		otelmetric.WithDescription("Events dropped due to capacity overflow"),
-		otelmetric.WithUnit("{event}"))
-	eventsSent, _ := meter.Int64Counter(eventsSentMeasureName,
-		otelmetric.WithDescription("Events successfully sent"),
-		otelmetric.WithUnit("{event}"))
-	eventsFailedSend, _ := meter.Int64Counter(eventsSendErrorsMeasureName,
-		otelmetric.WithDescription("Events that failed to send after all retries"),
-		otelmetric.WithUnit("{event}"))
-	eventsBytesSent, _ := meter.Int64Counter(eventsSentSizeMeasureName,
-		otelmetric.WithDescription("Bytes of event payloads successfully sent"),
-		otelmetric.WithUnit("By"))
-	pendingEvents, _ := meter.Int64Gauge(eventsPendingMeasureName,
-		otelmetric.WithDescription("Events buffered in the queue"),
-		otelmetric.WithUnit("{event}"))
-
-	instruments := &Instruments{
-		connections:         connections,
-		requestDuration:     requestDuration,
-		eventsReceivedBytes: eventsReceivedBytes,
-		eventsDropped:       eventsDropped,
-		eventsSent:          eventsSent,
-		eventsFailedSend:    eventsFailedSend,
-		eventsBytesSent:     eventsBytesSent,
-		pendingEvents:       pendingEvents,
+		instruments, err = newInstruments(meterProvider.Meter("ld-relay"))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	usageChan := make(chan any, 256)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -33,6 +33,7 @@ type Manager struct {
 	closed         bool
 	lock           sync.Mutex
 	environments   []*EnvironmentManager
+	unscopedEnv    *EnvironmentManager
 
 	usageChan            chan any
 	environmentsForUsage map[string]*environmentMetricUsage
@@ -135,6 +136,12 @@ func NewManager(
 		logger:               logger,
 		usageChan:            usageChan,
 		environmentsForUsage: make(map[string]*environmentMetricUsage),
+		unscopedEnv: &EnvironmentManager{
+			envKVs: []attribute.KeyValue{
+				relayIDAttrKey.String(metricsRelayID),
+				envNameAttrKey.String(sanitizeTagValue("")),
+			},
+		},
 	}
 	if m.flushInterval <= 0 {
 		m.flushInterval = defaultFlushInterval
@@ -148,6 +155,14 @@ func NewManager(
 // GetInstruments returns the OTel instruments for recording metrics.
 func (m *Manager) GetInstruments() *Instruments {
 	return m.instruments
+}
+
+// GetUnscopedEnvironment returns an EnvironmentManager for recording metrics on requests that are not
+// associated with any LD environment, such as the status endpoints and requests that matched no route.
+// Its environment.name attribute is the not-provided sentinel, and it has no collector, since there is
+// no environment to report usage data for.
+func (m *Manager) GetUnscopedEnvironment() *EnvironmentManager {
+	return m.unscopedEnv
 }
 
 // SetInstrumentsForTest replaces the instruments on this Manager. Intended for testing only.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -13,27 +13,62 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-func TestNewManagerWithNoExporters(t *testing.T) {
+// With OpenTelemetry disabled there are no instruments at all, rather than instruments backed by a
+// noop meter. That is what allows the recording paths to skip building attribute sets for
+// measurements that would be discarded, so it is worth asserting directly.
+func TestNewManagerWithoutOpenTelemetryHasNoInstruments(t *testing.T) {
 	manager, err := NewManager(config.OpenTelemetryConfig{}, 0, slog.Default())
 	require.NoError(t, err)
 	defer manager.Close()
 
-	assert.NotNil(t, manager.instruments)
+	assert.Nil(t, manager.instruments)
+	assert.Nil(t, manager.GetInstruments())
 }
 
-func TestNewManagerReturnsInstruments(t *testing.T) {
+// Every recording path has to tolerate nil instruments, since that is the normal state when
+// OpenTelemetry is disabled.
+func TestRecordingIsSafeWithoutInstruments(t *testing.T) {
 	manager, err := NewManager(config.OpenTelemetryConfig{}, 0, slog.Default())
 	require.NoError(t, err)
 	defer manager.Close()
 
-	instruments := manager.GetInstruments()
-	assert.NotNil(t, instruments)
+	em, err := manager.AddEnvironment("testenv", nil)
+	require.NoError(t, err)
+
+	ri := RequestInfo{UserAgent: userAgentValue, Route: "/test", Method: "GET", EndpointType: EndpointTypePoll}
+
+	assert.NotPanics(t, func() {
+		StartActiveRequest(manager.GetInstruments(), em, ServerPlatformCategory, ri)()
+		StartActiveRequest(manager.GetInstruments(), manager.GetUnscopedEnvironment(), "", ri)()
+		RecordRequestDuration(context.Background(), manager.GetInstruments(), em, ri, time.Millisecond, ServerDuration)
+		RecordEventsReceivedBytes(context.Background(), manager.GetInstruments(), em, ServerPlatformCategory, ri, 100)
+
+		recorder := em.NewEventMetricsRecorder(manager.GetInstruments())
+		recorder.RecordDroppedEvents(1)
+		recorder.RecordEventsSent(1)
+		recorder.RecordPendingEvents(1)
+		recorder.RecordEventsBytesSent(1)
+		recorder.RecordEventsFailedSend(1, ldevents.EventSendFailureMetadata{StatusCode: 500})
+	})
+}
+
+func TestNewInstrumentsCreatesEveryInstrument(t *testing.T) {
+	instruments, err := newInstruments(noop.Meter{})
+	require.NoError(t, err)
+	require.NotNil(t, instruments)
+
 	assert.NotNil(t, instruments.connections)
 	assert.NotNil(t, instruments.requestDuration)
 	assert.NotNil(t, instruments.eventsReceivedBytes)
+	assert.NotNil(t, instruments.eventsDropped)
+	assert.NotNil(t, instruments.eventsSent)
+	assert.NotNil(t, instruments.eventsFailedSend)
+	assert.NotNil(t, instruments.eventsBytesSent)
+	assert.NotNil(t, instruments.pendingEvents)
 }
 
 func TestAddEnvironmentWithoutEventPublisher(t *testing.T) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -96,36 +96,75 @@ func TestRemoveEnvironment(t *testing.T) {
 	assert.Len(t, manager.environments, 0)
 }
 
-func TestConnectionMetrics(t *testing.T) {
+func TestActiveRequestMetrics(t *testing.T) {
 	specs := []struct {
-		platform string
-		measure  Measure
+		platform     string
+		endpointType EndpointType
 	}{
-		{platform: BrowserPlatformCategory, measure: BrowserConns},
-		{platform: MobilePlatformCategory, measure: MobileConns},
-		{platform: ServerPlatformCategory, measure: ServerConns},
+		{platform: BrowserPlatformCategory, endpointType: EndpointTypeStream},
+		{platform: MobilePlatformCategory, endpointType: EndpointTypePoll},
+		{platform: ServerPlatformCategory, endpointType: EndpointTypeEvents},
 	}
 
 	for _, tt := range specs {
 		t.Run(tt.platform, func(t *testing.T) {
 			testWithOTel(t, func(p testWithOTelParams) {
-				WithGauge(p.env, p.instruments, RequestInfo{UserAgent: userAgentValue, Route: "/test", Method: "GET"}, func() {
-					// While the gauge is active, check that the connection count is 1
-					rm, err := p.collectMetrics()
-					require.NoError(t, err)
-					m := findMetric(rm, connMeasureName)
-					require.NotNil(t, m, "connections metric not found")
-					assertGaugeValue(t, m, p.envName, tt.platform, 1)
-				}, tt.measure)
+				ri := RequestInfo{UserAgent: userAgentValue, Route: "/test", Method: "GET", EndpointType: tt.endpointType}
+				requestFinished := StartActiveRequest(p.instruments, p.env, tt.platform, ri)
 
-				// After the gauge function returns, check that the connection count is 0
+				// While the request is in flight, the count should be 1
 				rm, err := p.collectMetrics()
 				require.NoError(t, err)
 				m := findMetric(rm, connMeasureName)
-				require.NotNil(t, m, "connections metric not found")
+				require.NotNil(t, m, "active requests metric not found")
+				assertGaugeValue(t, m, p.envName, tt.platform, 1)
+				assertHasAttribute(t, m, endpointTypeAttrKey, string(tt.endpointType))
+
+				requestFinished()
+
+				// Once the request finishes, it should return to 0 rather than leaving a stray series
+				rm, err = p.collectMetrics()
+				require.NoError(t, err)
+				m = findMetric(rm, connMeasureName)
+				require.NotNil(t, m, "active requests metric not found")
 				assertGaugeValue(t, m, p.envName, tt.platform, 0)
+				assert.Len(t, m.Data.(metricdata.Sum[int64]).DataPoints, 1,
+					"increment and decrement should share one attribute set")
 			})
 		})
+	}
+}
+
+// The status endpoints and unmatched requests have no environment, so they report the not-provided
+// sentinel for both environment.name and platform.category.
+func TestActiveRequestMetricsWithoutEnvironment(t *testing.T) {
+	testWithOTel(t, func(p testWithOTelParams) {
+		manager, err := NewManager(config.OpenTelemetryConfig{}, time.Minute, slog.Default())
+		require.NoError(t, err)
+		defer manager.Close()
+		manager.SetInstrumentsForTest(p.instruments)
+
+		ri := RequestInfo{Route: "/status", Method: "GET", EndpointType: EndpointTypeStatus}
+		requestFinished := StartActiveRequest(manager.GetInstruments(), manager.GetUnscopedEnvironment(), "", ri)
+		defer requestFinished()
+
+		rm, err := p.collectMetrics()
+		require.NoError(t, err)
+		m := findMetric(rm, connMeasureName)
+		require.NotNil(t, m, "active requests metric not found")
+		assertGaugeValue(t, m, notProvidedValue, notProvidedValue, 1)
+		assertHasAttribute(t, m, endpointTypeAttrKey, string(EndpointTypeStatus))
+	})
+}
+
+func assertHasAttribute(t *testing.T, m *metricdata.Metrics, key attribute.Key, expected string) {
+	t.Helper()
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "expected Sum[int64] data for %s", m.Name)
+	for _, dp := range sum.DataPoints {
+		val, found := dp.Attributes.Value(key)
+		require.True(t, found, "%s attribute not present on %s", key, m.Name)
+		assert.Equal(t, expected, val.AsString())
 	}
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/launchdarkly/ld-relay/v9/config"
 
@@ -457,6 +458,33 @@ func TestSanitizeTagValue(t *testing.T) {
 	assert.Equal(t, "not-provided", sanitizeTagValue(""))
 	assert.Equal(t, "not-provided", sanitizeTagValue("   "))
 	assert.Equal(t, "react_2.0.0", sanitizeTagValue("react/2.0.0"))
+}
+
+// Attribute values are serialized into OTLP protobuf string fields, which proto3 requires to be valid
+// UTF-8. One bad byte fails the marshal for the whole export batch, and the poisoned series is
+// cumulative, so exports keep failing until restart. Header values are not restricted to ASCII, so this
+// has to be handled here rather than assumed away.
+func TestSanitizeTagValueStripsInvalidUTF8(t *testing.T) {
+	specs := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "invalid bytes in the middle", input: "bad-\xff\xfe-agent", want: "bad--agent"},
+		{name: "leading invalid byte", input: "\xffGoClient", want: "GoClient"},
+		{name: "entirely invalid collapses to sentinel", input: "\xff\xfe", want: notProvidedValue},
+		{name: "invalid plus a slash", input: "Node\xff/3.4.0", want: "Node_3.4.0"},
+		{name: "valid multi-byte UTF-8 is preserved", input: "Ruby-\u00e9", want: "Ruby-\u00e9"},
+		{name: "valid ASCII is untouched", input: "GoClient", want: "GoClient"},
+	}
+
+	for _, tt := range specs {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeTagValue(tt.input)
+			assert.Equal(t, tt.want, got)
+			assert.True(t, utf8.ValidString(got), "sanitized value must be valid UTF-8, got %q", got)
+		})
+	}
 }
 
 func TestSanitizeRouteValue(t *testing.T) {

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -122,11 +122,11 @@ func withCount(handler http.Handler, measure metrics.Measure) http.Handler {
 	})
 }
 
-func withGauge(handler http.Handler, measure metrics.Measure) http.Handler {
+func withStreamConnection(handler http.Handler, measure metrics.Measure) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		env := GetEnvContextInfo(req.Context()).Env
 		ri := requestInfoFromHTTP(req)
-		metrics.WithGauge(env.GetMetricsEnv(), getInstruments(env), ri, func() {
+		metrics.WithStreamConnection(env.GetMetricsEnv(), ri, func() {
 			handler.ServeHTTP(w, req)
 		}, measure)
 	})
@@ -135,19 +135,19 @@ func withGauge(handler http.Handler, measure metrics.Measure) http.Handler {
 // CountMobileConns is a middleware function that increments the number of active mobile connections
 // until the handler ends.
 func CountMobileConns(handler http.Handler) http.Handler {
-	return withGauge(handler, metrics.MobileConns)
+	return withStreamConnection(handler, metrics.MobileConns)
 }
 
 // CountBrowserConns is a middleware function that increments the number of active browser connections
 // until the handler ends.
 func CountBrowserConns(handler http.Handler) http.Handler {
-	return withGauge(handler, metrics.BrowserConns)
+	return withStreamConnection(handler, metrics.BrowserConns)
 }
 
 // CountServerConns is a middleware function that increments the number of active server-side connections
 // until the handler ends.
 func CountServerConns(handler http.Handler) http.Handler {
-	return withGauge(handler, metrics.ServerConns)
+	return withStreamConnection(handler, metrics.ServerConns)
 }
 
 // ServerPollingRequestCount is a middleware function that increments the total number of server-side polling requests.
@@ -183,9 +183,9 @@ func CountClientConns(handler http.Handler) http.Handler {
 	})
 }
 
-// DynamicDurationMetrics is a middleware function for FDv2 client-side endpoints that dynamically
-// determines the duration metric platform based on the credential type.
-func DynamicDurationMetrics() mux.MiddlewareFunc {
+// DynamicRequestMetrics is a middleware function for FDv2 client-side endpoints that dynamically
+// determines the metric platform based on the credential type.
+func DynamicRequestMetrics(endpointType metrics.EndpointType) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			cred := GetEnvContextInfo(req.Context()).Credential
@@ -195,17 +195,29 @@ func DynamicDurationMetrics() mux.MiddlewareFunc {
 			} else {
 				measure = metrics.BrowserDuration
 			}
-			DurationMetrics(measure)(next).ServeHTTP(w, req)
+			RequestMetrics(measure, endpointType)(next).ServeHTTP(w, req)
 		})
 	}
 }
 
-// DurationMetrics is a middleware function that records the request duration for the specified metric.
-func DurationMetrics(measure metrics.Measure) mux.MiddlewareFunc {
+// RequestMetrics is a middleware function that tracks a request in http.server.active_requests for as
+// long as it is in flight, and records its duration once it completes.
+//
+// Active requests cover every request this middleware sees, streaming included, per the OTEL semantic
+// convention for the instrument. Duration is still skipped for streaming responses, whose lifetime is
+// unbounded.
+func RequestMetrics(measure metrics.Measure, endpointType metrics.EndpointType) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			env := GetEnvContextInfo(req.Context()).Env
+			instruments := getInstruments(env)
+			metricsEnv := env.GetMetricsEnv()
 			ri := requestInfoFromHTTP(req)
+			ri.EndpointType = endpointType
+
+			requestFinished := metrics.StartActiveRequest(instruments, metricsEnv, measure.PlatformCategory(), ri)
+			defer requestFinished()
+
 			recorder := &statusRecorder{ResponseWriter: w, statusCode: 200}
 			start := time.Now()
 			next.ServeHTTP(recorder, req)
@@ -215,8 +227,28 @@ func DurationMetrics(measure metrics.Measure) mux.MiddlewareFunc {
 				if recorder.statusCode >= 500 {
 					ri.ErrorType = fmt.Sprintf("%d", recorder.statusCode)
 				}
-				metrics.RecordRequestDuration(req.Context(), getInstruments(env), env.GetMetricsEnv(), ri, time.Since(start), measure)
+				metrics.RecordRequestDuration(req.Context(), instruments, metricsEnv, ri, time.Since(start), measure)
 			}
+		})
+	}
+}
+
+// UnscopedActiveRequests tracks a request in http.server.active_requests without an LD environment, for
+// endpoints that have no environment to attribute the request to. Its environment.name and
+// platform.category attributes are the not-provided sentinel.
+//
+// This is applied directly to a handler rather than registered with Router.Use for requests that matched
+// no route: gorilla/mux skips router middleware entirely when a request fails to match.
+func UnscopedActiveRequests(manager *metrics.Manager, endpointType metrics.EndpointType) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ri := requestInfoFromHTTP(req)
+			ri.EndpointType = endpointType
+
+			requestFinished := metrics.StartActiveRequest(manager.GetInstruments(), manager.GetUnscopedEnvironment(), "", ri)
+			defer requestFinished()
+
+			next.ServeHTTP(w, req)
 		})
 	}
 }
@@ -235,6 +267,7 @@ func EventBytesMetrics(platformCategory string) mux.MiddlewareFunc {
 			next.ServeHTTP(w, req)
 			env := GetEnvContextInfo(req.Context()).Env
 			ri := requestInfoFromHTTP(req)
+			ri.EndpointType = metrics.EndpointTypeEvents
 			metrics.RecordEventsReceivedBytes(req.Context(), getInstruments(env), env.GetMetricsEnv(), platformCategory, ri, cr.bytesRead.Load())
 		})
 	}

--- a/internal/middleware/metrics_middleware_benchmark_test.go
+++ b/internal/middleware/metrics_middleware_benchmark_test.go
@@ -1,0 +1,137 @@
+package middleware
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/config"
+	"github.com/launchdarkly/ld-relay/v9/internal/metrics"
+	"github.com/launchdarkly/ld-relay/v9/internal/relayenv"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest/testclient"
+
+	"github.com/gorilla/mux"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// durationOnlyMetrics reconstructs the pre-change middleware: status recording, timing, and the
+// duration histogram, with no active-request tracking. It exists solely so the benchmark below can
+// price the active-request half against a like-for-like baseline in a single tree, without checking
+// out the parent commit.
+func durationOnlyMetrics(measure metrics.Measure, endpointType metrics.EndpointType) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			env := GetEnvContextInfo(req.Context()).Env
+			ri := requestInfoFromHTTP(req)
+			ri.EndpointType = endpointType
+			recorder := &statusRecorder{ResponseWriter: w, statusCode: 200}
+			start := time.Now()
+			next.ServeHTTP(recorder, req)
+			if !strings.HasPrefix(strings.ToLower(recorder.Header().Get("Content-Type")), "text/event-stream") {
+				ri.StatusCode = recorder.statusCode
+				if recorder.statusCode >= 500 {
+					ri.ErrorType = fmt.Sprintf("%d", recorder.statusCode)
+				}
+				metrics.RecordRequestDuration(req.Context(), getInstruments(env), env.GetMetricsEnv(), ri, time.Since(start), measure)
+			}
+		})
+	}
+}
+
+// discardWriter is a minimal ResponseWriter so the benchmark measures the middleware rather than
+// httptest.NewRecorder's per-call buffer allocation.
+type discardWriter struct{ header http.Header }
+
+func (d *discardWriter) Header() http.Header         { return d.header }
+func (d *discardWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (d *discardWriter) WriteHeader(int)             {}
+
+func benchmarkEnv(b *testing.B, realMeter bool) relayenv.EnvContext {
+	b.Helper()
+	manager, err := metrics.NewManager(config.OpenTelemetryConfig{}, time.Minute, slog.New(slog.DiscardHandler))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(manager.Close)
+
+	if realMeter {
+		// A fresh reader per call: reusing one across sub-benchmarks fails to register on the second
+		// provider ("duplicate reader registration"), which silently turns the real-meter case into a
+		// no-aggregation one.
+		provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewManualReader()))
+		instruments, err := metrics.NewInstrumentsForTest(provider.Meter("ld-relay"))
+		if err != nil {
+			b.Fatal(err)
+		}
+		manager.SetInstrumentsForTest(instruments)
+	}
+
+	env, err := relayenv.NewEnvContext(relayenv.EnvContextImplParams{
+		Identifiers:    relayenv.EnvIdentifiers{ConfiguredName: "benchenv"},
+		EnvConfig:      config.EnvConfig{},
+		AllConfig:      config.Config{},
+		ClientFactory:  testclient.FakeLDClientFactory(true),
+		MetricsManager: manager,
+		LogNameMode:    relayenv.LogNameIsEnvID,
+		Logger:         slog.New(slog.DiscardHandler),
+	}, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = env.Close() })
+	return env
+}
+
+// BenchmarkRequestMetricsMiddleware prices the middleware that every non-streaming request passes
+// through, comparing the shipped version (active requests + duration) against a reconstruction of the
+// pre-change version (duration only). The delta is what broadening
+// http.server.active_requests beyond streams costs per request.
+//
+// "real meter" is the OTLP-enabled case. "noop meter" is the OpenTelemetry-disabled case, which still
+// builds attribute sets, so it shows what operators who export nothing now pay.
+func BenchmarkRequestMetricsMiddleware(b *testing.B) {
+	specs := []struct {
+		name       string
+		middleware mux.MiddlewareFunc
+	}{
+		{name: "active+duration", middleware: RequestMetrics(metrics.ServerDuration, metrics.EndpointTypePoll)},
+		{name: "duration-only (pre-change)", middleware: durationOnlyMetrics(metrics.ServerDuration, metrics.EndpointTypePoll)},
+	}
+
+	for _, meterCase := range []struct {
+		name string
+		real bool
+	}{
+		{name: "real meter", real: true},
+		{name: "noop meter", real: false},
+	} {
+		for _, spec := range specs {
+			b.Run(meterCase.name+"/"+spec.name, func(b *testing.B) {
+				env := benchmarkEnv(b, meterCase.real)
+
+				router := mux.NewRouter()
+				router.Use(spec.middleware)
+				router.Handle("/sdk/evalx/{envId}/contexts/{context}",
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusOK)
+					})).Methods("GET")
+
+				req, _ := http.NewRequest("GET", "/sdk/evalx/env-id/contexts/ctx", nil)
+				req.Header.Set("User-Agent", "GoClient/7.15.4")
+				req.Header.Set("X-LaunchDarkly-Tags", "application-id/my-app application-version/1.2.3")
+				req.Header.Set("X-LaunchDarkly-Instance-Id", "instance-abc")
+				req = req.WithContext(WithEnvContextInfo(req.Context(), EnvContextInfo{Env: env}))
+
+				w := &discardWriter{header: make(http.Header)}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					router.ServeHTTP(w, req)
+				}
+			})
+		}
+	}
+}

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -32,6 +32,7 @@ type metricsMiddlewareTestParams struct {
 	env     relayenv.EnvContext
 	envName string
 	reader  sdkmetric.Reader
+	manager *metrics.Manager
 }
 
 func (p metricsMiddlewareTestParams) collectMetrics(t *testing.T) *metricdata.ResourceMetrics {
@@ -75,47 +76,156 @@ func metricsMiddlewareTest(t *testing.T, action func(metricsMiddlewareTestParams
 		env:     env,
 		envName: envName,
 		reader:  reader,
+		manager: manager,
 	})
 }
 
-func TestCountConnections(t *testing.T) {
-	t.Run("browser", func(t *testing.T) {
-		testCountConnections(t, CountBrowserConns, "browser")
-	})
-	t.Run("mobile", func(t *testing.T) {
-		testCountConnections(t, CountMobileConns, "mobile")
-	})
-	t.Run("server", func(t *testing.T) {
-		testCountConnections(t, CountServerConns, "server")
-	})
+// The CountXConns middlewares feed only the stream-connection counts that Relay reports back to
+// LaunchDarkly. http.server.active_requests is handled by RequestMetrics, which wraps every endpoint,
+// so counting here as well would double count every streaming request.
+func TestCountConnectionsDoesNotRecordActiveRequests(t *testing.T) {
+	specs := []struct {
+		name    string
+		countFn func(http.Handler) http.Handler
+	}{
+		{name: "browser", countFn: CountBrowserConns},
+		{name: "mobile", countFn: CountMobileConns},
+		{name: "server", countFn: CountServerConns},
+	}
+
+	for _, tt := range specs {
+		t.Run(tt.name, func(t *testing.T) {
+			metricsMiddlewareTest(t, func(p metricsMiddlewareTestParams) {
+				req, _ := http.NewRequest("GET", "", nil)
+				req.Header.Set("User-Agent", metricsTestUserAgent)
+				req = req.WithContext(WithEnvContextInfo(req.Context(), EnvContextInfo{Env: p.env}))
+
+				tt.countFn(nullHandler()).ServeHTTP(httptest.NewRecorder(), req)
+
+				rm := p.collectMetrics(t)
+				assert.Nil(t, st.FindMetricByName(rm, "http.server.active_requests"),
+					"stream connection counting must not touch the active requests instrument")
+			})
+		})
+	}
 }
 
-func testCountConnections(t *testing.T, countFn func(http.Handler) http.Handler, category string) {
+// Active requests must be tracked for every kind of endpoint, not just streams, per the OTEL semantic
+// convention for http.server.active_requests.
+func TestActiveRequests(t *testing.T) {
+	specs := []struct {
+		endpointType metrics.EndpointType
+		measure      metrics.Measure
+		platform     string
+	}{
+		{endpointType: metrics.EndpointTypeStream, measure: metrics.ServerDuration, platform: "server"},
+		{endpointType: metrics.EndpointTypePoll, measure: metrics.ServerDuration, platform: "server"},
+		{endpointType: metrics.EndpointTypeEvents, measure: metrics.MobileDuration, platform: "mobile"},
+		{endpointType: metrics.EndpointTypeGoals, measure: metrics.BrowserDuration, platform: "browser"},
+	}
+
+	for _, tt := range specs {
+		t.Run(string(tt.endpointType), func(t *testing.T) {
+			metricsMiddlewareTest(t, func(p metricsMiddlewareTestParams) {
+				router := mux.NewRouter()
+				router.Use(RequestMetrics(tt.measure, tt.endpointType))
+				router.Handle("/test-route", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// While inside the handler, the request should be counted as active
+					rm := p.collectMetrics(t)
+					m := st.FindMetricByName(rm, "http.server.active_requests")
+					require.NotNil(t, m, "active requests metric not found")
+					assertMetricHasValue(t, m, p.envName, tt.platform, 1)
+					assertMetricHasAttribute(t, m, "relay.endpoint.type", string(tt.endpointType))
+				})).Methods("GET")
+
+				req, _ := http.NewRequest("GET", "/test-route", nil)
+				req.Header.Set("User-Agent", metricsTestUserAgent)
+				req = req.WithContext(WithEnvContextInfo(req.Context(), EnvContextInfo{Env: p.env}))
+				router.ServeHTTP(httptest.NewRecorder(), req)
+
+				// Once the request finishes it should return to 0, on the same series
+				rm := p.collectMetrics(t)
+				m := st.FindMetricByName(rm, "http.server.active_requests")
+				require.NotNil(t, m, "active requests metric not found")
+				assertMetricHasValue(t, m, p.envName, tt.platform, 0)
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok)
+				assert.Len(t, sum.DataPoints, 1, "increment and decrement should share one attribute set")
+			})
+		})
+	}
+}
+
+// A streaming response is counted as an active request for as long as it is held open, even though its
+// duration is deliberately not recorded.
+func TestActiveRequestsIncludesStreamingResponses(t *testing.T) {
 	metricsMiddlewareTest(t, func(p metricsMiddlewareTestParams) {
-		req, _ := http.NewRequest("GET", "", nil)
+		router := mux.NewRouter()
+		router.Use(RequestMetrics(metrics.ServerDuration, metrics.EndpointTypeStream))
+		router.Handle("/stream", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+
+			rm := p.collectMetrics(t)
+			m := st.FindMetricByName(rm, "http.server.active_requests")
+			require.NotNil(t, m, "active requests metric not found")
+			assertMetricHasValue(t, m, p.envName, "server", 1)
+		})).Methods("GET")
+
+		req, _ := http.NewRequest("GET", "/stream", nil)
 		req.Header.Set("User-Agent", metricsTestUserAgent)
 		req = req.WithContext(WithEnvContextInfo(req.Context(), EnvContextInfo{Env: p.env}))
-		rr := httptest.NewRecorder()
+		router.ServeHTTP(httptest.NewRecorder(), req)
 
-		countFn(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// While inside the handler, connections should be active
-			rm := p.collectMetrics(t)
-			connMetric := st.FindMetricByName(rm, "http.server.active_requests")
-			require.NotNil(t, connMetric, "connections metric not found")
-			assertMetricHasValue(t, connMetric, p.envName, category, 1)
-		})).ServeHTTP(rr, req)
-
-		// After handler returns, connection gauge should be 0
 		rm := p.collectMetrics(t)
-		connMetric := st.FindMetricByName(rm, "http.server.active_requests")
-		require.NotNil(t, connMetric, "connections metric not found")
-		assertMetricHasValue(t, connMetric, p.envName, category, 0)
+		m := st.FindMetricByName(rm, "http.server.active_requests")
+		require.NotNil(t, m)
+		assertMetricHasValue(t, m, p.envName, "server", 0)
+
+		assert.Nil(t, st.FindMetricByName(rm, "http.server.request.duration"),
+			"duration must not be recorded for a streaming response")
 	})
+}
+
+// Requests with no environment -- the status endpoints and anything that matched no route -- still get
+// counted, reporting the not-provided sentinel for environment.name and platform.category.
+func TestUnscopedActiveRequests(t *testing.T) {
+	specs := []struct {
+		name         string
+		endpointType metrics.EndpointType
+	}{
+		{name: "status", endpointType: metrics.EndpointTypeStatus},
+		{name: "unmatched", endpointType: metrics.EndpointTypeNotProvided},
+	}
+
+	for _, tt := range specs {
+		t.Run(tt.name, func(t *testing.T) {
+			metricsMiddlewareTest(t, func(p metricsMiddlewareTestParams) {
+				handler := UnscopedActiveRequests(p.manager, tt.endpointType)(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						rm := p.collectMetrics(t)
+						m := st.FindMetricByName(rm, "http.server.active_requests")
+						require.NotNil(t, m, "active requests metric not found")
+						assertMetricHasValue(t, m, "not-provided", "not-provided", 1)
+						assertMetricHasAttribute(t, m, "relay.endpoint.type", string(tt.endpointType))
+					}))
+
+				// No environment context is attached, exactly as for a real status or unmatched request
+				req, _ := http.NewRequest("GET", "/status", nil)
+				handler.ServeHTTP(httptest.NewRecorder(), req)
+
+				rm := p.collectMetrics(t)
+				m := st.FindMetricByName(rm, "http.server.active_requests")
+				require.NotNil(t, m)
+				assertMetricHasValue(t, m, "not-provided", "not-provided", 0)
+			})
+		})
+	}
 }
 
 func TestRequestDuration(t *testing.T) {
 	router := mux.NewRouter()
-	router.Use(DurationMetrics(metrics.ServerDuration))
+	router.Use(RequestMetrics(metrics.ServerDuration, metrics.EndpointTypePoll))
 	router.Handle("/test-route", nullHandler()).Methods("GET")
 
 	metricsMiddlewareTest(t, func(p metricsMiddlewareTestParams) {
@@ -199,4 +309,17 @@ func assertMetricHasValue(t *testing.T, m *metricdata.Metrics, envName, platform
 		}
 	}
 	assert.True(t, found, "no data point found for %s with platform=%s, env=%s", m.Name, platform, envName)
+}
+
+// assertMetricHasAttribute checks that every data point of a metric carries the expected attribute value.
+func assertMetricHasAttribute(t *testing.T, m *metricdata.Metrics, key, expected string) {
+	t.Helper()
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "expected Sum[int64] data for %s", m.Name)
+	require.NotEmpty(t, sum.DataPoints)
+	for _, dp := range sum.DataPoints {
+		val, found := dp.Attributes.Value(attribute.Key(key))
+		require.True(t, found, "%s attribute not present on %s", key, m.Name)
+		assert.Equal(t, expected, val.AsString())
+	}
 }

--- a/internal/middleware/tracing_middleware.go
+++ b/internal/middleware/tracing_middleware.go
@@ -2,6 +2,9 @@ package middleware
 
 import (
 	"net/http"
+	"unicode/utf8"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/util"
 
 	"github.com/gorilla/mux"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -12,27 +15,56 @@ import (
 // must match the variable name used by the routes in relay_routes.go.
 const contextPathVar = "context"
 
-// RedactContextFromSpanPath replaces the url.path attribute of the current request span
-// with the matched route template, for routes that take an evaluation context in the path.
+// SanitizeRequestSpan corrects two problems with the attributes the HTTP tracing middleware records on
+// the request span. Attributes cannot be removed from a span once set, but they are deduplicated
+// last-write-wins when they are read, so overwriting a value here is what keeps the original out of the
+// exported trace.
 //
-// The HTTP tracing middleware records the raw request path, which on those routes holds the
-// end user's context: keys, names, emails and custom attributes. Attributes cannot be
-// removed from a span once set, but they are deduplicated last-write-wins when they are
-// read, so overwriting the value here keeps the context out of the exported trace. Nothing
-// is lost by doing so: the same middleware records the route template as http.route.
-//
+// First, url.path holds the raw request path, which on routes that take an evaluation context contains
+// the end user's data: keys, names, emails and custom attributes. Those are replaced with the matched
+// route template. Nothing is lost, since the same middleware also records the template as http.route.
 // Routes with no context variable keep their real path.
 //
+// Second, three of the recorded attributes come from request data that is not restricted to valid
+// UTF-8, and OTLP cannot serialize a span carrying an invalid byte -- the marshal fails and the whole
+// export batch is dropped. They are:
+//
+//	user_agent.original  the User-Agent header
+//	client.address       the X-Forwarded-For header, used unvalidated
+//	url.path             the percent-decoded request path
+//
+// This list is specific to the instrumentation in use and will need revisiting if it starts recording
+// further attributes from request data; TestSpanAttributesAreValidUTF8 fails if that happens.
+//
 // This must be registered after the middleware that starts the request span.
-func RedactContextFromSpanPath(next http.Handler) http.Handler {
+func SanitizeRequestSpan(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if _, hasContext := mux.Vars(r)[contextPathVar]; hasContext {
-			if span := trace.SpanFromContext(r.Context()); span.IsRecording() {
+		if span := trace.SpanFromContext(r.Context()); span.IsRecording() {
+			if _, hasContext := mux.Vars(r)[contextPathVar]; hasContext {
 				// A route that produced a path variable always has a path template.
 				template, _ := mux.CurrentRoute(r).GetPathTemplate()
 				span.SetAttributes(semconv.URLPath(template))
+			} else if !utf8.ValidString(r.URL.Path) {
+				span.SetAttributes(semconv.URLPath(util.SanitizeUTF8(r.URL.Path)))
+			}
+			if ua := r.UserAgent(); !utf8.ValidString(ua) {
+				span.SetAttributes(semconv.UserAgentOriginal(util.SanitizeUTF8(ua)))
+			}
+			if xff := r.Header.Get("X-Forwarded-For"); !utf8.ValidString(xff) {
+				span.SetAttributes(semconv.ClientAddress(util.SanitizeUTF8(clientAddressFromXFF(xff))))
 			}
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// clientAddressFromXFF mirrors how the tracing instrumentation derives client.address from
+// X-Forwarded-For: the first entry, with no validation of its contents.
+func clientAddressFromXFF(xForwardedFor string) string {
+	for i := range len(xForwardedFor) {
+		if xForwardedFor[i] == ',' {
+			return xForwardedFor[:i]
+		}
+	}
+	return xForwardedFor
 }

--- a/internal/middleware/tracing_middleware_test.go
+++ b/internal/middleware/tracing_middleware_test.go
@@ -49,7 +49,7 @@ func tracedRouter(t *testing.T, templates ...string) (*mux.Router, *tracetest.Sp
 
 	router := mux.NewRouter()
 	router.Use(otelmux.Middleware("test", otelmux.WithTracerProvider(provider)))
-	router.Use(RedactContextFromSpanPath)
+	router.Use(SanitizeRequestSpan)
 	for _, template := range templates {
 		router.HandleFunc(template, func(http.ResponseWriter, *http.Request) {}).Methods("GET")
 	}
@@ -115,7 +115,7 @@ func TestRedactionSurvivesNestedSubrouters(t *testing.T) {
 
 	router := mux.NewRouter()
 	router.Use(otelmux.Middleware("test", otelmux.WithTracerProvider(provider)))
-	router.Use(RedactContextFromSpanPath)
+	router.Use(SanitizeRequestSpan)
 	sdkRouter := router.PathPrefix("/sdk/").Subrouter()
 	pollRouter := sdkRouter.PathPrefix("/poll/eval").Subrouter()
 	pollRouter.HandleFunc("/{context}", func(http.ResponseWriter, *http.Request) {}).Methods("GET")
@@ -130,7 +130,7 @@ func TestRedactionSurvivesNestedSubrouters(t *testing.T) {
 func TestRedactionWithoutARecordingSpan(t *testing.T) {
 	handled := false
 	router := mux.NewRouter()
-	router.Use(RedactContextFromSpanPath)
+	router.Use(SanitizeRequestSpan)
 	router.HandleFunc("/meval/{context}", func(http.ResponseWriter, *http.Request) { handled = true }).Methods("GET")
 
 	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/meval/"+contextBase64, nil))

--- a/internal/relayenv/env_context_impl_test.go
+++ b/internal/relayenv/env_context_impl_test.go
@@ -312,7 +312,7 @@ func TestMetricsAreExportedForEnvironment(t *testing.T) {
 		require.NoError(t, err)
 		defer env.Close()
 		envImpl := env.(*envContextImpl)
-		metrics.WithGauge(env.GetMetricsEnv(), env.GetMetricsManager().GetInstruments(), metrics.RequestInfo{UserAgent: fakeUserAgent, Route: "/test", Method: "GET"}, func() {
+		metrics.WithStreamConnection(env.GetMetricsEnv(), metrics.RequestInfo{UserAgent: fakeUserAgent, Route: "/test", Method: "GET"}, func() {
 			require.Eventually(t, func() bool {
 				flushMetricsEvents(envImpl)
 				select {
@@ -365,7 +365,7 @@ func testMetricsDisabled(t *testing.T, allConfig config.Config) {
 		require.NoError(t, err)
 		defer env.Close()
 		envImpl := env.(*envContextImpl)
-		metrics.WithGauge(env.GetMetricsEnv(), env.GetMetricsManager().GetInstruments(), metrics.RequestInfo{UserAgent: fakeUserAgent, Route: "/test", Method: "GET"}, func() {
+		metrics.WithStreamConnection(env.GetMetricsEnv(), metrics.RequestInfo{UserAgent: fakeUserAgent, Route: "/test", Method: "GET"}, func() {
 			require.Never(t, func() bool {
 				flushMetricsEvents(envImpl)
 				select {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
+	"unicode/utf8"
 )
 
 type errorJSON struct {
@@ -47,4 +49,23 @@ func DecompressGzipData(data []byte) ([]byte, error) {
 	}
 
 	return io.ReadAll(reader)
+}
+
+// SanitizeUTF8 removes invalid UTF-8 byte sequences from v.
+//
+// OpenTelemetry serializes attribute values into OTLP protobuf string fields, and proto3 requires
+// those to be valid UTF-8. An invalid byte does not merely spoil the value: proto.Marshal fails, so
+// the entire export batch is dropped rather than just the offending span or data point. For metrics
+// that is unrecoverable, because the poisoned series is cumulative and gets re-collected on every
+// interval until the process restarts.
+//
+// This is reachable from ordinary request data. HTTP header values are not restricted to ASCII --
+// RFC 7230 permits obs-text, and Go's parser passes those bytes through unchanged -- and a
+// percent-encoded URL path decodes to arbitrary bytes. Any attribute value derived from either has to
+// pass through here.
+func SanitizeUTF8(v string) string {
+	if utf8.ValidString(v) {
+		return v
+	}
+	return strings.ToValidUTF8(v, "")
 }

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -772,7 +772,7 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 		tr := tracing.Tracer()
 
 		_, storeSpan := tr.Start(req.Context(), tracing.SpanStoreGet)
-		storeSpan.SetAttributes(tracing.StoreKeyKey.String(key))
+		storeSpan.SetAttributes(tracing.StoreKeyKey.String(util.SanitizeUTF8(key)))
 		item, err := clientContext.GetStore().Get(kind, key)
 		if err != nil {
 			storeSpan.RecordError(err)

--- a/relay/relay_endpoints_active_requests_test.go
+++ b/relay/relay_endpoints_active_requests_test.go
@@ -137,6 +137,18 @@ func TestActiveRequestsCoverAllEndpointTypes(t *testing.T) {
 			},
 			endpointType: metrics.EndpointTypeNotProvided,
 		},
+		{
+			// A path that matches a route but with the wrong method. Relay never answers 405, so this
+			// does not depend on Router.MethodNotAllowedHandler: the catch-all serverSideRouter
+			// (PathPrefix "") matches the path, which clears the pending ErrMethodMismatch
+			// (gorilla/mux route.go:69-79), and the request ends up on the not-found handler. So it is
+			// counted, and MethodNotAllowedHandler stays nil rather than changing the response code.
+			name: "wrong method on a real route",
+			buildReq: func() *http.Request {
+				return st.BuildRequest("POST", "/status", nil, nil)
+			},
+			endpointType: metrics.EndpointTypeNotProvided,
+		},
 	}
 
 	for _, tc := range cases {
@@ -178,5 +190,49 @@ func TestActiveRequestsCountLiveStream(t *testing.T) {
 		dp := requireSingleActiveRequestPoint(t, reader)
 		requireEndpointType(t, dp, metrics.EndpointTypeStream)
 		assert.Zero(t, dp.Value, "a closed stream should no longer be counted as active")
+	})
+}
+
+// TestWrongMethodIsNotFoundAndIsCounted pins down why Router.MethodNotAllowedHandler does not need the
+// same treatment as Router.NotFoundHandler. gorilla/mux does assign MethodNotAllowedHandler without
+// building the middleware chain, but that branch is unreachable in this router: the catch-all
+// serverSideRouter (PathPrefix "") matches every path, and a matcher that succeeds clears a pending
+// ErrMethodMismatch, so Match finishes with ErrNotFound instead. Relay therefore never answers 405,
+// and a wrong-method request is counted under not-provided.
+//
+// If a future change removes the catch-all subrouter, this test fails with a 405, which is the signal
+// to wrap MethodNotAllowedHandler as well.
+func TestWrongMethodIsNotFoundAndIsCounted(t *testing.T) {
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		reader := installActiveRequestReader(t, p.relay)
+
+		for _, method := range []string{"POST", "PUT", "DELETE", "PATCH"} {
+			result, _ := st.DoRequest(st.BuildRequest(method, "/status", nil, nil), p.relay)
+			assert.Equal(t, http.StatusNotFound, result.StatusCode,
+				"%s /status should be 404, not 405 -- see the comment on this test", method)
+		}
+
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &rm))
+		m := st.FindMetricByName(&rm, activeRequestsMetricName)
+		require.NotNil(t, m, "wrong-method requests were not counted at all")
+
+		sum, ok := m.Data.(metricdata.Sum[int64])
+		require.True(t, ok)
+		methods := map[string]bool{}
+		for _, dp := range sum.DataPoints {
+			endpointType, ok := dp.Attributes.Value("relay.endpoint.type")
+			require.True(t, ok)
+			assert.Equal(t, string(metrics.EndpointTypeNotProvided), endpointType.AsString())
+			if method, ok := dp.Attributes.Value("http.request.method"); ok {
+				methods[method.AsString()] = true
+			}
+		}
+		for _, method := range []string{"POST", "PUT", "DELETE", "PATCH"} {
+			assert.True(t, methods[method], "%s was not recorded in active requests", method)
+		}
 	})
 }

--- a/relay/relay_endpoints_active_requests_test.go
+++ b/relay/relay_endpoints_active_requests_test.go
@@ -1,0 +1,182 @@
+package relay
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	c "github.com/launchdarkly/ld-relay/v9/config"
+	"github.com/launchdarkly/ld-relay/v9/internal/metrics"
+	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+
+	"github.com/launchdarkly/eventsource"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const activeRequestsMetricName = "http.server.active_requests"
+
+// installActiveRequestReader swaps in reader-backed instruments for a started relay. The middleware
+// resolves instruments through the Manager per request, so this takes effect for requests made after
+// the swap.
+func installActiveRequestReader(t *testing.T, relay *Relay) sdkmetric.Reader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	instruments, err := metrics.NewInstrumentsForTest(meterProvider.Meter("ld-relay"))
+	require.NoError(t, err)
+	relay.metricsManager.SetInstrumentsForTest(instruments)
+	return reader
+}
+
+// requireSingleActiveRequestPoint collects the active requests metric and requires that it holds
+// exactly one series, returning that data point. One series per request is what proves the increment
+// and the decrement used an identical attribute set.
+func requireSingleActiveRequestPoint(t *testing.T, reader sdkmetric.Reader) metricdata.DataPoint[int64] {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	m := st.FindMetricByName(&rm, activeRequestsMetricName)
+	require.NotNil(t, m, "%s was not recorded", activeRequestsMetricName)
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "expected Sum[int64] data for %s", activeRequestsMetricName)
+	require.Len(t, sum.DataPoints, 1, "expected exactly one active requests series")
+	return sum.DataPoints[0]
+}
+
+func requireEndpointType(t *testing.T, dp metricdata.DataPoint[int64], expected metrics.EndpointType) {
+	t.Helper()
+	val, ok := dp.Attributes.Value("relay.endpoint.type")
+	require.True(t, ok, "relay.endpoint.type attribute not present")
+	assert.Equal(t, string(expected), val.AsString())
+}
+
+// TestActiveRequestsCoverAllEndpointTypes drives a representative route for each endpoint type through
+// the full relay and asserts that http.server.active_requests recorded it under the expected
+// relay.endpoint.type. Polling, event ingestion, goals and status are all included: per the OTEL
+// semantic convention this instrument counts every in-flight HTTP request, not just streams.
+func TestActiveRequestsCoverAllEndpointTypes(t *testing.T) {
+	contextJSON := []byte(`{"kind":"user","key":"me"}`)
+	contextBase64 := base64.StdEncoding.EncodeToString(contextJSON)
+
+	cases := []struct {
+		name         string
+		buildReq     func() *http.Request
+		endpointType metrics.EndpointType
+	}{
+		{
+			name: "server-side poll",
+			buildReq: func() *http.Request {
+				return st.BuildRequestWithAuth("GET", "/sdk/poll", st.EnvMain.Config.SDKKey, nil)
+			},
+			endpointType: metrics.EndpointTypePoll,
+		},
+		{
+			name: "PHP poll",
+			buildReq: func() *http.Request {
+				return st.BuildRequestWithAuth("GET", "/sdk/flags", st.EnvMain.Config.SDKKey, nil)
+			},
+			endpointType: metrics.EndpointTypePoll,
+		},
+		{
+			name: "mobile poll",
+			buildReq: func() *http.Request {
+				return st.BuildRequestWithAuth("GET", "/msdk/evalx/contexts/"+contextBase64,
+					st.EnvWithAllCredentials.Config.MobileKey, nil)
+			},
+			endpointType: metrics.EndpointTypePoll,
+		},
+		{
+			name: "client-side poll",
+			buildReq: func() *http.Request {
+				return st.BuildRequest("GET",
+					"/sdk/evalx/"+string(st.EnvClientSide.Config.EnvID)+"/contexts/"+contextBase64, nil, nil)
+			},
+			endpointType: metrics.EndpointTypePoll,
+		},
+		{
+			name: "server-side events",
+			buildReq: func() *http.Request {
+				return st.BuildRequestWithAuth("POST", "/bulk", st.EnvMain.Config.SDKKey, []byte(`[]`))
+			},
+			endpointType: metrics.EndpointTypeEvents,
+		},
+		{
+			name: "mobile events",
+			buildReq: func() *http.Request {
+				return st.BuildRequestWithAuth("POST", "/mobile/events/bulk",
+					st.EnvWithAllCredentials.Config.MobileKey, []byte(`[]`))
+			},
+			endpointType: metrics.EndpointTypeEvents,
+		},
+		{
+			name: "client-side events",
+			buildReq: func() *http.Request {
+				return st.BuildRequest("POST",
+					"/events/bulk/"+string(st.EnvClientSide.Config.EnvID), []byte(`[]`), nil)
+			},
+			endpointType: metrics.EndpointTypeEvents,
+		},
+		{
+			name: "status",
+			buildReq: func() *http.Request {
+				return st.BuildRequest("GET", "/status", nil, nil)
+			},
+			endpointType: metrics.EndpointTypeStatus,
+		},
+		{
+			name: "unmatched route",
+			buildReq: func() *http.Request {
+				return st.BuildRequest("GET", "/no/such/endpoint", nil, nil)
+			},
+			endpointType: metrics.EndpointTypeNotProvided,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var config c.Config
+			config.Environment = st.MakeEnvConfigs(st.EnvMain, st.EnvWithAllCredentials, st.EnvClientSide)
+
+			withStartedRelay(t, config, func(p relayTestParams) {
+				reader := installActiveRequestReader(t, p.relay)
+
+				st.DoRequest(tc.buildReq(), p.relay)
+
+				dp := requireSingleActiveRequestPoint(t, reader)
+				requireEndpointType(t, dp, tc.endpointType)
+				assert.Zero(t, dp.Value, "request finished, so it should no longer be counted as active")
+			})
+		})
+	}
+}
+
+// TestActiveRequestsCountLiveStream asserts that a held-open SSE connection reads as active for as long
+// as it is open, and returns to zero once it closes.
+func TestActiveRequestsCountLiveStream(t *testing.T) {
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		reader := installActiveRequestReader(t, p.relay)
+
+		req := st.BuildRequestWithAuth("GET", "/all", st.EnvMain.Config.SDKKey, nil)
+		st.WithStreamRequest(t, req, p.relay, func(events <-chan eventsource.Event) {
+			<-events // wait until the stream is established
+
+			dp := requireSingleActiveRequestPoint(t, reader)
+			requireEndpointType(t, dp, metrics.EndpointTypeStream)
+			assert.Equal(t, int64(1), dp.Value, "an open stream should be counted as an active request")
+		})
+
+		dp := requireSingleActiveRequestPoint(t, reader)
+		requireEndpointType(t, dp, metrics.EndpointTypeStream)
+		assert.Zero(t, dp.Value, "a closed stream should no longer be counted as active")
+	})
+}

--- a/relay/relay_endpoints_active_requests_test.go
+++ b/relay/relay_endpoints_active_requests_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"testing"
+	"unicode/utf8"
 
 	c "github.com/launchdarkly/ld-relay/v9/config"
 	"github.com/launchdarkly/ld-relay/v9/internal/metrics"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/launchdarkly/eventsource"
 
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
@@ -234,5 +236,64 @@ func TestWrongMethodIsNotFoundAndIsCounted(t *testing.T) {
 		for _, method := range []string{"POST", "PUT", "DELETE", "PATCH"} {
 			assert.True(t, methods[method], "%s was not recorded in active requests", method)
 		}
+	})
+}
+
+// TestRecordedAttributesAreValidUTF8 covers the whole chain from a hostile header to the recorded
+// attribute set. Attribute values are serialized into OTLP protobuf string fields, which proto3
+// requires to be valid UTF-8; one bad byte fails the marshal for the entire export batch, and because
+// these series are cumulative the failure repeats every interval until the process restarts.
+//
+// Header values are not restricted to ASCII -- RFC 7230 permits obs-text and Go's HTTP parser passes
+// those bytes through unchanged -- and the status and not-found handlers record metrics without
+// requiring credentials, so an unauthenticated caller can reach this.
+func TestRecordedAttributesAreValidUTF8(t *testing.T) {
+	const invalid = "\xff\xfe"
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		reader := installActiveRequestReader(t, p.relay)
+
+		poison := func(req *http.Request) *http.Request {
+			req.Header.Set("User-Agent", "agent-"+invalid)
+			req.Header.Set("X-LaunchDarkly-Wrapper", "wrapper-"+invalid)
+			req.Header.Set("X-LaunchDarkly-Instance-Id", "instance-"+invalid)
+			req.Header.Set("X-LaunchDarkly-Tags",
+				"application-id/app-"+invalid+" application-version/ver-"+invalid)
+			return req
+		}
+
+		// Unauthenticated first: these paths need no credentials at all.
+		st.DoRequest(poison(st.BuildRequest("GET", "/no/such/route", nil, nil)), p.relay)
+		st.DoRequest(poison(st.BuildRequest("GET", "/status", nil, nil)), p.relay)
+		// Then an authenticated request, which carries the full attribute set.
+		st.DoRequest(poison(st.BuildRequestWithAuth("GET", "/sdk/poll", st.EnvMain.Config.SDKKey, nil)), p.relay)
+
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &rm))
+
+		checked := 0
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				if !ok {
+					continue
+				}
+				for _, dp := range sum.DataPoints {
+					for _, kv := range dp.Attributes.ToSlice() {
+						if kv.Value.Type() != attribute.STRING {
+							continue
+						}
+						checked++
+						assert.True(t, utf8.ValidString(kv.Value.AsString()),
+							"%s attribute %s is not valid UTF-8: %q -- this fails the whole OTLP export batch",
+							m.Name, kv.Key, kv.Value.AsString())
+					}
+				}
+			}
+		}
+		assert.Positive(t, checked, "no string attributes were examined")
 	})
 }

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -35,7 +35,7 @@ const (
 // in metrics data under the "route" tag if Relay is configured to export metrics. Therefore, we should use
 // variable names like {envId} consistently and make sure they correspond to how the routes are shown in
 // docs/endpoints.md. The {context} variable name is also load-bearing for tracing: it is how
-// middleware.RedactContextFromSpanPath recognizes a route that carries end-user data in the path.
+// middleware.SanitizeRequestSpan recognizes a route that carries end-user data in the path.
 func (r *Relay) makeRouter() *mux.Router {
 	router := mux.NewRouter()
 	router.Use(logging.ContextLoggerMiddleware(r.logger))
@@ -44,7 +44,7 @@ func (r *Relay) makeRouter() *mux.Router {
 	}
 	router.Use(otelmux.Middleware(tracing.TracerName))
 	// Must come after the tracing middleware, which records the raw request path on the span it starts.
-	router.Use(middleware.RedactContextFromSpanPath)
+	router.Use(middleware.SanitizeRequestSpan)
 	if r.config.HTTP.EnableCompression {
 		router.Use(func(next http.Handler) http.Handler {
 			return h.GzipHandler(next)

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -50,13 +50,21 @@ func (r *Relay) makeRouter() *mux.Router {
 			return h.GzipHandler(next)
 		})
 	}
-	router.Handle("/status", statusHandler(r)).Methods("GET")
+	// Status endpoints are not scoped to a single environment, so they are tracked in
+	// http.server.active_requests without environment or platform attributes.
+	statusMetrics := middleware.UnscopedActiveRequests(r.metricsManager, metrics.EndpointTypeStatus)
+	router.Handle("/status", statusMetrics(statusHandler(r))).Methods("GET")
 	// Register more specific routes first (with /filters/ literal)
-	router.Handle("/status/{identifier}/filters/{filterKey}", singleEnvironmentStatusHandler(r)).Methods("GET")
-	router.Handle("/status/{projKey}/{envKey}/filters/{filterKey}", singleEnvironmentStatusHandler(r)).Methods("GET")
+	router.Handle("/status/{identifier}/filters/{filterKey}", statusMetrics(singleEnvironmentStatusHandler(r))).Methods("GET")
+	router.Handle("/status/{projKey}/{envKey}/filters/{filterKey}", statusMetrics(singleEnvironmentStatusHandler(r))).Methods("GET")
 	// Then register the general routes
-	router.Handle("/status/{projKey}/{envKey}", singleEnvironmentStatusHandler(r)).Methods("GET")
-	router.Handle("/status/{identifier}", singleEnvironmentStatusHandler(r)).Methods("GET")
+	router.Handle("/status/{projKey}/{envKey}", statusMetrics(singleEnvironmentStatusHandler(r))).Methods("GET")
+	router.Handle("/status/{identifier}", statusMetrics(singleEnvironmentStatusHandler(r))).Methods("GET")
+
+	// gorilla/mux does not run router middleware for a request that matched no route, so the counting
+	// for unmatched requests has to live inside the not-found handler itself.
+	router.NotFoundHandler = middleware.UnscopedActiveRequests(r.metricsManager, metrics.EndpointTypeNotProvided)(
+		http.NotFoundHandler())
 
 	environmentGetters := relayEnvironmentGetters{r}
 	sdkKeySelector := middleware.SelectEnvironmentByAuthorizationKey(basictypes.ServerSDK, environmentGetters)
@@ -70,32 +78,36 @@ func (r *Relay) makeRouter() *mux.Router {
 	)
 
 	// Client-side evaluation (for JS, not mobile)
-	jsClientSideMiddlewareStack := func(subrouter *mux.Router) mux.MiddlewareFunc {
+	// The endpointType parameter is what a request served by this stack reports as its
+	// relay.endpoint.type; the stack itself is shared across several kinds of endpoint.
+	jsClientSideMiddlewareStack := func(subrouter *mux.Router, endpointType metrics.EndpointType) mux.MiddlewareFunc {
 		return middleware.Chain(
 			mux.CORSMethodMiddleware(subrouter),
 			jsClientSelector, // selects an environment based on the client-side ID in the URL
 			middleware.CORS,  // must apply this after jsClientSelector because the CORS headers can be environment-specific
 			middleware.TrackUsageActivity(metrics.BrowserPlatformCategory),
-			middleware.DurationMetrics(metrics.BrowserDuration),
+			middleware.RequestMetrics(metrics.BrowserDuration, endpointType),
 		)
 	}
 
 	goalsRouter := router.PathPrefix("/sdk/goals").Subrouter()
-	goalsRouter.Use(jsClientSideMiddlewareStack(goalsRouter))
+	goalsRouter.Use(jsClientSideMiddlewareStack(goalsRouter, metrics.EndpointTypeGoals))
 	goalsRouter.HandleFunc("/{envId}", getGoals).Methods("GET", "OPTIONS")
 
 	clientSideSdkEvalXRouter := router.PathPrefix("/sdk/evalx/{envId}/").Subrouter()
-	clientSideSdkEvalXRouter.Use(jsClientSideMiddlewareStack(clientSideSdkEvalXRouter))
+	clientSideSdkEvalXRouter.Use(jsClientSideMiddlewareStack(clientSideSdkEvalXRouter, metrics.EndpointTypePoll))
 	clientSideSdkEvalXRouter.HandleFunc("/contexts/{context}", evaluateAllFeatureFlags(basictypes.JSClientSDK, maxClientRequestBodySize)).Methods("GET", "OPTIONS")
 	clientSideSdkEvalXRouter.HandleFunc("/context", evaluateAllFeatureFlags(basictypes.JSClientSDK, maxClientRequestBodySize)).Methods("REPORT", "OPTIONS")
 	clientSideSdkEvalXRouter.HandleFunc("/users/{context}", evaluateAllFeatureFlags(basictypes.JSClientSDK, maxClientRequestBodySize)).Methods("GET", "OPTIONS")
 	clientSideSdkEvalXRouter.HandleFunc("/user", evaluateAllFeatureFlags(basictypes.JSClientSDK, maxClientRequestBodySize)).Methods("REPORT", "OPTIONS")
 
-	serverSideMiddlewareStack := middleware.Chain(
-		sdkKeySelector,
-		middleware.TrackUsageActivity(metrics.ServerPlatformCategory),
-		middleware.DurationMetrics(metrics.ServerDuration),
-	)
+	serverSideMiddlewareStack := func(endpointType metrics.EndpointType) mux.MiddlewareFunc {
+		return middleware.Chain(
+			sdkKeySelector,
+			middleware.TrackUsageActivity(metrics.ServerPlatformCategory),
+			middleware.RequestMetrics(metrics.ServerDuration, endpointType),
+		)
+	}
 
 	sdkRouter := router.PathPrefix("/sdk/").Subrouter()
 	// (?)TODO: there is a bug in gorilla mux (see see https://github.com/gorilla/mux/pull/378) that means the middleware below
@@ -103,10 +115,10 @@ func (r *Relay) makeRouter() *mux.Router {
 	// sdkRouter.Use(sdkRouterMiddleware)
 
 	// FDv2 server-side endpoints
-	sdkRouter.Handle("/stream", serverSideMiddlewareStack(middleware.UsageActivityStreamMonitoring(metrics.ServerPlatformCategory, middleware.CountServerConns(middleware.Streaming(
+	sdkRouter.Handle("/stream", serverSideMiddlewareStack(metrics.EndpointTypeStream)(middleware.UsageActivityStreamMonitoring(metrics.ServerPlatformCategory, middleware.CountServerConns(middleware.Streaming(
 		streamHandlerV2(r.serverSideStreamProvider, serverSideStreamLogMessage),
 	))))).Methods("GET")
-	sdkRouter.Handle("/poll", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollHandlerV2)))).Methods("GET")
+	sdkRouter.Handle("/poll", serverSideMiddlewareStack(metrics.EndpointTypePoll)(middleware.ServerPollingRequestCount(http.HandlerFunc(pollHandlerV2)))).Methods("GET")
 
 	// FDv2 client-side endpoints (unified mobile + JS client)
 	clientSideFDv2EnvAuth := middleware.SelectEnvironmentByClientSideAuth(environmentGetters)
@@ -117,7 +129,7 @@ func (r *Relay) makeRouter() *mux.Router {
 		clientSideFDv2EnvAuth,
 		middleware.CORS,
 		middleware.DynamicTrackUsageActivity(),
-		middleware.DynamicDurationMetrics(),
+		middleware.DynamicRequestMetrics(metrics.EndpointTypeStream),
 	)
 	clientSideFDv2StreamRouter.Use(clientSideFDv2StreamMiddleware, middleware.Streaming)
 	clientSideFDv2PingHandler := pingStreamHandlerWithContextV2(r.mobileStreamProvider, r.jsClientStreamProvider, maxClientRequestBodySize)
@@ -130,33 +142,37 @@ func (r *Relay) makeRouter() *mux.Router {
 		clientSideFDv2EnvAuth,
 		middleware.CORS,
 		middleware.DynamicTrackUsageActivity(),
-		middleware.DynamicDurationMetrics(),
+		middleware.DynamicRequestMetrics(metrics.EndpointTypePoll),
 	)
 	clientSideFDv2PollRouter.Use(clientSideFDv2PollMiddleware)
 	clientSideFDv2PollRouter.Handle("/{context}", middleware.DynamicPollingRequestCount(http.HandlerFunc(pollEvalHandlerV2(maxClientRequestBodySize)))).Methods("GET", "OPTIONS")
 	clientSideFDv2PollRouter.Handle("", middleware.DynamicPollingRequestCount(http.HandlerFunc(pollEvalHandlerV2(maxClientRequestBodySize)))).Methods("POST", "OPTIONS")
 
+	serverSidePollStack := serverSideMiddlewareStack(metrics.EndpointTypePoll)
+
 	serverSideEvalXRouter := sdkRouter.PathPrefix("/evalx/").Subrouter()
-	serverSideEvalXRouter.Handle("/contexts/{context}", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK, maxClientRequestBodySize))))).Methods("GET")
-	serverSideEvalXRouter.Handle("/context", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK, maxClientRequestBodySize))))).Methods("REPORT")
+	serverSideEvalXRouter.Handle("/contexts/{context}", serverSidePollStack(middleware.ServerPollingRequestCount(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK, maxClientRequestBodySize))))).Methods("GET")
+	serverSideEvalXRouter.Handle("/context", serverSidePollStack(middleware.ServerPollingRequestCount(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK, maxClientRequestBodySize))))).Methods("REPORT")
 	// /users and /user are obsolete names for /contexts and /context, still used by some supported SDKs; the handler is
 	// the same, because in both cases LD accepts any valid user *or* context JSON.
-	serverSideEvalXRouter.Handle("/users/{context}", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK, maxClientRequestBodySize))))).Methods("GET")
-	serverSideEvalXRouter.Handle("/user", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK, maxClientRequestBodySize))))).Methods("REPORT")
+	serverSideEvalXRouter.Handle("/users/{context}", serverSidePollStack(middleware.ServerPollingRequestCount(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK, maxClientRequestBodySize))))).Methods("GET")
+	serverSideEvalXRouter.Handle("/user", serverSidePollStack(middleware.ServerPollingRequestCount(http.HandlerFunc(evaluateAllFeatureFlags(basictypes.ServerSDK, maxClientRequestBodySize))))).Methods("REPORT")
 
 	// PHP SDK endpoints
-	sdkRouter.Handle("/flags", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollAllFlagsHandler)))).Methods("GET")
-	sdkRouter.Handle("/flags/{key}", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollFlagHandler)))).Methods("GET")
-	sdkRouter.Handle("/segments/{key}", serverSideMiddlewareStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollSegmentHandler)))).Methods("GET")
+	sdkRouter.Handle("/flags", serverSidePollStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollAllFlagsHandler)))).Methods("GET")
+	sdkRouter.Handle("/flags/{key}", serverSidePollStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollFlagHandler)))).Methods("GET")
+	sdkRouter.Handle("/segments/{key}", serverSidePollStack(middleware.ServerPollingRequestCount(http.HandlerFunc(pollSegmentHandler)))).Methods("GET")
 
 	// Mobile evaluation
-	mobileMiddlewareStack := middleware.Chain(
-		mobileKeySelector,
-		middleware.TrackUsageActivity(metrics.MobilePlatformCategory),
-		middleware.DurationMetrics(metrics.MobileDuration))
+	mobileMiddlewareStack := func(endpointType metrics.EndpointType) mux.MiddlewareFunc {
+		return middleware.Chain(
+			mobileKeySelector,
+			middleware.TrackUsageActivity(metrics.MobilePlatformCategory),
+			middleware.RequestMetrics(metrics.MobileDuration, endpointType))
+	}
 
 	msdkRouter := router.PathPrefix("/msdk/").Subrouter()
-	msdkRouter.Use(mobileMiddlewareStack)
+	msdkRouter.Use(mobileMiddlewareStack(metrics.EndpointTypePoll))
 
 	msdkEvalXRouter := msdkRouter.PathPrefix("/evalx/").Subrouter()
 	msdkEvalXRouter.HandleFunc("/contexts/{context}", evaluateAllFeatureFlags(basictypes.MobileSDK, maxClientRequestBodySize)).Methods("GET")
@@ -167,60 +183,63 @@ func (r *Relay) makeRouter() *mux.Router {
 	msdkEvalXRouter.HandleFunc("/user", evaluateAllFeatureFlags(basictypes.MobileSDK, maxClientRequestBodySize)).Methods("REPORT")
 
 	mobileStreamRouter := router.PathPrefix("/meval").Subrouter()
-	mobileStreamRouter.Use(mobileMiddlewareStack, middleware.Streaming)
+	mobileStreamRouter.Use(mobileMiddlewareStack(metrics.EndpointTypeStream), middleware.Streaming)
 	mobilePingWithUser := pingStreamHandlerWithContextV1(basictypes.MobileSDK, maxClientRequestBodySize, r.mobileStreamProvider)
 	mobileStreamRouter.Handle("", middleware.UsageActivityStreamMonitoring(metrics.MobilePlatformCategory, middleware.CountMobileConns(mobilePingWithUser))).Methods("REPORT")
 	mobileStreamRouter.Handle("/{context}", middleware.UsageActivityStreamMonitoring(metrics.MobilePlatformCategory, middleware.CountMobileConns(mobilePingWithUser))).Methods("GET")
 
-	router.Handle("/mping", mobileMiddlewareStack(
+	router.Handle("/mping", mobileMiddlewareStack(metrics.EndpointTypeStream)(
 		middleware.UsageActivityStreamMonitoring(metrics.MobilePlatformCategory, middleware.CountMobileConns(middleware.Streaming(pingStreamHandlerV1(r.mobileStreamProvider)))))).Methods("GET")
 
 	jsPing := pingStreamHandlerV1(r.jsClientStreamProvider)
 	jsPingWithUser := pingStreamHandlerWithContextV1(basictypes.JSClientSDK, maxClientRequestBodySize, r.jsClientStreamProvider)
 
 	clientSidePingRouter := router.PathPrefix("/ping/{envId}").Subrouter()
-	clientSidePingRouter.Use(jsClientSideMiddlewareStack(clientSidePingRouter), middleware.Streaming)
+	clientSidePingRouter.Use(jsClientSideMiddlewareStack(clientSidePingRouter, metrics.EndpointTypeStream), middleware.Streaming)
 	clientSidePingRouter.Handle("", middleware.UsageActivityStreamMonitoring(metrics.BrowserPlatformCategory, middleware.CountBrowserConns(jsPing))).Methods("GET", "OPTIONS")
 
 	clientSideStreamEvalRouter := router.PathPrefix("/eval/{envId}").Subrouter()
-	clientSideStreamEvalRouter.Use(jsClientSideMiddlewareStack(clientSideStreamEvalRouter), middleware.Streaming)
+	clientSideStreamEvalRouter.Use(jsClientSideMiddlewareStack(clientSideStreamEvalRouter, metrics.EndpointTypeStream), middleware.Streaming)
 	// For now we implement eval as simply ping
 	clientSideStreamEvalRouter.Handle("/{context}", middleware.UsageActivityStreamMonitoring(metrics.BrowserPlatformCategory, middleware.CountBrowserConns(jsPingWithUser))).Methods("GET", "OPTIONS")
 	clientSideStreamEvalRouter.Handle("", middleware.UsageActivityStreamMonitoring(metrics.BrowserPlatformCategory, middleware.CountBrowserConns(jsPingWithUser))).Methods("REPORT", "OPTIONS")
 
 	mobileEventsRouter := router.PathPrefix("/mobile").Subrouter()
-	mobileEventsRouter.Use(mobileMiddlewareStack, middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.MobilePlatformCategory))
+	mobileEventsRouter.Use(mobileMiddlewareStack(metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.MobilePlatformCategory))
 	mobileEventsRouter.Handle("/events/bulk", bulkEventHandler(basictypes.MobileSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST")
 	mobileEventsRouter.Handle("/events", bulkEventHandler(basictypes.MobileSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST")
 	mobileEventsRouter.Handle("", bulkEventHandler(basictypes.MobileSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST")
 	mobileEventsRouter.Handle("/events/diagnostic", bulkEventHandler(basictypes.MobileSDK, ldevents.DiagnosticEventDataKind, offlineMode)).Methods("POST")
 
 	clientSideBulkEventsRouter := router.PathPrefix("/events/bulk/{envId}").Subrouter()
-	clientSideBulkEventsRouter.Use(jsClientSideMiddlewareStack(clientSideBulkEventsRouter), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.BrowserPlatformCategory))
+	clientSideBulkEventsRouter.Use(jsClientSideMiddlewareStack(clientSideBulkEventsRouter, metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.BrowserPlatformCategory))
 	clientSideBulkEventsRouter.Handle("", bulkEventHandler(basictypes.JSClientSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST", "OPTIONS")
 
 	clientSideDiagnosticEventsRouter := router.PathPrefix("/events/diagnostic/{envId}").Subrouter()
-	clientSideDiagnosticEventsRouter.Use(jsClientSideMiddlewareStack(clientSideBulkEventsRouter), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.BrowserPlatformCategory))
+	clientSideDiagnosticEventsRouter.Use(jsClientSideMiddlewareStack(clientSideBulkEventsRouter, metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.BrowserPlatformCategory))
 	clientSideDiagnosticEventsRouter.Handle("", bulkEventHandler(basictypes.JSClientSDK, ldevents.DiagnosticEventDataKind, offlineMode)).Methods("POST", "OPTIONS")
 
 	clientSideImageEventsRouter := router.PathPrefix("/a/{envId}.gif").Subrouter()
-	clientSideImageEventsRouter.Use(jsClientSideMiddlewareStack(clientSideImageEventsRouter))
+	clientSideImageEventsRouter.Use(jsClientSideMiddlewareStack(clientSideImageEventsRouter, metrics.EndpointTypeEvents))
 	clientSideImageEventsRouter.HandleFunc("", getEventsImage).Methods("GET", "OPTIONS")
 
 	serverSideRouter := router.PathPrefix("").Subrouter()
-	serverSideRouter.Use(serverSideMiddlewareStack)
 
+	// This subrouter carries both event ingestion and streaming endpoints, which report different
+	// endpoint types, so the middleware stack is applied per endpoint group instead of to the whole
+	// subrouter.
 	serverSideBulkEventsRouter := serverSideRouter.NewRoute().Subrouter()
-	serverSideBulkEventsRouter.Use(middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.ServerPlatformCategory))
+	serverSideBulkEventsRouter.Use(serverSideMiddlewareStack(metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.ServerPlatformCategory))
 	serverSideBulkEventsRouter.Handle("/bulk", bulkEventHandler(basictypes.ServerSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST")
 	serverSideBulkEventsRouter.Handle("/diagnostic", bulkEventHandler(basictypes.ServerSDK, ldevents.DiagnosticEventDataKind, offlineMode)).Methods("POST")
 
-	serverSideRouter.Handle("/all", middleware.UsageActivityStreamMonitoring(metrics.ServerPlatformCategory, middleware.CountServerConns(middleware.Streaming(
+	serverSideStreamStack := serverSideMiddlewareStack(metrics.EndpointTypeStream)
+	serverSideRouter.Handle("/all", serverSideStreamStack(middleware.UsageActivityStreamMonitoring(metrics.ServerPlatformCategory, middleware.CountServerConns(middleware.Streaming(
 		streamHandlerV1(r.serverSideStreamProvider, serverSideStreamLogMessage),
-	)))).Methods("GET")
-	serverSideRouter.Handle("/flags", middleware.UsageActivityStreamMonitoring(metrics.ServerPlatformCategory, middleware.CountServerConns(middleware.Streaming(
+	))))).Methods("GET")
+	serverSideRouter.Handle("/flags", serverSideStreamStack(middleware.UsageActivityStreamMonitoring(metrics.ServerPlatformCategory, middleware.CountServerConns(middleware.Streaming(
 		streamHandlerV1(r.serverSideFlagsStreamProvider, serverSideFlagsOnlyStreamLogMessage),
-	)))).Methods("GET")
+	))))).Methods("GET")
 
 	return router
 }

--- a/relay/relay_tracing_privacy_test.go
+++ b/relay/relay_tracing_privacy_test.go
@@ -5,9 +5,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"unicode/utf8"
 
 	c "github.com/launchdarkly/ld-relay/v9/config"
 	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,7 +19,7 @@ import (
 // TestEndUserContextIsNotExportedInSpans drives the polling routes that take an evaluation
 // context in the path through a real relay, and asserts that no span produced while handling
 // the request carries the context anywhere in its attributes. The HTTP tracing middleware
-// records the raw request path, so without middleware.RedactContextFromSpanPath the base64
+// records the raw request path, so without middleware.SanitizeRequestSpan the base64
 // context - keys, names, emails, custom attributes - is exported to the tracing backend.
 //
 // The streaming eval routes carry a context in the path too; they are covered by the
@@ -100,5 +103,59 @@ func TestEndUserContextIsNotExportedInSpans(t *testing.T) {
 				assert.NotContains(t, root.Name(), contextBase64)
 			})
 		}
+	})
+}
+
+// TestSpanAttributesAreValidUTF8 drives hostile request data through the relay and asserts that no span
+// field carries invalid UTF-8. OTLP cannot serialize such a span: the marshal fails and the whole export
+// batch is dropped, so one bad request costs every span batched alongside it.
+//
+// This deliberately checks *every* string attribute rather than the three the tracing instrumentation
+// is known to derive from request data (user_agent.original, client.address, url.path). If it starts
+// recording another one, this fails and points at what SanitizeRequestSpan has to cover.
+func TestSpanAttributesAreValidUTF8(t *testing.T) {
+	const invalid = "\xff\xfe"
+
+	recorder := installSpanRecorder(t)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		poison := func(req *http.Request) *http.Request {
+			req.Header.Set("User-Agent", "agent-"+invalid)
+			req.Header.Set("X-Forwarded-For", "1.2.3.4"+invalid+", 5.6.7.8")
+			return req
+		}
+
+		requests := []*http.Request{
+			// Unauthenticated, and the path variable decodes to invalid bytes.
+			poison(st.BuildRequest("GET", "/status/%ff%fe", nil, nil)),
+			poison(st.BuildRequest("GET", "/status", nil, nil)),
+			// Authenticated: exercises relay.store.key, which comes from a decoded path variable.
+			poison(st.BuildRequestWithAuth("GET", "/sdk/flags/%ff%fe", st.EnvMain.Config.SDKKey, nil)),
+			poison(st.BuildRequestWithAuth("GET", "/sdk/poll", st.EnvMain.Config.SDKKey, nil)),
+		}
+		for _, req := range requests {
+			st.DoRequest(req, p.relay)
+		}
+
+		spans := recorder.Ended()
+		require.NotEmpty(t, spans, "no spans were recorded")
+
+		checked := 0
+		for _, s := range spans {
+			assert.True(t, utf8.ValidString(s.Name()), "span name is not valid UTF-8: %q", s.Name())
+			for _, kv := range s.Attributes() {
+				if kv.Value.Type() != attribute.STRING {
+					continue
+				}
+				checked++
+				assert.True(t, utf8.ValidString(kv.Value.AsString()),
+					"span %q attribute %s is not valid UTF-8: %q -- this fails the whole OTLP export batch",
+					s.Name(), kv.Key, kv.Value.AsString())
+			}
+		}
+		assert.Positive(t, checked, "no string attributes were examined")
 	})
 }


### PR DESCRIPTION
## Summary

The OTEL semantic convention defines `http.server.active_requests` as *"Number of active HTTP server requests"* (confirmed in `otel@v1.44.0/semconv/v1.26.0/metric.go`); its required attributes are `http.request.method` and `url.scheme`, and nothing in the definition is streaming-specific. Relay only incremented it inside the `CountServerConns` / `CountBrowserConns` / `CountMobileConns` / `CountClientConns` wrappers, which are applied to the SSE handlers only, so polling, event ingestion, goals, the gif pixel, status, and unmatched requests were all invisible.

The code and docs already disagreed about this: the instrument description in `internal/metrics/metrics.go` already read "Number of active HTTP server requests" while `docs/metrics.md` described "currently active stream connections from SDKs".

Active-request tracking moves out of the `CountXConns` wrappers into a `RequestMetrics` middleware. That middleware is the former `DurationMetrics`, renamed because it now does both; it already sat in all five middleware stacks after the environment selector, so every SDK endpoint is now counted with the correct `environment.name` and `platform.category`. Duration keeps its existing exclusion of streaming responses, whose lifetime is unbounded.

`CountXConns` is reduced to feeding only the stream-connection counts Relay reports back to LaunchDarkly. LaunchDarkly's notion of a "connection" is a held-open stream, so counting polls or event posts there would misreport usage. A test asserts these wrappers leave the active-requests instrument untouched, guarding against double counting.

Status endpoints and requests that matched no route have no environment, so they are tracked through a separate `UnscopedActiveRequests` middleware and report the `not-provided` sentinel for the environment and SDK attributes. For unmatched requests this is applied to the router's `NotFoundHandler` rather than registered with `Router.Use`, because gorilla/mux skips middleware entirely when a request matches no route (`mux.go:138-148`).

A new `relay.endpoint.type` attribute makes the broadened metric usable, with values `stream`, `poll`, `events`, `goals`, `status`, and `not-provided`. It is parameterized at each route registration site rather than inferred from the route template, so a route added later cannot be silently mislabeled. Two of the five stacks became functions of the endpoint type and `jsClientSideMiddlewareStack` gained a parameter; one structural change was needed, because `serverSideRouter.Use(serverSideMiddlewareStack)` covered both `/bulk` + `/diagnostic` (events) and `/all` + `/flags` (stream), so the stack is now applied per endpoint group instead of to the whole subrouter. Middleware ordering is preserved.

The attribute also lands on `http.server.request.duration` and `launchdarkly.relay.events.received.size`, which share the attribute builders. This adds no new series, since the endpoint type is functionally determined by `http.route`, which is already an attribute on both.

The increment and decrement share one pre-built attribute set; a mismatch between them would leak a permanently non-zero series.

### Notes for reviewers

- Filtering to `relay.endpoint.type=stream` reproduces the previous, streams-only meaning of this metric.
- Only streams stay open long enough to register as concurrent. Polls and event posts finish in microseconds, so their gauge sits at 0 between requests; the value is in the series existing at all, and in being able to break the metric down.
- A failed auth (401) is still not counted: the environment selector rejects the request before the metrics middleware runs.
- Relay never answers 405, so there is no method-mismatch gap. A wrong method falls through the catch-all `serverSideRouter` (`PathPrefix("")`) to the not-found handler and is counted as `not-provided`.

Closes SDK-2892

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Broadens `http.server.active_requests` to cover **every in-flight request** (poll, events, goals, status, unmatched), matching the OTEL semantic convention. Previously only SSE handlers incremented it.
> 
> Active-request tracking moves into renamed `RequestMetrics` middleware (formerly `DurationMetrics`). Stream wrappers (`CountXConns`) now only feed LaunchDarkly usage reporting, avoiding double-counting. A new `relay.endpoint.type` attribute (`stream`/`poll`/`events`/`goals`/`status`/`not-provided`) keeps the metric filterable; filtering to `stream` restores the old meaning.
> 
> Status and unmatched routes use `UnscopedActiveRequests` with `not-provided` for environment/SDK attributes. Also strips invalid UTF-8 from metric and span attributes so a hostile header cannot poison an entire OTLP export batch, and skips instrument/attribute construction when OpenTelemetry is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2339bdbdf49a8893ce32030a6692bb18b0a19f16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->