### PR TITLE
fix: Prevent invalid UTF-8 in request data from dropping OTel export batches

### DIFF
--- a/internal/middleware/tracing_middleware.go
+++ b/internal/middleware/tracing_middleware.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"net/http"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/launchdarkly/ld-relay/v9/internal/util"
 
@@ -20,27 +19,20 @@ const contextPathVar = "context"
 // conventions use this placeholder for the same purpose when scrubbing a URL.
 const redactedValue = "REDACTED"
 
-// SanitizeRequestSpan corrects two problems with the attributes the HTTP tracing middleware records on
-// the request span. Attributes cannot be removed from a span once set, but they are deduplicated
-// last-write-wins when they are read, so overwriting a value here is what keeps the original out of the
-// exported trace.
+// SanitizeRequestSpan removes end-user data from the request span.
 //
-// First, url.path holds the raw request path, which on routes that take an evaluation context contains
-// the end user's data: keys, names, emails and custom attributes. Only that one segment is replaced,
-// with the REDACTED placeholder the semantic conventions use for scrubbing a URL, so the rest of the
-// path -- which identifies the endpoint and the environment, and is not sensitive -- survives. Routes
-// with no context variable keep their real path.
+// url.path holds the raw request path, which on routes that take an evaluation context contains the
+// end user's data: keys, names, emails and custom attributes. Only that one segment is replaced, with
+// the REDACTED placeholder the semantic conventions use for scrubbing a URL, so the rest of the path
+// -- which identifies the endpoint and the environment, and is not sensitive -- survives. Routes with
+// no context variable keep their real path.
 //
-// Second, three of the recorded attributes come from request data that is not restricted to valid
-// UTF-8, and OTLP cannot serialize a span carrying an invalid byte -- the marshal fails and the whole
-// export batch is dropped. They are:
+// Attributes cannot be removed from a span once set, but they are deduplicated last-write-wins when
+// they are read, so overwriting the value here is what keeps the original out of the exported trace.
 //
-//	user_agent.original  the User-Agent header
-//	client.address       the X-Forwarded-For header, used unvalidated
-//	url.path             the percent-decoded request path
-//
-// This list is specific to the instrumentation in use and will need revisiting if it starts recording
-// further attributes from request data; TestSpanAttributesAreValidUTF8 fails if that happens.
+// This middleware does not repair invalid UTF-8. tracing.NewUTF8Sanitizer does that for every span,
+// which covers each attribute the instrumentation derives from request data without naming them. The
+// redacted path is the one exception: it is written after that sanitizer runs, so it is sanitized here.
 //
 // This must be registered after the middleware that starts the request span.
 func SanitizeRequestSpan(next http.Handler) http.Handler {
@@ -51,14 +43,6 @@ func SanitizeRequestSpan(next http.Handler) http.Handler {
 				template, _ := mux.CurrentRoute(r).GetPathTemplate()
 				redacted := redactContextSegment(r.URL.Path, contextValue, template)
 				span.SetAttributes(semconv.URLPath(util.SanitizeUTF8(redacted)))
-			} else if !utf8.ValidString(r.URL.Path) {
-				span.SetAttributes(semconv.URLPath(util.SanitizeUTF8(r.URL.Path)))
-			}
-			if ua := r.UserAgent(); !utf8.ValidString(ua) {
-				span.SetAttributes(semconv.UserAgentOriginal(util.SanitizeUTF8(ua)))
-			}
-			if xff := r.Header.Get("X-Forwarded-For"); !utf8.ValidString(xff) {
-				span.SetAttributes(semconv.ClientAddress(util.SanitizeUTF8(clientAddressFromXFF(xff))))
 			}
 		}
 		next.ServeHTTP(w, r)
@@ -86,15 +70,4 @@ func redactContextSegment(path, contextValue, template string) string {
 		return template
 	}
 	return strings.Join(segments, "/")
-}
-
-// clientAddressFromXFF mirrors how the tracing instrumentation derives client.address from
-// X-Forwarded-For: the first entry, with no validation of its contents.
-func clientAddressFromXFF(xForwardedFor string) string {
-	for i := range len(xForwardedFor) {
-		if xForwardedFor[i] == ',' {
-			return xForwardedFor[:i]
-		}
-	}
-	return xForwardedFor
 }

--- a/internal/middleware/tracing_middleware_test.go
+++ b/internal/middleware/tracing_middleware_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode/utf8"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,14 +43,12 @@ var contextRouteTemplates = []string{
 
 // tracedRouter builds a router instrumented the same way as relay's, recording its spans, and
 // registers the given templates with a handler that does nothing.
