### PR TITLE
fix: Honor operator resource attributes and keep the resource on a partial error

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -47,7 +47,7 @@ being repeated on each measurement:
 
 | Attribute | Description |
 |-----------|-------------|
-| `service.name` | `ld-relay`, unless overridden with `OTEL_SERVICE_NAME`. |
+| `service.name` | `ld-relay`, unless overridden with `OTEL_SERVICE_NAME` or with `service.name` in `OTEL_RESOURCE_ATTRIBUTES`. `OTEL_SERVICE_NAME` wins between the two. |
 | `service.instance.id` | A unique identifier for this Relay Proxy process, generated at startup, unless you supply your own via `OTEL_RESOURCE_ATTRIBUTES`. Prometheus exposes it as the `instance` label. Example: `5f313039-df4e-45f5-ad9e-4afd840cb210` |
 
 Note that resource attributes are **not** copied onto every series. Prometheus reports them through

--- a/internal/tracing/resource.go
+++ b/internal/tracing/resource.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"unicode/utf8"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/util"
 
 	"github.com/pborman/uuid"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
@@ -46,9 +50,43 @@ func NewResource(logger *slog.Logger) *resource.Resource {
 	}
 
 	res, err := resource.New(context.Background(), opts...)
-	if err != nil || res == nil {
-		logger.Warn("failed to create OTel resource, falling back to default", "error", err)
+	if err != nil {
+		// resource.New reports a partial-resource error but still returns everything it merged, so
+		// the resource is usable. One malformed OTEL_RESOURCE_ATTRIBUTES entry -- an entry with no
+		// "=", which a stray comma also produces -- is enough to reach this. Keeping the resource
+		// preserves Relay's defaults and every attribute that did parse. resource.Default() would
+		// drop both service.name and service.instance.id, leaving the process with no identity for
+		// target_info to join against.
+		logger.Warn("some OTel resource attributes were not applied", "error", err)
+	}
+	if res == nil {
+		logger.Warn("failed to create OTel resource, falling back to default")
 		res = resource.Default()
 	}
-	return res
+	return sanitizeResource(res)
+}
+
+// sanitizeResource replaces invalid UTF-8 in resource attribute values.
+//
+// OTEL_RESOURCE_ATTRIBUTES values are percent-decoded, so an operator can put a byte outside UTF-8
+// into one without meaning to. OTLP cannot serialize it. The resource travels with every batch of
+// spans, metrics and logs, so a single bad value stops all telemetry export for the life of the
+// process, rather than costing one batch the way a bad span attribute does.
+func sanitizeResource(res *resource.Resource) *resource.Resource {
+	var repaired []attribute.KeyValue
+	for _, kv := range res.Attributes() {
+		if kv.Value.Type() == attribute.STRING && !utf8.ValidString(kv.Value.AsString()) {
+			repaired = append(repaired, kv.Key.String(util.SanitizeUTF8(kv.Value.AsString())))
+		}
+	}
+	if len(repaired) == 0 {
+		return res
+	}
+	// A later value replaces an earlier one, so merging the repairs over the original resource
+	// overwrites just the offending attributes.
+	merged, err := resource.Merge(res, resource.NewWithAttributes(res.SchemaURL(), repaired...))
+	if err != nil {
+		return res
+	}
+	return merged
 }

