### PR TITLE
feat: build the shared init-delivery budget from configuration

### DIFF
--- a/relay/concurrency.go
+++ b/relay/concurrency.go
@@ -1,0 +1,100 @@
+package relay
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/config"
+	"github.com/launchdarkly/ld-relay/v9/internal/concurrency"
+	"github.com/launchdarkly/ld-relay/v9/internal/initwrite"
+)
+
+// defaultInitSendTimeout is the absolute cap on how long a single gated delivery may hold a
+// slot. It is generous because the throughput floor (see internal/initwrite) does the
+// fast-stall detection; this only backstops a client that stays right at the floor on a very
+// large payload.
+const defaultInitSendTimeout = 2 * time.Minute
+
+const (
+	// maxInitMaxConcurrent bounds the slot count. Each slot represents one resident full
+	// payload, and the limiter fills one token per slot at construction, so an absurd value
+	// (for example 2^31) stalls startup for close to a minute and promises memory the host
+	// cannot have. Values above this are treated as misconfiguration and clamped.
+	maxInitMaxConcurrent = 65536
+	// maxInitMaxQueued bounds the queue. Each queued request holds an open connection and
+	// its goroutines while it waits, so a bound far beyond any real client population only
+	// hides a misconfiguration.
+	maxInitMaxQueued = 1_000_000
+	// minInitSendTimeout is the smallest usable delivery cap. The write deadline adds
+	// initwrite.WriteSlack per write; a cap below that expires before even a small first
+	// write, which would cut every delivery.
+	minInitSendTimeout = initwrite.WriteSlack
+)
+
+// initConcurrency holds Relay's shared initialization-delivery budget. Every poll and
+// every full-basis stream replay -- across FDv1 and FDv2 -- draws from this one
+// limiter, because they all contend for the same resident payload memory and egress
+// bandwidth. Cheap operations (FDv2 up-to-date replies, deltas, heartbeats, pings) are
+// never gated.
+type initConcurrency struct {
+	limiter     *concurrency.Limiter
+	sendTimeout time.Duration
+}
+
+// newInitConcurrency builds the shared budget from the [Concurrency] config, clamping
+// nonsensical values rather than failing so a bad edit can't crashloop the Relay. Each
+// clamp logs a warning with the value it applied. A MaxConcurrent that is unset or <=0
+// yields a disabled (pass-through) limiter.
+func newInitConcurrency(c config.ConcurrencyConfig, log *slog.Logger) initConcurrency {
+	maxConcurrent := c.MaxConcurrent.GetOrElse(0)
+	if maxConcurrent > maxInitMaxConcurrent {
+		log.Warn("INIT_MAX_CONCURRENT is beyond the supported range; clamping",
+			"configured", maxConcurrent, "effective", maxInitMaxConcurrent)
+		maxConcurrent = maxInitMaxConcurrent
+	}
+
+	maxQueued := c.MaxQueued.GetOrElse(0)
+	if maxQueued < 0 {
+		log.Warn("INIT_MAX_QUEUED is negative; treating it as 0 (no queue)",
+			"configured", maxQueued)
+		maxQueued = 0
+	}
+	if maxQueued > maxInitMaxQueued {
+		log.Warn("INIT_MAX_QUEUED is beyond the supported range; clamping",
+			"configured", maxQueued, "effective", maxInitMaxQueued)
+		maxQueued = maxInitMaxQueued
+	}
+
+	// A zero or negative timeout (unset, or explicitly 0) falls back to the default so both
+	// the poll and stream paths get a consistent, non-zero deadline rather than none. A tiny
+	// timeout is clamped up: below the writer's per-write slack it would cut every delivery.
+	sendTimeout := c.SendTimeout.GetOrElse(defaultInitSendTimeout)
+	if sendTimeout <= 0 {
+		sendTimeout = defaultInitSendTimeout
+	} else if sendTimeout < minInitSendTimeout {
+		log.Warn("INIT_SEND_TIMEOUT is too small to deliver anything; clamping",
+			"configured", sendTimeout, "effective", minInitSendTimeout)
+		sendTimeout = minInitSendTimeout
+	}
+
+	return initConcurrency{
+		limiter: concurrency.New("init_delivery", concurrency.Params{
+			MaxConcurrent: maxConcurrent,
+			MaxQueued:     maxQueued,
+		}),
+		sendTimeout: sendTimeout,
+	}
+}
+
+func (ic initConcurrency) close() {
+	ic.limiter.Close()
+}
+
+// logEnabled emits an info line describing the effective budget when it is active.
+func (ic initConcurrency) logEnabled(log *slog.Logger) {
+	if ic.limiter.Enabled() {
+		s := ic.limiter.Stats()
+		log.Info("initialization-delivery concurrency limit enabled (shared by polls and full-basis stream replays)",
+			"maxConcurrent", s.MaxConcurrent, "maxQueued", s.MaxQueued, "sendTimeout", ic.sendTimeout)
+	}
+}