-func tracedRouter(t *testing.T, templates ...string) (*mux.Router, *tracetest.SpanRecorder) {
+func tracedRouter(t *testing.T, templates ...string) (*mux.Router, *spanCapture) {
 	t.Helper()
-	recorder := tracetest.NewSpanRecorder()
-	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
-	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	recorder, provider := sanitizingProvider(t)
 
 	router := mux.NewRouter()
-	router.Use(otelmux.Middleware("test", otelmux.WithTracerProvider(provider)))
+	router.Use(otelmux.Middleware("", otelmux.WithTracerProvider(provider)))
 	router.Use(SanitizeRequestSpan)
 	for _, template := range templates {
 		router.HandleFunc(template, func(http.ResponseWriter, *http.Request) {}).Methods("GET")
@@ -56,17 +56,50 @@ func tracedRouter(t *testing.T, templates ...string) (*mux.Router, *tracetest.Sp
 	return router, recorder
 }
 
-func requireURLPath(t *testing.T, recorder *tracetest.SpanRecorder) string {
+// spanCapture collects exported spans. These tests go through an exporter rather than a span processor,
+// because that is where the UTF-8 sanitizer runs in the pipeline tracing.NewTracingProvider builds.
+type spanCapture struct {
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (c *spanCapture) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	c.spans = append(c.spans, spans...)
+	return nil
+}
+
+func (c *spanCapture) Shutdown(context.Context) error { return nil }
+
+// Ended matches the SpanRecorder method these tests were written against.
+func (c *spanCapture) Ended() []sdktrace.ReadOnlySpan { return c.spans }
+
+// sanitizingProvider builds the pipeline relay builds: a UTF-8 sanitizer wrapping the exporter.
+// WithSyncer exports on span end, so a captured span is ready as soon as the request returns.
+func sanitizingProvider(t *testing.T) (*spanCapture, *sdktrace.TracerProvider) {
+	t.Helper()
+	capture := &spanCapture{}
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(tracing.NewUTF8SanitizingExporter(capture)),
+	)
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	return capture, provider
+}
+
+func requireSpanAttr(t *testing.T, recorder *spanCapture, key string) string {
 	t.Helper()
 	spans := recorder.Ended()
 	require.Len(t, spans, 1)
 	for _, kv := range spans[0].Attributes() {
-		if kv.Key == attribute.Key("url.path") {
+		if kv.Key == attribute.Key(key) {
 			return kv.Value.AsString()
 		}
 	}
-	require.Fail(t, "span has no url.path attribute")
+	require.Failf(t, "attribute is missing", "span has no %s attribute", key)
 	return ""
+}
+
+func requireURLPath(t *testing.T, recorder *spanCapture) string {
+	t.Helper()
+	return requireSpanAttr(t, recorder, "url.path")
 }
 
 // Only the context segment is replaced. Everything else in the path, including the environment
@@ -160,12 +193,10 @@ func TestPathsWithoutAContextAreLeftAlone(t *testing.T) {
 // the context route lives several subrouters deep, and the middleware runs on the top-level
 // router, so it must still see the full template of the innermost matched route.
 func TestRedactionSurvivesNestedSubrouters(t *testing.T) {
-	recorder := tracetest.NewSpanRecorder()
-	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
-	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	recorder, provider := sanitizingProvider(t)
 
 	router := mux.NewRouter()
-	router.Use(otelmux.Middleware("test", otelmux.WithTracerProvider(provider)))
+	router.Use(otelmux.Middleware("", otelmux.WithTracerProvider(provider)))
 	router.Use(SanitizeRequestSpan)
 	sdkRouter := router.PathPrefix("/sdk/").Subrouter()
 	pollRouter := sdkRouter.PathPrefix("/poll/eval").Subrouter()
@@ -187,4 +218,118 @@ func TestRedactionWithoutARecordingSpan(t *testing.T) {
 	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/meval/"+contextBase64, nil))
 
 	assert.True(t, handled)
+}
+
+// The Host is not restricted to valid UTF-8. The HTTP/1.1 server rejects a Host that holds a byte
+// outside US-ASCII, but the HTTP/2 server passes the :authority pseudo-header through as it arrives,
+// and Relay serves HTTP/2 whenever TLS is configured. One invalid byte fails the OTLP marshal for
+// every span in the same export batch.
+func TestInvalidUTF8IsStrippedFromTheServerAddress(t *testing.T) {
+	for _, params := range []struct{ name, host, want string }{
+		{"host and port", "relay-\xff\xfe.example.com:8030", "relay-.example.com"},
+		{"host only", "relay-\xff\xfe.example.com", "relay-.example.com"},
+		{"ipv6 literal", "[fe80::\xff\xfe]:8030", "fe80::"},
+		{"nothing left", "\xff\xfe", ""},
+	} {
+		t.Run(params.name, func(t *testing.T) {
+			router, recorder := tracedRouter(t, "/status")
+			req := httptest.NewRequest("GET", "/status", nil)
+			req.Host = params.host
+
+			router.ServeHTTP(httptest.NewRecorder(), req)
+
+			recorded := requireSpanAttr(t, recorder, "server.address")
+			assert.Equal(t, params.want, recorded)
+			assert.True(t, utf8.ValidString(recorded))
+		})
+	}
+}
+
+// A Host that is already valid UTF-8 is left to the instrumentation, port and all.
+func TestAValidHostIsNotRewritten(t *testing.T) {
+	router, recorder := tracedRouter(t, "/status")
+	req := httptest.NewRequest("GET", "/status", nil)
+	req.Host = "relay.example.com:8030"
+
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "relay.example.com", requireSpanAttr(t, recorder, "server.address"))
+}
+
+// A Host the instrumentation cannot split reports an empty address, and the sanitizer has to leave
+// that alone rather than substitute something of its own.
+func TestAnUnparsableHostReportsNoServerAddress(t *testing.T) {
+	for _, host := range []string{"[fe80::1", "relay.example.com:80:90"} {
+		t.Run(host, func(t *testing.T) {
+			router, recorder := tracedRouter(t, "/status")
+			req := httptest.NewRequest("GET", "/status", nil)
+			req.Host = host
+
+			router.ServeHTTP(httptest.NewRecorder(), req)
+
+			assert.Empty(t, requireSpanAttr(t, recorder, "server.address"))
+		})
+	}
+}
+
+// The instrumentation reads more request fields than the Host, and the ones below are outside the
+// standalone server's control but not outside a host application's: relay can be embedded behind
+// middleware that rewrites RemoteAddr from a forwarded header. The sanitizer covers whatever the
+// instrumentation recorded, so no field needs to be enumerated here.
+func TestInvalidUTF8IsStrippedFromEveryRequestDerivedAttribute(t *testing.T) {
+	for _, params := range []struct {
+		name   string
+		mutate func(*http.Request)
+		attrs  map[string]string
+	}{
+		{
+			name:   "peer address",
+			mutate: func(r *http.Request) { r.RemoteAddr = "10.0.0.1\xff\xfe:4242" },
+			// client.address falls back to the peer when X-Forwarded-For is absent.
+			attrs: map[string]string{"network.peer.address": "10.0.0.1", "client.address": "10.0.0.1"},
+		},
+		{
+			name:   "protocol version",
+			mutate: func(r *http.Request) { r.Proto = "HTTP/1.\xff\xfe" },
+			attrs:  map[string]string{"network.protocol.version": "1."},
+		},
+		{
+			name:   "user agent",
+			mutate: func(r *http.Request) { r.Header.Set("User-Agent", "agent-\xff\xfe") },
+			attrs:  map[string]string{"user_agent.original": "agent-"},
+		},
+		{
+			name:   "forwarded for",
+			mutate: func(r *http.Request) { r.Header.Set("X-Forwarded-For", "1.2.3.4\xff\xfe, 5.6.7.8") },
+			attrs:  map[string]string{"client.address": "1.2.3.4"},
+		},
+	} {
+		t.Run(params.name, func(t *testing.T) {
+			router, recorder := tracedRouter(t, "/status")
+			req := httptest.NewRequest("GET", "/status", nil)
+			params.mutate(req)
+
+			router.ServeHTTP(httptest.NewRecorder(), req)
+
+			for key, want := range params.attrs {
+				recorded := requireSpanAttr(t, recorder, key)
+				assert.Equal(t, want, recorded, "attribute %s", key)
+				assert.True(t, utf8.ValidString(recorded), "attribute %s", key)
+			}
+		})
+	}
+}
+
+// The span name also carries request data: the instrumentation interpolates the request method into
+// it for a request that matches no route.
+func TestInvalidUTF8IsStrippedFromTheSpanName(t *testing.T) {
+	recorder, provider := sanitizingProvider(t)
+
+	tracer := provider.Tracer("test")
+	_, span := tracer.Start(context.Background(), "HTTP GET\xff\xfe route not found")
+	span.End()
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "HTTP GET route not found", spans[0].Name())
 }

--- a/internal/tracing/provider.go
+++ b/internal/tracing/provider.go
@@ -34,7 +34,9 @@ func NewTracingProvider(cfg TracingConfig, logger *slog.Logger) (*TracingProvide
 	res := NewResource(logger)
 
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
+		// Wrapping the exporter, rather than adding a span processor, keeps the UTF-8 repair off the
+		// request path: the batcher calls the exporter from its own goroutine.
+		sdktrace.WithBatcher(NewUTF8SanitizingExporter(exporter)),
 		sdktrace.WithResource(res),
 	)
 

--- a/internal/tracing/utf8_sanitizer.go
+++ b/internal/tracing/utf8_sanitizer.go
@@ -1,0 +1,196 @@
+package tracing
+
+import (
+	"context"
+	"unicode/utf8"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/util"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// NewUTF8SanitizingExporter wraps a span exporter and replaces invalid UTF-8 before the spans reach it.
+//
+// OTLP cannot serialize a string field that holds a byte outside UTF-8. The marshal fails for the whole
+// export batch, so one bad value costs every span batched alongside it. Several attributes the HTTP
+// instrumentation records come from request data that carries no such restriction: the Host, the
+// User-Agent, X-Forwarded-For, the peer address, the protocol version, and the percent-decoded path.
+//
+// This sanitizes whatever the instrumentation recorded rather than a list of attributes named in
+// advance. Relay maintained such a list twice and both times it was missing an attribute. A list also
+// has to be revisited on every dependency upgrade, and nothing fails when it is not.
+//
+// It runs at export rather than at span start for two reasons. The batch processor exports on its own
+// goroutine, so no request pays for it. And a span reaching an exporter is an immutable snapshot whose
+// attributes are free to read, whereas reading them from a live span allocates a map each time to
+// deduplicate them.
+//
+// Attribute keys are not checked. Every key comes from an instrumentation constant, so a key cannot
+// carry request data.
+func NewUTF8SanitizingExporter(wrapped sdktrace.SpanExporter) sdktrace.SpanExporter {
+	return sanitizingExporter{wrapped: wrapped}
+}
+
+type sanitizingExporter struct {
+	wrapped sdktrace.SpanExporter
+}
+
+func (e sanitizingExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	// The batch belongs to the caller, which reuses it, so replace a span only in a copy.
+	var sanitized []sdktrace.ReadOnlySpan
+	for i, span := range spans {
+		repaired, changed := sanitizeSpan(span)
+		if !changed {
+			continue
+		}
+		if sanitized == nil {
+			sanitized = append(make([]sdktrace.ReadOnlySpan, 0, len(spans)), spans...)
+		}
+		sanitized[i] = repaired
+	}
+	if sanitized != nil {
+		spans = sanitized
+	}
+	return e.wrapped.ExportSpans(ctx, spans)
+}
+
+func (e sanitizingExporter) Shutdown(ctx context.Context) error {
+	return e.wrapped.Shutdown(ctx)
+}
+
+// sanitizedSpan reports repaired values in place of the ones the span recorded.
+//
+// It embeds the interface rather than listing its methods, so a method added to ReadOnlySpan in a later
+// SDK release is forwarded to the original span instead of breaking the build.
+type sanitizedSpan struct {
+	sdktrace.ReadOnlySpan
+	name       string
+	attributes []attribute.KeyValue
+	status     sdktrace.Status
+	events     []sdktrace.Event
+	links      []sdktrace.Link
+}
+
+func (s sanitizedSpan) Name() string                     { return s.name }
+func (s sanitizedSpan) Attributes() []attribute.KeyValue { return s.attributes }
+func (s sanitizedSpan) Status() sdktrace.Status          { return s.status }
+func (s sanitizedSpan) Events() []sdktrace.Event         { return s.events }
+func (s sanitizedSpan) Links() []sdktrace.Link           { return s.links }
+
+// sanitizeSpan returns a span whose every string field is valid, and reports whether anything changed.
+// It returns the original span when there is nothing to repair, which is the usual case.
+func sanitizeSpan(span sdktrace.ReadOnlySpan) (sdktrace.ReadOnlySpan, bool) {
+	name, nameChanged := sanitizeString(span.Name())
+	attributes, attributesChanged := sanitizeAttrs(span.Attributes())
+
+	status := span.Status()
+	description, statusChanged := sanitizeString(status.Description)
+	if statusChanged {
+		status.Description = description
+	}
+
+	events, eventsChanged := sanitizeEvents(span.Events())
+	links, linksChanged := sanitizeLinks(span.Links())
+
+	if !nameChanged && !attributesChanged && !statusChanged && !eventsChanged && !linksChanged {
+		return span, false
+	}
+	return sanitizedSpan{
+		ReadOnlySpan: span,
+		name:         name,
+		attributes:   attributes,
+		status:       status,
+		events:       events,
+		links:        links,
+	}, true
+}
+
+func sanitizeString(v string) (string, bool) {
+	if utf8.ValidString(v) {
+		return v, false
+	}
+	return util.SanitizeUTF8(v), true
+}
+
+// sanitizeAttrs repairs string and string-slice values, and copies only when there is something to
+// repair.
+func sanitizeAttrs(attrs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+	changed := false
+	for i, kv := range attrs {
+		var repaired attribute.KeyValue
+		switch kv.Value.Type() {
+		case attribute.STRING:
+			value, dirty := sanitizeString(kv.Value.AsString())
+			if !dirty {
+				continue
+			}
+			repaired = kv.Key.String(value)
+		case attribute.STRINGSLICE:
+			values, dirty := sanitizeStrings(kv.Value.AsStringSlice())
+			if !dirty {
+				continue
+			}
+			repaired = kv.Key.StringSlice(values)
+		default:
+			// Every other type is numeric or boolean, so it cannot hold invalid UTF-8.
+			continue
+		}
+		if !changed {
+			attrs = append([]attribute.KeyValue(nil), attrs...)
+			changed = true
+		}
+		attrs[i] = repaired
+	}
+	return attrs, changed
+}
+
+func sanitizeStrings(values []string) ([]string, bool) {
+	changed := false
+	for i, value := range values {
+		repaired, dirty := sanitizeString(value)
+		if !dirty {
+			continue
+		}
+		if !changed {
+			values = append([]string(nil), values...)
+			changed = true
+		}
+		values[i] = repaired
+	}
+	return values, changed
+}
+
+func sanitizeEvents(events []sdktrace.Event) ([]sdktrace.Event, bool) {
+	changed := false
+	for i, event := range events {
+		name, nameDirty := sanitizeString(event.Name)
+		attrs, attrsDirty := sanitizeAttrs(event.Attributes)
+		if !nameDirty && !attrsDirty {
+			continue
+		}
+		if !changed {
+			events = append([]sdktrace.Event(nil), events...)
+			changed = true
+		}
+		events[i].Name = name
+		events[i].Attributes = attrs
+	}
+	return events, changed
+}
+
+func sanitizeLinks(links []sdktrace.Link) ([]sdktrace.Link, bool) {
+	changed := false
+	for i, link := range links {
+		attrs, dirty := sanitizeAttrs(link.Attributes)
+		if !dirty {
+			continue
+		}
+		if !changed {
+			links = append([]sdktrace.Link(nil), links...)
+			changed = true
+		}
+		links[i].Attributes = attrs
+	}
+	return links, changed
+}

--- a/internal/tracing/utf8_sanitizer_benchmark_test.go
+++ b/internal/tracing/utf8_sanitizer_benchmark_test.go
@@ -1,0 +1,80 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// These benchmarks measure the sanitizer's own cost. They use WithSyncer so that the exporter runs on
+// the benchmark's goroutine and its cost is actually counted. Relay uses WithBatcher, which calls the
+// exporter from its own goroutine, so in production no request waits for any of this.
+//
+// A realistic request span attribute set, matching what otelmux records: mostly valid strings, a
+// couple of ints. The common case is that nothing needs repair, so that is what this measures.
+func benchAttrs() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("server.address", "relay.example.com"),
+		attribute.Int("server.port", 8030),
+		attribute.String("http.request.method", "GET"),
+		attribute.String("url.scheme", "http"),
+		attribute.String("url.path", "/sdk/evalx/contexts/REDACTED"),
+		attribute.String("user_agent.original", "GoClient/7.15.4"),
+		attribute.String("client.address", "10.1.2.3"),
+		attribute.String("network.peer.address", "10.1.2.3"),
+		attribute.Int("network.peer.port", 54321),
+		attribute.String("network.protocol.version", "1.1"),
+		attribute.String("http.route", "/sdk/evalx/contexts/{context}"),
+		attribute.String("http.request.method_original", "REPORT"),
+	}
+}
+
+type discardExporter struct{}
+
+func (discardExporter) ExportSpans(context.Context, []sdktrace.ReadOnlySpan) error { return nil }
+func (discardExporter) Shutdown(context.Context) error                             { return nil }
+
+func benchmarkSpanStart(b *testing.B, withSanitizer bool) {
+	var exporter sdktrace.SpanExporter = discardExporter{}
+	if withSanitizer {
+		exporter = NewUTF8SanitizingExporter(exporter)
+	}
+	opts := []sdktrace.TracerProviderOption{sdktrace.WithSyncer(exporter)}
+	provider := sdktrace.NewTracerProvider(opts...)
+	b.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	tracer := provider.Tracer("bench")
+	attrs := benchAttrs()
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, span := tracer.Start(ctx, "GET /sdk/evalx/contexts/{context}", trace.WithAttributes(attrs...))
+		span.End()
+	}
+}
+
+func BenchmarkSpanStartWithoutSanitizer(b *testing.B) { benchmarkSpanStart(b, false) }
+func BenchmarkSpanStartWithSanitizer(b *testing.B)    { benchmarkSpanStart(b, true) }
+
+// The repair path, for contrast: one poisoned attribute out of twelve.
+func BenchmarkSpanStartWithSanitizerRepairing(b *testing.B) {
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(NewUTF8SanitizingExporter(discardExporter{})),
+	)
+	b.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	tracer := provider.Tracer("bench")
+	attrs := benchAttrs()
+	attrs[0] = attribute.String("server.address", "relay-\xff\xfe.example.com")
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, span := tracer.Start(ctx, "GET /sdk/evalx/contexts/{context}", trace.WithAttributes(attrs...))
+		span.End()
+	}
+}

