### PR TITLE
chore: Pin the OTel HTTP instrumentation to no-op meter providers

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,6 +54,13 @@ Note that resource attributes are **not** copied onto every series. Prometheus r
 `target_info`, so a query that needs the process identity has to join against it -- or use the
 `instance` label, which carries the same value.
 
+If you supply your own `service.instance.id`, give each process a distinct value. The attribute is what
+tells one Relay Proxy apart from another, so a value shared across replicas -- a literal in a ConfigMap,
+for instance -- merges their series and their `target_info`, and the `instance` label no longer
+identifies a process. Note also that the identifier Relay generates is the same one it reports to
+LaunchDarkly with its usage data; overriding the attribute changes what your telemetry backend sees, not
+what LaunchDarkly sees, so the two no longer match.
+
 ## Request attributes
 
 The request metrics -- `http.server.active_requests`, `launchdarkly.relay.requests`,

--- a/internal/httpconfig/httpconfig.go
+++ b/internal/httpconfig/httpconfig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 )
 
 var (
@@ -99,8 +100,19 @@ func NewHTTPConfig(proxyConfig config.ProxyConfig, httpConfig config.HTTPConfig,
 // Client creates a new HTTP client instance that isn't for SDK use. The
 // returned client's transport is wrapped with OpenTelemetry instrumentation
 // so that outgoing requests propagate trace context when a span is active.
+//
+// Trace context is the whole point of the wrap, so the instrumentation gets a no-op meter provider.
+// Without one it takes the global provider, which is a no-op that starts delegating the moment
+// anything calls otel.SetMeterProvider, and Relay's outbound HTTP metrics would switch on as a side
+// effect of an unrelated change. Nothing calls that today, so pinning the provider makes the current
+// behavior explicit rather than changing it. Reporting these metrics should be a deliberate decision,
+// with its own choice of attributes and cardinality limits, not an accident.
+//
+// Note this differs from the reason otelmux gets the same treatment. There, the instruments would
+// duplicate request metrics Relay already records. Here Relay records no outbound metrics at all.
 func (c HTTPConfig) Client() *http.Client {
 	client := c.SDKHTTPConfig.CreateHTTPClient()
-	client.Transport = otelhttp.NewTransport(client.Transport)
+	client.Transport = otelhttp.NewTransport(client.Transport,
+		otelhttp.WithMeterProvider(metricnoop.NewMeterProvider()))
 	return client
 }

--- a/internal/httpconfig/httpconfig_test.go
+++ b/internal/httpconfig/httpconfig_test.go
@@ -1,6 +1,7 @@
 package httpconfig
 
 import (
+	"context"
 	"crypto/x509"
 	"log/slog"
 	"net/http"
@@ -15,6 +16,11 @@ import (
 	"github.com/launchdarkly/go-configtypes"
 	helpers "github.com/launchdarkly/go-test-helpers/v3"
 	"github.com/launchdarkly/go-test-helpers/v3/httphelpers"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -172,4 +178,51 @@ func assertProxyLogMessage(t *testing.T, mockHandler *logtest.MockHandler, expec
 		}
 	}
 	assert.True(t, found, "expected to find 'using proxy server' log entry at Info level")
+}
+
+// TestClientRecordsNoMetrics guards the meter provider passed to otelhttp. The instrumentation builds
+// its own HTTP client instruments, and without a provider of its own it takes the global one. The
+// global provider is a no-op that delegates retroactively, so those instruments would come to life the
+// moment any code called otel.SetMeterProvider. Relay wraps the transport for trace context
+// propagation only; reporting outbound HTTP metrics should be a deliberate decision.
+func TestClientRecordsNoMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	previous := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetMeterProvider(previous)
+	})
+
+	handler, _ := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(http.StatusOK))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	hc, err := NewHTTPConfig(config.ProxyConfig{}, config.HTTPConfig{}, nil, "abc", slog.Default())
+	require.NoError(t, err)
+
+	resp, err := hc.Client().Get(server.URL)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &collected))
+
+	for _, scope := range collected.ScopeMetrics {
+		if scope.Scope.Name != otelhttp.ScopeName {
+			continue
+		}
+		for _, m := range scope.Metrics {
+			assert.Fail(t, "otelhttp recorded a metric through the global meter provider",
+				"scope %q reported %q", scope.Scope.Name, m.Name)
+		}
+	}
+
+	// A canary proves the reader would have seen a metric, so the assertion above is not vacuous.
+	counter, err := provider.Meter("canary").Int64Counter("canary.requests")
+	require.NoError(t, err)
+	counter.Add(context.Background(), 1)
+	require.NoError(t, reader.Collect(context.Background(), &collected))
+	require.NotEmpty(t, collected.ScopeMetrics, "the manual reader collected nothing at all")
 }

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -176,6 +176,11 @@ func sanitizeReplacingSlashes(v, absent string) string {
 // user_agent.original: replacing the slashes in "Node/3.4.0" would make the metric attribute disagree
 // with the identical attribute the tracing instrumentation records on the request span, so the two
 // could no longer be joined.
+//
+// A value that ends up empty is the exception, and it cannot be joined either way. When the header is
+// absent the instrumentation leaves the attribute off the span entirely. When it holds only whitespace,
+// or only bytes that are not valid UTF-8, the span reports whatever survives sanitizing while the metric
+// reports the sentinel. Neither shape identifies a client, so a join would have nothing to tell you.
 func sanitizeVerbatimValue(v string) string {
 	v = util.SanitizeUTF8(v)
 	if strings.TrimSpace(v) == "" {

--- a/relay/relay_request_span_test.go
+++ b/relay/relay_request_span_test.go
@@ -8,9 +8,9 @@ import (
 	c "github.com/launchdarkly/ld-relay/v9/config"
 	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
 
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
@@ -65,11 +65,15 @@ func TestRequestSpanReportsRequestHostAsServerAddress(t *testing.T) {
 func TestOtelmuxRecordsNoMetrics(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	previous := otel.GetMeterProvider()
 	otel.SetMeterProvider(provider)
 	t.Cleanup(func() {
 		_ = provider.Shutdown(context.Background())
-		// The global provider is process wide and cannot be restored, so leave a no-op behind.
-		otel.SetMeterProvider(metricnoop.NewMeterProvider())
+		// Restore the provider that was installed before, rather than leaving a hard no-op behind.
+		// otel.SetMeterProvider only rewires already-created instruments once per process, so a no-op
+		// left here can never be lit up again, and a later test asserting on global-provider metrics
+		// would silently observe nothing.
+		otel.SetMeterProvider(previous)
 	})
 
 	var config c.Config
@@ -86,10 +90,23 @@ func TestOtelmuxRecordsNoMetrics(t *testing.T) {
 		require.NoError(t, reader.Collect(context.Background(), &collected))
 
 		for _, scope := range collected.ScopeMetrics {
+			// Only otelmux's own instruments are in question. Anything else reaching this provider is
+			// a different subject, and failing on it here would report the wrong component.
+			if scope.Scope.Name != otelmux.ScopeName {
+				continue
+			}
 			for _, m := range scope.Metrics {
 				assert.Fail(t, "otelmux recorded a metric through the global meter provider",
 					"scope %q reported %q", scope.Scope.Name, m.Name)
 			}
 		}
+
+		// A canary proves the reader is wired up and would have seen a metric if one had been
+		// recorded, so the assertion above cannot pass merely because nothing was collected.
+		counter, err := provider.Meter("canary").Int64Counter("canary.requests")
+		require.NoError(t, err)
+		counter.Add(context.Background(), 1)
+		require.NoError(t, reader.Collect(context.Background(), &collected))
+		require.NotEmpty(t, collected.ScopeMetrics, "the manual reader collected nothing at all")
 	})
 }

--- a/relay/relay_request_span_test.go
+++ b/relay/relay_request_span_test.go
@@ -1,13 +1,18 @@
 package relay
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
 	c "github.com/launchdarkly/ld-relay/v9/config"
 	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,5 +53,43 @@ func TestRequestSpanReportsRequestHostAsServerAddress(t *testing.T) {
 		port, ok := attrs[serverPortKey]
 		require.True(t, ok, "request span is missing server.port")
 		assert.Equal(t, int64(8031), port.AsInt64())
+	})
+}
+
+// TestOtelmuxRecordsNoMetrics guards the meter provider passed to otelmux.Middleware. otelmux builds
+// its own HTTP server instruments, keyed on the client-controlled Host, and without a provider of its
+// own it takes the global one. The global provider is a no-op that delegates retroactively, so
+// otelmux's instruments would come to life -- reporting a second http.server.request.duration under
+// its own scope, and a series per Host -- the moment any code called otel.SetMeterProvider. Relay
+// records its own request metrics with a trimmed attribute set instead.
+func TestOtelmuxRecordsNoMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		// The global provider is process wide and cannot be restored, so leave a no-op behind.
+		otel.SetMeterProvider(metricnoop.NewMeterProvider())
+	})
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		for _, host := range []string{"one.relay.example.com", "two.relay.example.com"} {
+			req := st.BuildRequest("GET", "http://"+host+"/status", nil, nil)
+			result, _ := st.DoRequest(req, p.relay)
+			require.Equal(t, http.StatusOK, result.StatusCode)
+		}
+
+		var collected metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &collected))
+
+		for _, scope := range collected.ScopeMetrics {
+			for _, m := range scope.Metrics {
+				assert.Fail(t, "otelmux recorded a metric through the global meter provider",
+					"scope %q reported %q", scope.Scope.Name, m.Name)
+			}
+		}
 	})
 }

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gorilla/mux"
 	h "github.com/klauspost/compress/gzhttp"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 )
 
 const (
@@ -45,7 +46,14 @@ func (r *Relay) makeRouter() *mux.Router {
 	// Host header. Its parameter is the "primary server name", not an instrumentation name: a
 	// non-empty value overrides the real host on every span, so passing a service name here would
 	// report that name as the address the client connected to.
-	router.Use(otelmux.Middleware(""))
+	//
+	// Relay records its own request metrics, with an attribute set trimmed of high-cardinality
+	// dimensions, so otelmux's parallel HTTP server instruments must stay off. Without a meter
+	// provider of its own, otelmux takes the global one, which is a no-op that starts delegating the
+	// moment anything calls otel.SetMeterProvider. It would then report a second
+	// http.server.request.duration, under its own scope and with its own buckets, keyed on the
+	// client-controlled Host. Pinning a no-op provider keeps that from ever switching on.
+	router.Use(otelmux.Middleware("", otelmux.WithMeterProvider(metricnoop.NewMeterProvider())))
 	// Must come after the tracing middleware, which records the raw request path on the span it starts.
 	router.Use(middleware.SanitizeRequestSpan)
 	if r.config.HTTP.EnableCompression {


### PR DESCRIPTION
- **chore: Pin otelmux to a no-op meter provider**
- **test: Restore the meter provider the otelmux guard replaced**
- **chore: Pin the outbound HTTP client to a no-op meter provider**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Pins **no-op OpenTelemetry meter providers** on `otelmux` and outbound `otelhttp` so those libraries keep **trace propagation** without emitting their own HTTP metrics through the global meter provider.
> 
> For **incoming** traffic, `otelmux.Middleware` now uses `otelmux.WithMeterProvider(metricnoop.NewMeterProvider())` so it cannot duplicate Relay’s existing request metrics or add high-cardinality `Host`-keyed `http.server.request.duration` if something later calls `otel.SetMeterProvider`.
> 
> For **outbound** clients from `HTTPConfig.Client()`, `otelhttp.NewTransport` gets the same no-op meter provider so outbound HTTP metrics do not turn on accidentally; enabling them is left as an explicit product decision.
> 
> Adds regression tests **`TestOtelmuxRecordsNoMetrics`** and **`TestClientRecordsNoMetrics`** that install a real SDK meter provider globally, exercise traffic, and assert no metrics under the otelmux/otelhttp scopes (with canary counters proving the reader works). The otelmux test restores the prior global provider on cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61a9e2549558218092dd302b9959ab2a18b7234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->