--- a/internal/tracing/resource.go
+++ b/internal/tracing/resource.go
@@ -3,8 +3,6 @@ package tracing
 import (
 	"context"
 	"log/slog"
-	"os"
-	"strings"
 	"sync"
 
 	"github.com/pborman/uuid"
@@ -22,10 +20,10 @@ func RelayID() string {
 	return relayID()
 }
 
-// NewResource builds an OTel resource from standard environment variables
-// (OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME). If OTEL_SERVICE_NAME is
-// unset, it defaults to "ld-relay". If resource creation fails or returns
-// nil, it falls back to resource.Default() and logs a warning.
+// NewResource builds an OTel resource from Relay's own defaults and the standard environment
+// variables (OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME). Anything the operator sets there wins over
+// the defaults. If resource creation fails or returns nil, it falls back to resource.Default() and
+// logs a warning.
 //
 // The process identity is reported as service.instance.id alone. Relay used to publish the same value
 // again under a private relay.id key; that carried no information service.instance.id did not already
@@ -35,13 +33,16 @@ func RelayID() string {
 // through target_info, so a query that needs the process identity joins against it, or uses the
 // "instance" label.
 func NewResource(logger *slog.Logger) *resource.Resource {
-	opts := []resource.Option{resource.WithFromEnv()}
-	if os.Getenv("OTEL_SERVICE_NAME") == "" {
-		opts = append(opts, resource.WithAttributes(semconv.ServiceName("ld-relay")))
-	}
-	// Only supply service.instance.id when the operator has not configured one themselves.
-	if !strings.Contains(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"), string(semconv.ServiceInstanceIDKey)) {
-		opts = append(opts, resource.WithAttributes(semconv.ServiceInstanceID(RelayID())))
+	// resource.New merges its detectors in the order they are given, and a later value replaces an
+	// earlier one. Relay's defaults therefore go first and the environment detector goes last, which
+	// is what lets an operator override either default. Reading the variables here instead would mean
+	// reimplementing the parsing the detector already does.
+	opts := []resource.Option{
+		resource.WithAttributes(
+			semconv.ServiceName("ld-relay"),
+			semconv.ServiceInstanceID(RelayID()),
+		),
+		resource.WithFromEnv(),
 	}
 
 	res, err := resource.New(context.Background(), opts...)

--- a/internal/tracing/resource_test.go
+++ b/internal/tracing/resource_test.go
@@ -46,15 +46,47 @@ func TestResourceKeepsAnOperatorSuppliedServiceInstanceID(t *testing.T) {
 	assert.NotEqual(t, RelayID(), instanceID.AsString())
 }
 
-// OTEL_SERVICE_NAME wins over the built-in default.
+// An attribute whose key merely contains "service.instance.id" is a different attribute, so the
+// generated process identity must still be reported. Relay would otherwise report no process
+// identity at all.
+func TestResourceStillReportsAnIdentityAlongsideSimilarlyNamedAttributes(t *testing.T) {
+	for _, attrs := range []string{
+		"service.instance.id.source=kubernetes",
+		"custom.service.instance.id=pod-7",
+		"deployment.note=set service.instance.id here",
+	} {
+		t.Run(attrs, func(t *testing.T) {
+			t.Setenv("OTEL_SERVICE_NAME", "")
+			t.Setenv("OTEL_RESOURCE_ATTRIBUTES", attrs)
+
+			res := NewResource(slog.Default())
+			require.NotNil(t, res)
+
+			instanceID, ok := res.Set().Value(attribute.Key("service.instance.id"))
+			require.True(t, ok, "service.instance.id not present on the resource")
+			assert.Equal(t, RelayID(), instanceID.AsString())
+		})
+	}
+}
+
+// Either environment variable can carry the service name, and OTEL_SERVICE_NAME wins between them.
+// Both win over the built-in default.
 func TestResourceUsesTheConfiguredServiceName(t *testing.T) {
-	t.Setenv("OTEL_SERVICE_NAME", "my-relay")
-	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	for _, params := range []struct{ name, serviceName, attrs, want string }{
+		{"from OTEL_SERVICE_NAME", "my-relay", "", "my-relay"},
+		{"from OTEL_RESOURCE_ATTRIBUTES", "", "service.name=my-relay", "my-relay"},
+		{"OTEL_SERVICE_NAME wins", "from-env", "service.name=from-attrs", "from-env"},
+	} {
+		t.Run(params.name, func(t *testing.T) {
+			t.Setenv("OTEL_SERVICE_NAME", params.serviceName)
+			t.Setenv("OTEL_RESOURCE_ATTRIBUTES", params.attrs)
 
-	res := NewResource(slog.Default())
-	require.NotNil(t, res)
+			res := NewResource(slog.Default())
+			require.NotNil(t, res)
 
-	serviceName, ok := res.Set().Value(attribute.Key("service.name"))
-	require.True(t, ok, "service.name not present on the resource")
-	assert.Equal(t, "my-relay", serviceName.AsString())
+			serviceName, ok := res.Set().Value(attribute.Key("service.name"))
+			require.True(t, ok, "service.name not present on the resource")
+			assert.Equal(t, params.want, serviceName.AsString())
+		})
+	}
 }

--- a/internal/tracing/resource_test.go
+++ b/internal/tracing/resource_test.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"log/slog"
 	"testing"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -89,4 +90,92 @@ func TestResourceUsesTheConfiguredServiceName(t *testing.T) {
 			assert.Equal(t, params.want, serviceName.AsString())
 		})
 	}
+}
+
+// A malformed OTEL_RESOURCE_ATTRIBUTES entry must not cost Relay its identity. resource.New reports a
+// partial-resource error but still returns everything it merged, so the resource stays usable. A stray
+// comma is the realistic way to reach this -- templated configuration produces one whenever a
+// conditional attribute renders empty.
+func TestResourceSurvivesAMalformedResourceAttribute(t *testing.T) {
+	for _, attrs := range []string{
+		"no-equals-sign",
+		"service.namespace=relay,",
+		",service.namespace=relay",
+		"service.namespace=relay,,deployment.environment=production",
+		",",
+	} {
+		t.Run(attrs, func(t *testing.T) {
+			t.Setenv("OTEL_SERVICE_NAME", "")
+			t.Setenv("OTEL_RESOURCE_ATTRIBUTES", attrs)
+
+			res := NewResource(slog.Default())
+			require.NotNil(t, res)
+
+			serviceName, ok := res.Set().Value(attribute.Key("service.name"))
+			require.True(t, ok, "service.name not present on the resource")
+			assert.Equal(t, "ld-relay", serviceName.AsString())
+
+			instanceID, ok := res.Set().Value(attribute.Key("service.instance.id"))
+			require.True(t, ok, "service.instance.id not present on the resource")
+			assert.Equal(t, RelayID(), instanceID.AsString())
+		})
+	}
+}
+
+// Every attribute that did parse is kept, alongside Relay's defaults.
+func TestResourceKeepsTheValidAttributesBesideAMalformedOne(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=relay,oops,deployment.environment=production")
+
+	res := NewResource(slog.Default())
+	require.NotNil(t, res)
+
+	namespace, ok := res.Set().Value(attribute.Key("service.namespace"))
+	require.True(t, ok, "service.namespace was discarded")
+	assert.Equal(t, "relay", namespace.AsString())
+
+	environment, ok := res.Set().Value(attribute.Key("deployment.environment"))
+	require.True(t, ok, "deployment.environment was discarded")
+	assert.Equal(t, "production", environment.AsString())
+}
+
+// An operator's own service.instance.id survives a malformed entry elsewhere in the variable. Falling
+// back to the default resource would have discarded the value they explicitly supplied.
+func TestResourceKeepsAnOperatorInstanceIDBesideAMalformedEntry(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.instance.id=operator-id,oops")
+
+	res := NewResource(slog.Default())
+	require.NotNil(t, res)
+
+	instanceID, ok := res.Set().Value(attribute.Key("service.instance.id"))
+	require.True(t, ok, "service.instance.id not present on the resource")
+	assert.Equal(t, "operator-id", instanceID.AsString())
+}
+
+// OTEL_RESOURCE_ATTRIBUTES values are percent-decoded, so an operator can put a byte outside UTF-8
+// into one without meaning to. The resource travels with every export batch, so one invalid byte would
+// stop all telemetry for the life of the process.
+func TestResourceAttributesAreValidUTF8(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.note=%ff%fe,service.namespace=relay")
+
+	res := NewResource(slog.Default())
+	require.NotNil(t, res)
+
+	note, ok := res.Set().Value(attribute.Key("deployment.note"))
+	require.True(t, ok, "deployment.note not present on the resource")
+	assert.True(t, utf8.ValidString(note.AsString()),
+		"an invalid byte reached a resource attribute: %q", note.AsString())
+	assert.Empty(t, note.AsString())
+
+	for _, kv := range res.Attributes() {
+		if kv.Value.Type() == attribute.STRING {
+			assert.True(t, utf8.ValidString(kv.Value.AsString()), "attribute %s is not valid UTF-8", kv.Key)
+		}
+	}
+
+	namespace, ok := res.Set().Value(attribute.Key("service.namespace"))
+	require.True(t, ok, "the valid attribute alongside it was discarded")
+	assert.Equal(t, "relay", namespace.AsString())
 }


### PR DESCRIPTION
- **fix: Let the environment override Relay's resource defaults**
- **fix: Harden the OTel resource against malformed operator input**


The documentation and meter-provider pins this branch was previously stacked behind have merged (#813,
#814), so this now targets v9 directly.

Two distinct user-visible fixes, so the changelog entries are set explicitly rather than collapsing into
the squashed title.

`fix: Let the environment override Relay's resource defaults` replaces a `strings.Contains` substring
guard with detector ordering, so `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` reliably win over
Relay's defaults. The old guard matched any key merely *containing* `service.instance.id`, so an
unrelated attribute such as `service.instance.id.source=kubernetes` suppressed the generated identity
entirely.

`fix: Harden the OTel resource against malformed operator input` fixes `NewResource` discarding a usable
resource whenever `resource.New` reports a partial-resource error. One entry without an `=` -- which a
stray comma also produces, as templated configuration does whenever a conditional attribute renders
empty -- cost `service.name`, the generated `service.instance.id`, and every attribute the operator
supplied correctly, leaving the process with no identity for `target_info` to join against. It also
sanitizes resource attribute values, which are percent-decoded and so can carry a byte outside UTF-8
that would stop every export for the life of the process.

BEGIN_COMMIT_OVERRIDE
fix: Let OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES override Relay's resource defaults

fix: Keep a malformed OTEL_RESOURCE_ATTRIBUTES entry from erasing the resource identity
END_COMMIT_OVERRIDE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **OpenTelemetry resource building** in `NewResource` now applies Relay defaults (`ld-relay`, generated `service.instance.id`) first and `resource.WithFromEnv()` last, so `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` reliably override defaults. The previous `strings.Contains` guard on `service.instance.id` could suppress the real identity when unrelated keys merely contained that substring.
> 
> When `resource.New` returns a **partial-resource error** (e.g. stray commas or entries without `=`), Relay keeps the merged resource and logs a warning instead of falling back to `resource.Default()`, preserving `service.name`, instance identity, and any valid operator attributes for Prometheus `target_info`.
> 
> **Invalid UTF-8** in percent-decoded `OTEL_RESOURCE_ATTRIBUTES` values is repaired via `sanitizeResource` (using `util.SanitizeUTF8`) so OTLP export does not fail for the process lifetime.
> 
> Docs in `metrics.md` clarify that `service.name` can come from `OTEL_SERVICE_NAME` or `service.name` in `OTEL_RESOURCE_ATTRIBUTES`, with `OTEL_SERVICE_NAME` winning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02cec79511ca4f7cfbd6bc56bc9926324f9e5fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