--- a/internal/tracing/utf8_sanitizer_test.go
+++ b/internal/tracing/utf8_sanitizer_test.go
@@ -1,0 +1,244 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+	"unicode/utf8"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturingExporter records the spans it is given, after the sanitizer has run over them.
+type capturingExporter struct {
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (c *capturingExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	c.spans = append(c.spans, spans...)
+	return nil
+}
+
+func (c *capturingExporter) Shutdown(context.Context) error { return nil }
+
+// sanitizingProvider builds the pipeline NewTracingProvider builds: a sanitizer wrapping the exporter.
+// WithSyncer exports on span end, so the captured spans are ready when the test looks at them.
+func sanitizingProvider(t *testing.T, opts ...sdktrace.TracerProviderOption) (trace.Tracer, *capturingExporter) {
+	t.Helper()
+	capture := &capturingExporter{}
+	opts = append(opts, sdktrace.WithSyncer(NewUTF8SanitizingExporter(capture)))
+	provider := sdktrace.NewTracerProvider(opts...)
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	return provider.Tracer("test"), capture
+}
+
+func exportedSpan(t *testing.T, capture *capturingExporter) sdktrace.ReadOnlySpan {
+	t.Helper()
+	require.Len(t, capture.spans, 1)
+	return capture.spans[0]
+}
+
+func spanAttr(t *testing.T, span sdktrace.ReadOnlySpan, key string) attribute.Value {
+	t.Helper()
+	for _, kv := range span.Attributes() {
+		if kv.Key == attribute.Key(key) {
+			return kv.Value
+		}
+	}
+	require.Failf(t, "attribute is missing", "span has no %s attribute", key)
+	return attribute.Value{}
+}
+
+// A string attribute holding a byte outside UTF-8 fails the OTLP marshal for the whole export batch.
+func TestSanitizerRepairsStringAttributes(t *testing.T) {
+	tracer, capture := sanitizingProvider(t)
+
+	_, span := tracer.Start(context.Background(), "request", trace.WithAttributes(
+		attribute.String("server.address", "relay-\xff\xfe.example.com"),
+		attribute.String("user_agent.original", "agent-\xff\xfe"),
+		attribute.String("url.path", "/status/\xff\xfe"),
+	))
+	span.End()
+
+	exported := exportedSpan(t, capture)
+	assert.Equal(t, "relay-.example.com", spanAttr(t, exported, "server.address").AsString())
+	assert.Equal(t, "agent-", spanAttr(t, exported, "user_agent.original").AsString())
+	assert.Equal(t, "/status/", spanAttr(t, exported, "url.path").AsString())
+}
+
+// The span name carries request data too: the HTTP instrumentation interpolates the request method
+// into it for a request that matches no route.
+func TestSanitizerRepairsTheSpanName(t *testing.T) {
+	tracer, capture := sanitizingProvider(t)
+
+	_, span := tracer.Start(context.Background(), "HTTP GET\xff\xfe route not found")
+	span.End()
+
+	assert.Equal(t, "HTTP GET route not found", exportedSpan(t, capture).Name())
+}
+
+func TestSanitizerRepairsStringSlices(t *testing.T) {
+	tracer, capture := sanitizingProvider(t)
+
+	_, span := tracer.Start(context.Background(), "request", trace.WithAttributes(
+		attribute.StringSlice("custom.values", []string{"clean", "dirty-\xff\xfe", "also-clean"}),
+	))
+	span.End()
+
+	assert.Equal(t, []string{"clean", "dirty-", "also-clean"},
+		spanAttr(t, exportedSpan(t, capture), "custom.values").AsStringSlice())
+}
+
+// Every string field of the span protocol has to be covered, not just the attributes, because any one
+// of them fails the same marshal.
+func TestSanitizerRepairsTheStatusDescription(t *testing.T) {
+	tracer, capture := sanitizingProvider(t)
+
+	_, span := tracer.Start(context.Background(), "request")
+	span.SetStatus(codes.Error, "failed for \xff\xfe")
+	span.End()
+
+	assert.Equal(t, "failed for ", exportedSpan(t, capture).Status().Description)
+}
+
+func TestSanitizerRepairsEvents(t *testing.T) {
+	tracer, capture := sanitizingProvider(t)
+
+	_, span := tracer.Start(context.Background(), "request")
+	span.AddEvent("event-\xff\xfe", trace.WithAttributes(
+		attribute.String("detail", "value-\xff\xfe"),
+	))
+	span.End()
+
+	events := exportedSpan(t, capture).Events()
+	require.Len(t, events, 1)
+	assert.Equal(t, "event-", events[0].Name)
+	require.Len(t, events[0].Attributes, 1)
+	assert.Equal(t, "value-", events[0].Attributes[0].Value.AsString())
+}
+
+func TestSanitizerRepairsLinkAttributes(t *testing.T) {
+	tracer, capture := sanitizingProvider(t)
+
+	linked := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{0x01},
+		SpanID:  trace.SpanID{0x02},
+	})
+	_, span := tracer.Start(context.Background(), "request", trace.WithLinks(trace.Link{
+		SpanContext: linked,
+		Attributes:  []attribute.KeyValue{attribute.String("detail", "value-\xff\xfe")},
+	}))
+	span.End()
+
+	links := exportedSpan(t, capture).Links()
+	require.Len(t, links, 1)
+	require.Len(t, links[0].Attributes, 1)
+	assert.Equal(t, "value-", links[0].Attributes[0].Value.AsString())
+}
+
+// A span with nothing to repair is passed through untouched, which is the common case.
+func TestSanitizerLeavesValidSpansAlone(t *testing.T) {
+	tracer, capture := sanitizingProvider(t)
+
+	_, span := tracer.Start(context.Background(), "request", trace.WithAttributes(
+		attribute.String("server.address", "relay.example.com"),
+		attribute.Int("server.port", 8030),
+		attribute.Bool("custom.flag", true),
+	))
+	span.End()
+
+	exported := exportedSpan(t, capture)
+	assert.Equal(t, "request", exported.Name())
+	assert.Equal(t, "relay.example.com", spanAttr(t, exported, "server.address").AsString())
+	assert.Equal(t, int64(8030), spanAttr(t, exported, "server.port").AsInt64())
+	assert.Len(t, exported.Attributes(), 3)
+}
+
+// Repairing one span in a batch must not disturb the others, and every span still has to be exported.
+func TestSanitizerRepairsOneSpanInABatchWithoutLosingTheRest(t *testing.T) {
+	capture := &capturingExporter{}
+	exporter := NewUTF8SanitizingExporter(capture)
+
+	// Spans are built through a plain provider, so they arrive at the sanitizer unrepaired.
+	source := &capturingExporter{}
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(source))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	makeSpan := func(address string) sdktrace.ReadOnlySpan {
+		before := len(source.spans)
+		_, span := provider.Tracer("test").Start(context.Background(), "request",
+			trace.WithAttributes(attribute.String("server.address", address)))
+		span.End()
+		require.Len(t, source.spans, before+1)
+		return source.spans[before]
+	}
+
+	batch := []sdktrace.ReadOnlySpan{
+		makeSpan("clean-one.example.com"),
+		makeSpan("poisoned-\xff\xfe.example.com"),
+		makeSpan("clean-two.example.com"),
+	}
+	require.NoError(t, exporter.ExportSpans(context.Background(), batch))
+
+	require.Len(t, capture.spans, 3)
+	assert.Equal(t, "clean-one.example.com", spanAttr(t, capture.spans[0], "server.address").AsString())
+	assert.Equal(t, "poisoned-.example.com", spanAttr(t, capture.spans[1], "server.address").AsString())
+	assert.Equal(t, "clean-two.example.com", spanAttr(t, capture.spans[2], "server.address").AsString())
+
+	// The caller's batch is reused by the batch processor, so it must not have been rewritten.
+	assert.Equal(t, "poisoned-\xff\xfe.example.com",
+		spanAttr(t, batch[1], "server.address").AsString())
+}
+
+// Repairing an attribute must not leave any invalid value behind, at any attribute count limit.
+func TestSanitizerRepairsUnderAnAttributeCountLimit(t *testing.T) {
+	for _, limit := range []int{1, 2, 3, 6, 128, -1} {
+		t.Run("limit", func(t *testing.T) {
+			tracer, capture := sanitizingProvider(t, sdktrace.WithRawSpanLimits(sdktrace.SpanLimits{
+				AttributeCountLimit:         limit,
+				AttributeValueLengthLimit:   -1,
+				EventCountLimit:             128,
+				LinkCountLimit:              128,
+				AttributePerEventCountLimit: 128,
+				AttributePerLinkCountLimit:  128,
+			}))
+
+			_, span := tracer.Start(context.Background(), "request", trace.WithAttributes(
+				attribute.String("server.address", "relay-\xff\xfe.example.com"),
+				attribute.String("user_agent.original", "agent-\xff\xfe"),
+				attribute.String("client.address", "1.2.3.4\xff\xfe"),
+			))
+			span.End()
+
+			for _, kv := range exportedSpan(t, capture).Attributes() {
+				if kv.Value.Type() != attribute.STRING {
+					continue
+				}
+				assert.True(t, utf8.ValidString(kv.Value.AsString()),
+					"limit=%d: %s kept an invalid value %q", limit, kv.Key, kv.Value.AsString())
+			}
+		})
+	}
+}
+
+// Shutdown has to reach the exporter the sanitizer wraps.
+func TestSanitizingExporterForwardsShutdown(t *testing.T) {
+	capture := &shutdownRecorder{}
+	require.NoError(t, NewUTF8SanitizingExporter(capture).Shutdown(context.Background()))
+	assert.True(t, capture.shutdown)
+}
+
+type shutdownRecorder struct {
+	shutdown bool
+}
+
+func (s *shutdownRecorder) ExportSpans(context.Context, []sdktrace.ReadOnlySpan) error { return nil }
+
+func (s *shutdownRecorder) Shutdown(context.Context) error {
+	s.shutdown = true
+	return nil
+}

