### PR TITLE
docs: Clarify the user-agent join gap and service.instance.id uniqueness

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,6 +54,13 @@ Note that resource attributes are **not** copied onto every series. Prometheus r
 `target_info`, so a query that needs the process identity has to join against it -- or use the
 `instance` label, which carries the same value.
 
+If you supply your own `service.instance.id`, give each process a distinct value. The attribute is what
+tells one Relay Proxy apart from another, so a value shared across replicas -- a literal in a ConfigMap,
+for instance -- merges their series and their `target_info`, and the `instance` label no longer
+identifies a process. Note also that the identifier Relay generates is the same one it reports to
+LaunchDarkly with its usage data; overriding the attribute changes what your telemetry backend sees, not
+what LaunchDarkly sees, so the two no longer match.
+
 ## Request attributes
 
 The request metrics -- `http.server.active_requests`, `launchdarkly.relay.requests`,

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -176,6 +176,11 @@ func sanitizeReplacingSlashes(v, absent string) string {
 // user_agent.original: replacing the slashes in "Node/3.4.0" would make the metric attribute disagree
 // with the identical attribute the tracing instrumentation records on the request span, so the two
 // could no longer be joined.
+//
+// A value that ends up empty is the exception, and it cannot be joined either way. When the header is
+// absent the instrumentation leaves the attribute off the span entirely. When it holds only whitespace,
+// or only bytes that are not valid UTF-8, the span reports whatever survives sanitizing while the metric
+// reports the sentinel. Neither shape identifies a client, so a join would have nothing to tell you.
 func sanitizeVerbatimValue(v string) string {
 	v = util.SanitizeUTF8(v)
 	if strings.TrimSpace(v) == "" {


### PR DESCRIPTION
- **docs: Note that an empty user-agent cannot be joined either way**
- **docs: Warn that a shared service.instance.id merges Relay processes**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Documentation-only** updates that explain how operators should set `service.instance.id` and why empty or invalid `User-Agent` values cannot be joined between metrics and traces.
> 
> In **`docs/metrics.md`**, a new paragraph warns that each Relay process needs a **distinct** `service.instance.id` when you override it via `OTEL_RESOURCE_ATTRIBUTES`—shared values (e.g. a ConfigMap literal across replicas) merge series and `target_info`, and the Prometheus `instance` label stops identifying a single process. It also notes that Relay’s auto-generated ID is the same one sent to LaunchDarkly for usage data; overriding the OTel attribute changes what your telemetry backend sees, not what LaunchDarkly sees.
> 
> In **`internal/metrics/constants.go`**, comments on **`sanitizeVerbatimValue`** document the **metrics vs. spans** gap for `user_agent.original`: absent headers omit the attribute on spans; whitespace or invalid UTF-8 leaves the span with sanitized bytes while the metric uses the `not_provided` sentinel—so neither case supports a meaningful join.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1763e0c16f51dce4be8d0a3f3e66697eb189dfdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->