--- a/relay/concurrency_test.go
+++ b/relay/concurrency_test.go
@@ -1,0 +1,137 @@
+package relay
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v9/config"
+
+	ct "github.com/launchdarkly/go-configtypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingHandler struct{ recs *[]slog.Record }
+
+func (h recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.recs = append(*h.recs, r)
+	return nil
+}
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func warnCount(recs []slog.Record) int {
+	n := 0
+	for _, r := range recs {
+		if r.Level == slog.LevelWarn {
+			n++
+		}
+	}
+	return n
+}
+
+func optInt(v int) ct.OptInt { return ct.NewOptInt(v) }
+
+func optDuration(v time.Duration) ct.OptDuration { return ct.NewOptDuration(v) }
+
+func TestInitConcurrencyInRangeValuesPassThrough(t *testing.T) {
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(16),
+		MaxQueued:     optInt(100),
+		SendTimeout:   optDuration(45 * time.Second),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	s := ic.limiter.Stats()
+	assert.Equal(t, 16, s.MaxConcurrent)
+	assert.Equal(t, 100, s.MaxQueued)
+	assert.Equal(t, 45*time.Second, ic.sendTimeout)
+	assert.Zero(t, warnCount(recs), "in-range values must not warn")
+}
+
+func TestInitConcurrencyUnsetIsDisabledWithDefaults(t *testing.T) {
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.False(t, ic.limiter.Enabled())
+	assert.Equal(t, defaultInitSendTimeout, ic.sendTimeout)
+	assert.Zero(t, warnCount(recs))
+}
+
+func TestInitConcurrencyClampsHugeMaxConcurrent(t *testing.T) {
+	// The limiter fills one token per slot at construction, so an absurd slot count would
+	// stall startup for close to a minute; the clamp must keep construction fast.
+	var recs []slog.Record
+	start := time.Now()
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(1 << 30),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Less(t, time.Since(start), 5*time.Second, "construction must not stall on a huge slot count")
+	assert.Equal(t, maxInitMaxConcurrent, ic.limiter.Stats().MaxConcurrent)
+	assert.Equal(t, 1, warnCount(recs), "the clamp must be visible in the log")
+}
+
+func TestInitConcurrencyClampsHugeMaxQueued(t *testing.T) {
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(4),
+		MaxQueued:     optInt(1 << 30),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Equal(t, maxInitMaxQueued, ic.limiter.Stats().MaxQueued)
+	assert.Equal(t, 1, warnCount(recs))
+}
+
+func TestInitConcurrencyNegativeMaxQueuedWarnsAndDisablesQueue(t *testing.T) {
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(1),
+		MaxQueued:     optInt(-5),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Equal(t, 0, ic.limiter.Stats().MaxQueued)
+	assert.Equal(t, 1, warnCount(recs))
+
+	// With no queue, a second caller is rejected while the slot is held.
+	release, ok := ic.limiter.Acquire(context.Background())
+	require.True(t, ok)
+	defer release()
+	if _, ok2 := ic.limiter.Acquire(context.Background()); ok2 {
+		t.Fatal("expected rejection with the queue disabled")
+	}
+}
+
+func TestInitConcurrencyClampsTinySendTimeout(t *testing.T) {
+	// A cap below the writer's per-write slack expires before even a small first write and
+	// would cut every delivery; the clamp keeps the cap usable.
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(4),
+		SendTimeout:   optDuration(time.Millisecond),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Equal(t, minInitSendTimeout, ic.sendTimeout)
+	assert.Equal(t, 1, warnCount(recs))
+}
+
+func TestInitConcurrencyZeroSendTimeoutUsesDefaultQuietly(t *testing.T) {
+	// Zero means "unset": it takes the default and is not a misconfiguration.
+	var recs []slog.Record
+	ic := newInitConcurrency(config.ConcurrencyConfig{
+		MaxConcurrent: optInt(4),
+	}, slog.New(recordingHandler{&recs}))
+	defer ic.close()
+
+	assert.Equal(t, defaultInitSendTimeout, ic.sendTimeout)
+	assert.Zero(t, warnCount(recs))
+}

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -68,6 +68,7 @@ type Relay struct {
 	archiveManager                filedata.ArchiveManagerInterface
 	config                        config.Config
 	logger                        *slog.Logger
+	initConcurrency               initConcurrency
 }
 
 // ClientFactoryFunc is a function that can be used with NewRelay to specify custom behavior when