--- a/relay/relay_endpoints_spans_test.go
+++ b/relay/relay_endpoints_spans_test.go
@@ -283,3 +283,35 @@ func TestPollingEndpointSpansDoNotLeakOnEarlyReturn(t *testing.T) {
 		assert.Zero(t, countStarted(started, tracing.SpanWriteResponse))
 	})
 }
+
+// spanCapture collects exported spans.
+type spanCapture struct {
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (c *spanCapture) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	c.spans = append(c.spans, spans...)
+	return nil
+}
+
+func (c *spanCapture) Shutdown(context.Context) error { return nil }
+
+func (c *spanCapture) Ended() []sdktrace.ReadOnlySpan { return c.spans }
+
+// installSanitizedSpanRecorder is installSpanRecorder for the tests that assert on what actually
+// reaches the exporter. The UTF-8 sanitizer wraps the exporter rather than acting as a span processor,
+// so a SpanRecorder alone never sees its work. WithSyncer exports on span end.
+func installSanitizedSpanRecorder(t *testing.T) *spanCapture {
+	t.Helper()
+	previous := otel.GetTracerProvider()
+	capture := &spanCapture{}
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(tracing.NewUTF8SanitizingExporter(capture)),
+	)
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previous)
+	})
+	return capture
+}

--- a/relay/relay_tracing_privacy_test.go
+++ b/relay/relay_tracing_privacy_test.go
@@ -120,13 +120,22 @@ func TestEndUserContextIsNotExportedInSpans(t *testing.T) {
 // field carries invalid UTF-8. OTLP cannot serialize such a span: the marshal fails and the whole export
 // batch is dropped, so one bad request costs every span batched alongside it.
 //
-// This deliberately checks *every* string attribute rather than the three the tracing instrumentation
-// is known to derive from request data (user_agent.original, client.address, url.path). If it starts
-// recording another one, this fails and points at what SanitizeRequestSpan has to cover.
+// This deliberately checks *every* string attribute, and poisons *every* request field the tracing
+// instrumentation reads, rather than naming the attributes it derives from them. Relay named that list
+// twice and missed an attribute both times. tracing.NewUTF8Sanitizer now repairs whatever the
+// instrumentation recorded, so this test does not have to track the list either -- it only has to keep
+// poisoning the inputs.
+//
+// The fields are the Host, the User-Agent, X-Forwarded-For, the path, the peer address, the protocol
+// and the method. Reachability differs per field and does not matter here: an unreachable field costs
+// nothing to poison, and embedding relay behind another application widens what a client controls. The
+// Host is reachable against the standalone binary today -- an HTTP/1.1 client cannot deliver a Host
+// with a byte outside US-ASCII, because net/http answers it with 400, but the HTTP/2 server passes the
+// :authority pseudo-header through untouched, and relay serves HTTP/2 whenever TLS is configured.
 func TestSpanAttributesAreValidUTF8(t *testing.T) {
 	const invalid = "\xff\xfe"
 
-	recorder := installSpanRecorder(t)
+	recorder := installSanitizedSpanRecorder(t)
 
 	var config c.Config
 	config.Environment = st.MakeEnvConfigs(st.EnvMain)
@@ -135,6 +144,12 @@ func TestSpanAttributesAreValidUTF8(t *testing.T) {
 		poison := func(req *http.Request) *http.Request {
 			req.Header.Set("User-Agent", "agent-"+invalid)
 			req.Header.Set("X-Forwarded-For", "1.2.3.4"+invalid+", 5.6.7.8")
+			req.Host = "relay-" + invalid + ".example.com:8030"
+			// The server sets these two, so a client cannot reach them directly. Middleware in front
+			// of an embedded relay can rewrite RemoteAddr from a forwarded header, which makes it
+			// client-controlled, and both are cheap to cover.
+			req.RemoteAddr = "10.0.0.1" + invalid + ":4242"
+			req.Proto = "HTTP/1." + invalid
 			return req
 		}
 


### PR DESCRIPTION
The three pieces this branch was previously stacked behind have merged (#813, #814, #815), so this now
targets v9 directly and is the last of the split.

- **fix: Sanitize span UTF-8 at export instead of per attribute**

`SanitizeRequestSpan` repaired a named list of three attributes: `user_agent.original`, `client.address`,
and `url.path`. The instrumentation reads seven request fields, and four attributes were missing from
that list -- `server.address` from the request Host, `network.peer.address` and
`network.protocol.version`, and `client.address` again when it falls back to the peer address because
`X-Forwarded-For` is absent. A list also has to be revisited on every dependency upgrade, and nothing
fails when it is not.

Wrapping the exporter repairs whatever the instrumentation actually recorded -- span name, attributes,
status description, and event and link attributes -- so nothing has to be enumerated. Export is the right
place for it: the batch processor calls the exporter from its own goroutine, so no request pays for the
work, and a span arriving at an exporter is an immutable snapshot whose attributes are free to read. A
span processor doing the same repair measured 37% slower per span with three extra allocations, because
reading attributes from a live span allocates a map each time to deduplicate them.

The production change is three files: the new sanitizing exporter, a one-line change wiring it into the
tracer provider, and a net deletion in the middleware, which keeps only the privacy redaction. The rest
is tests.


