### PR TITLE
feat!: Align OTel naming with the semantic conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ You can also configure the Relay Proxy to persist segment information for Big Se
 For persistent storage configuration details, read [Persistent Storage](./docs/persistent-storage.md).
 
 
-## Exporting metrics
+## Exporting metrics and traces
 
-The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/) to any compatible backend. To learn more, read [Metrics](./docs/metrics.md).
+The Relay Proxy can export metrics and distributed traces via [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/) to any compatible backend. To learn more, read [Metrics](./docs/metrics.md) and [Tracing](./docs/tracing.md).
 
 
 ## Logging

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,7 +2,7 @@
 
 [(Back to README)](../README.md)
 
-The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/) to any compatible backend, such as Prometheus, Datadog, Grafana, or an OpenTelemetry Collector. To learn about configuration, read [Configuration](./configuration.md).
+The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/) to any compatible backend, such as Prometheus, Datadog, Grafana, or an OpenTelemetry Collector. To learn about configuration, read [Configuration](./configuration.md). The same setting also exports traces; to learn about those, read [Tracing](./tracing.md).
 
 ## Available metrics
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -46,7 +46,7 @@ The request metrics -- `http.server.active_requests`, `http.server.request.durat
 | `url.scheme` | The URL scheme. Example: `https` |
 | `application.id` | The application identifier, extracted from the `application-id` field of the `X-LaunchDarkly-Tags` header. |
 | `application.version` | The application version, extracted from the `application-version` field of the `X-LaunchDarkly-Tags` header. |
-| `relay.endpoint.type` | The kind of endpoint that served the request: `stream`, `poll`, `events`, `goals`, or `status`. Requests that matched no route report `not-provided`. |
+| `relay.endpoint.type` | The kind of endpoint that served the request: `stream`, `poll`, `events`, `goals`, or `status`. Requests that matched no route report `not_provided`. |
 
 `http.server.request.duration` additionally carries `http.response.status_code`,
 `network.protocol.version`, and -- for a 5xx response -- `error.type`.
@@ -59,9 +59,9 @@ service returned a response, `error.type` is that status code as a string and
 `http.response.status_code` carries it as a number. When the send failed before any response arrived
 -- a network error or a timeout -- `error.type` is `_OTHER` and no status code is reported.
 
-Attribute values that are absent are reported as `not-provided` rather than being omitted. The status
+Attribute values that are absent are reported as `not_provided` rather than being omitted. The status
 endpoints and requests that matched no route are not associated with an SDK or an LD environment, so
-they report `not-provided` for `environment.name` and the other SDK attributes.
+they report `not_provided` for `environment.name` and the other SDK attributes.
 
 `platform.category`, `sdk.wrapper`, and `instance.id` are no longer reported on metrics. `instance.id`
 in particular is per SDK *instance*, which made these metrics grow a series per client process. All

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -53,7 +53,11 @@ The request metrics -- `http.server.active_requests`, `http.server.request.durat
 
 The event delivery metrics (`launchdarkly.relay.events.sent`, `.sent.size`, `.send.errors`,
 `.dropped`, `.pending`) are recorded outside any request, so they carry only `environment.name`.
-`.send.errors` also carries `status_code`.
+
+Every measurement on `.send.errors` is a failure, so it always carries `error.type`. When the events
+service returned a response, `error.type` is that status code as a string and
+`http.response.status_code` carries it as a number. When the send failed before any response arrived
+-- a network error or a timeout -- `error.type` is `_OTHER` and no status code is reported.
 
 Attribute values that are absent are reported as `not-provided` rather than being omitted. The status
 endpoints and requests that matched no route are not associated with an SDK or an LD environment, so

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -43,8 +43,8 @@ The request metrics -- `http.server.active_requests`, `http.server.request.durat
 | `http.route` | The request URL path template. Variables appear as placeholders rather than actual values. Example: `/sdk/evalx/{envId}/contexts/{context}` |
 | `http.request.method` | The HTTP method. Example: `GET` |
 | `url.scheme` | The URL scheme. Example: `https` |
-| `application.id` | The application identifier, extracted from the `application-id` field of the `X-LaunchDarkly-Tags` header. |
-| `application.version` | The application version, extracted from the `application-version` field of the `X-LaunchDarkly-Tags` header. |
+| `launchdarkly.application.id` | The application identifier, extracted from the `application-id` field of the `X-LaunchDarkly-Tags` header. |
+| `launchdarkly.application.version` | The application version, extracted from the `application-version` field of the `X-LaunchDarkly-Tags` header. |
 | `relay.endpoint.type` | The kind of endpoint that served the request: `stream`, `poll`, `events`, `goals`, or `status`. Requests that matched no route report `not_provided`. |
 
 `http.server.request.duration` additionally carries `http.response.status_code`,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -40,7 +40,7 @@ The request metrics -- `http.server.active_requests`, `http.server.request.durat
 | Attribute | Description |
 |-----------|-------------|
 | `environment.name` | The name of the LaunchDarkly environment as configured in the Relay Proxy. In automatic configuration or offline mode, this is the actual project and environment name from LaunchDarkly. Example: `MyApplication Staging` |
-| `user_agent` | The user agent of the SDK making the request, with slashes replaced by underscores. Example: `Node_3.4.0` |
+| `user_agent.original` | The `User-Agent` header sent by the SDK making the request, as received. Example: `Node/3.4.0` |
 | `http.route` | The request URL path template. Variables appear as placeholders rather than actual values. Example: `/sdk/evalx/{envId}/contexts/{context}` |
 | `http.request.method` | The HTTP method. Example: `GET` |
 | `url.scheme` | The URL scheme. Example: `https` |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -25,12 +25,11 @@ being repeated on each measurement:
 | Attribute | Description |
 |-----------|-------------|
 | `service.name` | `ld-relay`, unless overridden with `OTEL_SERVICE_NAME`. |
-| `relay.id` | A unique identifier for this Relay Proxy process, generated at startup. Example: `5f313039-df4e-45f5-ad9e-4afd840cb210` |
-| `service.instance.id` | The same value as `relay.id`, unless you supply your own via `OTEL_RESOURCE_ATTRIBUTES`. This is the standard attribute for identifying a process instance, and Prometheus exposes it as the `instance` label. |
+| `service.instance.id` | A unique identifier for this Relay Proxy process, generated at startup, unless you supply your own via `OTEL_RESOURCE_ATTRIBUTES`. Prometheus exposes it as the `instance` label. Example: `5f313039-df4e-45f5-ad9e-4afd840cb210` |
 
 Note that resource attributes are **not** copied onto every series. Prometheus reports them through
-`target_info`, so a query that needs `relay.id` has to join against it -- or use the `instance` label,
-which carries the same value.
+`target_info`, so a query that needs the process identity has to join against it -- or use the
+`instance` label, which carries the same value.
 
 ## Request attributes
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -13,7 +13,7 @@ The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://o
 | `launchdarkly.relay.events.received.size` | Counter | `By` | The cumulative number of event bytes received by the Relay Proxy (measured after decompression). |
 | `launchdarkly.relay.events.sent` | Counter | `{event}` | The cumulative number of events successfully sent to LaunchDarkly. |
 | `launchdarkly.relay.events.sent.size` | Counter | `By` | The cumulative bytes of event payloads successfully sent to LaunchDarkly. |
-| `launchdarkly.relay.events.send.errors` | Counter | `{event}` | The cumulative number of events that failed to send after all retries. |
+| `launchdarkly.relay.events.failed` | Counter | `{event}` | The cumulative number of events that could not be delivered after all retries. |
 | `launchdarkly.relay.events.dropped` | Counter | `{event}` | The cumulative number of events dropped due to capacity overflow. |
 | `launchdarkly.relay.events.pending` | Gauge | `{event}` | The current number of events buffered in the queue. |
 
