### PR TITLE
feat: add HTTP middleware for the init-concurrency limiter

### DIFF
--- a/internal/middleware/concurrency.go
+++ b/internal/middleware/concurrency.go
@@ -1,0 +1,112 @@
+package middleware
+
+import (
+	"context"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/concurrency"
+	"github.com/launchdarkly/ld-relay/v9/internal/initwrite"
+	"github.com/launchdarkly/ld-relay/v9/internal/util"
+)
+
+type initLimiterCtxKey struct{}
+
+type initLimiterHolder struct {
+	limiter *concurrency.Limiter
+	maxHold time.Duration
+}
+
+// AcquireInitSlot draws one slot from the shared initialization-delivery limiter for the
+// current request, holding it until the returned release is called. If the budget is full it
+// writes a 503 (with a jittered Retry-After and a JSON body) and returns ok=false; the caller
+// must then write nothing further. A disabled or nil limiter always admits with a no-op
+// release, so callers can invoke this unconditionally.
+//
+// The response write itself is bounded separately, by the progress-aware writer that
+// LimitConcurrency / ProvideInitLimiter install, so a slow client cannot park the slot.
+//
+// It is called both by LimitConcurrency (which gates a whole handler, e.g. the FDv1 all-flags
+// poll) and directly by the FDv2 poll handlers, which acquire only on the full-basis branch so
+// a cheap up-to-date reply is never charged.
+func AcquireInitSlot(limiter *concurrency.Limiter, w http.ResponseWriter, r *http.Request) (release func(), ok bool) {
+	if !limiter.Enabled() {
+		return func() {}, true
+	}
+	rel, ok := limiter.Acquire(r.Context())
+	if !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds()))
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write(util.ErrorJSONMsg("relay initialization concurrency limit reached; retry shortly"))
+		return func() {}, false
+	}
+	return rel, true
+}
+
+// LimitConcurrency wraps a handler with the shared initialization-delivery limiter for a
+// request whose whole response is a full-dataset delivery (the FDv1 all-flags poll). The slot
+// is acquired on entry and held until the handler returns, and the response is written through
+// a progress-aware writer (see initwrite) so a slow or stalled client cannot park the slot. On
+// shed it responds 503 and does not invoke the wrapped handler. A disabled or nil limiter is a
+// pass-through with zero overhead. Handlers that have a cheap no-payload branch (the FDv2
+// polls) should instead call AcquireInitSlot directly, after that branch, so the cheap reply
+// is not charged.
+func LimitConcurrency(limiter *concurrency.Limiter, maxHold time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if !limiter.Enabled() {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			release, ok := AcquireInitSlot(limiter, w, r)
+			if !ok {
+				return
+			}
+			defer release()
+			defer clearWriteDeadline(w)
+			next.ServeHTTP(initwrite.Wrap(w, maxHold), r)
+		})
+	}
+}
+
+// clearWriteDeadline removes any write deadline the progress-aware writer armed on the
+// connection, so it cannot linger on a kept-alive connection and fire during a later request.
+// This server sets no http.Server.WriteTimeout, so net/http does not reset it for us.
+func clearWriteDeadline(w http.ResponseWriter) {
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+}
+
+// ProvideInitLimiter makes the shared initialization-delivery limiter available to a
+// downstream handler via the request context, without acquiring a slot, and wraps the response
+// in the progress-aware writer. It is used for the FDv2 poll endpoints, whose handlers acquire
+// lazily (via AcquireInitSlotFromContext) only on the full-basis branch, so a cheap up-to-date
+// reply is never charged. A disabled or nil limiter is a pass-through with zero overhead.
+func ProvideInitLimiter(limiter *concurrency.Limiter, maxHold time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if !limiter.Enabled() {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer clearWriteDeadline(w)
+			ctx := context.WithValue(r.Context(), initLimiterCtxKey{}, initLimiterHolder{limiter: limiter, maxHold: maxHold})
+			next.ServeHTTP(initwrite.Wrap(w, maxHold), r.WithContext(ctx))
+		})
+	}
+}
+
+// AcquireInitSlotFromContext acquires a slot from the limiter installed by ProvideInitLimiter,
+// with the same semantics as AcquireInitSlot. If no limiter was provided (or it is disabled)
+// it admits with a no-op release, so a handler can call it unconditionally on its full-basis
+// path.
+func AcquireInitSlotFromContext(w http.ResponseWriter, r *http.Request) (release func(), ok bool) {
+	holder, _ := r.Context().Value(initLimiterCtxKey{}).(initLimiterHolder)
+	return AcquireInitSlot(holder.limiter, w, r)
+}
+
+// retryAfterSeconds returns a small jittered Retry-After (in seconds) so a shed herd does
+// not retry in lockstep and re-synchronize the next burst.
+func retryAfterSeconds() int {
+	return 2 + rand.IntN(4) //nolint:gosec // Retry-After jitter is not security-sensitive; a fast PRNG is fine. 2..5 seconds
+}

