### PR TITLE
feat: add Closed() to the init-concurrency limiter

### DIFF
--- a/internal/concurrency/limiter.go
+++ b/internal/concurrency/limiter.go
@@ -196,6 +196,20 @@ func (l *Limiter) Close() {
 	l.closeOnce.Do(func() { close(l.shutdown) })
 }
 
+// Closed reports whether Close has stopped admissions. Callers use it to tell a shutdown
+// rejection apart from a full budget, so shutdown does not read as saturation.
+func (l *Limiter) Closed() bool {
+	if !l.Enabled() {
+		return false
+	}
+	select {
+	case <-l.shutdown:
+		return true
+	default:
+		return false
+	}
+}
+
 // Stats snapshots the limiter's counters.
 func (l *Limiter) Stats() Stats {
 	if !l.Enabled() {

--- a/internal/concurrency/limiter_test.go
+++ b/internal/concurrency/limiter_test.go
@@ -398,6 +398,24 @@ func TestWaitingReportsParkedCallersNotOccupancy(t *testing.T) {
 	l.inFlight.Add(-1)
 }
 
+func TestClosedReportsShutdown(t *testing.T) {
+	l := New("t", Params{MaxConcurrent: 1, MaxQueued: 1})
+	if l.Closed() {
+		t.Fatal("open limiter must not report closed")
+	}
+	l.Close()
+	if !l.Closed() {
+		t.Fatal("closed limiter must report closed")
+	}
+	var nilL *Limiter
+	if nilL.Closed() {
+		t.Fatal("nil limiter must not report closed")
+	}
+	if New("d", Params{}).Closed() {
+		t.Fatal("disabled limiter must not report closed")
+	}
+}
+
 func TestCloseUnblocksWaiters(t *testing.T) {
 	// The quiescent case: no slot is released while Close runs (the racing case is
 	// TestCloseBeatsARacingRelease).


### PR DESCRIPTION
Adds `Limiter.Closed()`, reporting whether `Close` has stopped admissions. Callers that log or branch on a rejected acquisition use it to tell a shutdown rejection apart from a full budget, so a normal Relay shutdown does not read as saturation. A nil or disabled limiter reports false.

Covered by a test for the open, closed, nil, and disabled cases.

Extracted verbatim from the wiring PR (#782) so that PR can stay wiring-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`Limiter.Closed()`**, which reports whether `Close` has closed the admission barrier (via the existing `shutdown` channel). Callers that log or branch on failed `Acquire` can use it so **normal shutdown rejections are not mistaken for saturation**.
> 
> **Nil and disabled limiters always return false**, matching the idea that they are not in a “shut down” admission state.
> 
> Adds **`TestClosedReportsShutdown`** covering open, after `Close`, nil, and disabled limiters. No wiring changes in this PR (intended for a follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09e2e4a704ae8057247d9a623e185b5a4ddf3867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review order

Split out of #782, which stays in draft until these merge:

1. #803 — limiter `Closed()`
2. #804 — initwrite `Cut()` + exported write slack
3. #805 — init-concurrency HTTP middleware
4. #806 — shared budget construction from config (depends on #804; the other three are mutually independent)

After these merge, #782 rebases down to the wiring: stream-provider integration, poll routes and endpoints, and docs.