@@ -54,11 +54,11 @@ Note that `launchdarkly.environment.name` is a *LaunchDarkly* environment, which
 with the OpenTelemetry `deployment.environment.name` attribute described under
 [Datadog](#datadog) below. The two are unrelated, and both can be set at once.
 
-The event delivery metrics (`launchdarkly.relay.events.sent`, `.sent.size`, `.send.errors`,
+The event delivery metrics (`launchdarkly.relay.events.sent`, `.sent.size`, `.failed`,
 `.dropped`, `.pending`) are recorded outside any request, so they carry only
 `launchdarkly.environment.name`.
 
-Every measurement on `.send.errors` is a failure, so it always carries `error.type`. When the events
+Every measurement on `.failed` is a failure, so it always carries `error.type`. When the events
 service returned a response, `error.type` is that status code as a string and
 `http.response.status_code` carries it as a number. When the send failed before any response arrived
 -- a network error or a timeout -- `error.type` is `_OTHER` and no status code is reported.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,7 +38,7 @@ The request metrics -- `http.server.active_requests`, `http.server.request.durat
 
 | Attribute | Description |
 |-----------|-------------|
-| `environment.name` | The name of the LaunchDarkly environment as configured in the Relay Proxy. In automatic configuration or offline mode, this is the actual project and environment name from LaunchDarkly. Example: `MyApplication Staging` |
+| `launchdarkly.environment.name` | The name of the LaunchDarkly environment as configured in the Relay Proxy. In automatic configuration or offline mode, this is the actual project and environment name from LaunchDarkly. Example: `MyApplication Staging` |
 | `user_agent.original` | The `User-Agent` header sent by the SDK making the request, as received. Example: `Node/3.4.0` |
 | `http.route` | The request URL path template. Variables appear as placeholders rather than actual values. Example: `/sdk/evalx/{envId}/contexts/{context}` |
 | `http.request.method` | The HTTP method. Example: `GET` |
@@ -50,8 +50,13 @@ The request metrics -- `http.server.active_requests`, `http.server.request.durat
 `http.server.request.duration` additionally carries `http.response.status_code`,
 `network.protocol.version`, and -- for a 5xx response -- `error.type`.
 
+Note that `launchdarkly.environment.name` is a *LaunchDarkly* environment, which has nothing to do
+with the OpenTelemetry `deployment.environment.name` attribute described under
+[Datadog](#datadog) below. The two are unrelated, and both can be set at once.
+
 The event delivery metrics (`launchdarkly.relay.events.sent`, `.sent.size`, `.send.errors`,
-`.dropped`, `.pending`) are recorded outside any request, so they carry only `environment.name`.
+`.dropped`, `.pending`) are recorded outside any request, so they carry only
+`launchdarkly.environment.name`.
 
 Every measurement on `.send.errors` is a failure, so it always carries `error.type`. When the events
 service returned a response, `error.type` is that status code as a string and
@@ -60,7 +65,7 @@ service returned a response, `error.type` is that status code as a string and
 
 Attribute values that are absent are reported as `not_provided` rather than being omitted. The status
 endpoints and requests that matched no route are not associated with an SDK or an LD environment, so
-they report `not_provided` for `environment.name` and the other SDK attributes.
+they report `not_provided` for `launchdarkly.environment.name` and the other SDK attributes.
 
 `platform.category`, `sdk.wrapper`, and `instance.id` are no longer reported on metrics. `instance.id`
 in particular is per SDK *instance*, which made these metrics grow a series per client process. All

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,7 +8,7 @@ The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://o
 
 | Metric | Type | Unit | Description |
 |--------|------|------|-------------|
-| `http.server.active_requests` | UpDownCounter | `{request}` | The number of requests currently in flight, across every endpoint the Relay Proxy serves. Use the `relay.endpoint.type` attribute to narrow this to a single kind of endpoint -- for example, filtering to `stream` gives the number of open SSE connections from SDKs. |
+| `http.server.active_requests` | UpDownCounter | `{request}` | The number of requests currently in flight, across every endpoint the Relay Proxy serves. Use the `launchdarkly.relay.endpoint.type` attribute to narrow this to a single kind of endpoint -- for example, filtering to `stream` gives the number of open SSE connections from SDKs. |
 | `http.server.request.duration` | Histogram | `s` | The duration of requests to the Relay Proxy's service endpoints, in seconds. |
 | `launchdarkly.relay.events.received.size` | Counter | `By` | The cumulative number of event bytes received by the Relay Proxy (measured after decompression). |
 | `launchdarkly.relay.events.sent` | Counter | `{event}` | The cumulative number of events successfully sent to LaunchDarkly. |
@@ -45,7 +45,7 @@ The request metrics -- `http.server.active_requests`, `http.server.request.durat
 | `url.scheme` | The URL scheme. Example: `https` |
 | `launchdarkly.application.id` | The application identifier, extracted from the `application-id` field of the `X-LaunchDarkly-Tags` header. |
 | `launchdarkly.application.version` | The application version, extracted from the `application-version` field of the `X-LaunchDarkly-Tags` header. |
-| `relay.endpoint.type` | The kind of endpoint that served the request: `stream`, `poll`, `events`, `goals`, or `status`. Requests that matched no route report `not_provided`. |
+| `launchdarkly.relay.endpoint.type` | The kind of endpoint that served the request: `stream`, `poll`, `events`, `goals`, or `status`. Requests that matched no route report `not_provided`. |
 
 `http.server.request.duration` additionally carries `http.response.status_code`,
 `network.protocol.version`, and -- for a 5xx response -- `error.type`.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,102 @@
+# LaunchDarkly Relay Proxy - Tracing
+
+[(Back to README)](../README.md)
+
+The Relay Proxy can export distributed traces via [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/) to any compatible backend, such as Grafana Tempo, Jaeger, Datadog, or an OpenTelemetry Collector. Tracing is enabled by the same setting as metrics. To learn about configuration, read [Configuration](./configuration.md).
+
+Traces and metrics share the resource attributes described in [Metrics](./metrics.md#resource-attributes), and the environment attribute is spelled the same way in both, so a trace can be correlated with a metric series for the same environment.
+
+## The request span
+
+Every request produces one span from the HTTP instrumentation, named after the method and the matched
+route -- `GET /sdk/poll`, `REPORT /sdk/evalx/context`. It carries the standard HTTP server attributes,
+including `http.route`, `http.request.method`, `http.response.status_code`, `url.path`, `url.scheme`,
+`server.address`, `client.address`, `user_agent.original`, and `network.protocol.version`.
+
+Streaming endpoints hold their connection open, so an SSE request span lasts as long as the client
+stays connected.
+
+### Redaction
+
+On the endpoints that take an evaluation context in the URL, that segment of `url.path` holds end-user
+data: context keys, names, emails, and any custom attributes the SDK sent. Relay replaces **that
+segment only** with the placeholder `REDACTED`:
+
+```
+request  GET /sdk/evalx/507f1f77bcf86cd799439011/contexts/eyJrZXkiOiJ1c2VyLTEyMyJ9
+url.path     /sdk/evalx/507f1f77bcf86cd799439011/contexts/REDACTED
+http.route   /sdk/evalx/{envId}/contexts/{context}
+```
+
+The rest of the path is preserved, so a trace still shows which endpoint and which environment served
+the request. Environment IDs are not sensitive: the Relay Proxy already returns them in the `X-LD-EnvId`
+response header, in the status endpoint, and in log prefixes.
+
+A context supplied in a `REPORT` body is never recorded on a span at all.
+
+## Relay spans
+
+These hang off the request span. Which ones appear depends on the endpoint: a polling request produces
+a store read, a serialize, and a write; an SSE connect produces an auth span and the stream's own
+activity.
+
+| Span | What it covers |
+|------|----------------|
+| `relay.auth` | Credential lookup and environment selection, before the handler runs |
+| `relay.store.snapshot` | Reading a consistent snapshot of the environment's data |
+| `relay.store.get_all` | Reading every item of one kind from the store |
+| `relay.store.get` | Reading a single flag or segment |
+| `relay.flags.evaluate` | Evaluating flags against an evaluation context |
+| `relay.payload.serialize` | Building the response body |
+| `relay.response.write` | Writing the response body to the client |
+| `relay.events.dispatch` | Handing a received analytics or diagnostic event batch to the publisher |
+| `relay.singleflight.wait` | A request waiting for a payload another request was already building |
+
+Span names are short and unprefixed on purpose: they are display strings in a trace waterfall, not
+queryable dimensions, and the semantic conventions do not namespace them either.
+
+A failure sets the span's status to `Error`. Where there is an underlying error value -- a store read
+that failed, a response that could not be written -- it is also recorded as a span event carrying the
+message. A rejected `relay.auth` has no such value: the reason is the
+`launchdarkly.relay.auth.result` attribute.
+
+## Span attributes
+
+Attribute keys are the queryable dimensions, so anything not defined by a semantic convention is
+prefixed with `launchdarkly.`. Keys describing the caller are `launchdarkly.<thing>`; keys describing
+the Relay Proxy's own work are `launchdarkly.relay.<thing>`.
+
+| Attribute | On | Description |
+|-----------|-----|-------------|
+| `launchdarkly.sdk.kind` | `relay.auth` | The category of SDK that authenticated: `server`, `mobile`, or `js` |
+| `launchdarkly.relay.auth.result` | `relay.auth` | `success`, `invalid_credential`, `not_ready`, `filter_not_found`, `not_found`, or `client_not_initialized` |
+| `launchdarkly.relay.store.key` | `relay.store.get` | The flag or segment key being read |
+| `launchdarkly.relay.flag.count` | `relay.flags.evaluate`, `relay.payload.serialize` | Number of flags in the evaluation or the payload |
+| `launchdarkly.relay.payload.event.count` | `relay.payload.serialize` | Number of protocol events in a payload |
+| `launchdarkly.relay.payload.size` | `relay.payload.serialize` | Size of the serialized payload, in bytes |
+| `launchdarkly.relay.events.kind` | `relay.events.dispatch` | The kind of event batch received |
+| `http.response.status_code` | `relay.response.write` | The status written to the client |
+
+`launchdarkly.relay.payload.size` is what the Relay Proxy *built*. What actually went out on the wire
+is `http.response.body.size` on the request span, counted outside the compression middleware, and the
+two differ whenever a response is compressed.
+
+### Request deduplication
+
+Concurrent requests that would build the same payload share one build. Both attributes below land on
+the **request** span:
+
+| Attribute | Description |
+|-----------|-------------|
+| `launchdarkly.relay.singleflight.shared` | Whether this payload build was shared with other in-flight requests |
+| `launchdarkly.relay.singleflight.wait.duration` | How long this request waited for another request's build, in seconds. Present only on a request that waited |
+
+The request that performed the build carries no wait attribute -- it did not wait, and its work appears
+as the child spans in its own trace. So a trace with `shared=true`, no wait attribute, and no store or
+serialize children means another request's trace holds the build. Tracing backends cannot join a
+waiting request to the trace that did the work; find it by timestamp proximity.
+
+## Instrumentation scope
+
+Spans the Relay Proxy creates itself report the scope name `ld-relay`. Spans created by the HTTP
+instrumentation report that library's own scope name, so the two can be told apart.

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -78,8 +78,11 @@ var (
 	urlSchemeAttrKey           = semconv.URLSchemeKey              //nolint:gochecknoglobals
 	networkProtoVersionAttrKey = semconv.NetworkProtocolVersionKey //nolint:gochecknoglobals
 	errorTypeAttrKey           = semconv.ErrorTypeKey              //nolint:gochecknoglobals
-	statusCodeAttrKey          = attribute.Key("status_code")      //nolint:gochecknoglobals
 )
+
+// errorTypeOther is the semantic-convention value for an error that the instrumentation cannot
+// classify further.
+const errorTypeOther = "_OTHER"
 
 // buildRequestAttributes creates an OTel attribute set for request metrics using semconv attribute names
 // where applicable. Values from the RequestInfo are sanitized here, so callers pass it through as-is.

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -71,7 +71,8 @@ const (
 
 // Attributes deliberately absent from these sets:
 //
-//   - relay.id is a resource attribute (see tracing.NewResource): it never varies within a process.
+//   - the relay process identity is a resource attribute, service.instance.id (refer to
+//     tracing.NewResource): it never varies within a process.
 //   - instance.id, platform.category and sdk.wrapper were dropped. instance.id is per SDK instance, so
 //     it made every request metric effectively per-client-process; the other two are largely implied by
 //     http.route. All three are still reported in the usage data Relay sends to LaunchDarkly, which is

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -23,8 +23,20 @@ const (
 
 	defaultFlushInterval = time.Minute
 
-	// notProvidedValue is the sentinel reported for an attribute whose value is absent.
-	notProvidedValue = "not-provided"
+	// notProvidedValue is the sentinel reported for an OTel attribute whose value is absent. It is
+	// snake_case to match the other attribute values Relay reports, such as the auth results on
+	// spans.
+	//
+	// OTel's own convention is to omit an absent attribute rather than fill one in. Relay fills one
+	// in deliberately: the increment and decrement of http.server.active_requests must carry
+	// identical attribute sets or the series never returns to zero, and Prometheus handles a label
+	// that is present on only some series of a metric poorly.
+	notProvidedValue = "not_provided"
+
+	// usageNotProvidedValue is the sentinel for an absent value in the usage data Relay reports to
+	// LaunchDarkly. That payload is a wire contract with a different consumer, so it keeps its own
+	// spelling rather than following the OTel attribute value above.
+	usageNotProvidedValue = "not-provided"
 
 	BrowserPlatformCategory = "browser"
 	MobilePlatformCategory  = "mobile"
@@ -126,19 +138,33 @@ func requestKVs(ri RequestInfo) []attribute.KeyValue {
 	}
 }
 
-// sanitizeTagValue ensures attribute values are valid.
-// Empty values are replaced with descriptive defaults, and slashes are replaced with underscores.
-// This is appropriate for SDK wrapper names in the usage data Relay reports to LaunchDarkly, but not
-// for routes, and not for values that a semantic convention defines as verbatim.
+// sanitizeTagValue ensures OTel attribute values are valid.
+// Empty values are replaced with the absent-value sentinel, and slashes are replaced with underscores.
+// This is not appropriate for routes, where slashes are meaningful, nor for values that a semantic
+// convention defines as verbatim.
+func sanitizeTagValue(v string) string {
+	return sanitizeReplacingSlashes(v, notProvidedValue)
+}
+
+// sanitizeUsageTagValue is sanitizeTagValue for the usage data Relay reports to LaunchDarkly. It
+// exists only to keep that payload's absent-value sentinel independent of the OTel one: the two
+// sinks have different consumers, so renaming an attribute value must not change what the usage
+// events carry.
+func sanitizeUsageTagValue(v string) string {
+	return sanitizeReplacingSlashes(v, usageNotProvidedValue)
+}
+
+// sanitizeReplacingSlashes replaces slashes with underscores and substitutes absent for a value that
+// is empty once sanitized.
 //
 // Invalid UTF-8 is stripped via util.SanitizeUTF8, which matters more than it looks: a single bad byte
 // fails the OTLP marshal for the entire export batch, and these series are cumulative, so exports keep
 // failing until the process restarts. Header values are not restricted to ASCII, so an unauthenticated
 // caller can supply one via the status and not-found handlers.
-func sanitizeTagValue(v string) string {
+func sanitizeReplacingSlashes(v, absent string) string {
 	v = util.SanitizeUTF8(strings.ReplaceAll(v, "/", "_"))
 	if strings.TrimSpace(v) == "" {
-		return notProvidedValue
+		return absent
 	}
 	return v
 }

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -44,7 +44,7 @@ const (
 )
 
 // EndpointType identifies the kind of Relay endpoint that served a request. It is reported on
-// request-scoped metrics as the relay.endpoint.type attribute, so that a metric covering all
+// request-scoped metrics as the launchdarkly.relay.endpoint.type attribute, so that a metric covering all
 // requests can still be broken down by the delivery mode the request belongs to.
 type EndpointType string
 
@@ -81,7 +81,7 @@ var (
 	envNameAttrKey            = attribute.Key("launchdarkly.environment.name")    //nolint:gochecknoglobals
 	applicationIDAttrKey      = attribute.Key("launchdarkly.application.id")      //nolint:gochecknoglobals
 	applicationVersionAttrKey = attribute.Key("launchdarkly.application.version") //nolint:gochecknoglobals
-	endpointTypeAttrKey       = attribute.Key("relay.endpoint.type")              //nolint:gochecknoglobals
+	endpointTypeAttrKey       = attribute.Key("launchdarkly.relay.endpoint.type") //nolint:gochecknoglobals
 
 	// OTEL HTTP semantic convention attribute keys (from semconv package)
 	userAgentAttrKey           = semconv.UserAgentOriginalKey      //nolint:gochecknoglobals

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -12,14 +12,14 @@ import (
 
 const (
 	// Metric instrument names.
-	connMeasureName             = "http.server.active_requests"
-	requestDurationMeasureName  = "http.server.request.duration"
-	eventsReceivedMeasureName   = "launchdarkly.relay.events.received.size"
-	eventsSentMeasureName       = "launchdarkly.relay.events.sent"
-	eventsSentSizeMeasureName   = "launchdarkly.relay.events.sent.size"
-	eventsSendErrorsMeasureName = "launchdarkly.relay.events.send.errors"
-	eventsDroppedMeasureName    = "launchdarkly.relay.events.dropped"
-	eventsPendingMeasureName    = "launchdarkly.relay.events.pending"
+	connMeasureName            = "http.server.active_requests"
+	requestDurationMeasureName = "http.server.request.duration"
+	eventsReceivedMeasureName  = "launchdarkly.relay.events.received.size"
+	eventsSentMeasureName      = "launchdarkly.relay.events.sent"
+	eventsSentSizeMeasureName  = "launchdarkly.relay.events.sent.size"
+	eventsFailedMeasureName    = "launchdarkly.relay.events.failed"
+	eventsDroppedMeasureName   = "launchdarkly.relay.events.dropped"
+	eventsPendingMeasureName   = "launchdarkly.relay.events.pending"
 
 	defaultFlushInterval = time.Minute
 

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -78,10 +78,10 @@ const (
 //     http.route. All three are still reported in the usage data Relay sends to LaunchDarkly, which is
 //     a separate sink with its own cardinality budget.
 var (
-	envNameAttrKey            = attribute.Key("environment.name")    //nolint:gochecknoglobals
-	applicationIDAttrKey      = attribute.Key("application.id")      //nolint:gochecknoglobals
-	applicationVersionAttrKey = attribute.Key("application.version") //nolint:gochecknoglobals
-	endpointTypeAttrKey       = attribute.Key("relay.endpoint.type") //nolint:gochecknoglobals
+	envNameAttrKey            = attribute.Key("launchdarkly.environment.name") //nolint:gochecknoglobals
+	applicationIDAttrKey      = attribute.Key("application.id")                //nolint:gochecknoglobals
+	applicationVersionAttrKey = attribute.Key("application.version")           //nolint:gochecknoglobals
+	endpointTypeAttrKey       = attribute.Key("relay.endpoint.type")           //nolint:gochecknoglobals
 
 	// OTEL HTTP semantic convention attribute keys (from semconv package)
 	userAgentAttrKey           = semconv.UserAgentOriginalKey      //nolint:gochecknoglobals
@@ -125,7 +125,7 @@ func buildDurationAttributes(baseKVs []attribute.KeyValue, ri RequestInfo) attri
 }
 
 // requestKVs returns the attributes that every request-scoped metric carries. Keeping this at seven,
-// plus environment.name from the environment, holds the common case within attribute.NewSet's
+// plus launchdarkly.environment.name from the environment, holds the common case within attribute.NewSet's
 // fixed-size fast path, which only covers sets of ten or fewer.
 func requestKVs(ri RequestInfo) []attribute.KeyValue {
 	return []attribute.KeyValue{

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -78,10 +78,10 @@ const (
 //     http.route. All three are still reported in the usage data Relay sends to LaunchDarkly, which is
 //     a separate sink with its own cardinality budget.
 var (
-	envNameAttrKey            = attribute.Key("launchdarkly.environment.name") //nolint:gochecknoglobals
-	applicationIDAttrKey      = attribute.Key("application.id")                //nolint:gochecknoglobals
-	applicationVersionAttrKey = attribute.Key("application.version")           //nolint:gochecknoglobals
-	endpointTypeAttrKey       = attribute.Key("relay.endpoint.type")           //nolint:gochecknoglobals
+	envNameAttrKey            = attribute.Key("launchdarkly.environment.name")    //nolint:gochecknoglobals
+	applicationIDAttrKey      = attribute.Key("launchdarkly.application.id")      //nolint:gochecknoglobals
+	applicationVersionAttrKey = attribute.Key("launchdarkly.application.version") //nolint:gochecknoglobals
+	endpointTypeAttrKey       = attribute.Key("relay.endpoint.type")              //nolint:gochecknoglobals
 
 	// OTEL HTTP semantic convention attribute keys (from semconv package)
 	userAgentAttrKey           = semconv.UserAgentOriginalKey      //nolint:gochecknoglobals

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -7,7 +7,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v9/internal/util"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
 const (

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -65,13 +65,13 @@ const (
 //     http.route. All three are still reported in the usage data Relay sends to LaunchDarkly, which is
 //     a separate sink with its own cardinality budget.
 var (
-	userAgentAttrKey          = attribute.Key("user_agent")          //nolint:gochecknoglobals
 	envNameAttrKey            = attribute.Key("environment.name")    //nolint:gochecknoglobals
 	applicationIDAttrKey      = attribute.Key("application.id")      //nolint:gochecknoglobals
 	applicationVersionAttrKey = attribute.Key("application.version") //nolint:gochecknoglobals
 	endpointTypeAttrKey       = attribute.Key("relay.endpoint.type") //nolint:gochecknoglobals
 
 	// OTEL HTTP semantic convention attribute keys (from semconv package)
+	userAgentAttrKey           = semconv.UserAgentOriginalKey      //nolint:gochecknoglobals
 	httpRouteAttrKey           = semconv.HTTPRouteKey              //nolint:gochecknoglobals
 	httpRequestMethodAttrKey   = semconv.HTTPRequestMethodKey      //nolint:gochecknoglobals
 	httpResponseStatusAttrKey  = semconv.HTTPResponseStatusCodeKey //nolint:gochecknoglobals
@@ -113,7 +113,7 @@ func buildDurationAttributes(baseKVs []attribute.KeyValue, ri RequestInfo) attri
 // fixed-size fast path, which only covers sets of ten or fewer.
 func requestKVs(ri RequestInfo) []attribute.KeyValue {
 	return []attribute.KeyValue{
-		userAgentAttrKey.String(sanitizeTagValue(ri.UserAgent)),
+		userAgentAttrKey.String(sanitizeVerbatimValue(ri.UserAgent)),
 		httpRouteAttrKey.String(sanitizeRouteValue(ri.Route)),
 		httpRequestMethodAttrKey.String(sanitizeTagValue(ri.Method)),
 		urlSchemeAttrKey.String(ri.URLScheme),
@@ -125,7 +125,8 @@ func requestKVs(ri RequestInfo) []attribute.KeyValue {
 
 // sanitizeTagValue ensures attribute values are valid.
 // Empty values are replaced with descriptive defaults, and slashes are replaced with underscores.
-// This is appropriate for user agent strings and SDK wrapper names, but not for routes.
+// This is appropriate for SDK wrapper names in the usage data Relay reports to LaunchDarkly, but not
+// for routes, and not for values that a semantic convention defines as verbatim.
 //
 // Invalid UTF-8 is stripped via util.SanitizeUTF8, which matters more than it looks: a single bad byte
 // fails the OTLP marshal for the entire export batch, and these series are cumulative, so exports keep
@@ -133,6 +134,19 @@ func requestKVs(ri RequestInfo) []attribute.KeyValue {
 // caller can supply one via the status and not-found handlers.
 func sanitizeTagValue(v string) string {
 	v = util.SanitizeUTF8(strings.ReplaceAll(v, "/", "_"))
+	if strings.TrimSpace(v) == "" {
+		return notProvidedValue
+	}
+	return v
+}
+
+// sanitizeVerbatimValue keeps a value as the client sent it, stripping only invalid UTF-8. Use it for
+// attributes whose semantic convention defines them as the original value, such as
+// user_agent.original: replacing the slashes in "Node/3.4.0" would make the metric attribute disagree
+// with the identical attribute the tracing instrumentation records on the request span, so the two
+// could no longer be joined.
+func sanitizeVerbatimValue(v string) string {
+	v = util.SanitizeUTF8(v)
 	if strings.TrimSpace(v) == "" {
 		return notProvidedValue
 	}

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	ldevents "github.com/launchdarkly/go-sdk-events/v3"
@@ -244,14 +245,26 @@ func (r *EventMetricsRecorder) RecordEventsBytesSent(bytes int) {
 }
 
 // RecordEventsFailedSend records the number of events that could not be delivered after all retries.
-// The status code from the metadata is included as an attribute on the metric.
+//
+// Every measurement on this instrument is a failure, so it always carries error.type. When the events
+// service answered, that is the status code as a string, alongside http.response.status_code. A failure
+// that happened before any response -- a network error, a timeout -- reports the unclassified sentinel
+// and no status code, because there was none: the metadata reports 0 in that case, and publishing 0 as
+// a status code would invent a response that never arrived.
 func (r *EventMetricsRecorder) RecordEventsFailedSend(count int, metadata ldevents.EventSendFailureMetadata) {
 	if r.instruments == nil || count <= 0 {
 		return
 	}
-	kvs := make([]attribute.KeyValue, len(r.envKVs), len(r.envKVs)+1)
+	kvs := make([]attribute.KeyValue, len(r.envKVs), len(r.envKVs)+2)
 	copy(kvs, r.envKVs)
-	kvs = append(kvs, statusCodeAttrKey.Int(metadata.StatusCode))
+	if metadata.StatusCode > 0 {
+		kvs = append(kvs,
+			httpResponseStatusAttrKey.Int(metadata.StatusCode),
+			errorTypeAttrKey.String(strconv.Itoa(metadata.StatusCode)),
+		)
+	} else {
+		kvs = append(kvs, errorTypeAttrKey.String(errorTypeOther))
+	}
 	attrs := attribute.NewSet(kvs...)
 	r.instruments.eventsFailedSend.Add(context.Background(), int64(count), metric.WithAttributeSet(attrs))
 }

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -90,8 +90,8 @@ func newInstruments(meter metric.Meter) (*Instruments, error) {
 	if err != nil {
 		return nil, err
 	}
-	eventsFailedSend, err := meter.Int64Counter(eventsSendErrorsMeasureName,
-		metric.WithDescription("Events that failed to send after all retries"),
+	eventsFailedSend, err := meter.Int64Counter(eventsFailedMeasureName,
+		metric.WithDescription("Events that could not be delivered after all retries"),
 		metric.WithUnit("{event}"))
 	if err != nil {
 		return nil, err

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -167,7 +167,7 @@ func WithStreamConnection(em *EnvironmentManager, ri RequestInfo, f func(), meas
 		return
 	}
 
-	ua, wrapper := sanitizeTagValue(ri.UserAgent), sanitizeTagValue(ri.SDKWrapper)
+	ua, wrapper := sanitizeUsageTagValue(ri.UserAgent), sanitizeUsageTagValue(ri.SDKWrapper)
 	em.collector.RecordConnectionChange(measure.platformCategory, ua, wrapper, 1)
 	defer em.collector.RecordConnectionChange(measure.platformCategory, ua, wrapper, -1)
 
@@ -177,7 +177,8 @@ func WithStreamConnection(em *EnvironmentManager, ri RequestInfo, f func(), meas
 // WithCount runs a function and records polling metrics if applicable.
 func WithCount(em *EnvironmentManager, ri RequestInfo, f func(), measure Measure) {
 	if em != nil && measure.recordPolling && em.collector != nil {
-		em.collector.RecordPollingRequest(measure.platformCategory, sanitizeTagValue(ri.UserAgent), sanitizeTagValue(ri.SDKWrapper))
+		em.collector.RecordPollingRequest(measure.platformCategory,
+			sanitizeUsageTagValue(ri.UserAgent), sanitizeUsageTagValue(ri.SDKWrapper))
 	}
 
 	f()

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -142,7 +142,7 @@ func (m *Manager) GetInstruments() *Instruments {
 
 // GetUnscopedEnvironment returns an EnvironmentManager for recording metrics on requests that are not
 // associated with any LD environment, such as the status endpoints and requests that matched no route.
-// Its environment.name attribute is the not-provided sentinel, and it has no collector, since there is
+// Its environment.name attribute is the not_provided sentinel, and it has no collector, since there is
 // no environment to report usage data for.
 func (m *Manager) GetUnscopedEnvironment() *EnvironmentManager {
 	return m.unscopedEnv

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -142,7 +142,7 @@ func (m *Manager) GetInstruments() *Instruments {
 
 // GetUnscopedEnvironment returns an EnvironmentManager for recording metrics on requests that are not
 // associated with any LD environment, such as the status endpoints and requests that matched no route.
-// Its environment.name attribute is the not_provided sentinel, and it has no collector, since there is
+// Its launchdarkly.environment.name attribute is the not_provided sentinel, and it has no collector, since there is
 // no environment to report usage data for.
 func (m *Manager) GetUnscopedEnvironment() *EnvironmentManager {
 	return m.unscopedEnv

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -598,7 +598,7 @@ func TestRequestMetricAttributeKeys(t *testing.T) {
 		"url.scheme",
 		"launchdarkly.application.id",
 		"launchdarkly.application.version",
-		"relay.endpoint.type",
+		"launchdarkly.relay.endpoint.type",
 	}, attributeKeys(buildRequestAttributes(envKVs, ri)))
 
 	// The duration histogram adds the semconv attributes that are only known once the handler has run.
@@ -614,7 +614,7 @@ func TestRequestMetricAttributeKeys(t *testing.T) {
 		"url.scheme",
 		"launchdarkly.application.id",
 		"launchdarkly.application.version",
-		"relay.endpoint.type",
+		"launchdarkly.relay.endpoint.type",
 		"network.protocol.version",
 		"http.response.status_code",
 		"error.type",

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -414,7 +414,7 @@ func TestRecordEventsFailedSend(t *testing.T) {
 
 		rm, err := p.collectMetrics()
 		require.NoError(t, err)
-		m := findMetric(rm, eventsSendErrorsMeasureName)
+		m := findMetric(rm, eventsFailedMeasureName)
 		require.NotNil(t, m, "events send errors metric not found")
 
 		sum, ok := m.Data.(metricdata.Sum[int64])
@@ -448,7 +448,7 @@ func TestRecordEventsFailedSendWithNoResponse(t *testing.T) {
 
 		rm, err := p.collectMetrics()
 		require.NoError(t, err)
-		m := findMetric(rm, eventsSendErrorsMeasureName)
+		m := findMetric(rm, eventsFailedMeasureName)
 		require.NotNil(t, m, "events send errors metric not found")
 
 		sum, ok := m.Data.(metricdata.Sum[int64])
@@ -475,7 +475,7 @@ func TestRecordEventsFailedSendSkipsZeroCount(t *testing.T) {
 
 		rm, err := p.collectMetrics()
 		require.NoError(t, err)
-		m := findMetric(rm, eventsSendErrorsMeasureName)
+		m := findMetric(rm, eventsFailedMeasureName)
 		if m != nil {
 			sum, ok := m.Data.(metricdata.Sum[int64])
 			if ok {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -596,8 +596,8 @@ func TestRequestMetricAttributeKeys(t *testing.T) {
 		"http.route",
 		"http.request.method",
 		"url.scheme",
-		"application.id",
-		"application.version",
+		"launchdarkly.application.id",
+		"launchdarkly.application.version",
 		"relay.endpoint.type",
 	}, attributeKeys(buildRequestAttributes(envKVs, ri)))
 
@@ -612,8 +612,8 @@ func TestRequestMetricAttributeKeys(t *testing.T) {
 		"http.route",
 		"http.request.method",
 		"url.scheme",
-		"application.id",
-		"application.version",
+		"launchdarkly.application.id",
+		"launchdarkly.application.version",
 		"relay.endpoint.type",
 		"network.protocol.version",
 		"http.response.status_code",

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -424,10 +424,46 @@ func TestRecordEventsFailedSend(t *testing.T) {
 		dp := sum.DataPoints[0]
 		assert.Equal(t, int64(3), dp.Value)
 
-		// Verify the status_code attribute is an int, not a string
-		statusVal, ok := dp.Attributes.Value(statusCodeAttrKey)
-		assert.True(t, ok, "status_code attribute missing")
+		// Verify the status code attribute is an int, not a string
+		statusVal, ok := dp.Attributes.Value(httpResponseStatusAttrKey)
+		assert.True(t, ok, "http.response.status_code attribute missing")
 		assert.Equal(t, int64(429), statusVal.AsInt64())
+
+		// Every measurement on this instrument is a failure, so error.type is always present. With a
+		// response, semconv reports the status code as its value.
+		errorVal, ok := dp.Attributes.Value(errorTypeAttrKey)
+		assert.True(t, ok, "error.type attribute missing")
+		assert.Equal(t, "429", errorVal.AsString())
+	})
+}
+
+// A send that failed before any response reports 0 in the metadata. Publishing that as a status code
+// would invent a response that never arrived, so the status code is omitted and the failure is reported
+// through the unclassified error.type value instead.
+func TestRecordEventsFailedSendWithNoResponse(t *testing.T) {
+	testWithOTel(t, func(p testWithOTelParams) {
+		recorder := p.env.NewEventMetricsRecorder(p.instruments)
+
+		recorder.RecordEventsFailedSend(2, ldevents.EventSendFailureMetadata{StatusCode: 0})
+
+		rm, err := p.collectMetrics()
+		require.NoError(t, err)
+		m := findMetric(rm, eventsSendErrorsMeasureName)
+		require.NotNil(t, m, "events send errors metric not found")
+
+		sum, ok := m.Data.(metricdata.Sum[int64])
+		require.True(t, ok, "expected Sum[int64] data")
+		require.NotEmpty(t, sum.DataPoints)
+
+		dp := sum.DataPoints[0]
+		assert.Equal(t, int64(2), dp.Value)
+
+		_, ok = dp.Attributes.Value(httpResponseStatusAttrKey)
+		assert.False(t, ok, "no response was received, so no status code should be reported")
+
+		errorVal, ok := dp.Attributes.Value(errorTypeAttrKey)
+		require.True(t, ok, "error.type attribute missing")
+		assert.Equal(t, "_OTHER", errorVal.AsString())
 	})
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -231,7 +231,7 @@ func TestActiveRequestMetrics(t *testing.T) {
 }
 
 // The status endpoints and unmatched requests have no environment, so they report the not_provided
-// sentinel for environment.name.
+// sentinel for launchdarkly.environment.name.
 func TestActiveRequestMetricsWithoutEnvironment(t *testing.T) {
 	testWithOTel(t, func(p testWithOTelParams) {
 		manager, err := NewManager(config.OpenTelemetryConfig{}, time.Minute, slog.Default())
@@ -573,6 +573,60 @@ func TestSanitizeVerbatimValue(t *testing.T) {
 	assert.Equal(t, "not_provided", sanitizeVerbatimValue("   "))
 	assert.Equal(t, "react/2.0.0", sanitizeVerbatimValue("react/2.0.0"))
 	assert.Equal(t, "Node/3.4.0", sanitizeVerbatimValue("Node\xff/3.4.0"))
+}
+
+// The attribute keys on the request metrics are a public contract: operators write dashboards and
+// alerts against them. Pinning the exact set means a rename cannot happen as a side effect of
+// something else.
+func TestRequestMetricAttributeKeys(t *testing.T) {
+	envKVs := []attribute.KeyValue{envNameAttrKey.String("testenv")}
+	ri := RequestInfo{
+		UserAgent:          userAgentValue,
+		Route:              "/sdk/poll",
+		Method:             "GET",
+		URLScheme:          "https",
+		ApplicationID:      "my-app",
+		ApplicationVersion: "1.0.0",
+		EndpointType:       EndpointTypePoll,
+	}
+
+	assert.ElementsMatch(t, []string{
+		"launchdarkly.environment.name",
+		"user_agent.original",
+		"http.route",
+		"http.request.method",
+		"url.scheme",
+		"application.id",
+		"application.version",
+		"relay.endpoint.type",
+	}, attributeKeys(buildRequestAttributes(envKVs, ri)))
+
+	// The duration histogram adds the semconv attributes that are only known once the handler has run.
+	ri.ProtocolVersion = "1.1"
+	ri.StatusCode = 500
+	ri.ErrorType = "500"
+
+	assert.ElementsMatch(t, []string{
+		"launchdarkly.environment.name",
+		"user_agent.original",
+		"http.route",
+		"http.request.method",
+		"url.scheme",
+		"application.id",
+		"application.version",
+		"relay.endpoint.type",
+		"network.protocol.version",
+		"http.response.status_code",
+		"error.type",
+	}, attributeKeys(buildDurationAttributes(envKVs, ri)))
+}
+
+func attributeKeys(set attribute.Set) []string {
+	keys := make([]string, 0, set.Len())
+	for _, kv := range set.ToSlice() {
+		keys = append(keys, string(kv.Key))
+	}
+	return keys
 }
 
 // The user agent is reported under the semantic-convention key, with the value the client sent. The

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -501,6 +501,28 @@ func TestSanitizeTagValue(t *testing.T) {
 	assert.Equal(t, "react_2.0.0", sanitizeTagValue("react/2.0.0"))
 }
 
+func TestSanitizeVerbatimValue(t *testing.T) {
+	assert.Equal(t, "abc", sanitizeVerbatimValue("abc"))
+	assert.Equal(t, "not-provided", sanitizeVerbatimValue(""))
+	assert.Equal(t, "not-provided", sanitizeVerbatimValue("   "))
+	assert.Equal(t, "react/2.0.0", sanitizeVerbatimValue("react/2.0.0"))
+	assert.Equal(t, "Node/3.4.0", sanitizeVerbatimValue("Node\xff/3.4.0"))
+}
+
+// The user agent is reported under the semantic-convention key, with the value the client sent. The
+// tracing instrumentation records the same attribute on the request span from the same header, so a
+// mangled value here would stop metrics and traces being joined on it.
+func TestUserAgentUsesSemconvKeyAndVerbatimValue(t *testing.T) {
+	attrs := buildRequestAttributes(nil, RequestInfo{UserAgent: "Node/3.4.0"})
+
+	value, ok := attrs.Value(attribute.Key("user_agent.original"))
+	require.True(t, ok, "user_agent.original attribute not present")
+	assert.Equal(t, "Node/3.4.0", value.AsString())
+
+	_, ok = attrs.Value(attribute.Key("user_agent"))
+	assert.False(t, ok, "the bare user_agent key shadows the semconv user_agent namespace")
+}
+
 // Attribute values are serialized into OTLP protobuf string fields, which proto3 requires to be valid
 // UTF-8. One bad byte fails the marshal for the whole export batch, and the poisoned series is
 // cumulative, so exports keep failing until restart. Header values are not restricted to ASCII, so this

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -230,7 +230,7 @@ func TestActiveRequestMetrics(t *testing.T) {
 	}
 }
 
-// The status endpoints and unmatched requests have no environment, so they report the not-provided
+// The status endpoints and unmatched requests have no environment, so they report the not_provided
 // sentinel for environment.name.
 func TestActiveRequestMetricsWithoutEnvironment(t *testing.T) {
 	testWithOTel(t, func(p testWithOTelParams) {
@@ -532,15 +532,45 @@ func TestWithCountCallsFunctionForNonPollingMeasure(t *testing.T) {
 
 func TestSanitizeTagValue(t *testing.T) {
 	assert.Equal(t, "abc", sanitizeTagValue("abc"))
-	assert.Equal(t, "not-provided", sanitizeTagValue(""))
-	assert.Equal(t, "not-provided", sanitizeTagValue("   "))
+	assert.Equal(t, "not_provided", sanitizeTagValue(""))
+	assert.Equal(t, "not_provided", sanitizeTagValue("   "))
 	assert.Equal(t, "react_2.0.0", sanitizeTagValue("react/2.0.0"))
+}
+
+// The usage payload Relay reports to LaunchDarkly is a separate sink with its own consumer, so its
+// absent-value sentinel does not follow the OTel attribute one.
+func TestSanitizeUsageTagValue(t *testing.T) {
+	assert.Equal(t, "abc", sanitizeUsageTagValue("abc"))
+	assert.Equal(t, "not-provided", sanitizeUsageTagValue(""))
+	assert.Equal(t, "not-provided", sanitizeUsageTagValue("   "))
+	assert.Equal(t, "react_2.0.0", sanitizeUsageTagValue("react/2.0.0"))
+}
+
+// End to end for the same boundary: a request with no user agent or wrapper must still put the usage
+// payload's own sentinel on the wire, whatever the OTel attributes report.
+func TestUsageEventsKeepTheirOwnAbsentValueSentinel(t *testing.T) {
+	publisher := newTestEventsPublisher()
+
+	manager, err := NewManager(config.OpenTelemetryConfig{}, time.Millisecond*10, slog.Default())
+	require.NoError(t, err)
+	defer manager.Close()
+
+	env, err := manager.AddEnvironment("sentinel-test", publisher)
+	require.NoError(t, err)
+
+	WithCount(env, RequestInfo{}, func() {}, ServerPollingRequests)
+
+	env.FlushEventsExporter()
+	metricsEvent := publisher.expectMetricsEvent(t, time.Second)
+	require.Len(t, metricsEvent.PollingCounts, 1)
+	assert.Equal(t, "not-provided", metricsEvent.PollingCounts[0].UserAgent)
+	assert.Equal(t, "not-provided", metricsEvent.PollingCounts[0].SDKWrapper)
 }
 
 func TestSanitizeVerbatimValue(t *testing.T) {
 	assert.Equal(t, "abc", sanitizeVerbatimValue("abc"))
-	assert.Equal(t, "not-provided", sanitizeVerbatimValue(""))
-	assert.Equal(t, "not-provided", sanitizeVerbatimValue("   "))
+	assert.Equal(t, "not_provided", sanitizeVerbatimValue(""))
+	assert.Equal(t, "not_provided", sanitizeVerbatimValue("   "))
 	assert.Equal(t, "react/2.0.0", sanitizeVerbatimValue("react/2.0.0"))
 	assert.Equal(t, "Node/3.4.0", sanitizeVerbatimValue("Node\xff/3.4.0"))
 }
@@ -588,8 +618,8 @@ func TestSanitizeTagValueStripsInvalidUTF8(t *testing.T) {
 
 func TestSanitizeRouteValue(t *testing.T) {
 	assert.Equal(t, "/sdk/evalx/contexts/{context}", sanitizeRouteValue("/sdk/evalx/contexts/{context}"))
-	assert.Equal(t, "not-provided", sanitizeRouteValue(""))
-	assert.Equal(t, "not-provided", sanitizeRouteValue("   "))
+	assert.Equal(t, "not_provided", sanitizeRouteValue(""))
+	assert.Equal(t, "not_provided", sanitizeRouteValue("   "))
 }
 
 // Helper functions for asserting OTel metric data

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -219,8 +219,8 @@ func RequestMetrics(endpointType metrics.EndpointType) mux.MiddlewareFunc {
 }
 
 // UnscopedActiveRequests tracks a request in http.server.active_requests without an LD environment, for
-// endpoints that have no environment to attribute the request to. Its environment.name and
-// platform.category attributes are the not_provided sentinel.
+// endpoints that have no environment to attribute the request to. Its
+// launchdarkly.environment.name attribute is the not_provided sentinel.
 //
 // This is applied directly to a handler rather than registered with Router.Use for requests that matched
 // no route: gorilla/mux skips router middleware entirely when a request fails to match.

--- a/internal/middleware/metrics_middleware.go
+++ b/internal/middleware/metrics_middleware.go
@@ -220,7 +220,7 @@ func RequestMetrics(endpointType metrics.EndpointType) mux.MiddlewareFunc {
 
 // UnscopedActiveRequests tracks a request in http.server.active_requests without an LD environment, for
 // endpoints that have no environment to attribute the request to. Its environment.name and
-// platform.category attributes are the not-provided sentinel.
+// platform.category attributes are the not_provided sentinel.
 //
 // This is applied directly to a handler rather than registered with Router.Use for requests that matched
 // no route: gorilla/mux skips router middleware entirely when a request fails to match.

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -184,7 +184,7 @@ func TestActiveRequestsIncludesStreamingResponses(t *testing.T) {
 }
 
 // Requests with no environment -- the status endpoints and anything that matched no route -- still get
-// counted, reporting the not-provided sentinel for environment.name.
+// counted, reporting the not_provided sentinel for environment.name.
 func TestUnscopedActiveRequests(t *testing.T) {
 	specs := []struct {
 		name         string
@@ -202,7 +202,7 @@ func TestUnscopedActiveRequests(t *testing.T) {
 						rm := p.collectMetrics(t)
 						m := st.FindMetricByName(rm, "http.server.active_requests")
 						require.NotNil(t, m, "active requests metric not found")
-						assertMetricHasValue(t, m, "not-provided", 1)
+						assertMetricHasValue(t, m, "not_provided", 1)
 						assertMetricHasAttribute(t, m, "relay.endpoint.type", string(tt.endpointType))
 					}))
 
@@ -213,7 +213,7 @@ func TestUnscopedActiveRequests(t *testing.T) {
 				rm := p.collectMetrics(t)
 				m := st.FindMetricByName(rm, "http.server.active_requests")
 				require.NotNil(t, m)
-				assertMetricHasValue(t, m, "not-provided", 0)
+				assertMetricHasValue(t, m, "not_provided", 0)
 			})
 		})
 	}

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -131,7 +131,7 @@ func TestActiveRequests(t *testing.T) {
 					m := st.FindMetricByName(rm, "http.server.active_requests")
 					require.NotNil(t, m, "active requests metric not found")
 					assertMetricHasValue(t, m, p.envName, 1)
-					assertMetricHasAttribute(t, m, "relay.endpoint.type", string(endpointType))
+					assertMetricHasAttribute(t, m, "launchdarkly.relay.endpoint.type", string(endpointType))
 				})).Methods("GET")
 
 				req, _ := http.NewRequest("GET", "/test-route", nil)
@@ -203,7 +203,7 @@ func TestUnscopedActiveRequests(t *testing.T) {
 						m := st.FindMetricByName(rm, "http.server.active_requests")
 						require.NotNil(t, m, "active requests metric not found")
 						assertMetricHasValue(t, m, "not_provided", 1)
-						assertMetricHasAttribute(t, m, "relay.endpoint.type", string(tt.endpointType))
+						assertMetricHasAttribute(t, m, "launchdarkly.relay.endpoint.type", string(tt.endpointType))
 					}))
 
 				// No environment context is attached, exactly as for a real status or unmatched request

--- a/internal/middleware/metrics_middleware_test.go
+++ b/internal/middleware/metrics_middleware_test.go
@@ -184,7 +184,7 @@ func TestActiveRequestsIncludesStreamingResponses(t *testing.T) {
 }
 
 // Requests with no environment -- the status endpoints and anything that matched no route -- still get
-// counted, reporting the not_provided sentinel for environment.name.
+// counted, reporting the not_provided sentinel for launchdarkly.environment.name.
 func TestUnscopedActiveRequests(t *testing.T) {
 	specs := []struct {
 		name         string
@@ -297,7 +297,7 @@ func assertMetricHasValue(t *testing.T, m *metricdata.Metrics, envName string, e
 	require.True(t, ok, "expected Sum[int64] data for %s", m.Name)
 	found := false
 	for _, dp := range sum.DataPoints {
-		envVal, envOK := dp.Attributes.Value(attribute.Key("environment.name"))
+		envVal, envOK := dp.Attributes.Value(attribute.Key("launchdarkly.environment.name"))
 		if envOK && envVal.AsString() == envName {
 			assert.Equal(t, expected, dp.Value, "unexpected value for %s (env=%s)", m.Name, envName)
 			found = true

--- a/internal/middleware/tracing_middleware.go
+++ b/internal/middleware/tracing_middleware.go
@@ -7,7 +7,7 @@ import (
 	"github.com/launchdarkly/ld-relay/v9/internal/util"
 
 	"github.com/gorilla/mux"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/internal/middleware/tracing_middleware.go
+++ b/internal/middleware/tracing_middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/launchdarkly/ld-relay/v9/internal/util"
@@ -15,15 +16,20 @@ import (
 // must match the variable name used by the routes in relay_routes.go.
 const contextPathVar = "context"
 
+// redactedValue replaces a path segment whose contents must not be recorded. The semantic
+// conventions use this placeholder for the same purpose when scrubbing a URL.
+const redactedValue = "REDACTED"
+
 // SanitizeRequestSpan corrects two problems with the attributes the HTTP tracing middleware records on
 // the request span. Attributes cannot be removed from a span once set, but they are deduplicated
 // last-write-wins when they are read, so overwriting a value here is what keeps the original out of the
 // exported trace.
 //
 // First, url.path holds the raw request path, which on routes that take an evaluation context contains
-// the end user's data: keys, names, emails and custom attributes. Those are replaced with the matched
-// route template. Nothing is lost, since the same middleware also records the template as http.route.
-// Routes with no context variable keep their real path.
+// the end user's data: keys, names, emails and custom attributes. Only that one segment is replaced,
+// with the REDACTED placeholder the semantic conventions use for scrubbing a URL, so the rest of the
+// path -- which identifies the endpoint and the environment, and is not sensitive -- survives. Routes
+// with no context variable keep their real path.
 //
 // Second, three of the recorded attributes come from request data that is not restricted to valid
 // UTF-8, and OTLP cannot serialize a span carrying an invalid byte -- the marshal fails and the whole
@@ -40,10 +46,11 @@ const contextPathVar = "context"
 func SanitizeRequestSpan(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if span := trace.SpanFromContext(r.Context()); span.IsRecording() {
-			if _, hasContext := mux.Vars(r)[contextPathVar]; hasContext {
+			if contextValue, hasContext := mux.Vars(r)[contextPathVar]; hasContext {
 				// A route that produced a path variable always has a path template.
 				template, _ := mux.CurrentRoute(r).GetPathTemplate()
-				span.SetAttributes(semconv.URLPath(template))
+				redacted := redactContextSegment(r.URL.Path, contextValue, template)
+				span.SetAttributes(semconv.URLPath(util.SanitizeUTF8(redacted)))
 			} else if !utf8.ValidString(r.URL.Path) {
 				span.SetAttributes(semconv.URLPath(util.SanitizeUTF8(r.URL.Path)))
 			}
@@ -56,6 +63,29 @@ func SanitizeRequestSpan(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// redactContextSegment returns path with the whole segment holding the evaluation context replaced by
+// the REDACTED placeholder. The comparison is per segment rather than a substring replacement, so a
+// context value that also appears inside another segment cannot corrupt it.
+//
+// If no segment matches the context value, the route template is returned instead. That happens when
+// the value does not line up with a single segment, as a context carrying an encoded slash would, and
+// falling back keeps the invariant that end-user data never reaches a span: the template is the same
+// value this attribute reported before the redaction became segment-scoped.
+func redactContextSegment(path, contextValue, template string) string {
+	segments := strings.Split(path, "/")
+	found := false
+	for i, segment := range segments {
+		if segment == contextValue {
+			segments[i] = redactedValue
+			found = true
+		}
+	}
+	if !found {
+		return template
+	}
+	return strings.Join(segments, "/")
 }
 
 // clientAddressFromXFF mirrors how the tracing instrumentation derives client.address from

--- a/internal/middleware/tracing_middleware_test.go
+++ b/internal/middleware/tracing_middleware_test.go
@@ -69,18 +69,69 @@ func requireURLPath(t *testing.T, recorder *tracetest.SpanRecorder) string {
 	return ""
 }
 
+// Only the context segment is replaced. Everything else in the path, including the environment
+// identifier, is not sensitive and stays, so url.path still says which endpoint and which environment
+// served the request rather than collapsing to a copy of http.route.
 func TestContextIsRedactedFromSpanPath(t *testing.T) {
 	for _, template := range contextRouteTemplates {
 		t.Run(template, func(t *testing.T) {
 			router, recorder := tracedRouter(t, template)
-			// Substituting the context variable last leaves any other variable in place, so
-			// the request path differs from the template only by the redacted value.
 			path := strings.Replace(template, "{envId}", "507f1f77bcf86cd799439011", 1)
 			path = strings.Replace(path, "{context}", contextBase64, 1)
 
 			router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", path, nil))
 
-			assert.Equal(t, template, requireURLPath(t, recorder))
+			want := strings.Replace(template, "{envId}", "507f1f77bcf86cd799439011", 1)
+			want = strings.Replace(want, "{context}", "REDACTED", 1)
+			recorded := requireURLPath(t, recorder)
+			assert.Equal(t, want, recorded)
+			assert.NotContains(t, recorded, contextBase64, "the context must never reach the span")
+		})
+	}
+}
+
+// A context value that does not line up with a whole path segment cannot be redacted segment-wise. The
+// fallback reports the route template, so end-user data still never reaches the span.
+func TestRedactContextSegmentFallsBackToTheTemplate(t *testing.T) {
+	const template = "/sdk/evalx/{envId}/contexts/{context}"
+
+	specs := []struct {
+		name         string
+		path         string
+		contextValue string
+		want         string
+	}{
+		{
+			name:         "context is a whole segment",
+			path:         "/sdk/evalx/env-1/contexts/" + contextBase64,
+			contextValue: contextBase64,
+			want:         "/sdk/evalx/env-1/contexts/REDACTED",
+		},
+		{
+			name:         "context spans segments",
+			path:         "/sdk/evalx/env-1/contexts/one/two",
+			contextValue: "one/two",
+			want:         template,
+		},
+		{
+			name:         "context value not present in the path",
+			path:         "/sdk/evalx/env-1/contexts/something-else",
+			contextValue: contextBase64,
+			want:         template,
+		},
+		{
+			name:         "a value repeated in another segment is redacted too",
+			path:         "/sdk/evalx/" + contextBase64 + "/contexts/" + contextBase64,
+			contextValue: contextBase64,
+			want:         "/sdk/evalx/REDACTED/contexts/REDACTED",
+		},
+	}
+
+	for _, tt := range specs {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactContextSegment(tt.path, tt.contextValue, template)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, tt.contextValue, "the context must never survive redaction")
 		})
 	}
 }
@@ -122,7 +173,7 @@ func TestRedactionSurvivesNestedSubrouters(t *testing.T) {
 
 	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/sdk/poll/eval/"+contextBase64, nil))
 
-	assert.Equal(t, "/sdk/poll/eval/{context}", requireURLPath(t, recorder))
+	assert.Equal(t, "/sdk/poll/eval/REDACTED", requireURLPath(t, recorder))
 }
 
 // TestRedactionWithoutARecordingSpan covers a relay with tracing disabled, where the request

--- a/internal/streams/stream_flight_telemetry_test.go
+++ b/internal/streams/stream_flight_telemetry_test.go
@@ -21,8 +21,9 @@ import (
 )
 
 // TestReplayAnnotatesSubscriberSpanWithFlightTelemetry checks that every repository whose replay
-// goes through a flight group reports the flight-group telemetry (relay.singleflight.shared, and
-// relay.singleflight.wait_ms when a replay waits on another's) on the subscribing request's span,
+// goes through a flight group reports the flight-group telemetry
+// (launchdarkly.relay.singleflight.shared, and the wait duration when a replay waits on another's)
+// on the subscribing request's span,
 // matching what the polling endpoints record. The shared/waiting semantics themselves are covered
 // by the tracing package's SingleflightDo tests; these subtests prove each replay call site hands
 // the subscriber's context through.
@@ -66,7 +67,7 @@ func TestReplayAnnotatesSubscriberSpanWithFlightTelemetry(t *testing.T) {
 			require.True(t, ok, "the subscriber's span should report whether the replay build was shared")
 			assert.False(t, shared.AsBool(), "a lone replay shares with nobody")
 
-			_, waited := attrs[tracing.SingleflightWaitMSKey]
+			_, waited := attrs[tracing.SingleflightWaitDurationKey]
 			assert.False(t, waited, "a lone replay builds its own payload, so it should record no wait")
 		})
 	}

--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -28,7 +28,10 @@ const (
 
 // Relay-specific span attribute keys.
 const (
-	SDKKindKey       = attribute.Key("relay.sdk_kind")
+	// SDKKindKey reports the category of SDK that made the request. It describes the caller rather
+	// than Relay itself, so it sits beside the other LaunchDarkly attributes rather than under
+	// launchdarkly.relay.
+	SDKKindKey       = attribute.Key("launchdarkly.sdk.kind")
 	AuthResultKey    = attribute.Key("launchdarkly.relay.auth.result")
 	FlagCountKey     = attribute.Key("relay.flags.count")
 	EventsKindKey    = attribute.Key("launchdarkly.relay.events.kind")

--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -29,10 +29,10 @@ const (
 // Relay-specific span attribute keys.
 const (
 	SDKKindKey       = attribute.Key("relay.sdk_kind")
-	AuthResultKey    = attribute.Key("relay.auth.result")
+	AuthResultKey    = attribute.Key("launchdarkly.relay.auth.result")
 	FlagCountKey     = attribute.Key("relay.flags.count")
-	EventsKindKey    = attribute.Key("relay.events.kind")
-	StoreKeyKey      = attribute.Key("relay.store.key")
+	EventsKindKey    = attribute.Key("launchdarkly.relay.events.kind")
+	StoreKeyKey      = attribute.Key("launchdarkly.relay.store.key")
 	PayloadEventsKey = attribute.Key("relay.payload.events")
 	PayloadBytesKey  = attribute.Key("relay.payload.bytes")
 
@@ -40,7 +40,7 @@ const (
 	// replay, whether the payload build was shared with concurrent requests through a flight
 	// group. When it is true and the request's trace shows no sign of the build itself,
 	// another request's trace carries it.
-	SingleflightSharedKey = attribute.Key("relay.singleflight.shared")
+	SingleflightSharedKey = attribute.Key("launchdarkly.relay.singleflight.shared")
 
 	// SingleflightWaitMSKey reports, on the request span of a request that received its
 	// payload from a flight another request was already executing, how many milliseconds it

--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -19,7 +19,7 @@ const (
 	SpanStoreSnapshot    = "relay.store.snapshot"
 	SpanStoreGetAll      = "relay.store.get_all"
 	SpanStoreGet         = "relay.store.get"
-	SpanEvaluateFlags    = "relay.evaluate_flags"
+	SpanEvaluateFlags    = "relay.flags.evaluate"
 	SpanEventsDispatch   = "relay.events.dispatch"
 	SpanSerializePayload = "relay.payload.serialize"
 	SpanWriteResponse    = "relay.response.write"

--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -31,13 +31,17 @@ const (
 	// SDKKindKey reports the category of SDK that made the request. It describes the caller rather
 	// than Relay itself, so it sits beside the other LaunchDarkly attributes rather than under
 	// launchdarkly.relay.
-	SDKKindKey       = attribute.Key("launchdarkly.sdk.kind")
-	AuthResultKey    = attribute.Key("launchdarkly.relay.auth.result")
-	FlagCountKey     = attribute.Key("relay.flags.count")
-	EventsKindKey    = attribute.Key("launchdarkly.relay.events.kind")
-	StoreKeyKey      = attribute.Key("launchdarkly.relay.store.key")
-	PayloadEventsKey = attribute.Key("relay.payload.events")
-	PayloadBytesKey  = attribute.Key("relay.payload.bytes")
+	SDKKindKey    = attribute.Key("launchdarkly.sdk.kind")
+	AuthResultKey = attribute.Key("launchdarkly.relay.auth.result")
+	EventsKindKey = attribute.Key("launchdarkly.relay.events.kind")
+	StoreKeyKey   = attribute.Key("launchdarkly.relay.store.key")
+
+	// FlagCountKey, PayloadEventCountKey and PayloadSizeKey report how much a payload contained.
+	// Quantities follow one shape: a count of something ends in .count, and a size in bytes ends in
+	// .size, with the unit left out of the name.
+	FlagCountKey         = attribute.Key("launchdarkly.relay.flag.count")
+	PayloadEventCountKey = attribute.Key("launchdarkly.relay.payload.event.count")
+	PayloadSizeKey       = attribute.Key("launchdarkly.relay.payload.size")
 
 	// SingleflightSharedKey reports, on the request span of a polling request or an SSE
 	// replay, whether the payload build was shared with concurrent requests through a flight

--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -49,10 +49,11 @@ const (
 	// another request's trace carries it.
 	SingleflightSharedKey = attribute.Key("launchdarkly.relay.singleflight.shared")
 
-	// SingleflightWaitMSKey reports, on the request span of a request that received its
-	// payload from a flight another request was already executing, how many milliseconds it
-	// spent waiting for that flight. It is absent from the request that executed the build:
-	// that request did not wait. The same window is also visible in the trace timeline as a
-	// SpanSingleflightWait child span.
-	SingleflightWaitMSKey = attribute.Key("relay.singleflight.wait_ms")
+	// SingleflightWaitDurationKey reports, on the request span of a request that received its
+	// payload from a flight another request was already executing, how long it spent waiting for
+	// that flight. The value is in seconds, OTel's base unit for a duration, so the unit stays out
+	// of the name. It is absent from the request that executed the build: that request did not
+	// wait. The same window is also visible in the trace timeline as a SpanSingleflightWait child
+	// span.
+	SingleflightWaitDurationKey = attribute.Key("launchdarkly.relay.singleflight.wait.duration")
 )

--- a/internal/tracing/attributes_test.go
+++ b/internal/tracing/attributes_test.go
@@ -16,15 +16,15 @@ import (
 // work are launchdarkly.relay.<thing>, counts end in .count and byte sizes end in .size.
 func TestSpanAttributeKeyNames(t *testing.T) {
 	expected := map[attribute.Key]string{
-		SDKKindKey:            "launchdarkly.sdk.kind",
-		AuthResultKey:         "launchdarkly.relay.auth.result",
-		EventsKindKey:         "launchdarkly.relay.events.kind",
-		StoreKeyKey:           "launchdarkly.relay.store.key",
-		FlagCountKey:          "launchdarkly.relay.flag.count",
-		PayloadEventCountKey:  "launchdarkly.relay.payload.event.count",
-		PayloadSizeKey:        "launchdarkly.relay.payload.size",
-		SingleflightSharedKey: "launchdarkly.relay.singleflight.shared",
-		SingleflightWaitMSKey: "relay.singleflight.wait_ms",
+		SDKKindKey:                  "launchdarkly.sdk.kind",
+		AuthResultKey:               "launchdarkly.relay.auth.result",
+		EventsKindKey:               "launchdarkly.relay.events.kind",
+		StoreKeyKey:                 "launchdarkly.relay.store.key",
+		FlagCountKey:                "launchdarkly.relay.flag.count",
+		PayloadEventCountKey:        "launchdarkly.relay.payload.event.count",
+		PayloadSizeKey:              "launchdarkly.relay.payload.size",
+		SingleflightSharedKey:       "launchdarkly.relay.singleflight.shared",
+		SingleflightWaitDurationKey: "launchdarkly.relay.singleflight.wait.duration",
 	}
 
 	for key, want := range expected {

--- a/internal/tracing/attributes_test.go
+++ b/internal/tracing/attributes_test.go
@@ -1,0 +1,48 @@
+package tracing
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Span attribute keys are what operators write TraceQL against, so the wire names are a contract.
+// Asserting the literal strings here means a rename cannot happen as a side effect of renaming the Go
+// identifier, and it keeps the whole naming scheme visible in one place.
+//
+// The scheme: keys that describe the caller are launchdarkly.<thing>, keys specific to Relay's own
+// work are launchdarkly.relay.<thing>, counts end in .count and byte sizes end in .size.
+func TestSpanAttributeKeyNames(t *testing.T) {
+	expected := map[attribute.Key]string{
+		SDKKindKey:            "launchdarkly.sdk.kind",
+		AuthResultKey:         "launchdarkly.relay.auth.result",
+		FlagCountKey:          "relay.flags.count",
+		EventsKindKey:         "launchdarkly.relay.events.kind",
+		StoreKeyKey:           "launchdarkly.relay.store.key",
+		PayloadEventsKey:      "relay.payload.events",
+		PayloadBytesKey:       "relay.payload.bytes",
+		SingleflightSharedKey: "launchdarkly.relay.singleflight.shared",
+		SingleflightWaitMSKey: "relay.singleflight.wait_ms",
+	}
+
+	for key, want := range expected {
+		assert.Equal(t, want, string(key))
+	}
+}
+
+// Span names stay short and unprefixed: they are display strings in a trace waterfall rather than
+// queryable dimensions, and the semantic conventions do not namespace them either. They read
+// object-then-verb so that related spans sort together.
+func TestSpanNames(t *testing.T) {
+	assert.Equal(t, "relay.auth", SpanAuth)
+	assert.Equal(t, "relay.store.snapshot", SpanStoreSnapshot)
+	assert.Equal(t, "relay.store.get_all", SpanStoreGetAll)
+	assert.Equal(t, "relay.store.get", SpanStoreGet)
+	assert.Equal(t, "relay.evaluate_flags", SpanEvaluateFlags)
+	assert.Equal(t, "relay.events.dispatch", SpanEventsDispatch)
+	assert.Equal(t, "relay.payload.serialize", SpanSerializePayload)
+	assert.Equal(t, "relay.response.write", SpanWriteResponse)
+	assert.Equal(t, "relay.singleflight.wait", SpanSingleflightWait)
+}

--- a/internal/tracing/attributes_test.go
+++ b/internal/tracing/attributes_test.go
@@ -18,11 +18,11 @@ func TestSpanAttributeKeyNames(t *testing.T) {
 	expected := map[attribute.Key]string{
 		SDKKindKey:            "launchdarkly.sdk.kind",
 		AuthResultKey:         "launchdarkly.relay.auth.result",
-		FlagCountKey:          "relay.flags.count",
 		EventsKindKey:         "launchdarkly.relay.events.kind",
 		StoreKeyKey:           "launchdarkly.relay.store.key",
-		PayloadEventsKey:      "relay.payload.events",
-		PayloadBytesKey:       "relay.payload.bytes",
+		FlagCountKey:          "launchdarkly.relay.flag.count",
+		PayloadEventCountKey:  "launchdarkly.relay.payload.event.count",
+		PayloadSizeKey:        "launchdarkly.relay.payload.size",
 		SingleflightSharedKey: "launchdarkly.relay.singleflight.shared",
 		SingleflightWaitMSKey: "relay.singleflight.wait_ms",
 	}

--- a/internal/tracing/attributes_test.go
+++ b/internal/tracing/attributes_test.go
@@ -40,7 +40,7 @@ func TestSpanNames(t *testing.T) {
 	assert.Equal(t, "relay.store.snapshot", SpanStoreSnapshot)
 	assert.Equal(t, "relay.store.get_all", SpanStoreGetAll)
 	assert.Equal(t, "relay.store.get", SpanStoreGet)
-	assert.Equal(t, "relay.evaluate_flags", SpanEvaluateFlags)
+	assert.Equal(t, "relay.flags.evaluate", SpanEvaluateFlags)
 	assert.Equal(t, "relay.events.dispatch", SpanEventsDispatch)
 	assert.Equal(t, "relay.payload.serialize", SpanSerializePayload)
 	assert.Equal(t, "relay.response.write", SpanWriteResponse)

--- a/internal/tracing/resource.go
+++ b/internal/tracing/resource.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pborman/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
 // relayIDAttrKey identifies the relay process. It is a resource attribute rather than a per-measurement

--- a/internal/tracing/resource.go
+++ b/internal/tracing/resource.go
@@ -8,22 +8,16 @@ import (
 	"sync"
 
 	"github.com/pborman/uuid"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
-
-// relayIDAttrKey identifies the relay process. It is a resource attribute rather than a per-measurement
-// one: it never varies within a process, so repeating it on every data point only inflated the attribute
-// set that has to be built and sorted for each request.
-const relayIDAttrKey = attribute.Key("relay.id")
 
 // relayID is generated once per process, so that the metrics and trace providers -- which each build
 // their own resource -- report the same identity.
 var relayID = sync.OnceValue(uuid.New) //nolint:gochecknoglobals
 
-// RelayID returns the identifier for this relay process. It is reported as the relay.id resource
-// attribute, and is also the ID used in the usage data Relay sends to LaunchDarkly.
+// RelayID returns the identifier for this relay process. It is reported as the service.instance.id
+// resource attribute, and is also the ID used in the usage data Relay sends to LaunchDarkly.
 func RelayID() string {
 	return relayID()
 }
@@ -33,20 +27,22 @@ func RelayID() string {
 // unset, it defaults to "ld-relay". If resource creation fails or returns
 // nil, it falls back to resource.Default() and logs a warning.
 //
+// The process identity is reported as service.instance.id alone. Relay used to publish the same value
+// again under a private relay.id key; that carried no information service.instance.id did not already
+// carry, and Prometheus surfaces the standard attribute directly as the "instance" label.
+//
 // Note for Prometheus users: resource attributes are not copied onto every series. They are exposed
-// through target_info, so a query that needs relay.id has to join against it. service.instance.id is
-// set to the same value because Prometheus surfaces that one directly as the "instance" label.
+// through target_info, so a query that needs the process identity joins against it, or uses the
+// "instance" label.
 func NewResource(logger *slog.Logger) *resource.Resource {
 	opts := []resource.Option{resource.WithFromEnv()}
 	if os.Getenv("OTEL_SERVICE_NAME") == "" {
 		opts = append(opts, resource.WithAttributes(semconv.ServiceName("ld-relay")))
 	}
-	attrs := []attribute.KeyValue{relayIDAttrKey.String(RelayID())}
 	// Only supply service.instance.id when the operator has not configured one themselves.
 	if !strings.Contains(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"), string(semconv.ServiceInstanceIDKey)) {
-		attrs = append(attrs, semconv.ServiceInstanceID(RelayID()))
+		opts = append(opts, resource.WithAttributes(semconv.ServiceInstanceID(RelayID())))
 	}
-	opts = append(opts, resource.WithAttributes(attrs...))
 
 	res, err := resource.New(context.Background(), opts...)
 	if err != nil || res == nil {

--- a/internal/tracing/resource_test.go
+++ b/internal/tracing/resource_test.go
@@ -1,0 +1,60 @@
+package tracing
+
+import (
+	"log/slog"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The process identity is reported once, as service.instance.id. Relay used to publish the same value
+// again under a private relay.id key, which carried nothing the standard attribute did not.
+func TestResourceReportsProcessIdentityAsServiceInstanceID(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+
+	res := NewResource(slog.Default())
+	require.NotNil(t, res)
+
+	instanceID, ok := res.Set().Value(attribute.Key("service.instance.id"))
+	require.True(t, ok, "service.instance.id not present on the resource")
+	assert.Equal(t, RelayID(), instanceID.AsString())
+
+	_, ok = res.Set().Value(attribute.Key("relay.id"))
+	assert.False(t, ok, "relay.id duplicated service.instance.id and should no longer be reported")
+
+	serviceName, ok := res.Set().Value(attribute.Key("service.name"))
+	require.True(t, ok, "service.name not present on the resource")
+	assert.Equal(t, "ld-relay", serviceName.AsString())
+}
+
+// An operator who sets service.instance.id themselves owns it, so relay must not overwrite it with its
+// own generated value.
+func TestResourceKeepsAnOperatorSuppliedServiceInstanceID(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.instance.id=pod-7")
+
+	res := NewResource(slog.Default())
+	require.NotNil(t, res)
+
+	instanceID, ok := res.Set().Value(attribute.Key("service.instance.id"))
+	require.True(t, ok, "service.instance.id not present on the resource")
+	assert.Equal(t, "pod-7", instanceID.AsString())
+	assert.NotEqual(t, RelayID(), instanceID.AsString())
+}
+
+// OTEL_SERVICE_NAME wins over the built-in default.
+func TestResourceUsesTheConfiguredServiceName(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "my-relay")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+
+	res := NewResource(slog.Default())
+	require.NotNil(t, res)
+
+	serviceName, ok := res.Set().Value(attribute.Key("service.name"))
+	require.True(t, ok, "service.name not present on the resource")
+	assert.Equal(t, "my-relay", serviceName.AsString())
+}

--- a/internal/tracing/singleflight.go
+++ b/internal/tracing/singleflight.go
@@ -10,7 +10,7 @@ import (
 
 // SingleflightDo runs fn through group under key and annotates the span in ctx with how the
 // flight resolved: SingleflightSharedKey reports whether the result was handed to multiple
-// callers, and SingleflightWaitMSKey records, only on a caller that waited for a flight another
+// callers, and SingleflightWaitDurationKey records, only on a caller that waited for a flight another
 // caller was already executing, how long it waited. That wait is additionally emitted as a
 // SpanSingleflightWait child span covering exactly the waiting window, so a trace's timeline
 // shows a labeled bar instead of an unexplained gap. The caller that executed fn records
@@ -33,8 +33,7 @@ func SingleflightDo(
 	span.SetAttributes(SingleflightSharedKey.Bool(shared))
 	if !executed {
 		end := time.Now()
-		span.SetAttributes(SingleflightWaitMSKey.Float64(
-			float64(end.Sub(start)) / float64(time.Millisecond)))
+		span.SetAttributes(SingleflightWaitDurationKey.Float64(end.Sub(start).Seconds()))
 		// The wait span is back-dated: whether this caller waited (rather than executed) is
 		// only known once Do returns, so it cannot be opened beforehand without also giving
 		// the executing caller a bogus wait span. It comes from the provider that owns the

--- a/internal/tracing/singleflight_test.go
+++ b/internal/tracing/singleflight_test.go
@@ -43,7 +43,7 @@ func TestSingleflightDoAnnotatesALoneCaller(t *testing.T) {
 	require.True(t, ok, "the span should always report whether the flight was shared")
 	assert.False(t, shared.AsBool())
 
-	_, waited := attrs[SingleflightWaitMSKey]
+	_, waited := attrs[SingleflightWaitDurationKey]
 	assert.False(t, waited, "the caller executed the function itself, so it should record no wait")
 }
 
@@ -95,7 +95,7 @@ func TestSingleflightDoAnnotatesSharedCallers(t *testing.T) {
 	ended := recorder.Ended()
 	require.Len(t, ended, 3, "expected the leader span, the follower span, and the follower's wait span")
 
-	var followerWaitMS float64
+	var followerWaitSeconds float64
 	var waitSpan, followerSpan sdktrace.ReadOnlySpan
 	for _, s := range ended {
 		attrs := attrsOf(s)
@@ -108,15 +108,15 @@ func TestSingleflightDoAnnotatesSharedCallers(t *testing.T) {
 		require.True(t, ok, "the span should always report whether the flight was shared")
 		assert.True(t, shared.AsBool())
 
-		wait, waited := attrs[SingleflightWaitMSKey]
+		wait, waited := attrs[SingleflightWaitDurationKey]
 		switch s.Name() {
 		case "leader":
 			assert.False(t, waited, "the leader executed the function, so it should record no wait")
 		case "follower":
 			followerSpan = s
 			require.True(t, waited, "the follower waited on the leader's flight, so it should record its wait")
-			followerWaitMS = wait.AsFloat64()
-			assert.Positive(t, followerWaitMS)
+			followerWaitSeconds = wait.AsFloat64()
+			assert.Positive(t, followerWaitSeconds)
 		}
 	}
 
@@ -128,9 +128,9 @@ func TestSingleflightDoAnnotatesSharedCallers(t *testing.T) {
 		"the wait span should live in the follower's trace")
 	assert.Equal(t, followerSpan.SpanContext().SpanID(), waitSpan.Parent().SpanID(),
 		"the wait span should be a child of the follower's span")
-	spanMS := float64(waitSpan.EndTime().Sub(waitSpan.StartTime())) / float64(time.Millisecond)
-	assert.InDelta(t, followerWaitMS, spanMS, 0.001,
-		"the wait span should cover the same window the wait_ms attribute reports")
+	spanSeconds := waitSpan.EndTime().Sub(waitSpan.StartTime()).Seconds()
+	assert.InDelta(t, followerWaitSeconds, spanSeconds, 0.000001,
+		"the wait span should cover the same window the wait duration attribute reports")
 }
 
 func TestSingleflightDoToleratesASpanlessContext(t *testing.T) {

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -343,8 +343,8 @@ func buildServerSidePollPayload(
 		return pollResult{}, err
 	}
 	span.SetAttributes(
-		tracing.PayloadEventsKey.Int(eventCount),
-		tracing.PayloadBytesKey.Int(len(data)),
+		tracing.PayloadEventCountKey.Int(eventCount),
+		tracing.PayloadSizeKey.Int(len(data)),
 	)
 	return pollResult{data: data, etag: selector.State()}, nil
 }
@@ -483,8 +483,8 @@ func pollEvalHandlerV2Shared(w http.ResponseWriter, req *http.Request, maxBodySi
 			return nil, false
 		}
 		span.SetAttributes(
-			tracing.PayloadEventsKey.Int(eventCount),
-			tracing.PayloadBytesKey.Int(len(data)),
+			tracing.PayloadEventCountKey.Int(eventCount),
+			tracing.PayloadSizeKey.Int(len(data)),
 		)
 		return data, true
 	}()
@@ -551,7 +551,7 @@ func buildAllFlagsPayload(ctx context.Context, tr trace.Tracer, env relayenv.Env
 	etag := hex.EncodeToString(hash.Sum(nil))[:15]
 	span.SetAttributes(
 		tracing.FlagCountKey.Int(flagCount),
-		tracing.PayloadBytesKey.Int(len(respData)),
+		tracing.PayloadSizeKey.Int(len(respData)),
 	)
 	return pollResult{data: respData, etag: etag}, nil
 }
@@ -765,7 +765,7 @@ func evaluateAllShared(w http.ResponseWriter, req *http.Request, sdkKind basicty
 		data := responseWriter.Bytes()
 		span.SetAttributes(
 			tracing.FlagCountKey.Int(len(evalResults)),
-			tracing.PayloadBytesKey.Int(len(data)),
+			tracing.PayloadSizeKey.Int(len(data)),
 		)
 		return data
 	}()
@@ -812,7 +812,7 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 				w.WriteHeader(http.StatusInternalServerError)
 				return nil, false
 			}
-			span.SetAttributes(tracing.PayloadBytesKey.Int(len(data)))
+			span.SetAttributes(tracing.PayloadSizeKey.Int(len(data)))
 			return data, true
 		}()
 		if !ok {
@@ -832,7 +832,7 @@ func pollFlagOrSegment(clientContext relayenv.EnvContext, kind ldstoretypes.Data
 // disconnected, a body that was truncated -- cannot change the status code the request span
 // reports, so this span is the only place such a failure surfaces.
 //
-// The span deliberately carries no byte count. relay.payload.bytes on the serialize span
+// The span deliberately carries no byte count. launchdarkly.relay.payload.size on the serialize span
 // reports what was built, and http.response.body.size on the request span reports what
 // actually went out; the latter is counted outside the compression middleware, which is the
 // only place the wire size is observable. A count taken here could only ever repeat the

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/relay/relay_endpoints_active_requests_test.go
+++ b/relay/relay_endpoints_active_requests_test.go
@@ -54,14 +54,14 @@ func requireSingleActiveRequestPoint(t *testing.T, reader sdkmetric.Reader) metr
 
 func requireEndpointType(t *testing.T, dp metricdata.DataPoint[int64], expected metrics.EndpointType) {
 	t.Helper()
-	val, ok := dp.Attributes.Value("relay.endpoint.type")
-	require.True(t, ok, "relay.endpoint.type attribute not present")
+	val, ok := dp.Attributes.Value("launchdarkly.relay.endpoint.type")
+	require.True(t, ok, "launchdarkly.relay.endpoint.type attribute not present")
 	assert.Equal(t, string(expected), val.AsString())
 }
 
 // TestActiveRequestsCoverAllEndpointTypes drives a representative route for each endpoint type through
 // the full relay and asserts that http.server.active_requests recorded it under the expected
-// relay.endpoint.type. Polling, event ingestion, goals and status are all included: per the OTEL
+// launchdarkly.relay.endpoint.type. Polling, event ingestion, goals and status are all included: per the OTEL
 // semantic convention this instrument counts every in-flight HTTP request, not just streams.
 func TestActiveRequestsCoverAllEndpointTypes(t *testing.T) {
 	contextJSON := []byte(`{"kind":"user","key":"me"}`)
@@ -226,7 +226,7 @@ func TestWrongMethodIsNotFoundAndIsCounted(t *testing.T) {
 		require.True(t, ok)
 		methods := map[string]bool{}
 		for _, dp := range sum.DataPoints {
-			endpointType, ok := dp.Attributes.Value("relay.endpoint.type")
+			endpointType, ok := dp.Attributes.Value("launchdarkly.relay.endpoint.type")
 			require.True(t, ok)
 			assert.Equal(t, string(metrics.EndpointTypeNotProvided), endpointType.AsString())
 			if method, ok := dp.Attributes.Value("http.request.method"); ok {

--- a/relay/relay_endpoints_active_requests_test.go
+++ b/relay/relay_endpoints_active_requests_test.go
@@ -200,7 +200,7 @@ func TestActiveRequestsCountLiveStream(t *testing.T) {
 // building the middleware chain, but that branch is unreachable in this router: the catch-all
 // serverSideRouter (PathPrefix "") matches every path, and a matcher that succeeds clears a pending
 // ErrMethodMismatch, so Match finishes with ErrNotFound instead. Relay therefore never answers 405,
-// and a wrong-method request is counted under not-provided.
+// and a wrong-method request is counted under not_provided.
 //
 // If a future change removes the catch-all subrouter, this test fails with a 405, which is the signal
 // to wrap MethodNotAllowedHandler as well.

--- a/relay/relay_endpoints_singleflight_test.go
+++ b/relay/relay_endpoints_singleflight_test.go
@@ -149,7 +149,7 @@ func TestPollingHandlersShareOnePayloadBuildAcrossConcurrentRequests(t *testing.
 				require.True(t, ok, "the request span should report whether the payload build was shared")
 				assert.True(t, shared.AsBool())
 
-				wait, waited := attrs[tracing.SingleflightWaitMSKey]
+				wait, waited := attrs[tracing.SingleflightWaitDurationKey]
 				if root.SpanContext().TraceID() == serialize.SpanContext().TraceID() {
 					executedRoots++
 					assert.False(t, waited, "the request that built the payload did not wait")
@@ -221,7 +221,7 @@ func TestPollingSingleflightAttributesForALoneRequest(t *testing.T) {
 			require.True(t, ok, "the request span should always report whether the payload build was shared")
 			assert.False(t, shared.AsBool())
 
-			_, waited := attrs[tracing.SingleflightWaitMSKey]
+			_, waited := attrs[tracing.SingleflightWaitDurationKey]
 			assert.False(t, waited, "a request that built its own payload should record no wait time")
 		})
 	}

--- a/relay/relay_endpoints_spans_test.go
+++ b/relay/relay_endpoints_spans_test.go
@@ -137,14 +137,14 @@ func TestPollingEndpointSpansAreRecorded(t *testing.T) {
 				buildReq: func() *http.Request {
 					return st.BuildRequestWithAuth("GET", "/sdk/poll", serverSDKKey, nil)
 				},
-				countKey: tracing.PayloadEventsKey,
+				countKey: tracing.PayloadEventCountKey,
 			},
 			{
 				name: "pollEvalHandlerV2Shared GET /sdk/poll/eval",
 				buildReq: func() *http.Request {
 					return st.BuildRequestWithAuth("GET", "/sdk/poll/eval/"+contextBase64, mobileKey, nil)
 				},
-				countKey: tracing.PayloadEventsKey,
+				countKey: tracing.PayloadEventCountKey,
 			},
 			{
 				name: "evaluateAllShared REPORT /sdk/evalx/context",
@@ -190,7 +190,7 @@ func TestPollingEndpointSpansAreRecorded(t *testing.T) {
 				serializeAttrs := spanAttrs(serialize)
 				writeAttrs := spanAttrs(write)
 
-				payloadBytes, ok := serializeAttrs[tracing.PayloadBytesKey]
+				payloadBytes, ok := serializeAttrs[tracing.PayloadSizeKey]
 				require.True(t, ok, "serialize span is missing the payload bytes attribute")
 				assert.Positive(t, payloadBytes.AsInt64())
 
@@ -210,7 +210,7 @@ func TestPollingEndpointSpansAreRecorded(t *testing.T) {
 					require.Truef(t, ok, "serialize span is missing the %q attribute", tc.countKey)
 					assert.GreaterOrEqual(t, count.AsInt64(), int64(1))
 				} else {
-					_, hasEvents := serializeAttrs[tracing.PayloadEventsKey]
+					_, hasEvents := serializeAttrs[tracing.PayloadEventCountKey]
 					_, hasFlags := serializeAttrs[tracing.FlagCountKey]
 					assert.False(t, hasEvents, "single-item serialize span should record no event count")
 					assert.False(t, hasFlags, "single-item serialize span should record no flag count")

--- a/relay/relay_endpoints_write_span_test.go
+++ b/relay/relay_endpoints_write_span_test.go
@@ -73,7 +73,7 @@ func TestWriteSpanReportsNotModified(t *testing.T) {
 		// The payload was built even though it was not sent, and the serialize span still
 		// reports its size. The request span reports no body size at all, since nothing was
 		// written.
-		assert.Positive(t, spanAttrs(serialize)[tracing.PayloadBytesKey].AsInt64())
+		assert.Positive(t, spanAttrs(serialize)[tracing.PayloadSizeKey].AsInt64())
 		_, hasBodySize := spanAttrs(rootSpan(t, spans))[httpBodySizeKey]
 		assert.False(t, hasBodySize, "a 304 writes no body, so no body size should be recorded")
 	})
@@ -101,7 +101,7 @@ func TestWriteSpanUnderCompression(t *testing.T) {
 		require.Equal(t, "gzip", w.Header().Get("Content-Encoding"))
 
 		spans := recorder.Ended()
-		payloadBytes := spanAttrs(requireSpan(t, spans, tracing.SpanSerializePayload))[tracing.PayloadBytesKey].AsInt64()
+		payloadBytes := spanAttrs(requireSpan(t, spans, tracing.SpanSerializePayload))[tracing.PayloadSizeKey].AsInt64()
 		bodySize := spanAttrs(rootSpan(t, spans))[httpBodySizeKey].AsInt64()
 
 		assert.Equal(t, int64(w.Body.Len()), bodySize,

--- a/relay/relay_request_span_test.go
+++ b/relay/relay_request_span_test.go
@@ -1,0 +1,52 @@
+package relay
+
+import (
+	"net/http"
+	"testing"
+
+	c "github.com/launchdarkly/ld-relay/v9/config"
+	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The semantic-convention attributes the HTTP tracing middleware derives from the request host.
+// These are asserted by their wire names, because that is what a backend queries on.
+const (
+	serverAddressKey = attribute.Key("server.address")
+	serverPortKey    = attribute.Key("server.port")
+)
+
+// TestRequestSpanReportsRequestHostAsServerAddress guards the argument passed to
+// otelmux.Middleware. That argument is the "primary server name", and a non-empty value
+// replaces the request host in server.address on every span, so passing a service name there
+// makes every trace claim the client connected to that name. Relay passes an empty string so
+// that both server.address and server.port come from the same request.
+func TestRequestSpanReportsRequestHostAsServerAddress(t *testing.T) {
+	recorder := installSpanRecorder(t)
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		headers := make(http.Header)
+		headers.Set("Authorization", string(st.EnvMain.Config.SDKKey))
+		req := st.BuildRequest("GET", "http://relay.example.com:8031/sdk/flags", nil, headers)
+
+		result, _ := st.DoRequest(req, p.relay)
+		require.Equal(t, http.StatusOK, result.StatusCode)
+
+		attrs := spanAttrs(rootSpan(t, recorder.Ended()))
+
+		address, ok := attrs[serverAddressKey]
+		require.True(t, ok, "request span is missing server.address")
+		assert.Equal(t, "relay.example.com", address.AsString())
+
+		port, ok := attrs[serverPortKey]
+		require.True(t, ok, "request span is missing server.port")
+		assert.Equal(t, int64(8031), port.AsInt64())
+	})
+}

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -82,7 +82,7 @@ func (r *Relay) makeRouter() *mux.Router {
 
 	// Client-side evaluation (for JS, not mobile)
 	// The endpointType parameter is what a request served by this stack reports as its
-	// relay.endpoint.type; the stack itself is shared across several kinds of endpoint.
+	// launchdarkly.relay.endpoint.type; the stack itself is shared across several kinds of endpoint.
 	jsClientSideMiddlewareStack := func(subrouter *mux.Router, endpointType metrics.EndpointType) mux.MiddlewareFunc {
 		return middleware.Chain(
 			mux.CORSMethodMiddleware(subrouter),

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/gorilla/mux"
 	h "github.com/klauspost/compress/gzhttp"
-	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 )
 
@@ -42,7 +41,11 @@ func (r *Relay) makeRouter() *mux.Router {
 	if r.logger.Enabled(context.Background(), slog.LevelDebug) {
 		router.Use(logging.RequestLoggerMiddleware(r.logger))
 	}
-	router.Use(otelmux.Middleware(tracing.TracerName))
+	// The empty string tells otelmux to derive server.address and server.port from each request's
+	// Host header. Its parameter is the "primary server name", not an instrumentation name: a
+	// non-empty value overrides the real host on every span, so passing a service name here would
+	// report that name as the address the client connected to.
+	router.Use(otelmux.Middleware(""))
 	// Must come after the tracing middleware, which records the raw request path on the span it starts.
 	router.Use(middleware.SanitizeRequestSpan)
 	if r.config.HTTP.EnableCompression {

--- a/relay/relay_tracing_privacy_test.go
+++ b/relay/relay_tracing_privacy_test.go
@@ -71,6 +71,13 @@ func TestEndUserContextIsNotExportedInSpans(t *testing.T) {
 				route: "/msdk/evalx/users/{context}",
 				req:   st.BuildRequestWithAuth("GET", "/msdk/evalx/users/"+contextBase64, mobileKey, nil),
 			},
+			{
+				// A context in a REPORT body has nothing to redact in the path, but no span may
+				// carry the body either.
+				route: "/sdk/evalx/context",
+				req: st.BuildRequest("REPORT", "/sdk/evalx/context", []byte(contextJSON),
+					http.Header{"Authorization": []string{string(sdkKey)}, "Content-Type": []string{"application/json"}}),
+			},
 		}
 
 		for _, params := range cases {

--- a/relay/relay_tracing_privacy_test.go
+++ b/relay/relay_tracing_privacy_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -94,11 +95,13 @@ func TestEndUserContextIsNotExportedInSpans(t *testing.T) {
 					}
 				}
 
-				// The path is reported as the route template, which is also what http.route
-				// holds, so nothing is lost by redacting it.
+				// Only the context segment is replaced: the rest of the path is not sensitive and
+				// still says which endpoint and environment served the request. http.route
+				// continues to carry the template.
 				root := rootSpan(t, spans)
 				attrs := spanAttrs(root)
-				assert.Equal(t, params.route, attrs["url.path"].AsString())
+				wantPath := strings.Replace(params.req.URL.Path, contextBase64, "REDACTED", 1)
+				assert.Equal(t, wantPath, attrs["url.path"].AsString())
 				assert.Equal(t, params.route, attrs["http.route"].AsString())
 				assert.NotContains(t, root.Name(), contextBase64)
 			})


### PR DESCRIPTION
**Summary**

A review of every OTel metric, span, and attribute name the Relay Proxy emits, checked against the OpenTelemetry [attribute](https://opentelemetry.io/docs/specs/semconv/general/naming/) and [metric](https://opentelemetry.io/docs/specs/semconv/general/metrics/) naming rules and the HTTP semantic conventions, found the instrument names in good shape and the attribute keys in three different naming systems: real semconv names, semconv lookalikes that are not semconv (`user_agent`, `status_code`), and two vendor roots (`relay.*` for spans and attributes, `launchdarkly.relay.*` for metrics). Four keys had no namespace at all. One attribute also carried an outright wrong value.

Every one of these names is new in v9 -- v8 emitted OpenCensus names (`connections`, `requests`, `request_duration`) -- and v9 has only shipped as `9.0.0-rc.1` through `rc.5`, so this is the last cheap moment to rename. Doing it now costs release notes; doing it after GA costs a deprecation cycle.

Resolves SDK-2900.

**What was wrong, not just inconsistent**

- Every request span reported `server.address = "ld-relay"`. otelmux's first parameter is the "primary server name", not an instrumentation name, and it overrides the request Host. `server.port` beside it still came from the real request, so the pair did not compose into a reachable address and multi-hostname deployments could not break traffic down by host.
- `user_agent` shadowed the semconv `user_agent.*` namespace, and its value was slash-mangled while the span attribute of the same meaning was verbatim, so metrics and traces could not be joined on it.
- `status_code` on the events send-error counter reported `0` when the send failed before any response arrived, inventing a response that never happened.
- `url.path` was replaced wholesale with the route template on context-carrying routes. The redaction is necessary, but it discarded the environment identifier too and made `url.path` a duplicate of `http.route`.

**Naming scheme now applied**

Reuse semconv names where a convention exists. Everything else is prefixed `launchdarkly.`: keys describing the caller are `launchdarkly.<thing>`, keys describing the Relay Proxy's own work are `launchdarkly.relay.<thing>`. Counts end in `.count`, byte sizes end in `.size`, and units stay out of names. Span *names* keep the short unprefixed `relay.*` form, because they are display strings in a waterfall rather than queryable dimensions, and semconv does not namespace them either.

**Decisions worth flagging for review**

- `relay.id` was dropped rather than renamed. It duplicated `service.instance.id`, which Prometheus already surfaces as the `instance` label. The generated ID is unchanged and still identifies the process in the usage data the Relay Proxy sends to LaunchDarkly.
- The `not-provided` sentinel became `not_provided` **for OTel attributes only**. The same sanitizer also fed the usage payload the Relay Proxy POSTs to LaunchDarkly, which is a wire contract with a different consumer, so it keeps its own spelling. The sanitizer is split by sink and `TestUsageEventsKeepTheirOwnAbsentValueSentinel` pins the boundary.
- `application.id` / `.version` were renamed but their values still go through the slash replacement. Unlike `user_agent.original` there is no convention defining them as verbatim and no span attribute to join against.
- No `url.template` was added. `http.route` already carries the template on every span.
- The semconv import moved from v1.26.0 to v1.41.0 to match what otelmux and otelhttp actually emit; every key the Relay Proxy uses is spelled identically in both versions, so that changed no output.

**Found but deliberately not fixed**

The two usage pipelines disagree about an absent user agent: `RelayMetricsCollector` reports the sentinel, while `usage.go` never sanitizes and reports `""`. That is in LaunchDarkly's usage protocol rather than OTel, so it is outside this ticket.

**Full rename table**

| Kind | Before | After |
|---|---|---|
| metric | `launchdarkly.relay.events.send.errors` | `launchdarkly.relay.events.failed` |
| metric attr | `user_agent` | `user_agent.original` (verbatim value) |
| metric attr | `status_code` | `http.response.status_code` (+ `error.type`) |
| metric attr | `environment.name` | `launchdarkly.environment.name` |
| metric attr | `application.id` | `launchdarkly.application.id` |
| metric attr | `application.version` | `launchdarkly.application.version` |
| metric attr | `relay.endpoint.type` | `launchdarkly.relay.endpoint.type` |
| resource | `relay.id` | removed; use `service.instance.id` |
| span attr | `relay.sdk_kind` | `launchdarkly.sdk.kind` |
| span attr | `relay.auth.result` | `launchdarkly.relay.auth.result` |
| span attr | `relay.events.kind` | `launchdarkly.relay.events.kind` |
| span attr | `relay.store.key` | `launchdarkly.relay.store.key` |
| span attr | `relay.flags.count` | `launchdarkly.relay.flag.count` |
| span attr | `relay.payload.events` | `launchdarkly.relay.payload.event.count` |
| span attr | `relay.payload.bytes` | `launchdarkly.relay.payload.size` |
| span attr | `relay.singleflight.shared` | `launchdarkly.relay.singleflight.shared` |
| span attr | `relay.singleflight.wait_ms` | `launchdarkly.relay.singleflight.wait.duration` (seconds) |
| span name | `relay.evaluate_flags` | `relay.flags.evaluate` |
| attr value | `not-provided` | `not_provided` (OTel attributes only) |

Three contract tests now pin the wire names so no future rename can happen incidentally: `TestRequestMetricAttributeKeys` covers the exact attribute-key set on both request instruments, and `TestSpanAttributeKeyNames` / `TestSpanNames` cover every span key and name as a literal string. `NewResource` had no test coverage at all and now does, including the operator-supplied `service.instance.id` branch.

BEGIN_COMMIT_OVERRIDE
feat!: Rename OTel attributes to follow the semantic conventions and a single vendor namespace

Attribute keys the Relay Proxy defines itself are now prefixed `launchdarkly.`, and keys with a semantic-convention equivalent use it. Operators must update dashboards, alerts, and TraceQL queries.

Metric attributes: `user_agent` is now `user_agent.original` and reports the header verbatim rather than replacing slashes with underscores; `environment.name` is now `launchdarkly.environment.name`; `application.id` and `application.version` are now `launchdarkly.application.id` and `launchdarkly.application.version`; `relay.endpoint.type` is now `launchdarkly.relay.endpoint.type`.

Span attributes: `relay.sdk_kind` is now `launchdarkly.sdk.kind`; `relay.auth.result`, `relay.events.kind`, `relay.store.key` and `relay.singleflight.shared` gain the `launchdarkly.` prefix; `relay.flags.count` is now `launchdarkly.relay.flag.count`; `relay.payload.events` is now `launchdarkly.relay.payload.event.count`; `relay.payload.bytes` is now `launchdarkly.relay.payload.size`; `relay.singleflight.wait_ms` is now `launchdarkly.relay.singleflight.wait.duration` and reports seconds instead of milliseconds.

The `relay.evaluate_flags` span is now named `relay.flags.evaluate`.

Absent attribute values are reported as `not_provided` rather than `not-provided`. This applies to OTel attributes only; the usage data the Relay Proxy sends to LaunchDarkly is unchanged.

A LaunchDarkly environment is not a deployment environment, and `environment.name` sat one segment away from the OpenTelemetry `deployment.environment.name` attribute that the metrics doc recommends setting for Datadog unified service tagging, where it maps to Datadog's reserved `env` tag.
BEGIN_NESTED_COMMIT
feat!: Rename the events send-error metric to launchdarkly.relay.events.failed

`launchdarkly.relay.events.send.errors` is now `launchdarkly.relay.events.failed`, so that every metric in the event-delivery family names its outcome the same way alongside `events.sent`, `events.dropped` and `events.pending`.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
feat!: Remove the relay.id resource attribute

The Relay Proxy reported the same generated identifier twice, as both `relay.id` and the standard `service.instance.id`. Only `service.instance.id` is reported now; Prometheus exposes it as the `instance` label. Queries that joined `target_info` on `relay.id` must use `service.instance.id` instead.

The identifier itself is unchanged, including in the usage data the Relay Proxy sends to LaunchDarkly, and an operator-supplied `service.instance.id` is still respected.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix: Report server.address from the request host

Request spans reported `server.address` as the literal service name `ld-relay` rather than the host the client connected to, while `server.port` beside it came from the real request. Deployments serving several hostnames can now break traffic down by host.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix: Redact only the evaluation context segment of url.path

On endpoints that take an evaluation context in the URL, `url.path` was replaced entirely with the route template, which also discarded the environment identifier and made the attribute a duplicate of `http.route`. Only the context segment is replaced now, with the `REDACTED` placeholder the semantic conventions use for scrubbing a URL, so `/sdk/evalx/<envId>/contexts/<context>` is reported as `/sdk/evalx/<envId>/contexts/REDACTED`.

End-user context data still never reaches a span, including a context supplied in a REPORT body.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
fix: Report the events send failure status per semantic convention

The send-failure counter reported a status under a private `status_code` attribute, including the value 0 when delivery failed before any response arrived. It now reports `http.response.status_code` only when the events service answered, and always reports `error.type`: the status code as a string when there was a response, and `_OTHER` when the failure was a network error or timeout.
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
docs: Document the Relay Proxy tracing surface

Adds docs/tracing.md, covering the request span and how the evaluation context is redacted from it, the spans the Relay Proxy creates, every span attribute and which span carries it, and the request-deduplication attributes.
END_NESTED_COMMIT
END_COMMIT_OVERRIDE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> This is a **breaking** telemetry rename before v9 GA: custom OpenTelemetry metric and span attribute keys move under `launchdarkly.*` (and semconv where applicable), so existing dashboards, alerts, and TraceQL need updating.
> 
> **Metrics:** Request attributes use `launchdarkly.environment.name`, `launchdarkly.application.id` / `.version`, `launchdarkly.relay.endpoint.type`, and `user_agent.original` with the header value verbatim (slashes preserved so metrics join traces). The events failure counter is `launchdarkly.relay.events.failed` (was `events.send.errors`) and always carries `error.type`; when there was no HTTP response it reports `_OTHER` instead of inventing `status_code` 0. Absent OTel attribute values are `not_provided` (usage payloads to LaunchDarkly still use `not-provided`).
> 
> **Resource / HTTP spans:** `relay.id` is removed; process identity is only `service.instance.id`. `otelmux` is configured with an empty primary server name so `server.address` and `server.port` come from the request Host. On context-in-URL routes, `url.path` redacts only the evaluation-context segment to `REDACTED` (environment id and route shape remain), not the full route template.
> 
> **Tracing:** Span attributes follow the same naming scheme (`launchdarkly.relay.flag.count`, `payload.event.count`, `payload.size`, singleflight wait as **seconds** on `launchdarkly.relay.singleflight.wait.duration`). Adds **docs/tracing.md** and README/metrics cross-links. Semconv import bumps to v1.41.0; contract tests pin public metric and span key names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b20d06c4690886f84a6d898e209e4078af21be07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->