@@ -145,6 +146,12 @@ func newRelayInternal(c config.Config, options relayInternalOptions) (*Relay, er
 
 	userAgent := "LDRelay/" + version.Version
 
+	// The shared initialization-delivery budget bounds concurrent full-dataset writes
+	// (polls + full-basis stream replays) so a reconnect herd can't pin unbounded memory
+	// or egress. Disabled by default.
+	initConc := newInitConcurrency(c.Concurrency, logger)
+	initConc.logEnabled(logger)
+
 	r := &Relay{
 		envsByCredential:              NewEnvironmentLookup(),
 		serverSideStreamProvider:      streams.NewStreamProvider(basictypes.ServerSideStream, maxConnTime, 0),
@@ -159,6 +166,7 @@ func newRelayInternal(c config.Config, options relayInternalOptions) (*Relay, er
 		envLogNameMode:                logNameMode,
 		config:                        c,
 		logger:                        logger,
+		initConcurrency:               initConc,
 	}
 
 	thingsToCleanUp.AddCloser(r)
@@ -336,6 +344,8 @@ func (r *Relay) Close() error {
 	for _, sp := range r.allStreamProviders() {
 		sp.Close()
 	}
+
+	r.initConcurrency.close()
 
 	return nil
 }


### PR DESCRIPTION
`newInitConcurrency` constructs Relay's one shared initialization-delivery limiter from the `[Concurrency]` config, clamping nonsensical values with a warning rather than failing, so a bad config edit cannot crashloop the Relay:

- `MaxConcurrent` is capped at 65,536 — each slot represents one resident full payload, and the limiter fills one token per slot at construction, so an absurd value (e.g. 2^31) would stall startup and promise memory the host cannot have. Unset or ≤ 0 yields a disabled pass-through limiter.
- `MaxQueued` is floored at 0 and capped at 1,000,000 — each queued request holds an open connection and its goroutines while it waits.
- `SendTimeout` defaults to 2 minutes and is floored at `initwrite.WriteSlack`: below the writer's per-write slack, every delivery would be cut before its first write. The default is generous because the throughput floor in `initwrite` does the fast-stall detection; this only backstops a client that stays right at the floor on a very large payload.

Relay constructs the budget at startup, logs the effective values when it is enabled, and closes it at shutdown. Nothing draws from it yet — the polling and streaming consumers arrive with the wiring PR (#782).

Tests cover in-range pass-through, each clamp (with its warning), the disabled case, and the timeout fallbacks.

`relay/concurrency.go` and its tests are extracted verbatim from #782; the three `relay.go` lifecycle lines (construct, log, close) are the corresponding subset of #782's `relay.go` change, so the wiring PR's remaining `relay.go` delta is only handing the limiter to the stream provider.

Based on the `Cut()` branch because the timeout floor uses `initwrite.WriteSlack`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cf6a94be1a45585ab7e12cf2effa32b2cb4c196c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review order

Split out of #782, which stays in draft until these merge:

1. #803 — limiter `Closed()`
2. #804 — initwrite `Cut()` + exported write slack
3. #805 — init-concurrency HTTP middleware
4. #806 — shared budget construction from config (depends on #804; the other three are mutually independent)

After these merge, #782 rebases down to the wiring: stream-provider integration, poll routes and endpoints, and docs.
