### PR TITLE
feat: add Cut() to the init-delivery writer and export its write slack

### DIFF
--- a/internal/initwrite/initwrite.go
+++ b/internal/initwrite/initwrite.go
@@ -69,6 +69,11 @@ import (
 	"time"
 )
 
+// WriteSlack is the fixed allowance added to each per-write deadline. It is exported so a
+// caller that configures an absolute delivery cap can keep that cap at or above it; a cap
+// below the slack would expire before even a small first write.
+const WriteSlack = 5 * time.Second
+
 const (
 	// minBytesPerSec is the throughput floor a full-size chunk must sustain.
 	minBytesPerSec = 64 * 1024
@@ -77,7 +82,7 @@ const (
 	// time rather than the whole payload at once.
 	chunkSize = 1 << 20 // 1 MiB
 	// slack is added to each per-write deadline to tolerate a brief stall.
-	slack = 5 * time.Second
+	slack = WriteSlack
 	// minExtension avoids a SetWriteDeadline syscall for a trivially small change.
 	minExtension = 100 * time.Millisecond
 )
@@ -98,6 +103,11 @@ type Writer struct {
 	// gen identifies the current gated delivery. Begin bumps it so a teardown (the end-of-batch
 	// flush) that observed an earlier delivery cannot clear the deadline of a newer one.
 	gen uint64
+	// cut records that the connection was cut because its client is gone. The flag is
+	// terminal -- Begin does not clear it -- so a cut that lands between a slot acquisition
+	// and Begin is not lost: the delivery that then begins fails on its first write instead
+	// of draining. arm must never grant a cut delivery a fresh budget.
+	cut bool
 	// done is closed once the current gated delivery ends. It is never nil: outside a delivery
 	// it is a closed channel, so a producer waiting on it releases its slot immediately rather
 	// than blocking forever. doneClosed guards against a double close.
@@ -211,6 +221,28 @@ func (w *Writer) waitAndFinish(ctx context.Context, done <-chan struct{}) {
 	}
 }
 
+// Cut marks the connection as cut: the delivery in progress -- or the next one to begin --
+// has its writes fail at once instead of draining until a per-chunk deadline, because the
+// client is gone. The mark is terminal; there is no way back. With a delivery in progress
+// the write deadline moves to now immediately; otherwise the deadline is left alone (so a
+// connection that never carried a gated delivery still closes gracefully) and the first
+// write of a later delivery applies it instead.
+//
+// A write deadline is a capability scoped to the handler's lifetime (see the package
+// comment), so Cut must be called only from the handler goroutine, or from a goroutine that
+// provably cannot outlive the handler. The producer goroutine must never call it.
+func (w *Writer) Cut() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.cut {
+		return
+	}
+	w.cut = true
+	if w.active {
+		_ = w.rc.SetWriteDeadline(w.now())
+	}
+}
+
 // Unwrap exposes the wrapped ResponseWriter so http.NewResponseController and other wrappers
 // can reach the underlying connection through this one.
 func (w *Writer) Unwrap() http.ResponseWriter { return w.ResponseWriter }
@@ -312,6 +344,12 @@ func (w *Writer) arm(n int) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if !w.active {
+		return
+	}
+	if w.cut {
+		// The connection is cut: this delivery must fail now, not get a fresh budget. This
+		// runs on the handler goroutine, so it may touch the deadline.
+		_ = w.rc.SetWriteDeadline(w.now())
 		return
 	}
 	now := w.now()

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -813,6 +813,76 @@ func TestFlushTearsDownOnNonFlusherChain(t *testing.T) {
 	assertClosed(t, w.Done(), "teardown must release the waiter without a Flusher")
 }
 
