### PR TITLE
feat: Add a cumulative request counter

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -9,13 +9,36 @@ The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://o
 | Metric | Type | Unit | Description |
 |--------|------|------|-------------|
 | `http.server.active_requests` | UpDownCounter | `{request}` | The number of requests currently in flight, across every endpoint the Relay Proxy serves. Use the `launchdarkly.relay.endpoint.type` attribute to narrow this to a single kind of endpoint -- for example, filtering to `stream` gives the number of open SSE connections from SDKs. |
-| `http.server.request.duration` | Histogram | `s` | The duration of requests to the Relay Proxy's service endpoints, in seconds. |
+| `launchdarkly.relay.requests` | Counter | `{request}` | The cumulative number of requests the Relay Proxy has received since startup, across every endpoint it serves. Counted when the request starts, so a streaming request is counted when the connection is made rather than when it closes. |
+| `http.server.request.duration` | Histogram | `s` | The duration of requests to the Relay Proxy's service endpoints, in seconds. This is not recorded for streaming responses, whose lifetime is unbounded. |
 | `launchdarkly.relay.events.received.size` | Counter | `By` | The cumulative number of event bytes received by the Relay Proxy (measured after decompression). |
 | `launchdarkly.relay.events.sent` | Counter | `{event}` | The cumulative number of events successfully sent to LaunchDarkly. |
 | `launchdarkly.relay.events.sent.size` | Counter | `By` | The cumulative bytes of event payloads successfully sent to LaunchDarkly. |
 | `launchdarkly.relay.events.failed` | Counter | `{event}` | The cumulative number of events that could not be delivered after all retries. |
 | `launchdarkly.relay.events.dropped` | Counter | `{event}` | The cumulative number of events dropped due to capacity overflow. |
 | `launchdarkly.relay.events.pending` | Gauge | `{event}` | The current number of events buffered in the queue. |
+
+### Counting stream connections
+
+Version 8 exported two stream-specific metrics, `connections` and `newconnections`. Neither has a
+metric of its own now, because active requests and total requests are counted for every endpoint and
+the `launchdarkly.relay.endpoint.type` attribute says which kind of endpoint served the request.
+Filter that attribute to `stream` to get the same numbers:
+
+| Version 8 metric | Equivalent |
+|---|---|
+| `connections` | `http.server.active_requests` where `launchdarkly.relay.endpoint.type="stream"` |
+| `newconnections` | `launchdarkly.relay.requests` where `launchdarkly.relay.endpoint.type="stream"` |
+
+In Prometheus, the rate at which SDKs open stream connections is:
+
+```
+sum(rate(launchdarkly_relay_requests_total{launchdarkly_relay_endpoint_type="stream"}[5m]))
+```
+
+Version 8 reported these per SDK kind through a `platformCategory` tag. That attribute is no longer
+reported, so break the same query down by `http_route` instead -- the server-side, mobile, and
+client-side stream endpoints are separate routes.
 
 ## Resource attributes
 
@@ -33,8 +56,9 @@ Note that resource attributes are **not** copied onto every series. Prometheus r
 
 ## Request attributes
 
-The request metrics -- `http.server.active_requests`, `http.server.request.duration`, and
-`launchdarkly.relay.events.received.size` -- include the following:
+The request metrics -- `http.server.active_requests`, `launchdarkly.relay.requests`,
+`http.server.request.duration`, and `launchdarkly.relay.events.received.size` -- include the
+following:
 
 | Attribute | Description |
 |-----------|-------------|
