### PR TITLE
feat: Make the OTel metric cardinality limit configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -327,7 +327,13 @@ type HTTPConfig struct {
 // Most standard OTEL environment variables (OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS,
 // OTEL_SERVICE_NAME, etc.) are read directly by the OpenTelemetry SDK and should not be duplicated here.
 // Only Relay-specific settings belong in this struct.
+//
+// MetricsCardinalityLimit is an exception to that rule: the OpenTelemetry specification defines no
+// environment variable for the cardinality limit, and the Go SDK's own OTEL_GO_X_CARDINALITY_LIMIT sits
+// in its experimental namespace, so Relay owns this setting. When it is undefined, Relay applies no
+// option and the SDK's default (or OTEL_GO_X_CARDINALITY_LIMIT, if the operator set it) stands.
 type OpenTelemetryConfig struct {
-	Enabled  bool   `conf:"USE_OTLP"`
-	Protocol string `conf:"OTEL_EXPORTER_OTLP_PROTOCOL"`
+	Enabled                 bool      `conf:"USE_OTLP"`
+	Protocol                string    `conf:"OTEL_EXPORTER_OTLP_PROTOCOL"`
+	MetricsCardinalityLimit ct.OptInt `conf:"OTEL_METRICS_CARDINALITY_LIMIT"`
 }

--- a/config/config_validation.go
+++ b/config/config_validation.go
@@ -20,7 +20,8 @@ var (
 	errMaxClientRequestBodySize        = errors.New("max client request body size must be greater than zero")
 	errAutoConfWithoutDBDisambig       = errors.New(`when using auto-configuration with database storage, database prefix (or,` +
 		` if using DynamoDB, table name) must be specified and must contain "` + AutoConfigEnvironmentIDPlaceholder + `"`)
-	errOTLPInvalidProtocol = errors.New(`OTLP protocol must be "grpc" or "http" (OTEL_EXPORTER_OTLP_PROTOCOL)`) //nolint:stylecheck
+	errOTLPInvalidProtocol          = errors.New(`OTLP protocol must be "grpc" or "http" (OTEL_EXPORTER_OTLP_PROTOCOL)`) //nolint:stylecheck
+	errOTLPNegativeCardinalityLimit = errors.New("metrics cardinality limit must not be negative; use 0 for no limit (OTEL_METRICS_CARDINALITY_LIMIT)")
 
 	errRedisURLWithHostAndPort                 = errors.New("please specify Redis URL or host/port, but not both")
 	errRedisBadHostname                        = errors.New("invalid Redis hostname")
@@ -326,6 +327,9 @@ func validateConfigMetrics(result *ct.ValidationResult, c *Config) {
 		protocol := strings.ToLower(c.OpenTelemetry.Protocol)
 		if protocol != "" && protocol != "grpc" && protocol != "http" {
 			result.AddError(nil, errOTLPInvalidProtocol)
+		}
+		if limit := c.OpenTelemetry.MetricsCardinalityLimit; limit.IsDefined() && limit.GetOrElse(0) < 0 {
+			result.AddError(nil, errOTLPNegativeCardinalityLimit)
 		}
 	}
 }

--- a/config/test_data_configs_invalid_test.go
+++ b/config/test_data_configs_invalid_test.go
@@ -44,6 +44,7 @@ func makeInvalidConfigs() []testDataInvalidConfig {
 		makeInvalidConfigDynamoDBAutoConfNoPrefixOrTableName(),
 		makeInvalidConfigMultipleDatabases(),
 		makeInvalidConfigOTLPInvalidProtocol(),
+		makeInvalidConfigOTLPNegativeCardinalityLimit(),
 		makeInvalidConfigMaxClientRequestBodySize("0B"),
 	}
 }