+func TestCutMovesDeadlineToNowAndStaysCut(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize)) // arms start+21s
+	require.NoError(t, err)
+
+	w.Cut()
+	armed := base.armed()
+	require.Len(t, armed, 2)
+	assert.Equal(t, c.now(), armed[1], "Cut must move the deadline to now")
+
+	// A later chunk of the same delivery must never get a fresh budget: every deadline after
+	// the cut is "now", not a future instant. (The write itself passes through; the transport
+	// fails it in production.)
+	c.advance(time.Second)
+	_, err = w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	armed = base.armed()
+	assert.Equal(t, c.now(), armed[len(armed)-1], "a write after the cut must re-assert now, never a future budget")
+
+	// Idempotent: a second Cut adds nothing.
+	before := len(base.armed())
+	w.Cut()
+	assert.Len(t, base.armed(), before)
+}
+
+func TestCutIsTerminalForTheConnection(t *testing.T) {
+	base := newDeadlineConn()
+	w, c := wrapClocked(base, 2*time.Minute, true)
+
+	// A cut that lands before Begin -- the watcher firing in the window between a slot
+	// acquisition and the delivery's start -- must not be lost, but it must also not touch
+	// the deadline yet: a connection with no gated delivery still closes gracefully.
+	w.Cut()
+	require.Empty(t, base.armed(), "a cut with no delivery in progress must leave the deadline alone")
+
+	// The delivery that then begins fails on its first write instead of getting a budget.
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	armed := base.armed()
+	require.Len(t, armed, 1)
+	assert.Equal(t, c.now(), armed[0], "a delivery begun after the cut must arm now, not a fresh budget")
+}
+
+func TestCutRacesWritesSafely(t *testing.T) {
+	// The watcher calls Cut from its own goroutine while the handler is writing; the race
+	// detector pins the lock discipline between them.
+	w := WrapGated(&syncConn{}, 2*time.Minute)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			w.Begin()
+			_, _ = w.Write([]byte("data: x\n\n"))
+			w.End()
+			w.Flush()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			w.Cut()
+		}
+	}()
+	wg.Wait()
+}
+
 func TestReBeginReleasesPriorWaiter(t *testing.T) {
 	base := newDeadlineConn()
 	w := WrapGated(base, time.Minute)

--- a/relay/concurrency.go
+++ b/relay/concurrency.go
@@ -1,0 +1,100 @@
+package relay
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/config"
+	"github.com/launchdarkly/ld-relay/v9/internal/concurrency"
+	"github.com/launchdarkly/ld-relay/v9/internal/initwrite"
+)
+
+// defaultInitSendTimeout is the absolute cap on how long a single gated delivery may hold a
+// slot. It is generous because the throughput floor (see internal/initwrite) does the
+// fast-stall detection; this only backstops a client that stays right at the floor on a very
+// large payload.
+const defaultInitSendTimeout = 2 * time.Minute
+
+const (
+	// maxInitMaxConcurrent bounds the slot count. Each slot represents one resident full
+	// payload, and the limiter fills one token per slot at construction, so an absurd value
+	// (for example 2^31) stalls startup for close to a minute and promises memory the host
+	// cannot have. Values above this are treated as misconfiguration and clamped.
+	maxInitMaxConcurrent = 65536
+	// maxInitMaxQueued bounds the queue. Each queued request holds an open connection and
+	// its goroutines while it waits, so a bound far beyond any real client population only
+	// hides a misconfiguration.
+	maxInitMaxQueued = 1_000_000
+	// minInitSendTimeout is the smallest usable delivery cap. The write deadline adds
+	// initwrite.WriteSlack per write; a cap below that expires before even a small first
+	// write, which would cut every delivery.
+	minInitSendTimeout = initwrite.WriteSlack
+)
+
+// initConcurrency holds Relay's shared initialization-delivery budget. Every poll and
+// every full-basis stream replay -- across FDv1 and FDv2 -- draws from this one
+// limiter, because they all contend for the same resident payload memory and egress
+// bandwidth. Cheap operations (FDv2 up-to-date replies, deltas, heartbeats, pings) are
+// never gated.
+type initConcurrency struct {
+	limiter     *concurrency.Limiter
+	sendTimeout time.Duration
+}
+
+// newInitConcurrency builds the shared budget from the [Concurrency] config, clamping
+// nonsensical values rather than failing so a bad edit can't crashloop the Relay. Each
+// clamp logs a warning with the value it applied. A MaxConcurrent that is unset or <=0
+// yields a disabled (pass-through) limiter.
+func newInitConcurrency(c config.ConcurrencyConfig, log *slog.Logger) initConcurrency {
+	maxConcurrent := c.MaxConcurrent.GetOrElse(0)
+	if maxConcurrent > maxInitMaxConcurrent {
+		log.Warn("INIT_MAX_CONCURRENT is beyond the supported range; clamping",
+			"configured", maxConcurrent, "effective", maxInitMaxConcurrent)
+		maxConcurrent = maxInitMaxConcurrent
+	}
+
+	maxQueued := c.MaxQueued.GetOrElse(0)
+	if maxQueued < 0 {
+		log.Warn("INIT_MAX_QUEUED is negative; treating it as 0 (no queue)",
+			"configured", maxQueued)
+		maxQueued = 0
+	}
+	if maxQueued > maxInitMaxQueued {
+		log.Warn("INIT_MAX_QUEUED is beyond the supported range; clamping",
+			"configured", maxQueued, "effective", maxInitMaxQueued)
+		maxQueued = maxInitMaxQueued
+	}
+
+	// A zero or negative timeout (unset, or explicitly 0) falls back to the default so both
+	// the poll and stream paths get a consistent, non-zero deadline rather than none. A tiny
+	// timeout is clamped up: below the writer's per-write slack it would cut every delivery.
+	sendTimeout := c.SendTimeout.GetOrElse(defaultInitSendTimeout)
+	if sendTimeout <= 0 {
+		sendTimeout = defaultInitSendTimeout
+	} else if sendTimeout < minInitSendTimeout {
+		log.Warn("INIT_SEND_TIMEOUT is too small to deliver anything; clamping",
+			"configured", sendTimeout, "effective", minInitSendTimeout)
+		sendTimeout = minInitSendTimeout
+	}
+
+	return initConcurrency{
+		limiter: concurrency.New("init_delivery", concurrency.Params{
+			MaxConcurrent: maxConcurrent,
+			MaxQueued:     maxQueued,
+		}),
+		sendTimeout: sendTimeout,
+	}
+}
+
+func (ic initConcurrency) close() {
+	ic.limiter.Close()
+}
+
+// logEnabled emits an info line describing the effective budget when it is active.
+func (ic initConcurrency) logEnabled(log *slog.Logger) {
+	if ic.limiter.Enabled() {
+		s := ic.limiter.Stats()
+		log.Info("initialization-delivery concurrency limit enabled (shared by polls and full-basis stream replays)",
+			"maxConcurrent", s.MaxConcurrent, "maxQueued", s.MaxQueued, "sendTimeout", ic.sendTimeout)
+	}
+}

