### PR TITLE
perf!: Trim high-cardinality attributes off the request metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,28 +17,51 @@ The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://o
 | `launchdarkly.relay.events.dropped` | Counter | `{event}` | The cumulative number of events dropped due to capacity overflow. |
 | `launchdarkly.relay.events.pending` | Gauge | `{event}` | The current number of events buffered in the queue. |
 
-## Attributes
+## Resource attributes
 
-All metrics include the following attributes:
+These describe the Relay Proxy process itself and are attached to every metric and span, rather than
+being repeated on each measurement:
 
 | Attribute | Description |
 |-----------|-------------|
-| `relay.id` | A unique identifier for this Relay Proxy instance, generated at startup. |
+| `service.name` | `ld-relay`, unless overridden with `OTEL_SERVICE_NAME`. |
+| `relay.id` | A unique identifier for this Relay Proxy process, generated at startup. Example: `5f313039-df4e-45f5-ad9e-4afd840cb210` |
+| `service.instance.id` | The same value as `relay.id`, unless you supply your own via `OTEL_RESOURCE_ATTRIBUTES`. This is the standard attribute for identifying a process instance, and Prometheus exposes it as the `instance` label. |
+
+Note that resource attributes are **not** copied onto every series. Prometheus reports them through
+`target_info`, so a query that needs `relay.id` has to join against it -- or use the `instance` label,
+which carries the same value.
+
+## Request attributes
+
+The request metrics -- `http.server.active_requests`, `http.server.request.duration`, and
+`launchdarkly.relay.events.received.size` -- include the following:
+
+| Attribute | Description |
+|-----------|-------------|
 | `environment.name` | The name of the LaunchDarkly environment as configured in the Relay Proxy. In automatic configuration or offline mode, this is the actual project and environment name from LaunchDarkly. Example: `MyApplication Staging` |
-| `platform.category` | The kind of SDK that generated the metric: `server`, `mobile`, or `browser`. |
-| `user_agent` | The user agent of the SDK making the request. Example: `Node/3.4.0` |
-| `sdk.wrapper` | The SDK wrapper identifier, if provided. Example: `flutter-client/2.0.0` |
+| `user_agent` | The user agent of the SDK making the request, with slashes replaced by underscores. Example: `Node_3.4.0` |
 | `http.route` | The request URL path template. Variables appear as placeholders rather than actual values. Example: `/sdk/evalx/{envId}/contexts/{context}` |
 | `http.request.method` | The HTTP method. Example: `GET` |
 | `url.scheme` | The URL scheme. Example: `https` |
 | `application.id` | The application identifier, extracted from the `application-id` field of the `X-LaunchDarkly-Tags` header. |
 | `application.version` | The application version, extracted from the `application-version` field of the `X-LaunchDarkly-Tags` header. |
-| `instance.id` | The SDK instance identifier from the `X-LaunchDarkly-Instance-Id` header. |
 | `relay.endpoint.type` | The kind of endpoint that served the request: `stream`, `poll`, `events`, `goals`, or `status`. Requests that matched no route report `not-provided`. |
+
+`http.server.request.duration` additionally carries `http.response.status_code`,
+`network.protocol.version`, and -- for a 5xx response -- `error.type`.
+
+The event delivery metrics (`launchdarkly.relay.events.sent`, `.sent.size`, `.send.errors`,
+`.dropped`, `.pending`) are recorded outside any request, so they carry only `environment.name`.
+`.send.errors` also carries `status_code`.
 
 Attribute values that are absent are reported as `not-provided` rather than being omitted. The status
 endpoints and requests that matched no route are not associated with an SDK or an LD environment, so
-they report `not-provided` for `environment.name`, `platform.category`, and the other SDK attributes.
+they report `not-provided` for `environment.name` and the other SDK attributes.
+
+`platform.category`, `sdk.wrapper`, and `instance.id` are no longer reported on metrics. `instance.id`
+in particular is per SDK *instance*, which made these metrics grow a series per client process. All
+three are still included in the usage data the Relay Proxy sends to LaunchDarkly.
 
 ## Backend-specific notes
 

--- a/internal/metrics/active_requests_benchmark_test.go
+++ b/internal/metrics/active_requests_benchmark_test.go
@@ -18,7 +18,6 @@ func benchRequestInfo() RequestInfo {
 		Method:             "GET",
 		ApplicationID:      "my-app",
 		ApplicationVersion: "1.2.3",
-		InstanceID:         "instance-abc",
 		EndpointType:       EndpointTypePoll,
 		URLScheme:          "https",
 		ProtocolVersion:    "1.1",
@@ -29,7 +28,6 @@ func benchEnvironmentManager(b *testing.B) *EnvironmentManager {
 	b.Helper()
 	return &EnvironmentManager{
 		envKVs: []attribute.KeyValue{
-			relayIDAttrKey.String("bench-relay-id"),
 			envNameAttrKey.String("bench-env"),
 		},
 	}
@@ -56,7 +54,7 @@ func BenchmarkStartActiveRequest(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			StartActiveRequest(instruments, em, ServerPlatformCategory, ri)()
+			StartActiveRequest(instruments, em, ri)()
 		}
 	})
 
@@ -68,19 +66,20 @@ func BenchmarkStartActiveRequest(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			StartActiveRequest(instruments, em, ServerPlatformCategory, ri)()
+			StartActiveRequest(instruments, em, ri)()
 		}
 	})
 }
 
-// BenchmarkBuildRequestAttributes isolates the attribute set construction -- the allocation and sort
-// of ~12 attributes that dominates the cost above.
+// BenchmarkBuildRequestAttributes isolates the attribute set construction, which dominates the cost
+// above. At eight attributes this stays inside attribute.NewSet's fixed-size fast path (ten or fewer);
+// it was twelve before platform.category, sdk.wrapper, instance.id and relay.id came off.
 func BenchmarkBuildRequestAttributes(b *testing.B) {
 	ri := benchRequestInfo()
 	em := benchEnvironmentManager(b)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = buildRequestAttributes(em.envKVs, ServerPlatformCategory, ri)
+		_ = buildRequestAttributes(em.envKVs, ri)
 	}
 }

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -57,15 +57,18 @@ const (
 	EndpointTypeNotProvided EndpointType = notProvidedValue
 )
 