@@ -471,6 +472,21 @@ func makeInvalidConfigOTLPInvalidProtocol() testDataInvalidConfig {
 [OpenTelemetry]
 Enabled = true
 Protocol = websocket
+`
+	return c
+}
+
+func makeInvalidConfigOTLPNegativeCardinalityLimit() testDataInvalidConfig {
+	c := testDataInvalidConfig{name: "OTLP - negative cardinality limit"}
+	c.envVarsError = errOTLPNegativeCardinalityLimit.Error()
+	c.envVars = map[string]string{
+		"USE_OTLP":                       "1",
+		"OTEL_METRICS_CARDINALITY_LIMIT": "-1",
+	}
+	c.fileContent = `
+[OpenTelemetry]
+Enabled = true
+MetricsCardinalityLimit = -1
 `
 	return c
 }

--- a/config/test_data_configs_valid_test.go
+++ b/config/test_data_configs_valid_test.go
@@ -98,6 +98,7 @@ func makeValidConfigs() []testDataValidConfig {
 		makeValidConfigDynamoDBOneEnvNoPrefixOrTable(),
 		makeValidConfigOTLPMinimal(),
 		makeValidConfigOTLPAll(),
+		makeValidConfigOTLPUnlimitedCardinality(),
 		makeValidConfigProxy(),
 	}
 }
@@ -768,18 +769,41 @@ func makeValidConfigOTLPAll() testDataValidConfig {
 	c := testDataValidConfig{name: "OpenTelemetry - all parameters"}
 	c.makeConfig = func(c *Config) {
 		c.OpenTelemetry = OpenTelemetryConfig{
-			Enabled:  true,
-			Protocol: "grpc",
+			Enabled:                 true,
+			Protocol:                "grpc",
+			MetricsCardinalityLimit: ct.NewOptInt(20000),
 		}
 	}
 	c.envVars = map[string]string{
-		"USE_OTLP":                    "1",
-		"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+		"USE_OTLP":                       "1",
+		"OTEL_EXPORTER_OTLP_PROTOCOL":    "grpc",
+		"OTEL_METRICS_CARDINALITY_LIMIT": "20000",
 	}
 	c.fileContent = `
 [OpenTelemetry]
 Enabled = true
 Protocol = grpc
+MetricsCardinalityLimit = 20000
+`
+	return c
+}
+
+func makeValidConfigOTLPUnlimitedCardinality() testDataValidConfig {
+	c := testDataValidConfig{name: "OpenTelemetry - cardinality limit disabled"}
+	c.makeConfig = func(c *Config) {
+		c.OpenTelemetry = OpenTelemetryConfig{
+			Enabled:                 true,
+			MetricsCardinalityLimit: ct.NewOptInt(0),
+		}
+	}
+	c.envVars = map[string]string{
+		"USE_OTLP":                       "1",
+		"OTEL_METRICS_CARDINALITY_LIMIT": "0",
+	}
+	c.fileContent = `
+[OpenTelemetry]
+Enabled = true
+MetricsCardinalityLimit = 0
 `
 	return c
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,6 +247,7 @@ To learn more, read [Metrics](./metrics.md).
 |------------------|--------------------------------|:-------:|:--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `enabled`        | `USE_OTLP`                     | Boolean | `false` | If true, enables exporting metrics via OTLP.                                                                                                                                                                       |
 | `protocol`       | `OTEL_EXPORTER_OTLP_PROTOCOL` | String  |         | The OTLP transport protocol. Must be `grpc` or `http`.                                                                                                                                                             |
+| `metricsCardinalityLimit` | `OTEL_METRICS_CARDINALITY_LIMIT` | Int | `2000` | The maximum number of distinct attribute sets recorded for a single metric instrument in one export cycle. Set to `0` for no limit. To learn more, read [Metrics](./metrics.md). |
 
 All other OTLP configuration — including endpoint, headers, TLS, compression, timeouts, and service name — is handled by standard [OpenTelemetry environment variables](https://opentelemetry.io/docs/specs/otel/protocol/exporter/). The OpenTelemetry SDK reads these directly from the environment. Commonly used variables include:
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -63,6 +63,29 @@ they report `not-provided` for `environment.name` and the other SDK attributes.
 in particular is per SDK *instance*, which made these metrics grow a series per client process. All
 three are still included in the usage data the Relay Proxy sends to LaunchDarkly.
 
+## Cardinality limit
+
+The OpenTelemetry SDK caps how many distinct attribute sets a single instrument can record in one
+export cycle. The default cap is 2000. Once an instrument reaches it, any attribute set it has not
+already recorded in that cycle is folded into one series carrying only `otel.metric.overflow=true`;
+attribute sets already being recorded continue normally. Nothing is logged when this happens, so an
+`otel.metric.overflow` series showing up in your backend is the signal that the cap has been reached
+and that some series are being merged.
+
+Because the request attributes above multiply together -- environments times user agents times routes
+times status codes, and so on -- a Relay Proxy serving many environments or a diverse SDK fleet can
+reach the cap. Raise it, or remove it entirely, with `metricsCardinalityLimit` /
+`OTEL_METRICS_CARDINALITY_LIMIT`:
+
+```
+OTEL_METRICS_CARDINALITY_LIMIT=20000   # raise the cap
+OTEL_METRICS_CARDINALITY_LIMIT=0       # no cap
+```
+
+The limit applies to every instrument, including the Go runtime metrics. Removing it entirely means
+memory use and the size of each export grow with however many attribute combinations your traffic
+produces, so prefer raising it to a value your backend can absorb.
+
 ## Backend-specific notes
 
 ### Prometheus

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -84,6 +84,7 @@ func NewManager(
 			sdkmetric.Instrument{Name: requestDurationMeasureName},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationBase2ExponentialHistogram{MaxSize: 160, MaxScale: 20}},
 		)))
+		opts = append(opts, cardinalityLimitOptions(otlpConfig, logger)...)
 		meterProvider = sdkmetric.NewMeterProvider(opts...)
 		if err := runtime.Start(runtime.WithMeterProvider(meterProvider)); err != nil {
 			logger.Warn("failed to start Go runtime metrics", "error", err)
@@ -114,6 +115,24 @@ func NewManager(
 	go m.consumeUsageStats()
 
 	return m, nil
+}
+
+// cardinalityLimitOptions returns the MeterProvider options implied by the configured cardinality
+// limit. The SDK caps each instrument at 2000 distinct attribute sets per collection cycle by
+// default, folding everything past that into a single otel.metric.overflow series. When the operator
+// configured nothing we return no options, because passing one unconditionally would also shadow the
+// SDK's own OTEL_GO_X_CARDINALITY_LIMIT. A configured limit of zero means no limit at all.
+func cardinalityLimitOptions(otlpConfig config.OpenTelemetryConfig, logger *slog.Logger) []sdkmetric.Option {
+	if !otlpConfig.MetricsCardinalityLimit.IsDefined() {
+		return nil
+	}
+	limit := otlpConfig.MetricsCardinalityLimit.GetOrElse(0)
+	if limit == 0 {
+		logger.Info("OTel metrics cardinality limit disabled")
+	} else {
+		logger.Info("using OTel metrics cardinality limit", "limit", limit)
+	}
+	return []sdkmetric.Option{sdkmetric.WithCardinalityLimit(limit)}
 }
 
 // GetInstruments returns the OTel instruments for recording metrics.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -9,12 +9,15 @@ import (
 
 	"github.com/launchdarkly/ld-relay/v9/config"
 
+	ct "github.com/launchdarkly/go-configtypes"
 	ldevents "github.com/launchdarkly/go-sdk-events/v3"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
@@ -70,6 +73,71 @@ func TestNewInstrumentsCreatesEveryInstrument(t *testing.T) {
 	assert.NotNil(t, instruments.eventsFailedSend)
 	assert.NotNil(t, instruments.eventsBytesSent)
 	assert.NotNil(t, instruments.pendingEvents)
+}
+
+// The cardinality limit is only meaningful through the MeterProvider it is applied to, so these
+// tests record more distinct attribute sets than the limit allows and check what actually comes
+// back out of a reader.
+func recordDistinctAttributeSets(t *testing.T, otlpConfig config.OpenTelemetryConfig, count int) metricdata.Sum[int64] {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	opts := append([]sdkmetric.Option{sdkmetric.WithReader(reader)},
+		cardinalityLimitOptions(otlpConfig, slog.Default())...)
+	meterProvider := sdkmetric.NewMeterProvider(opts...)
+	defer func() {
+		require.NoError(t, meterProvider.Shutdown(context.Background()))
+	}()
+
+	counter, err := meterProvider.Meter("ld-relay").Int64Counter("test.counter")
+	require.NoError(t, err)
+	for i := range count {
+		counter.Add(context.Background(), 1, otelmetric.WithAttributes(attribute.Int("index", i)))
+	}
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	require.Len(t, rm.ScopeMetrics, 1)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+
+	sum, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	return sum
+}
+
+func hasOverflowDataPoint(sum metricdata.Sum[int64]) bool {
+	for _, dp := range sum.DataPoints {
+		if value, ok := dp.Attributes.Value(attribute.Key("otel.metric.overflow")); ok && value.AsBool() {
+			return true
+		}
+	}
+	return false
+}
+
+func TestConfiguredCardinalityLimitIsAppliedToTheMeterProvider(t *testing.T) {
+	otlpConfig := config.OpenTelemetryConfig{Enabled: true, MetricsCardinalityLimit: ct.NewOptInt(3)}
+
+	sum := recordDistinctAttributeSets(t, otlpConfig, 10)
+
+	// The SDK reserves one of the allotted series for the overflow data point, so a limit of 3
+	// yields two real series plus the overflow.
+	assert.Len(t, sum.DataPoints, 3)
+	assert.True(t, hasOverflowDataPoint(sum))
+}
+
+func TestCardinalityLimitOfZeroRemovesTheLimit(t *testing.T) {
+	otlpConfig := config.OpenTelemetryConfig{Enabled: true, MetricsCardinalityLimit: ct.NewOptInt(0)}
+
+	sum := recordDistinctAttributeSets(t, otlpConfig, 10)
+
+	assert.Len(t, sum.DataPoints, 10)
+	assert.False(t, hasOverflowDataPoint(sum))
+}
+
+// Leaving the setting undefined has to mean "pass no option", so that the SDK default and its own
+// OTEL_GO_X_CARDINALITY_LIMIT still decide the limit.
+func TestUnconfiguredCardinalityLimitAddsNoOption(t *testing.T) {
+	assert.Empty(t, cardinalityLimitOptions(config.OpenTelemetryConfig{Enabled: true}, slog.Default()))
 }
 
 func TestAddEnvironmentWithoutEventPublisher(t *testing.T) {


### PR DESCRIPTION
The OpenTelemetry Go metrics SDK caps each instrument at 2000 distinct
attribute sets per collection cycle by default. Past that, every attribute
set the instrument has not already recorded in the cycle is folded into a
single otel.metric.overflow series, and nothing is logged when it happens.

Relay's request metrics cross environment.name, user_agent, http.route,
http.request.method, http.response.status_code, url.scheme,
network.protocol.version, error.type, application.id and
application.version, so a Relay serving many environments or a diverse SDK
fleet can reach the cap. Until now Relay exposed no way to change it: the
Go SDK does read OTEL_GO_X_CARDINALITY_LIMIT, but that lives in its
experimental namespace, is not part of the OpenTelemetry specification, and
is absent from the standard OTEL variable docs our configuration reference
points operators at.

Add metricsCardinalityLimit / OTEL_METRICS_CARDINALITY_LIMIT to the
[OpenTelemetry] section. It is an OptInt so that "unset" stays distinct
from 0, which the SDK treats as no limit; when unset we pass no option at
all, leaving the SDK default and OTEL_GO_X_CARDINALITY_LIMIT in charge.
Negative values are rejected during validation rather than silently
uncapping cardinality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`metricsCardinalityLimit`** / **`OTEL_METRICS_CARDINALITY_LIMIT`** under `[OpenTelemetry]` so operators can raise or remove the OpenTelemetry Go SDK’s per-instrument attribute-set cap (default 2000), which matters when Relay’s high-cardinality request metrics hit overflow (`otel.metric.overflow`).
> 
> The value is an **`OptInt`**: unset means Relay does **not** pass `WithCardinalityLimit`, leaving the SDK default and experimental **`OTEL_GO_X_CARDINALITY_LIMIT`** in effect; **`0`** disables the limit. **Negative** values fail validation at startup.
> 
> When OTLP export is enabled, **`cardinalityLimitOptions`** wires the limit into the **`MeterProvider`**; docs describe cardinality behavior and configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b287230226dd62ac5d5325fbe1e014c9e6d74b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->