--- a/relay/concurrency_test.go
+++ b/relay/concurrency_test.go
@@ -1,0 +1,137 @@
+package relay
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/config"
+
+	ct "github.com/launchdarkly/go-configtypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingHandler struct{ recs *[]slog.Record }
+
+func (h recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.recs = append(*h.recs, r)
+	return nil
+}
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func warnCount(recs []slog.Record) int {
+	n := 0
+	for _, r := range recs {
+		if r.Level == slog.LevelWarn {
+			n++
+		}
+	}
+	return n
+}
+
+func optInt(v int) ct.OptInt { return ct.NewOptInt(v) }
+
+func optDuration(v time.Duration) ct.OptDuration { return ct.NewOptDuration(v) }
+
+func TestInitConcurrencyInRangeValuesPassThrough(t *testing.T) {
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(16),
+		MaxQueued:     optInt(100),
+		SendTimeout:   optDuration(45 * time.Second),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	s := ic.limiter.Stats()
+	assert.Equal(t, 16, s.MaxConcurrent)
+	assert.Equal(t, 100, s.MaxQueued)
+	assert.Equal(t, 45*time.Second, ic.sendTimeout)
+	assert.Zero(t, warnCount(recs), "in-range values must not warn")
+}
+
+func TestInitConcurrencyUnsetIsDisabledWithDefaults(t *testing.T) {
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.False(t, ic.limiter.Enabled())
+	assert.Equal(t, defaultInitSendTimeout, ic.sendTimeout)
+	assert.Zero(t, warnCount(recs))
+}
+
+func TestInitConcurrencyClampsHugeMaxConcurrent(t *testing.T) {
+	// The limiter fills one token per slot at construction, so an absurd slot count would
+	// stall startup for close to a minute; the clamp must keep construction fast.
+	var recs []slog.Record
+	start := time.Now()
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(1 << 30),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Less(t, time.Since(start), 5*time.Second, "construction must not stall on a huge slot count")
+	assert.Equal(t, maxInitMaxConcurrent, ic.limiter.Stats().MaxConcurrent)
+	assert.Equal(t, 1, warnCount(recs), "the clamp must be visible in the log")
+}
+
+func TestInitConcurrencyClampsHugeMaxQueued(t *testing.T) {
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(4),
+		MaxQueued:     optInt(1 << 30),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Equal(t, maxInitMaxQueued, ic.limiter.Stats().MaxQueued)
+	assert.Equal(t, 1, warnCount(recs))
+}
+
+func TestInitConcurrencyNegativeMaxQueuedWarnsAndDisablesQueue(t *testing.T) {
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(1),
+		MaxQueued:     optInt(-5),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Equal(t, 0, ic.limiter.Stats().MaxQueued)
+	assert.Equal(t, 1, warnCount(recs))
+
+	// With no queue, a second caller is rejected while the slot is held.
+	release, ok := ic.limiter.Acquire(context.Background())
+	require.True(t, ok)
+	defer release()
+	if _, ok2 := ic.limiter.Acquire(context.Background()); ok2 {
+		t.Fatal("expected rejection with the queue disabled")
+	}
+}
+
+func TestInitConcurrencyClampsTinySendTimeout(t *testing.T) {
+	// A cap below the writer's per-write slack expires before even a small first write and
+	// would cut every delivery; the clamp keeps the cap usable.
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(4),
+		SendTimeout:   optDuration(time.Millisecond),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Equal(t, minInitSendTimeout, ic.sendTimeout)
+	assert.Equal(t, 1, warnCount(recs))
+}
+
+func TestInitConcurrencyZeroSendTimeoutUsesDefaultQuietly(t *testing.T) {
+	// Zero means "unset": it takes the default and is not a misconfiguration.
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(4),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Equal(t, defaultInitSendTimeout, ic.sendTimeout)
+	assert.Zero(t, warnCount(recs))
+}

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -68,6 +68,7 @@ type Relay struct {
 	archiveManager                filedata.ArchiveManagerInterface
 	config                        config.Config
 	logger                        *slog.Logger
+	initConcurrency               initConcurrency
 }
 
 // ClientFactoryFunc is a function that can be used with NewRelay to specify custom behavior when