@@ -47,8 +71,12 @@ The request metrics -- `http.server.active_requests`, `http.server.request.durat
 | `launchdarkly.application.version` | The application version, extracted from the `application-version` field of the `X-LaunchDarkly-Tags` header. |
 | `launchdarkly.relay.endpoint.type` | The kind of endpoint that served the request: `stream`, `poll`, `events`, `goals`, or `status`. Requests that matched no route report `not_provided`. |
 
-`http.server.request.duration` additionally carries `http.response.status_code`,
-`network.protocol.version`, and -- for a 5xx response -- `error.type`.
+`http.server.active_requests` and `launchdarkly.relay.requests` carry exactly the attributes above, so
+the two can be joined. Neither can report anything that is only known once the handler has finished,
+because both are recorded when the request starts: `http.server.active_requests` would leak a
+permanently non-zero series if its increment and decrement disagreed on the attributes.
+`http.server.request.duration` is recorded at the end of the request, so it additionally carries
+`http.response.status_code`, `network.protocol.version`, and -- for a 5xx response -- `error.type`.
 
 Note that `launchdarkly.environment.name` is a *LaunchDarkly* environment, which has nothing to do
 with the OpenTelemetry `deployment.environment.name` attribute described under
@@ -106,7 +134,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://<prometheus-host>:9090/api/v1/otlp/v1/metrics
 OTEL_EXPORTER_OTLP_PROTOCOL=http
 ```
 
-Prometheus converts OpenTelemetry metric names by replacing dots with underscores, so the metrics will appear as `http_server_active_requests`, `http_server_request_duration_seconds`, `launchdarkly_relay_events_received_size_total`, etc.
+Prometheus converts OpenTelemetry metric names by replacing dots with underscores, and appends `_total` to counters, so the metrics will appear as `http_server_active_requests`, `launchdarkly_relay_requests_total`, `http_server_request_duration_seconds`, `launchdarkly_relay_events_received_size_total`, etc.
 
 ### Datadog
 

--- a/internal/metrics/active_requests_benchmark_test.go
+++ b/internal/metrics/active_requests_benchmark_test.go
@@ -33,9 +33,15 @@ func benchEnvironmentManager(b *testing.B) *EnvironmentManager {
 	}
 }
 