+// Attributes deliberately absent from these sets:
+//
+//   - relay.id is a resource attribute (see tracing.NewResource): it never varies within a process.
+//   - instance.id, platform.category and sdk.wrapper were dropped. instance.id is per SDK instance, so
+//     it made every request metric effectively per-client-process; the other two are largely implied by
+//     http.route. All three are still reported in the usage data Relay sends to LaunchDarkly, which is
+//     a separate sink with its own cardinality budget.
 var (
-	relayIDAttrKey            = attribute.Key("relay.id")            //nolint:gochecknoglobals
-	platformCategoryAttrKey   = attribute.Key("platform.category")   //nolint:gochecknoglobals
 	userAgentAttrKey          = attribute.Key("user_agent")          //nolint:gochecknoglobals
-	sdkWrapperAttrKey         = attribute.Key("sdk.wrapper")         //nolint:gochecknoglobals
 	envNameAttrKey            = attribute.Key("environment.name")    //nolint:gochecknoglobals
 	applicationIDAttrKey      = attribute.Key("application.id")      //nolint:gochecknoglobals
 	applicationVersionAttrKey = attribute.Key("application.version") //nolint:gochecknoglobals
-	instanceIDAttrKey         = attribute.Key("instance.id")         //nolint:gochecknoglobals
 	endpointTypeAttrKey       = attribute.Key("relay.endpoint.type") //nolint:gochecknoglobals
 
 	// OTEL HTTP semantic convention attribute keys (from semconv package)
@@ -80,19 +83,19 @@ var (
 
 // buildRequestAttributes creates an OTel attribute set for request metrics using semconv attribute names
 // where applicable. Values from the RequestInfo are sanitized here, so callers pass it through as-is.
-func buildRequestAttributes(baseKVs []attribute.KeyValue, platform string, ri RequestInfo) attribute.Set {
-	attrs := make([]attribute.KeyValue, len(baseKVs), len(baseKVs)+10)
+func buildRequestAttributes(baseKVs []attribute.KeyValue, ri RequestInfo) attribute.Set {
+	attrs := make([]attribute.KeyValue, len(baseKVs), len(baseKVs)+7)
 	copy(attrs, baseKVs)
-	attrs = append(attrs, requestKVs(platform, ri)...)
+	attrs = append(attrs, requestKVs(ri)...)
 	return attribute.NewSet(attrs...)
 }
 
 // buildDurationAttributes creates an OTel attribute set for the http.server.request.duration histogram,
 // including all semconv required/conditionally-required attributes.
-func buildDurationAttributes(baseKVs []attribute.KeyValue, platform string, ri RequestInfo) attribute.Set {
-	attrs := make([]attribute.KeyValue, len(baseKVs), len(baseKVs)+13)
+func buildDurationAttributes(baseKVs []attribute.KeyValue, ri RequestInfo) attribute.Set {
+	attrs := make([]attribute.KeyValue, len(baseKVs), len(baseKVs)+10)
 	copy(attrs, baseKVs)
-	attrs = append(attrs, requestKVs(platform, ri)...)
+	attrs = append(attrs, requestKVs(ri)...)
 	if ri.ProtocolVersion != "" {
 		attrs = append(attrs, networkProtoVersionAttrKey.String(ri.ProtocolVersion))
 	}
@@ -105,18 +108,17 @@ func buildDurationAttributes(baseKVs []attribute.KeyValue, platform string, ri R
 	return attribute.NewSet(attrs...)
 }
 
-// requestKVs returns the attributes that every request-scoped metric carries.
-func requestKVs(platform string, ri RequestInfo) []attribute.KeyValue {
+// requestKVs returns the attributes that every request-scoped metric carries. Keeping this at seven,
+// plus environment.name from the environment, holds the common case within attribute.NewSet's
+// fixed-size fast path, which only covers sets of ten or fewer.
+func requestKVs(ri RequestInfo) []attribute.KeyValue {
 	return []attribute.KeyValue{
-		platformCategoryAttrKey.String(sanitizeTagValue(platform)),
 		userAgentAttrKey.String(sanitizeTagValue(ri.UserAgent)),
-		sdkWrapperAttrKey.String(sanitizeTagValue(ri.SDKWrapper)),
 		httpRouteAttrKey.String(sanitizeRouteValue(ri.Route)),
 		httpRequestMethodAttrKey.String(sanitizeTagValue(ri.Method)),
 		urlSchemeAttrKey.String(ri.URLScheme),
 		applicationIDAttrKey.String(sanitizeTagValue(ri.ApplicationID)),
 		applicationVersionAttrKey.String(sanitizeTagValue(ri.ApplicationVersion)),
-		instanceIDAttrKey.String(sanitizeTagValue(ri.InstanceID)),
 		endpointTypeAttrKey.String(sanitizeTagValue(string(ri.EndpointType))),
 	}
 }

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -21,18 +21,12 @@ type Instruments struct {
 	pendingEvents       metric.Int64Gauge         // current number of events pending delivery
 }
 
-// Measure identifies what to record. Each pre-defined Measure var specifies which
-// instruments should be incremented and what platform category to use.
+// Measure identifies what to record in the usage data Relay reports to LaunchDarkly. The platform
+// category lives on here rather than on the OTEL metrics, which no longer carry it.
 type Measure struct {
 	recordConnections bool
-	recordDuration    bool
 	recordPolling     bool
 	platformCategory  string
-}
-
-// PlatformCategory returns the SDK platform category that this Measure reports under.
-func (m Measure) PlatformCategory() string {
-	return m.platformCategory
 }
 
 // To avoid having to put nolint:gochecknoglobals on everything here, that linter is excluded
@@ -46,15 +40,6 @@ var (
 
 	// ServerConns is a Measure representing the current number of active stream connections from server-side SDKs.
 	ServerConns = Measure{recordConnections: true, platformCategory: ServerPlatformCategory}
-
-	// BrowserDuration is a Measure for recording request duration from browsers.
-	BrowserDuration = Measure{recordDuration: true, platformCategory: BrowserPlatformCategory}
-
-	// MobileDuration is a Measure for recording request duration from mobile SDKs.
-	MobileDuration = Measure{recordDuration: true, platformCategory: MobilePlatformCategory}
-
-	// ServerDuration is a Measure for recording request duration from server-side SDKs.
-	ServerDuration = Measure{recordDuration: true, platformCategory: ServerPlatformCategory}
 
 	// ServerPollingRequests is a Measure representing the total number of polling style requests received from server-side SDKs.
 	ServerPollingRequests = Measure{recordPolling: true, platformCategory: ServerPlatformCategory}
@@ -142,7 +127,6 @@ type RequestInfo struct {
 	Method             string
 	ApplicationID      string
 	ApplicationVersion string
-	InstanceID         string
 	EndpointType       EndpointType
 	// Semconv fields populated after handler execution
 	StatusCode      int
@@ -157,13 +141,13 @@ type RequestInfo struct {
 // The attribute set is computed once, up front, and reused for the decrement. Anything only known after
 // the handler runs (status code, error type) therefore cannot be reported on this metric: a mismatched
 // attribute set between the increment and the decrement would leak a permanently non-zero series.
-func StartActiveRequest(instruments *Instruments, em *EnvironmentManager, platformCategory string, ri RequestInfo) func() {
+func StartActiveRequest(instruments *Instruments, em *EnvironmentManager, ri RequestInfo) func() {
 	if instruments == nil || em == nil {
 		return func() {}
 	}
 
 	// Built once and shared by both calls, so that the two can't drift apart.
-	attrs := metric.WithAttributeSet(buildRequestAttributes(em.envKVs, platformCategory, ri))
+	attrs := metric.WithAttributeSet(buildRequestAttributes(em.envKVs, ri))
 	instruments.connections.Add(context.Background(), 1, attrs)
 	return func() {
 		instruments.connections.Add(context.Background(), -1, attrs)
@@ -199,21 +183,21 @@ func WithCount(em *EnvironmentManager, ri RequestInfo, f func(), measure Measure
 }
 
 // RecordEventsReceivedBytes records the number of event bytes received.
-func RecordEventsReceivedBytes(ctx context.Context, instruments *Instruments, em *EnvironmentManager, platformCategory string, ri RequestInfo, bytes int64) {
+func RecordEventsReceivedBytes(ctx context.Context, instruments *Instruments, em *EnvironmentManager, ri RequestInfo, bytes int64) {
 	if em == nil || instruments == nil || bytes <= 0 {
 		return
 	}
-	attrs := buildRequestAttributes(em.envKVs, platformCategory, ri)
+	attrs := buildRequestAttributes(em.envKVs, ri)
 	instruments.eventsReceivedBytes.Add(ctx, bytes, metric.WithAttributeSet(attrs))
 }
 
 // RecordRequestDuration records a request duration measurement with the given attributes.
 // Duration is recorded in seconds per OTEL HTTP semantic conventions.
-func RecordRequestDuration(ctx context.Context, instruments *Instruments, em *EnvironmentManager, ri RequestInfo, duration time.Duration, measure Measure) {
-	if em == nil || instruments == nil || !measure.recordDuration {
+func RecordRequestDuration(ctx context.Context, instruments *Instruments, em *EnvironmentManager, ri RequestInfo, duration time.Duration) {
+	if em == nil || instruments == nil {
 		return
 	}
-	attrs := buildDurationAttributes(em.envKVs, measure.platformCategory, ri)
+	attrs := buildDurationAttributes(em.envKVs, ri)
 	instruments.requestDuration.Record(ctx, duration.Seconds(), metric.WithAttributeSet(attrs))
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -11,7 +11,6 @@ import (
 	"github.com/launchdarkly/ld-relay/v9/internal/events"
 	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
 
-	"github.com/pborman/uuid"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -63,7 +62,9 @@ func NewManager(
 	flushInterval time.Duration,
 	logger *slog.Logger,
 ) (*Manager, error) {
-	metricsRelayID := uuid.New()
+	// The relay ID is a resource attribute now, generated once per process by the tracing package so
+	// that metrics, traces and the usage data sent to LaunchDarkly all report the same identity.
+	metricsRelayID := tracing.RelayID()
 
 	res := tracing.NewResource(logger)
 
@@ -103,10 +104,7 @@ func NewManager(
 		usageChan:            usageChan,
 		environmentsForUsage: make(map[string]*environmentMetricUsage),
 		unscopedEnv: &EnvironmentManager{
-			envKVs: []attribute.KeyValue{
-				relayIDAttrKey.String(metricsRelayID),
-				envNameAttrKey.String(sanitizeTagValue("")),
-			},
+			envKVs: []attribute.KeyValue{envNameAttrKey.String(sanitizeTagValue(""))},
 		},
 	}
 	if m.flushInterval <= 0 {
@@ -217,10 +215,7 @@ func (m *Manager) AddEnvironment(envName string, publisher events.EventPublisher
 		return nil, errAddEnvironmentAfterClosed
 	}
 
-	envKVs := []attribute.KeyValue{
-		relayIDAttrKey.String(m.metricsRelayID),
-		envNameAttrKey.String(sanitizeTagValue(envName)),
-	}
+	envKVs := []attribute.KeyValue{envNameAttrKey.String(sanitizeTagValue(envName))}
 
 	var collector *RelayMetricsCollector
 	if publisher != nil {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -43,10 +43,10 @@ func TestRecordingIsSafeWithoutInstruments(t *testing.T) {
 	ri := RequestInfo{UserAgent: userAgentValue, Route: "/test", Method: "GET", EndpointType: EndpointTypePoll}
 
 	assert.NotPanics(t, func() {
-		StartActiveRequest(manager.GetInstruments(), em, ServerPlatformCategory, ri)()
-		StartActiveRequest(manager.GetInstruments(), manager.GetUnscopedEnvironment(), "", ri)()
-		RecordRequestDuration(context.Background(), manager.GetInstruments(), em, ri, time.Millisecond, ServerDuration)
-		RecordEventsReceivedBytes(context.Background(), manager.GetInstruments(), em, ServerPlatformCategory, ri, 100)
+		StartActiveRequest(manager.GetInstruments(), em, ri)()
+		StartActiveRequest(manager.GetInstruments(), manager.GetUnscopedEnvironment(), ri)()
+		RecordRequestDuration(context.Background(), manager.GetInstruments(), em, ri, time.Millisecond)
+		RecordEventsReceivedBytes(context.Background(), manager.GetInstruments(), em, ri, 100)
 
 		recorder := em.NewEventMetricsRecorder(manager.GetInstruments())
 		recorder.RecordDroppedEvents(1)
@@ -133,28 +133,19 @@ func TestRemoveEnvironment(t *testing.T) {
 }
 
 func TestActiveRequestMetrics(t *testing.T) {
-	specs := []struct {
-		platform     string
-		endpointType EndpointType
-	}{
-		{platform: BrowserPlatformCategory, endpointType: EndpointTypeStream},
-		{platform: MobilePlatformCategory, endpointType: EndpointTypePoll},
-		{platform: ServerPlatformCategory, endpointType: EndpointTypeEvents},
-	}
-
-	for _, tt := range specs {
-		t.Run(tt.platform, func(t *testing.T) {
+	for _, endpointType := range []EndpointType{EndpointTypeStream, EndpointTypePoll, EndpointTypeEvents} {
+		t.Run(string(endpointType), func(t *testing.T) {
 			testWithOTel(t, func(p testWithOTelParams) {
-				ri := RequestInfo{UserAgent: userAgentValue, Route: "/test", Method: "GET", EndpointType: tt.endpointType}
-				requestFinished := StartActiveRequest(p.instruments, p.env, tt.platform, ri)
+				ri := RequestInfo{UserAgent: userAgentValue, Route: "/test", Method: "GET", EndpointType: endpointType}
+				requestFinished := StartActiveRequest(p.instruments, p.env, ri)
 
 				// While the request is in flight, the count should be 1
 				rm, err := p.collectMetrics()
 				require.NoError(t, err)
 				m := findMetric(rm, connMeasureName)
 				require.NotNil(t, m, "active requests metric not found")
-				assertGaugeValue(t, m, p.envName, tt.platform, 1)
-				assertHasAttribute(t, m, endpointTypeAttrKey, string(tt.endpointType))
+				assertGaugeValue(t, m, p.envName, 1)
+				assertHasAttribute(t, m, endpointTypeAttrKey, string(endpointType))
 
 				requestFinished()
 
@@ -163,7 +154,7 @@ func TestActiveRequestMetrics(t *testing.T) {
 				require.NoError(t, err)
 				m = findMetric(rm, connMeasureName)
 				require.NotNil(t, m, "active requests metric not found")
-				assertGaugeValue(t, m, p.envName, tt.platform, 0)
+				assertGaugeValue(t, m, p.envName, 0)
 				assert.Len(t, m.Data.(metricdata.Sum[int64]).DataPoints, 1,
 					"increment and decrement should share one attribute set")
 			})
@@ -172,7 +163,7 @@ func TestActiveRequestMetrics(t *testing.T) {
 }
 
 // The status endpoints and unmatched requests have no environment, so they report the not-provided
-// sentinel for both environment.name and platform.category.
+// sentinel for environment.name.
 func TestActiveRequestMetricsWithoutEnvironment(t *testing.T) {
 	testWithOTel(t, func(p testWithOTelParams) {
 		manager, err := NewManager(config.OpenTelemetryConfig{}, time.Minute, slog.Default())
@@ -181,14 +172,14 @@ func TestActiveRequestMetricsWithoutEnvironment(t *testing.T) {
 		manager.SetInstrumentsForTest(p.instruments)
 
 		ri := RequestInfo{Route: "/status", Method: "GET", EndpointType: EndpointTypeStatus}
-		requestFinished := StartActiveRequest(manager.GetInstruments(), manager.GetUnscopedEnvironment(), "", ri)
+		requestFinished := StartActiveRequest(manager.GetInstruments(), manager.GetUnscopedEnvironment(), ri)
 		defer requestFinished()
 
 		rm, err := p.collectMetrics()
 		require.NoError(t, err)
 		m := findMetric(rm, connMeasureName)
 		require.NotNil(t, m, "active requests metric not found")
-		assertGaugeValue(t, m, notProvidedValue, notProvidedValue, 1)
+		assertGaugeValue(t, m, notProvidedValue, 1)
 		assertHasAttribute(t, m, endpointTypeAttrKey, string(EndpointTypeStatus))
 	})
 }
@@ -206,7 +197,7 @@ func assertHasAttribute(t *testing.T, m *metricdata.Metrics, key attribute.Key, 
 
 func TestRecordRequestDuration(t *testing.T) {
 	testWithOTel(t, func(p testWithOTelParams) {
-		RecordRequestDuration(context.Background(), p.instruments, p.env, RequestInfo{UserAgent: userAgentValue, Route: "someRoute", Method: "GET"}, 50*time.Millisecond, ServerDuration)
+		RecordRequestDuration(context.Background(), p.instruments, p.env, RequestInfo{UserAgent: userAgentValue, Route: "someRoute", Method: "GET"}, 50*time.Millisecond)
 
 		rm, err := p.collectMetrics()
 		require.NoError(t, err)
@@ -231,7 +222,7 @@ func TestRecordRequestDuration(t *testing.T) {
 
 func TestRecordEventsReceivedBytes(t *testing.T) {
 	testWithOTel(t, func(p testWithOTelParams) {
-		RecordEventsReceivedBytes(context.Background(), p.instruments, p.env, ServerPlatformCategory, RequestInfo{UserAgent: userAgentValue, Route: "/bulk", Method: "POST"}, 1024)
+		RecordEventsReceivedBytes(context.Background(), p.instruments, p.env, RequestInfo{UserAgent: userAgentValue, Route: "/bulk", Method: "POST"}, 1024)
 
 		rm, err := p.collectMetrics()
 		require.NoError(t, err)
@@ -242,9 +233,8 @@ func TestRecordEventsReceivedBytes(t *testing.T) {
 		require.NotEmpty(t, sum.DataPoints)
 		found := false
 		for _, dp := range sum.DataPoints {
-			platVal, platOK := dp.Attributes.Value(platformCategoryAttrKey)
 			envVal, envOK := dp.Attributes.Value(envNameAttrKey)
-			if platOK && envOK && platVal.AsString() == ServerPlatformCategory && envVal.AsString() == p.envName {
+			if envOK && envVal.AsString() == p.envName {
 				assert.Equal(t, int64(1024), dp.Value)
 				found = true
 			}
@@ -290,7 +280,7 @@ func TestRecordRequestDurationWithAllAttributes(t *testing.T) {
 			StatusCode:      200,
 			ErrorType:       "",
 		}
-		RecordRequestDuration(context.Background(), p.instruments, p.env, ri, 100*time.Millisecond, ServerDuration)
+		RecordRequestDuration(context.Background(), p.instruments, p.env, ri, 100*time.Millisecond)
 
 		rm, err := p.collectMetrics()
 		require.NoError(t, err)
@@ -327,7 +317,7 @@ func TestRecordRequestDurationWithErrorType(t *testing.T) {
 			StatusCode: 500,
 			ErrorType:  "500",
 		}
-		RecordRequestDuration(context.Background(), p.instruments, p.env, ri, 50*time.Millisecond, ServerDuration)
+		RecordRequestDuration(context.Background(), p.instruments, p.env, ri, 50*time.Millisecond)
 
 		rm, err := p.collectMetrics()
 		require.NoError(t, err)
@@ -345,23 +335,6 @@ func TestRecordRequestDurationWithErrorType(t *testing.T) {
 		statusVal, ok := dp.Attributes.Value(httpResponseStatusAttrKey)
 		assert.True(t, ok, "http.response.status_code attribute missing")
 		assert.Equal(t, int64(500), statusVal.AsInt64())
-	})
-}
-
-func TestRecordRequestDurationSkipsWhenMeasureDoesNotRecordDuration(t *testing.T) {
-	testWithOTel(t, func(p testWithOTelParams) {
-		// ServerConns has recordDuration: false
-		RecordRequestDuration(context.Background(), p.instruments, p.env, RequestInfo{UserAgent: userAgentValue}, 50*time.Millisecond, ServerConns)
-
-		rm, err := p.collectMetrics()
-		require.NoError(t, err)
-		dm := findMetric(rm, requestDurationMeasureName)
-		if dm != nil {
-			hist, ok := dm.Data.(metricdata.Histogram[float64])
-			if ok {
-				assert.Empty(t, hist.DataPoints, "expected no duration data points for non-duration measure")
-			}
-		}
 	})
 }
 
@@ -445,10 +418,10 @@ func TestWithCountCallsFunctionWhenEnvNil(t *testing.T) {
 func TestWithCountCallsFunctionForNonPollingMeasure(t *testing.T) {
 	testWithOTel(t, func(p testWithOTelParams) {
 		called := false
-		// ServerDuration has recordPolling: false, so no polling metric should be recorded
+		// ServerConns has recordPolling: false, so no polling metric should be recorded
 		WithCount(p.env, RequestInfo{UserAgent: userAgentValue}, func() {
 			called = true
-		}, ServerDuration)
+		}, ServerConns)
 		assert.True(t, called, "function should have been called")
 	})
 }
@@ -506,20 +479,19 @@ func findMetric(rm *metricdata.ResourceMetrics, name string) *metricdata.Metrics
 	return nil
 }
 
-func assertGaugeValue(t *testing.T, m *metricdata.Metrics, envName, platform string, expected int64) {
+func assertGaugeValue(t *testing.T, m *metricdata.Metrics, envName string, expected int64) {
 	t.Helper()
 	sum, ok := m.Data.(metricdata.Sum[int64])
 	require.True(t, ok, "expected Sum[int64] data for %s", m.Name)
 	found := false
 	for _, dp := range sum.DataPoints {
-		platVal, platOK := dp.Attributes.Value(platformCategoryAttrKey)
 		envVal, envOK := dp.Attributes.Value(envNameAttrKey)
-		if platOK && envOK && platVal.AsString() == platform && envVal.AsString() == envName {
-			assert.Equal(t, expected, dp.Value, "unexpected value for %s (platform=%s, env=%s)", m.Name, platform, envName)
+		if envOK && envVal.AsString() == envName {
+			assert.Equal(t, expected, dp.Value, "unexpected value for %s (env=%s)", m.Name, envName)
 			found = true
 		}
 	}
-	assert.True(t, found, "no data point found for %s with platform=%s, env=%s", m.Name, platform, envName)
+	assert.True(t, found, "no data point found for %s with env=%s", m.Name, envName)
 }
 
 // Ignore unused import warning - context is needed for p.collectMetrics

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -106,7 +106,6 @@ func requestInfoFromHTTP(req *http.Request) metrics.RequestInfo {
 		Method:             req.Method,
 		ApplicationID:      appID,
 		ApplicationVersion: appVersion,
-		InstanceID:         getInstanceID(req),
 		URLScheme:          urlScheme,
 		ProtocolVersion:    protocolVersion,
 	}
@@ -183,30 +182,16 @@ func CountClientConns(handler http.Handler) http.Handler {
 	})
 }
 
-// DynamicRequestMetrics is a middleware function for FDv2 client-side endpoints that dynamically
-// determines the metric platform based on the credential type.
-func DynamicRequestMetrics(endpointType metrics.EndpointType) mux.MiddlewareFunc {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			cred := GetEnvContextInfo(req.Context()).Credential
-			var measure metrics.Measure
-			if _, ok := cred.(config.MobileKey); ok {
-				measure = metrics.MobileDuration
-			} else {
-				measure = metrics.BrowserDuration
-			}
-			RequestMetrics(measure, endpointType)(next).ServeHTTP(w, req)
-		})
-	}
-}
-
 // RequestMetrics is a middleware function that tracks a request in http.server.active_requests for as
 // long as it is in flight, and records its duration once it completes.
 //
 // Active requests cover every request this middleware sees, streaming included, per the OTEL semantic
 // convention for the instrument. Duration is still skipped for streaming responses, whose lifetime is
 // unbounded.
-func RequestMetrics(measure metrics.Measure, endpointType metrics.EndpointType) mux.MiddlewareFunc {
+//
+// There is no platform-dependent variant of this: since these metrics dropped platform.category, the
+// SDK platform no longer changes what gets recorded.
+func RequestMetrics(endpointType metrics.EndpointType) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			env := GetEnvContextInfo(req.Context()).Env
@@ -215,7 +200,7 @@ func RequestMetrics(measure metrics.Measure, endpointType metrics.EndpointType) 
 			ri := requestInfoFromHTTP(req)
 			ri.EndpointType = endpointType
 
-			requestFinished := metrics.StartActiveRequest(instruments, metricsEnv, measure.PlatformCategory(), ri)
+			requestFinished := metrics.StartActiveRequest(instruments, metricsEnv, ri)
 			defer requestFinished()
 
 			recorder := &statusRecorder{ResponseWriter: w, statusCode: 200}
@@ -227,7 +212,7 @@ func RequestMetrics(measure metrics.Measure, endpointType metrics.EndpointType) 
 				if recorder.statusCode >= 500 {
 					ri.ErrorType = fmt.Sprintf("%d", recorder.statusCode)
 				}
-				metrics.RecordRequestDuration(req.Context(), instruments, metricsEnv, ri, time.Since(start), measure)
+				metrics.RecordRequestDuration(req.Context(), instruments, metricsEnv, ri, time.Since(start))
 			}
 		})
 	}
@@ -245,7 +230,7 @@ func UnscopedActiveRequests(manager *metrics.Manager, endpointType metrics.Endpo
 			ri := requestInfoFromHTTP(req)
 			ri.EndpointType = endpointType
 
-			requestFinished := metrics.StartActiveRequest(manager.GetInstruments(), manager.GetUnscopedEnvironment(), "", ri)
+			requestFinished := metrics.StartActiveRequest(manager.GetInstruments(), manager.GetUnscopedEnvironment(), ri)
 			defer requestFinished()
 
 			next.ServeHTTP(w, req)
@@ -255,7 +240,7 @@ func UnscopedActiveRequests(manager *metrics.Manager, endpointType metrics.Endpo
 
 // EventBytesMetrics is a middleware function that records the number of event bytes received.
 // This should be applied after GzipMiddleware so that it measures decompressed bytes.
-func EventBytesMetrics(platformCategory string) mux.MiddlewareFunc {
+func EventBytesMetrics() mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			if req.Body == nil || req.Body == http.NoBody {
@@ -268,7 +253,7 @@ func EventBytesMetrics(platformCategory string) mux.MiddlewareFunc {
 			env := GetEnvContextInfo(req.Context()).Env
 			ri := requestInfoFromHTTP(req)
 			ri.EndpointType = metrics.EndpointTypeEvents
-			metrics.RecordEventsReceivedBytes(req.Context(), getInstruments(env), env.GetMetricsEnv(), platformCategory, ri, cr.bytesRead.Load())
+			metrics.RecordEventsReceivedBytes(req.Context(), getInstruments(env), env.GetMetricsEnv(), ri, cr.bytesRead.Load())
 		})
 	}
 }

--- a/internal/middleware/metrics_middleware_benchmark_test.go
+++ b/internal/middleware/metrics_middleware_benchmark_test.go
@@ -21,7 +21,7 @@ import (
 // duration histogram, with no active-request tracking. It exists solely so the benchmark below can
 // price the active-request half against a like-for-like baseline in a single tree, without checking
 // out the parent commit.
-func durationOnlyMetrics(measure metrics.Measure, endpointType metrics.EndpointType) mux.MiddlewareFunc {
+func durationOnlyMetrics(endpointType metrics.EndpointType) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			env := GetEnvContextInfo(req.Context()).Env
@@ -35,7 +35,7 @@ func durationOnlyMetrics(measure metrics.Measure, endpointType metrics.EndpointT
 				if recorder.statusCode >= 500 {
 					ri.ErrorType = fmt.Sprintf("%d", recorder.statusCode)
 				}
-				metrics.RecordRequestDuration(req.Context(), getInstruments(env), env.GetMetricsEnv(), ri, time.Since(start), measure)
+				metrics.RecordRequestDuration(req.Context(), getInstruments(env), env.GetMetricsEnv(), ri, time.Since(start))
 			}
 		})
 	}
@@ -97,8 +97,8 @@ func BenchmarkRequestMetricsMiddleware(b *testing.B) {
 		name       string
 		middleware mux.MiddlewareFunc
 	}{
-		{name: "active+duration", middleware: RequestMetrics(metrics.ServerDuration, metrics.EndpointTypePoll)},
-		{name: "duration-only (pre-change)", middleware: durationOnlyMetrics(metrics.ServerDuration, metrics.EndpointTypePoll)},
+		{name: "active+duration", middleware: RequestMetrics(metrics.EndpointTypePoll)},
+		{name: "duration-only (pre-change)", middleware: durationOnlyMetrics(metrics.EndpointTypePoll)},
 	}
 
 	for _, meterCase := range []struct {

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -113,29 +113,25 @@ func TestCountConnectionsDoesNotRecordActiveRequests(t *testing.T) {
 // Active requests must be tracked for every kind of endpoint, not just streams, per the OTEL semantic
 // convention for http.server.active_requests.
 func TestActiveRequests(t *testing.T) {
-	specs := []struct {
-		endpointType metrics.EndpointType
-		measure      metrics.Measure
-		platform     string
-	}{
-		{endpointType: metrics.EndpointTypeStream, measure: metrics.ServerDuration, platform: "server"},
-		{endpointType: metrics.EndpointTypePoll, measure: metrics.ServerDuration, platform: "server"},
-		{endpointType: metrics.EndpointTypeEvents, measure: metrics.MobileDuration, platform: "mobile"},
-		{endpointType: metrics.EndpointTypeGoals, measure: metrics.BrowserDuration, platform: "browser"},
+	endpointTypes := []metrics.EndpointType{
+		metrics.EndpointTypeStream,
+		metrics.EndpointTypePoll,
+		metrics.EndpointTypeEvents,
+		metrics.EndpointTypeGoals,
 	}
 
-	for _, tt := range specs {
-		t.Run(string(tt.endpointType), func(t *testing.T) {
+	for _, endpointType := range endpointTypes {
+		t.Run(string(endpointType), func(t *testing.T) {
 			metricsMiddlewareTest(t, func(p metricsMiddlewareTestParams) {
 				router := mux.NewRouter()
-				router.Use(RequestMetrics(tt.measure, tt.endpointType))
+				router.Use(RequestMetrics(endpointType))
 				router.Handle("/test-route", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					// While inside the handler, the request should be counted as active
 					rm := p.collectMetrics(t)
 					m := st.FindMetricByName(rm, "http.server.active_requests")
 					require.NotNil(t, m, "active requests metric not found")
-					assertMetricHasValue(t, m, p.envName, tt.platform, 1)
-					assertMetricHasAttribute(t, m, "relay.endpoint.type", string(tt.endpointType))
+					assertMetricHasValue(t, m, p.envName, 1)
+					assertMetricHasAttribute(t, m, "relay.endpoint.type", string(endpointType))
 				})).Methods("GET")
 
 				req, _ := http.NewRequest("GET", "/test-route", nil)
@@ -147,7 +143,7 @@ func TestActiveRequests(t *testing.T) {
 				rm := p.collectMetrics(t)
 				m := st.FindMetricByName(rm, "http.server.active_requests")
 				require.NotNil(t, m, "active requests metric not found")
-				assertMetricHasValue(t, m, p.envName, tt.platform, 0)
+				assertMetricHasValue(t, m, p.envName, 0)
 				sum, ok := m.Data.(metricdata.Sum[int64])
 				require.True(t, ok)
 				assert.Len(t, sum.DataPoints, 1, "increment and decrement should share one attribute set")
@@ -161,7 +157,7 @@ func TestActiveRequests(t *testing.T) {
 func TestActiveRequestsIncludesStreamingResponses(t *testing.T) {
 	metricsMiddlewareTest(t, func(p metricsMiddlewareTestParams) {
 		router := mux.NewRouter()
-		router.Use(RequestMetrics(metrics.ServerDuration, metrics.EndpointTypeStream))
+		router.Use(RequestMetrics(metrics.EndpointTypeStream))
 		router.Handle("/stream", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
@@ -169,7 +165,7 @@ func TestActiveRequestsIncludesStreamingResponses(t *testing.T) {
 			rm := p.collectMetrics(t)
 			m := st.FindMetricByName(rm, "http.server.active_requests")
 			require.NotNil(t, m, "active requests metric not found")
-			assertMetricHasValue(t, m, p.envName, "server", 1)
+			assertMetricHasValue(t, m, p.envName, 1)
 		})).Methods("GET")
 
 		req, _ := http.NewRequest("GET", "/stream", nil)
@@ -180,7 +176,7 @@ func TestActiveRequestsIncludesStreamingResponses(t *testing.T) {
 		rm := p.collectMetrics(t)
 		m := st.FindMetricByName(rm, "http.server.active_requests")
 		require.NotNil(t, m)
-		assertMetricHasValue(t, m, p.envName, "server", 0)
+		assertMetricHasValue(t, m, p.envName, 0)
 
 		assert.Nil(t, st.FindMetricByName(rm, "http.server.request.duration"),
 			"duration must not be recorded for a streaming response")
@@ -188,7 +184,7 @@ func TestActiveRequestsIncludesStreamingResponses(t *testing.T) {
 }
 
 // Requests with no environment -- the status endpoints and anything that matched no route -- still get
-// counted, reporting the not-provided sentinel for environment.name and platform.category.
+// counted, reporting the not-provided sentinel for environment.name.
 func TestUnscopedActiveRequests(t *testing.T) {
 	specs := []struct {
 		name         string
@@ -206,7 +202,7 @@ func TestUnscopedActiveRequests(t *testing.T) {
 						rm := p.collectMetrics(t)
 						m := st.FindMetricByName(rm, "http.server.active_requests")
 						require.NotNil(t, m, "active requests metric not found")
-						assertMetricHasValue(t, m, "not-provided", "not-provided", 1)
+						assertMetricHasValue(t, m, "not-provided", 1)
 						assertMetricHasAttribute(t, m, "relay.endpoint.type", string(tt.endpointType))
 					}))
 
@@ -217,7 +213,7 @@ func TestUnscopedActiveRequests(t *testing.T) {
 				rm := p.collectMetrics(t)
 				m := st.FindMetricByName(rm, "http.server.active_requests")
 				require.NotNil(t, m)
-				assertMetricHasValue(t, m, "not-provided", "not-provided", 0)
+				assertMetricHasValue(t, m, "not-provided", 0)
 			})
 		})
 	}
@@ -225,7 +221,7 @@ func TestUnscopedActiveRequests(t *testing.T) {
 
 func TestRequestDuration(t *testing.T) {
 	router := mux.NewRouter()
-	router.Use(RequestMetrics(metrics.ServerDuration, metrics.EndpointTypePoll))
+	router.Use(RequestMetrics(metrics.EndpointTypePoll))
 	router.Handle("/test-route", nullHandler()).Methods("GET")
 
 	metricsMiddlewareTest(t, func(p metricsMiddlewareTestParams) {
@@ -246,7 +242,7 @@ func TestRequestDuration(t *testing.T) {
 
 func TestEventBytesMetrics(t *testing.T) {
 	router := mux.NewRouter()
-	router.Use(EventBytesMetrics(metrics.ServerPlatformCategory))
+	router.Use(EventBytesMetrics())
 	router.Handle("/events", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// Consume the body so counting reader sees the bytes
 		_, _ = io.ReadAll(req.Body)
@@ -263,7 +259,7 @@ func TestEventBytesMetrics(t *testing.T) {
 		rm := p.collectMetrics(t)
 		bytesMetric := st.FindMetricByName(rm, "launchdarkly.relay.events.received.size")
 		require.NotNil(t, bytesMetric, "events received bytes metric not found")
-		assertMetricHasValue(t, bytesMetric, p.envName, "server", 35)
+		assertMetricHasValue(t, bytesMetric, p.envName, 35)
 	})
 }
 
@@ -295,20 +291,19 @@ func TestParseApplicationTags(t *testing.T) {
 }
 
 // assertMetricHasValue checks that a metric has the expected value for the given environment and platform.
-func assertMetricHasValue(t *testing.T, m *metricdata.Metrics, envName, platform string, expected int64) {
+func assertMetricHasValue(t *testing.T, m *metricdata.Metrics, envName string, expected int64) {
 	t.Helper()
 	sum, ok := m.Data.(metricdata.Sum[int64])
 	require.True(t, ok, "expected Sum[int64] data for %s", m.Name)
 	found := false
 	for _, dp := range sum.DataPoints {
-		platVal, platOK := dp.Attributes.Value(attribute.Key("platform.category"))
 		envVal, envOK := dp.Attributes.Value(attribute.Key("environment.name"))
-		if platOK && envOK && platVal.AsString() == platform && envVal.AsString() == envName {
-			assert.Equal(t, expected, dp.Value, "unexpected value for %s (platform=%s, env=%s)", m.Name, platform, envName)
+		if envOK && envVal.AsString() == envName {
+			assert.Equal(t, expected, dp.Value, "unexpected value for %s (env=%s)", m.Name, envName)
 			found = true
 		}
 	}
-	assert.True(t, found, "no data point found for %s with platform=%s, env=%s", m.Name, platform, envName)
+	assert.True(t, found, "no data point found for %s with env=%s", m.Name, envName)
 }
 
 // assertMetricHasAttribute checks that every data point of a metric carries the expected attribute value.

--- a/internal/tracing/resource.go
+++ b/internal/tracing/resource.go
@@ -4,20 +4,50 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
+	"sync"
 
+	"github.com/pborman/uuid"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
+
+// relayIDAttrKey identifies the relay process. It is a resource attribute rather than a per-measurement
+// one: it never varies within a process, so repeating it on every data point only inflated the attribute
+// set that has to be built and sorted for each request.
+const relayIDAttrKey = attribute.Key("relay.id")
+
+// relayID is generated once per process, so that the metrics and trace providers -- which each build
+// their own resource -- report the same identity.
+var relayID = sync.OnceValue(uuid.New) //nolint:gochecknoglobals
+
+// RelayID returns the identifier for this relay process. It is reported as the relay.id resource
+// attribute, and is also the ID used in the usage data Relay sends to LaunchDarkly.
+func RelayID() string {
+	return relayID()
+}
 
 // NewResource builds an OTel resource from standard environment variables
 // (OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME). If OTEL_SERVICE_NAME is
 // unset, it defaults to "ld-relay". If resource creation fails or returns
 // nil, it falls back to resource.Default() and logs a warning.
+//
+// Note for Prometheus users: resource attributes are not copied onto every series. They are exposed
+// through target_info, so a query that needs relay.id has to join against it. service.instance.id is
+// set to the same value because Prometheus surfaces that one directly as the "instance" label.
 func NewResource(logger *slog.Logger) *resource.Resource {
 	opts := []resource.Option{resource.WithFromEnv()}
 	if os.Getenv("OTEL_SERVICE_NAME") == "" {
 		opts = append(opts, resource.WithAttributes(semconv.ServiceName("ld-relay")))
 	}
+	attrs := []attribute.KeyValue{relayIDAttrKey.String(RelayID())}
+	// Only supply service.instance.id when the operator has not configured one themselves.
+	if !strings.Contains(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"), string(semconv.ServiceInstanceIDKey)) {
+		attrs = append(attrs, semconv.ServiceInstanceID(RelayID()))
+	}
+	opts = append(opts, resource.WithAttributes(attrs...))
+
 	res, err := resource.New(context.Background(), opts...)
 	if err != nil || res == nil {
 		logger.Warn("failed to create OTel resource, falling back to default", "error", err)

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -86,7 +86,7 @@ func (r *Relay) makeRouter() *mux.Router {
 			jsClientSelector, // selects an environment based on the client-side ID in the URL
 			middleware.CORS,  // must apply this after jsClientSelector because the CORS headers can be environment-specific
 			middleware.TrackUsageActivity(metrics.BrowserPlatformCategory),
-			middleware.RequestMetrics(metrics.BrowserDuration, endpointType),
+			middleware.RequestMetrics(endpointType),
 		)
 	}
 
@@ -105,7 +105,7 @@ func (r *Relay) makeRouter() *mux.Router {
 		return middleware.Chain(
 			sdkKeySelector,
 			middleware.TrackUsageActivity(metrics.ServerPlatformCategory),
-			middleware.RequestMetrics(metrics.ServerDuration, endpointType),
+			middleware.RequestMetrics(endpointType),
 		)
 	}
 
@@ -129,7 +129,7 @@ func (r *Relay) makeRouter() *mux.Router {
 		clientSideFDv2EnvAuth,
 		middleware.CORS,
 		middleware.DynamicTrackUsageActivity(),
-		middleware.DynamicRequestMetrics(metrics.EndpointTypeStream),
+		middleware.RequestMetrics(metrics.EndpointTypeStream),
 	)
 	clientSideFDv2StreamRouter.Use(clientSideFDv2StreamMiddleware, middleware.Streaming)
 	clientSideFDv2PingHandler := pingStreamHandlerWithContextV2(r.mobileStreamProvider, r.jsClientStreamProvider, maxClientRequestBodySize)
@@ -142,7 +142,7 @@ func (r *Relay) makeRouter() *mux.Router {
 		clientSideFDv2EnvAuth,
 		middleware.CORS,
 		middleware.DynamicTrackUsageActivity(),
-		middleware.DynamicRequestMetrics(metrics.EndpointTypePoll),
+		middleware.RequestMetrics(metrics.EndpointTypePoll),
 	)
 	clientSideFDv2PollRouter.Use(clientSideFDv2PollMiddleware)
 	clientSideFDv2PollRouter.Handle("/{context}", middleware.DynamicPollingRequestCount(http.HandlerFunc(pollEvalHandlerV2(maxClientRequestBodySize)))).Methods("GET", "OPTIONS")
@@ -168,7 +168,7 @@ func (r *Relay) makeRouter() *mux.Router {
 		return middleware.Chain(
 			mobileKeySelector,
 			middleware.TrackUsageActivity(metrics.MobilePlatformCategory),
-			middleware.RequestMetrics(metrics.MobileDuration, endpointType))
+			middleware.RequestMetrics(endpointType))
 	}
 
 	msdkRouter := router.PathPrefix("/msdk/").Subrouter()
@@ -205,18 +205,18 @@ func (r *Relay) makeRouter() *mux.Router {
 	clientSideStreamEvalRouter.Handle("", middleware.UsageActivityStreamMonitoring(metrics.BrowserPlatformCategory, middleware.CountBrowserConns(jsPingWithUser))).Methods("REPORT", "OPTIONS")
 
 	mobileEventsRouter := router.PathPrefix("/mobile").Subrouter()
-	mobileEventsRouter.Use(mobileMiddlewareStack(metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.MobilePlatformCategory))
+	mobileEventsRouter.Use(mobileMiddlewareStack(metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics())
 	mobileEventsRouter.Handle("/events/bulk", bulkEventHandler(basictypes.MobileSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST")
 	mobileEventsRouter.Handle("/events", bulkEventHandler(basictypes.MobileSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST")
 	mobileEventsRouter.Handle("", bulkEventHandler(basictypes.MobileSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST")
 	mobileEventsRouter.Handle("/events/diagnostic", bulkEventHandler(basictypes.MobileSDK, ldevents.DiagnosticEventDataKind, offlineMode)).Methods("POST")
 
 	clientSideBulkEventsRouter := router.PathPrefix("/events/bulk/{envId}").Subrouter()
-	clientSideBulkEventsRouter.Use(jsClientSideMiddlewareStack(clientSideBulkEventsRouter, metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.BrowserPlatformCategory))
+	clientSideBulkEventsRouter.Use(jsClientSideMiddlewareStack(clientSideBulkEventsRouter, metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics())
 	clientSideBulkEventsRouter.Handle("", bulkEventHandler(basictypes.JSClientSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST", "OPTIONS")
 
 	clientSideDiagnosticEventsRouter := router.PathPrefix("/events/diagnostic/{envId}").Subrouter()
-	clientSideDiagnosticEventsRouter.Use(jsClientSideMiddlewareStack(clientSideBulkEventsRouter, metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.BrowserPlatformCategory))
+	clientSideDiagnosticEventsRouter.Use(jsClientSideMiddlewareStack(clientSideBulkEventsRouter, metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics())
 	clientSideDiagnosticEventsRouter.Handle("", bulkEventHandler(basictypes.JSClientSDK, ldevents.DiagnosticEventDataKind, offlineMode)).Methods("POST", "OPTIONS")
 
 	clientSideImageEventsRouter := router.PathPrefix("/a/{envId}.gif").Subrouter()
@@ -229,7 +229,7 @@ func (r *Relay) makeRouter() *mux.Router {
 	// endpoint types, so the middleware stack is applied per endpoint group instead of to the whole
 	// subrouter.
 	serverSideBulkEventsRouter := serverSideRouter.NewRoute().Subrouter()
-	serverSideBulkEventsRouter.Use(serverSideMiddlewareStack(metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics(metrics.ServerPlatformCategory))
+	serverSideBulkEventsRouter.Use(serverSideMiddlewareStack(metrics.EndpointTypeEvents), middleware.GzipMiddleware(r.config.Events.MaxInboundPayloadSize), middleware.EventBytesMetrics())
 	serverSideBulkEventsRouter.Handle("/bulk", bulkEventHandler(basictypes.ServerSDK, ldevents.AnalyticsEventDataKind, offlineMode)).Methods("POST")
 	serverSideBulkEventsRouter.Handle("/diagnostic", bulkEventHandler(basictypes.ServerSDK, ldevents.DiagnosticEventDataKind, offlineMode)).Methods("POST")
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #802. The base is `mk/sdk-2892/expand-active-requests`, so the diff here is only this change; GitHub will retarget it to `v9` once #802 merges.

## Summary

The request metrics (`http.server.active_requests`, `http.server.request.duration`, `launchdarkly.relay.events.received.size`) carried twelve attributes. Only `http.request.method` and `url.scheme` are required by semconv, with `http.route` conditionally required on the duration histogram; the rest is our own enrichment, and several dimensions were multiplying the series count without earning it.

Dropped from all three:

- **`instance.id`** — comes from `X-LaunchDarkly-Instance-Id`, so one value per SDK *instance*. It made every request metric grow a series per client process, by far the largest contributor to cardinality here.
- **`platform.category`** and **`sdk.wrapper`** — largely implied by `http.route`.

All three are still reported in the usage data Relay sends to LaunchDarkly, which is a separate sink with its own cardinality budget, so no per-instance or per-platform detail is actually lost.

`relay.id` moves to a **resource** attribute. It never varies within a process, so repeating it on every data point only inflated the attribute set that has to be built and sorted per request. It is generated once in the `tracing` package now, so metrics, traces and the LaunchDarkly usage data all report the same identity — previously the metrics Manager minted its own and spans carried none. `service.instance.id` is set to the same value unless the operator supplies one via `OTEL_RESOURCE_ATTRIBUTES`, since that is the standard attribute for a process instance and Prometheus surfaces it as the `instance` label.

What remains: `environment.name`, `user_agent`, `http.route`, `http.request.method`, `url.scheme`, `application.id`, `application.version`, `relay.endpoint.type`.

### Knock-on simplification

With `platform.category` gone, the SDK platform no longer changes what these metrics record. That removes the reason for `DynamicRequestMetrics` and for the three separate duration `Measure` values, so `RequestMetrics` now takes only an endpoint type, and `Measure` keeps just the fields the usage sink uses.

### Measured effect

Eight attributes for active requests and ten for duration puts both inside `attribute.NewSet`'s fixed-size fast path (`computeDataFixed`, ten or fewer); the previous twelve fell through to the reflection-based path. Per request with OpenTelemetry enabled:

| | before | after |
|---|---|---|
| attribute set | 2,040 ns / 3,432 B / 6 allocs | **955 ns / 1,488 B / 4 allocs** |
| request metrics middleware | 8,367 ns / 8,764 B / 32 allocs | **5,216 ns / 4,930 B / 29 allocs** |

That is below the 5,477 ns / 5,262 B the middleware cost *before* `http.server.active_requests` was broadened beyond streaming in #802. So the metric now covers every endpoint **and** is cheaper than the streams-only version it replaced, which resolves the +53% regression measured on that PR.

### Breaking change

`platform.category`, `sdk.wrapper` and `instance.id` are no longer reported on metrics, and `relay.id` is a resource attribute rather than a per-series one. Dashboards and alerts that group or filter on these need updating.

Worth flagging for anyone writing PromQL: resource attributes are **not** copied onto every series. Prometheus exposes them through `target_info`, so a query that wants `relay.id` has to join against it — or use the `instance` label, which now carries the same value.

Closes SDK-2894

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Breaking:** request metrics no longer carry `instance.id`, `platform.category`, or `sdk.wrapper`. Those dimensions inflated series count (especially per-SDK-instance `instance.id`) and are still reported in LaunchDarkly usage data.
> 
> **`relay.id` becomes a resource attribute**, generated once in `tracing` so metrics, traces, and usage share the same process identity. `service.instance.id` defaults to the same value for Prometheus's `instance` label. Queries that filtered on `relay.id` as a series label need a `target_info` join (or the `instance` label).
> 
> With platform gone from these metrics, `RequestMetrics` / `EventBytesMetrics` no longer take a platform argument, and the duration-specific `Measure` values plus `DynamicRequestMetrics` are removed. Remaining request attributes stay within `attribute.NewSet`'s fast path, cutting per-request cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 814eac9b339d5716d1ad00e2776b578a938e5d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->