@@ -145,6 +146,12 @@ func newRelayInternal(c config.Config, options relayInternalOptions) (*Relay, er
 
 	userAgent := "LDRelay/" + version.Version
 
+	// The shared initialization-delivery budget bounds concurrent full-dataset writes
+	// (polls + full-basis stream replays) so a reconnect herd can't pin unbounded memory
+	// or egress. Disabled by default.
+	initConc := newInitConcurrency(c.Concurrency, logger)
+	initConc.logEnabled(logger)
+
 	r := &Relay{
 		envsByCredential:              NewEnvironmentLookup(),
 		serverSideStreamProvider:      streams.NewStreamProvider(basictypes.ServerSideStream, maxConnTime, 0),
@@ -159,6 +166,7 @@ func newRelayInternal(c config.Config, options relayInternalOptions) (*Relay, er
 		envLogNameMode:                logNameMode,
 		config:                        c,
 		logger:                        logger,
+		initConcurrency:               initConc,
 	}
 
 	thingsToCleanUp.AddCloser(r)
@@ -336,6 +344,8 @@ func (r *Relay) Close() error {
 	for _, sp := range r.allStreamProviders() {
 		sp.Close()
 	}
+
+	r.initConcurrency.close()
 
 	return nil
 }


### PR DESCRIPTION
Two additions to the progress-aware write-deadline writer, both needed by consumers of the initialization-delivery budget:

**`Writer.Cut()`** marks the connection as cut because its client is gone: the delivery in progress — or the next one to begin — has its writes fail at once instead of draining until a per-chunk deadline. The mark is terminal, and it is not lost if it lands between a slot acquisition and `Begin`: the delivery that then begins fails on its first write instead of getting a fresh budget. Because a write deadline is a capability scoped to the handler's lifetime (see the package comment), `Cut` must be called only from the handler goroutine or one that provably cannot outlive it.

Without a cut, a half-closed client's blocked write keeps draining until its per-chunk deadline expires — and a reconnect loop of such clients could keep many payloads resident while holding no slots.

**`WriteSlack`** exports the fixed per-write deadline allowance, so a caller that configures an absolute delivery cap can keep that cap at or above it; a cap below the slack would expire before even a small first write.

Covered by tests for deadline-moves-to-now, terminality across deliveries, and a race between `Cut` and concurrent writes.

Extracted verbatim from the wiring PR (#782) so that PR can stay wiring-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`Writer.Cut()`** and exported **`WriteSlack`** so init deliveries can stop writing immediately when the client is gone, instead of waiting on per-chunk deadlines. **`Cut`** is terminal (including if it happens before **`Begin`**), and **`arm`** no longer grants a fresh write budget after a cut—it keeps the deadline at **now**.
> 
> Introduces **`relay/concurrency`** to build the shared initialization-delivery limiter from **`Concurrency`** config (clamp absurd **`INIT_MAX_*`** / tiny **`INIT_SEND_TIMEOUT`**, default send cap, warn on misconfig). **`minInitSendTimeout`** ties to **`initwrite.WriteSlack`**. **`Relay`** constructs that budget at startup, logs when enabled, and closes the limiter on shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3db682baa6d648118fd4dc524c99e6ff33f462e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review order

Split out of #782, which stays in draft until these merge:

1. #803 — limiter `Closed()`
2. #804 — initwrite `Cut()` + exported write slack
3. #805 — init-concurrency HTTP middleware
4. #806 — shared budget construction from config (depends on #804; the other three are mutually independent)

After these merge, #782 rebases down to the wiring: stream-provider integration, poll routes and endpoints, and docs.