-// BenchmarkStartActiveRequest measures the work this change adds to every non-streaming request:
-// one attribute set built and one increment/decrement pair on the UpDownCounter. Duration recording
-// already built a comparable set before this change, so this is the marginal cost, not the total.
+// BenchmarkStartActiveRequest measures the per-request cost of the recording site: one attribute set
+// built, one increment/decrement pair on the active-request UpDownCounter, and one increment on the
+// cumulative request Counter. Duration recording already built a comparable set, so this is the
+// marginal cost of these two instruments, not the total cost of instrumenting a request.
+//
+// The three measurements share one attribute set, so the counter costs an instrument Add rather than
+// another set construction, which is what dominates here. Measured at roughly 80 ns/op against a real
+// meter, plus one 16-byte allocation for the extra call's variadic option slice. That allocation is
+// paid whether or not OpenTelemetry is enabled; the time is not, because a noop Add does no work.
 //
 // The noop case matters as much as the real one: an operator with OpenTelemetry disabled still pays
 // for the attribute set, because the instruments are noop but the attributes are built before the

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -13,6 +13,7 @@ import (
 const (
 	// Metric instrument names.
 	connMeasureName            = "http.server.active_requests"
+	requestsMeasureName        = "launchdarkly.relay.requests"
 	requestDurationMeasureName = "http.server.request.duration"
 	eventsReceivedMeasureName  = "launchdarkly.relay.events.received.size"
 	eventsSentMeasureName      = "launchdarkly.relay.events.sent"

--- a/internal/metrics/measures.go
+++ b/internal/metrics/measures.go
@@ -13,6 +13,7 @@ import (
 // Instruments holds the OTel metric instruments used for recording metrics.
 type Instruments struct {
 	connections         metric.Int64UpDownCounter // active connections (+1/-1)
+	requests            metric.Int64Counter       // cumulative count of requests received
 	requestDuration     metric.Float64Histogram   // request duration in seconds
 	eventsReceivedBytes metric.Int64Counter       // cumulative bytes of event data received
 	eventsDropped       metric.Int64Counter       // cumulative count of events dropped due to capacity overflow
@@ -66,6 +67,12 @@ func newInstruments(meter metric.Meter) (*Instruments, error) {
 	if err != nil {
 		return nil, err
 	}
+	requests, err := meter.Int64Counter(requestsMeasureName,
+		metric.WithDescription("Requests received, counted when the request starts"),
+		metric.WithUnit("{request}"))
+	if err != nil {
+		return nil, err
+	}
 	requestDuration, err := meter.Float64Histogram(requestDurationMeasureName,
 		metric.WithDescription("Duration of HTTP server requests"),
 		metric.WithUnit("s"))
@@ -110,6 +117,7 @@ func newInstruments(meter metric.Meter) (*Instruments, error) {
 	}
 	return &Instruments{
 		connections:         connections,
+		requests:            requests,
 		requestDuration:     requestDuration,
 		eventsReceivedBytes: eventsReceivedBytes,
 		eventsDropped:       eventsDropped,
@@ -136,19 +144,28 @@ type RequestInfo struct {
 	ErrorType       string
 }
 
-// StartActiveRequest increments http.server.active_requests and returns a function that decrements it
-// again. The returned function must be called exactly once, when the request is finished.
+// StartActiveRequest records the start of a request: it adds one to launchdarkly.relay.requests,
+// increments http.server.active_requests, and returns a function that decrements the latter again. The
+// returned function must be called exactly once, when the request is finished.
 //
-// The attribute set is computed once, up front, and reused for the decrement. Anything only known after
-// the handler runs (status code, error type) therefore cannot be reported on this metric: a mismatched
-// attribute set between the increment and the decrement would leak a permanently non-zero series.
+// launchdarkly.relay.requests is counted here, at the start of the request, rather than at the end.
+// Streaming requests hold the connection open for an unbounded time, so counting them on completion
+// would report a connection minutes or hours after it was made, and never report one that is still
+// open. Counting at the start is also what makes the metric a cumulative count of stream connections
+// established, once narrowed to the stream endpoint type.
+//
+// The attribute set is computed once, up front, and shared by all three calls. Anything only known
+// after the handler runs (status code, error type) therefore cannot be reported on these metrics: a
+// mismatched attribute set between the increment and the decrement would leak a permanently non-zero
+// active_requests series. http.server.request.duration carries those attributes instead.
 func StartActiveRequest(instruments *Instruments, em *EnvironmentManager, ri RequestInfo) func() {
 	if instruments == nil || em == nil {
 		return func() {}
 	}
 
-	// Built once and shared by both calls, so that the two can't drift apart.
+	// Built once and shared by every call, so that they can't drift apart.
 	attrs := metric.WithAttributeSet(buildRequestAttributes(em.envKVs, ri))
+	instruments.requests.Add(context.Background(), 1, attrs)
 	instruments.connections.Add(context.Background(), 1, attrs)
 	return func() {
 		instruments.connections.Add(context.Background(), -1, attrs)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -66,6 +66,7 @@ func TestNewInstrumentsCreatesEveryInstrument(t *testing.T) {
 	require.NotNil(t, instruments)
 
 	assert.NotNil(t, instruments.connections)
+	assert.NotNil(t, instruments.requests)
 	assert.NotNil(t, instruments.requestDuration)
 	assert.NotNil(t, instruments.eventsReceivedBytes)
 	assert.NotNil(t, instruments.eventsDropped)
@@ -212,7 +213,13 @@ func TestActiveRequestMetrics(t *testing.T) {
 				require.NoError(t, err)
 				m := findMetric(rm, connMeasureName)
 				require.NotNil(t, m, "active requests metric not found")
-				assertGaugeValue(t, m, p.envName, 1)
+				assertSumValue(t, m, p.envName, 1)
+				assertHasAttribute(t, m, endpointTypeAttrKey, string(endpointType))
+
+				// The cumulative counter is recorded at the same moment, off the same attribute set.
+				m = findMetric(rm, requestsMeasureName)
+				require.NotNil(t, m, "requests metric not found")
+				assertSumValue(t, m, p.envName, 1)
 				assertHasAttribute(t, m, endpointTypeAttrKey, string(endpointType))
 
 				requestFinished()
@@ -222,9 +229,14 @@ func TestActiveRequestMetrics(t *testing.T) {
 				require.NoError(t, err)
 				m = findMetric(rm, connMeasureName)
 				require.NotNil(t, m, "active requests metric not found")
-				assertGaugeValue(t, m, p.envName, 0)
+				assertSumValue(t, m, p.envName, 0)
 				assert.Len(t, m.Data.(metricdata.Sum[int64]).DataPoints, 1,
 					"increment and decrement should share one attribute set")
+
+				// The cumulative counter must not follow it back down.
+				m = findMetric(rm, requestsMeasureName)
+				require.NotNil(t, m, "requests metric not found")
+				assertSumValue(t, m, p.envName, 1)
 			})
 		})
 	}
@@ -247,8 +259,45 @@ func TestActiveRequestMetricsWithoutEnvironment(t *testing.T) {
 		require.NoError(t, err)
 		m := findMetric(rm, connMeasureName)
 		require.NotNil(t, m, "active requests metric not found")
-		assertGaugeValue(t, m, notProvidedValue, 1)
+		assertSumValue(t, m, notProvidedValue, 1)
 		assertHasAttribute(t, m, endpointTypeAttrKey, string(EndpointTypeStatus))
+
+		m = findMetric(rm, requestsMeasureName)
+		require.NotNil(t, m, "requests metric not found")
+		assertSumValue(t, m, notProvidedValue, 1)
+		assertHasAttribute(t, m, endpointTypeAttrKey, string(EndpointTypeStatus))
+	})
+}
+
+// launchdarkly.relay.requests replaces the newconnections metric that Relay exported before v9.
+// Narrowing it to the stream endpoint type gives what that metric reported: the cumulative number of
+// stream connections established. So it has to keep climbing as requests finish, which is what
+// separates it from http.server.active_requests, and it has to be monotonic, so that backends treat
+// it as a counter rather than a gauge.
+func TestRequestCounterAccumulatesAcrossRequests(t *testing.T) {
+	testWithOTel(t, func(p testWithOTelParams) {
+		ri := RequestInfo{UserAgent: userAgentValue, Route: "/test", Method: "GET", EndpointType: EndpointTypeStream}
+
+		for range 3 {
+			StartActiveRequest(p.instruments, p.env, ri)()
+		}
+
+		rm, err := p.collectMetrics()
+		require.NoError(t, err)
+
+		m := findMetric(rm, requestsMeasureName)
+		require.NotNil(t, m, "requests metric not found")
+		assertSumValue(t, m, p.envName, 3)
+
+		sum, ok := m.Data.(metricdata.Sum[int64])
+		require.True(t, ok, "expected Sum[int64] data for %s", m.Name)
+		assert.True(t, sum.IsMonotonic, "%s must be monotonic to be reported as a counter", m.Name)
+
+		// Over the same period the active-request gauge is back to zero, so the two instruments
+		// answer different questions from one recording site.
+		m = findMetric(rm, connMeasureName)
+		require.NotNil(t, m, "active requests metric not found")
+		assertSumValue(t, m, p.envName, 0)
 	})
 }
 
@@ -689,7 +738,9 @@ func findMetric(rm *metricdata.ResourceMetrics, name string) *metricdata.Metrics
 	return nil
 }
 
-func assertGaugeValue(t *testing.T, m *metricdata.Metrics, envName string, expected int64) {
+// assertSumValue covers both instruments that report a Sum[int64]: the active-request UpDownCounter
+// and the cumulative request Counter.
+func assertSumValue(t *testing.T, m *metricdata.Metrics, envName string, expected int64) {
 	t.Helper()
 	sum, ok := m.Data.(metricdata.Sum[int64])
 	require.True(t, ok, "expected Sum[int64] data for %s", m.Name)


### PR DESCRIPTION
## Summary

A customer asked for the `newconnections` metric back. It was dropped in #595 ("Remove 'new connections' usage metric", `d50c7803`), which removed both the exported `launchdarkly.relay.newconnections` counter and the `newConnections` field in the `relayMetrics` usage payload.

Nothing left can answer the question. `http.server.active_requests` is an UpDownCounter, so the number of connections opened cannot be recovered from it, and `middleware.RequestMetrics` deliberately skips `http.server.request.duration` for `text/event-stream` responses, whose lifetime is unbounded. Streaming requests were therefore counted by nothing at all -- so this closes a gap slightly wider than the original ask.

This adds `launchdarkly.relay.requests`, an `Int64Counter` in `{request}`, incremented in `metrics.StartActiveRequest` against the attribute set `http.server.active_requests` already builds. The two carry identical attributes and can be joined; narrowing `launchdarkly.relay.endpoint.type` to `stream` gives what `newconnections` reported:

```
sum(rate(launchdarkly_relay_requests_total{launchdarkly_relay_endpoint_type="stream"}[5m]))
```

### Why it counts at the start of the request

This is load-bearing rather than incidental. A stream held open for hours would otherwise be reported hours after the connection was made, and a connection still open would never be reported at all. Counting on arrival is what makes the metric a count of stream connections *established*.

The consequence is that neither instrument can report anything only known once the handler has run -- status code, `error.type`. For `http.server.active_requests` that is a hard constraint, since an increment and decrement that disagree on attributes leak a permanently non-zero series. `http.server.request.duration` carries those attributes instead.

### Cost

Measured `+80 ns/op` and one 16-byte allocation per request against a real meter, via `BenchmarkStartActiveRequest`. The allocation is the extra `Add`'s variadic option slice, and is paid whether or not OpenTelemetry is enabled; the time is not, since a noop `Add` does no work. All three measurements share one `attribute.NewSet`, which is what dominates the recording site.

### Deliberately out of scope

The usage payload is untouched. `newConnections` there is a wire contract with a different consumer, and its removal was a separate product decision; restoring it would need confirmation that anything still reads it. Note that this means LaunchDarkly still receives no new-connection counts from Relay -- a separate gap, if that turns out to be what the customer actually cares about.

### Also here

- `docs/metrics.md` gains the metric row, a "Counting stream connections" section mapping v8's `connections` and `newconnections` to their v9 equivalents, and a note that v8's `platformCategory` breakdown is now done with `http_route`, since the server-side, mobile, and client-side stream endpoints are distinct routes.
- The `assertGaugeValue` test helper is renamed `assertSumValue`. It reads `Sum[int64]` and now serves both a Counter and an UpDownCounter, so the old name was misleading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Restores the ability to count **new stream connections** (and all inbound requests) after v8’s `newconnections` metric was removed. **`launchdarkly.relay.requests`** is a cumulative `{request}` counter incremented in **`StartActiveRequest`** together with **`http.server.active_requests`**, using the **same request attribute set** so the two can be joined; filter **`launchdarkly.relay.endpoint.type="stream"`** for stream connection totals.
> 
> **Counting happens when the request starts**, not when it finishes, so long-lived SSE connections are recorded when opened and still-open streams are not missed—behavior **`http.server.request.duration`** deliberately skips for streaming responses.
> 
> **`docs/metrics.md`** documents the new metric, maps v8 `connections` / `newconnections` to v9 equivalents, notes Prometheus naming (`launchdarkly_relay_requests_total`), and explains **`platformCategory`** breakdown via **`http_route`** instead. Tests cover monotonic accumulation vs active requests returning to zero; the usage payload to LaunchDarkly is **not** changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646c4d63062b740580615d2ed001a878e72a8a7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->