--- a/internal/middleware/concurrency_test.go
+++ b/internal/middleware/concurrency_test.go
@@ -1,0 +1,117 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/concurrency"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitConcurrencyDisabledIsPassThrough(t *testing.T) {
+	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 0}) // disabled
+	called := false
+	h := LimitConcurrency(limiter, time.Second)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/sdk/flags", nil))
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestLimitConcurrencyShedsWhenBudgetFull(t *testing.T) {
+	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 0})
+	// Occupy the only slot so the wrapped request must shed.
+	release, ok := limiter.Acquire(context.Background())
+	require.True(t, ok)
+	defer release()
+
+	called := false
+	h := LimitConcurrency(limiter, time.Second)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/sdk/flags", nil))
+
+	assert.False(t, called, "handler must not run when shed")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.Contains(t, rr.Body.String(), "concurrency limit reached")
+
+	// Retry-After is a small positive integer, jittered into a range so a shed herd does not
+	// retry in lockstep.
+	ra, err := strconv.Atoi(rr.Header().Get("Retry-After"))
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, ra, 2)
+	assert.LessOrEqual(t, ra, 5)
+}
+
+func TestLimitConcurrencyReleasesSlotWhenHandlerReturns(t *testing.T) {
+	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 0})
+	h := LimitConcurrency(limiter, time.Second)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	// Two sequential requests both succeed, which is only possible if the single slot is
+	// released when each handler returns.
+	for range 2 {
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest("GET", "/sdk/flags", nil))
+		assert.Equal(t, http.StatusOK, rr.Code)
+	}
+	assert.Equal(t, int64(2), limiter.Stats().Admitted)
+}
+
+func TestAcquireInitSlotFromContextChargesOnlyWhenProvided(t *testing.T) {
+	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 0})
+
+	// With no limiter installed in the context, callers are admitted with a no-op release and
+	// the budget is untouched. This is what lets an FDv2 up-to-date reply avoid a slot.
+	rr := httptest.NewRecorder()
+	release, ok := AcquireInitSlotFromContext(rr, httptest.NewRequest("GET", "/sdk/poll", nil))
+	require.True(t, ok)
+	release()
+	assert.Equal(t, int64(0), limiter.Stats().Admitted, "absent limiter must not charge a slot")
+
+	// When ProvideInitLimiter installed the limiter, a full-basis handler charges a slot.
+	provided := ProvideInitLimiter(limiter, time.Second)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rel, ok := AcquireInitSlotFromContext(w, r)
+		require.True(t, ok)
+		defer rel()
+		w.WriteHeader(http.StatusOK)
+	}))
+	rr2 := httptest.NewRecorder()
+	provided.ServeHTTP(rr2, httptest.NewRequest("GET", "/sdk/poll", nil))
+	assert.Equal(t, http.StatusOK, rr2.Code)
+	assert.Equal(t, int64(1), limiter.Stats().Admitted)
+}
+
+func TestAcquireInitSlotFromContextShedsWhenBudgetFull(t *testing.T) {
+	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 0})
+	release, ok := limiter.Acquire(context.Background())
+	require.True(t, ok)
+	defer release()
+
+	handlerRan := false
+	provided := ProvideInitLimiter(limiter, time.Second)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rel, ok := AcquireInitSlotFromContext(w, r)
+		if !ok {
+			return
+		}
+		defer rel()
+		handlerRan = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	rr := httptest.NewRecorder()
+	provided.ServeHTTP(rr, httptest.NewRequest("GET", "/sdk/poll", nil))
+
+	assert.False(t, handlerRan, "full-basis handler must not proceed once shed")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}


### PR DESCRIPTION
HTTP-layer gating for the shared initialization-delivery budget, in two shapes; both wrap the response in the progress-aware writer (`initwrite`) so a slow client cannot park a slot:

- **`LimitConcurrency`** acquires a slot on entry and holds it until the handler returns, for an endpoint whose whole response is a full-dataset delivery (the FDv1 all-flags poll). A shed request gets **503 with a jittered `Retry-After`** (2–5 s) so a shed herd does not retry in lockstep.
- **`ProvideInitLimiter`** installs the limiter in the request context *without* charging, for handlers with a cheap no-payload branch (the FDv2 polls): the handler calls **`AcquireInitSlotFromContext`** lazily, only on its full-basis path, so an up-to-date reply is never charged.

A disabled or nil limiter is a pass-through with zero overhead. Any write deadline the writer armed is cleared at end of request, so it cannot linger on a kept-alive connection and fire during a later request (this server sets no `http.Server.WriteTimeout`, so net/http does not reset it for us).

Tests cover pass-through when disabled, shedding when the budget is full (including the 503 body and Retry-After bounds), slot release after the handler, lazy context acquisition, and deadline clearing.

Extracted verbatim from the wiring PR (#782), which applies this middleware to the poll routes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 23ea4e264845d65eb0af76a2a48585b06c53e373. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review order

Split out of #782, which stays in draft until these merge:

1. #803 — limiter `Closed()`
2. #804 — initwrite `Cut()` + exported write slack
3. #805 — init-concurrency HTTP middleware
4. #806 — shared budget construction from config (depends on #804; the other three are mutually independent)

After these merge, #782 rebases down to the wiring: stream-provider integration, poll routes and endpoints, and docs.
