### PR TITLE
feat: tracing for the init-concurrency limiter

### DIFF
--- a/internal/concurrency/limiter.go
+++ b/internal/concurrency/limiter.go
@@ -38,6 +38,11 @@ type Stats struct {
 	Waiting       int
 	Admitted      int64
 	Rejected      int64
+	// The rejection causes. Their sum is Rejected. A full budget is the only cause that
+	// shows saturation; the other two are normal client and process lifecycle.
+	RejectedFull       int64
+	RejectedClientGone int64
+	RejectedShutdown   int64
 }
 
 // Limiter bounds concurrency with two limits: a maximum number of slots held at once and
@@ -71,6 +76,11 @@ type Limiter struct {
 
 	admitted atomic.Int64
 	rejected atomic.Int64
+	// The rejection causes, split so that operators can tell saturation apart from the
+	// normal client and process lifecycle.
+	rejectedFull       atomic.Int64
+	rejectedClientGone atomic.Int64
+	rejectedShutdown   atomic.Int64
 }
 
 // New builds a Limiter. name identifies the limiter in logs and metrics.
@@ -115,18 +125,18 @@ func (l *Limiter) Acquire(ctx context.Context) (release func(), ok bool) {
 	// is free: Close is an admission barrier, and a dead request would only waste the slot.
 	select {
 	case <-l.shutdown:
-		return l.reject()
+		return l.reject(&l.rejectedShutdown)
 	default:
 	}
 	if ctx.Err() != nil {
-		return l.reject()
+		return l.reject(&l.rejectedClientGone)
 	}
 
 	// Reserve one unit of the budget's total capacity (slots plus queue). Rejecting on
 	// overflow here is what bounds the queue.
 	if l.inFlight.Add(1) > l.maxOccupancy {
 		l.inFlight.Add(-1)
-		return l.reject()
+		return l.reject(&l.rejectedFull)
 	}
 
 	// Take a free slot if one is available.
@@ -146,11 +156,11 @@ func (l *Limiter) Acquire(ctx context.Context) (release func(), ok bool) {
 	case <-ctx.Done():
 		l.parked.Add(-1)
 		l.inFlight.Add(-1)
-		return l.reject()
+		return l.reject(&l.rejectedClientGone)
 	case <-l.shutdown:
 		l.parked.Add(-1)
 		l.inFlight.Add(-1)
-		return l.reject()
+		return l.reject(&l.rejectedShutdown)
 	}
 }
 
@@ -162,7 +172,7 @@ func (l *Limiter) admit() (func(), bool) {
 	case <-l.shutdown:
 		l.tokens <- struct{}{} // never blocks: this slot's buffer capacity is unoccupied
 		l.inFlight.Add(-1)
-		return l.reject()
+		return l.reject(&l.rejectedShutdown)
 	default:
 	}
 	l.admitted.Add(1)
@@ -177,8 +187,9 @@ func (l *Limiter) admit() (func(), bool) {
 	}, true
 }
 
-func (l *Limiter) reject() (func(), bool) {
+func (l *Limiter) reject(cause *atomic.Int64) (func(), bool) {
 	l.rejected.Add(1)
+	cause.Add(1)
 	return func() {}, false
 }
 
@@ -216,12 +227,15 @@ func (l *Limiter) Stats() Stats {
 		return Stats{Enabled: false}
 	}
 	return Stats{
-		Enabled:       true,
-		MaxConcurrent: cap(l.tokens),
-		MaxQueued:     l.maxQueued,
-		Held:          cap(l.tokens) - len(l.tokens),
-		Waiting:       int(l.parked.Load()),
-		Admitted:      l.admitted.Load(),
-		Rejected:      l.rejected.Load(),
+		Enabled:            true,
+		MaxConcurrent:      cap(l.tokens),
+		MaxQueued:          l.maxQueued,
+		Held:               cap(l.tokens) - len(l.tokens),
+		Waiting:            int(l.parked.Load()),
+		Admitted:           l.admitted.Load(),
+		Rejected:           l.rejected.Load(),
+		RejectedFull:       l.rejectedFull.Load(),
+		RejectedClientGone: l.rejectedClientGone.Load(),
+		RejectedShutdown:   l.rejectedShutdown.Load(),
 	}
 }

--- a/internal/concurrency/limiter_test.go
+++ b/internal/concurrency/limiter_test.go
@@ -533,3 +533,33 @@ func TestConcurrentAcquireBoundsHeld(t *testing.T) {
 		t.Fatalf("held %d exceeded MaxConcurrent %d", maxObserved, maxC)
 	}
 }
+
+func TestRejectionCausesAreSplit(t *testing.T) {
+	l := New("t", Params{MaxConcurrent: 1, MaxQueued: 0})
+	r1, _ := l.Acquire(context.Background())
+
+	// A full budget.
+	if _, ok := l.Acquire(context.Background()); ok {
+		t.Fatal("expected a full-budget rejection")
+	}
+	// A client that is already gone.
+	gone, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, ok := l.Acquire(gone); ok {
+		t.Fatal("expected a client-gone rejection")
+	}
+	r1()
+	// A shutdown.
+	l.Close()
+	if _, ok := l.Acquire(context.Background()); ok {
+		t.Fatal("expected a shutdown rejection")
+	}
+
+	s := l.Stats()
+	if s.RejectedFull != 1 || s.RejectedClientGone != 1 || s.RejectedShutdown != 1 {
+		t.Fatalf("causes not split correctly: %+v", s)
+	}
+	if s.Rejected != s.RejectedFull+s.RejectedClientGone+s.RejectedShutdown {
+		t.Fatalf("cause sum does not equal the total: %+v", s)
+	}
+}

--- a/internal/initwrite/initwrite.go
+++ b/internal/initwrite/initwrite.go
@@ -66,6 +66,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -103,6 +104,12 @@ type Writer struct {
 	// gen identifies the current gated delivery. Begin bumps it so a teardown (the end-of-batch
 	// flush) that observed an earlier delivery cannot clear the deadline of a newer one.
 	gen uint64
+	// capEngaged records that the absolute cap clamped a deadline for the current delivery:
+	// the delivery is large enough that the cap, not the floor, decides when it is cut.
+	capEngaged bool
+	// deadlineSetErrors counts the SetWriteDeadline calls that failed. When it grows, the
+	// deadline protection is not in force on this connection.
+	deadlineSetErrors atomic.Int64
 	// cut records that the connection was cut because its client is gone. The flag is
 	// terminal -- Begin does not clear it -- so a cut that lands between a slot acquisition
 	// and Begin is not lost: the delivery that then begins fails on its first write instead
@@ -151,6 +158,7 @@ func (w *Writer) Begin() {
 	defer w.mu.Unlock()
 	w.active = true
 	w.ending = false
+	w.capEngaged = false
 	w.msgStart = time.Time{}
 	w.lastDeadline = time.Time{}
 	w.gen++
@@ -196,19 +204,24 @@ func (w *Writer) End() {
 // its slot, until the delivery flushes, and a context cancelled while the handler is still live
 // (a shutdown or producer-error signal, say) would return early without ending the delivery,
 // leaving the missed-End failure described in the package comment -- use End for that.
-func (w *Writer) WaitAndFinish(ctx context.Context) {
+//
+// The return value reports the outcome: true when the delivery's last byte was flushed to
+// the client, false when the connection ended first. A false return does not say why the
+// connection ended -- a client disconnect and a relay deadline cut look the same here.
+func (w *Writer) WaitAndFinish(ctx context.Context) bool {
 	w.mu.Lock()
 	done := w.done
 	w.mu.Unlock()
-	w.waitAndFinish(ctx, done)
+	return w.waitAndFinish(ctx, done)
 }
 
 // waitAndFinish is WaitAndFinish after the channel capture, split out so a test can drive the
 // cancellation branch with a stale captured channel.
-func (w *Writer) waitAndFinish(ctx context.Context, done <-chan struct{}) {
+func (w *Writer) waitAndFinish(ctx context.Context, done <-chan struct{}) bool {
 	select {
 	case <-done:
 		// Delivered: the handler's end-of-delivery flush closed done and cleared the deadline.
+		return true
 	case <-ctx.Done():
 		// The client went away before the delivery finished. Release the waiter, but do not
 		// touch the connection: it belongs to the handler, which may already have returned.
@@ -218,6 +231,7 @@ func (w *Writer) waitAndFinish(ctx context.Context, done <-chan struct{}) {
 			w.doneClosed = true
 		}
 		w.mu.Unlock()
+		return false
 	}
 }
 
@@ -241,6 +255,21 @@ func (w *Writer) Cut() {
 	if w.active {
 		_ = w.rc.SetWriteDeadline(w.now())
 	}
+}
+
+// CapEngaged reports whether the absolute cap clamped a deadline for the current delivery.
+// When it is true, the delivery is large enough that the cap, not the throughput floor,
+// decides when a slow client is cut.
+func (w *Writer) CapEngaged() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.capEngaged
+}
+
+// DeadlineSetErrors returns how many SetWriteDeadline calls have failed on this connection.
+// A value above zero means the deadline protection is not in force.
+func (w *Writer) DeadlineSetErrors() int64 {
+	return w.deadlineSetErrors.Load()
 }
 
 // Unwrap exposes the wrapped ResponseWriter so http.NewResponseController and other wrappers
@@ -361,11 +390,14 @@ func (w *Writer) arm(n int) {
 	if w.maxHold > 0 {
 		if capDL := w.msgStart.Add(w.maxHold); dl.After(capDL) {
 			dl = capDL
+			w.capEngaged = true
 		}
 	}
 	if dl.After(w.lastDeadline) && dl.Sub(w.lastDeadline) >= minExtension {
 		if err := w.rc.SetWriteDeadline(dl); err == nil {
 			w.lastDeadline = dl
+		} else {
+			w.deadlineSetErrors.Add(1)
 		}
 	}
 }

--- a/internal/initwrite/initwrite_test.go
+++ b/internal/initwrite/initwrite_test.go
@@ -1138,3 +1138,45 @@ func assertOpen(t *testing.T, ch <-chan struct{}, what string) {
 	case <-time.After(20 * time.Millisecond):
 	}
 }
+
+func TestWaitAndFinishReportsTheOutcome(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 2*time.Minute, true)
+	w.Begin()
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	w.End()
+	go w.Flush()
+	assert.True(t, w.WaitAndFinish(context.Background()), "a flushed delivery must report true")
+
+	w2, _ := wrapClocked(newDeadlineConn(), 2*time.Minute, true)
+	w2.Begin()
+	gone, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.False(t, w2.WaitAndFinish(gone), "an ended connection must report false")
+}
+
+func TestCapEngagedReportsTheClamp(t *testing.T) {
+	base := newDeadlineConn()
+	w, _ := wrapClocked(base, 500*time.Millisecond, true) // cap below one chunk's budget
+	w.Begin()
+	assert.False(t, w.CapEngaged())
+	_, err := w.Write(make([]byte, chunkSize))
+	require.NoError(t, err)
+	assert.True(t, w.CapEngaged(), "the clamped deadline must set the flag")
+
+	// A new delivery starts clean.
+	w.End()
+	w.Flush()
+	w.Begin()
+	assert.False(t, w.CapEngaged(), "Begin must clear the flag")
+}
+
+func TestDeadlineSetErrorsAreCounted(t *testing.T) {
+	base := newDeadlineConn()
+	base.setErr = errors.New("deadline not supported")
+	w, _ := wrapClocked(base, 2*time.Minute, false)
+	_, err := w.Write(make([]byte, 3*chunkSize))
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), w.DeadlineSetErrors(), "each failed SetWriteDeadline must count")
+}

--- a/internal/logging/bridge_test.go
+++ b/internal/logging/bridge_test.go
@@ -14,6 +14,7 @@ import (
 //   - Printf path: format is "LEVEL: " + format, so the rendered prefix has a space.
 //   - Println path: baseLogger.Println(prefix, value) -> fmt.Sprint inserts no
 //     separator between two string operands, so the rendered prefix has no space.
+//
 // The parser must accept both. https://github.com/launchdarkly/ld-relay/issues/670
 // shipped because the parser only matched the with-space shape.
 func TestParseLDLogPrefix(t *testing.T) {

--- a/internal/middleware/concurrency.go
+++ b/internal/middleware/concurrency.go
@@ -8,8 +8,11 @@ import (
 	"time"
 
 	"github.com/launchdarkly/ld-relay/v9/internal/concurrency"
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
+
 	"github.com/launchdarkly/ld-relay/v9/internal/initwrite"
 	"github.com/launchdarkly/ld-relay/v9/internal/util"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type initLimiterCtxKey struct{}
@@ -35,8 +38,18 @@ func AcquireInitSlot(limiter *concurrency.Limiter, w http.ResponseWriter, r *htt
 	if !limiter.Enabled() {
 		return func() {}, true
 	}
+	// The request span, from the router's tracing middleware, records how the budget
+	// treated this request: whether it was admitted, how long it waited for a slot, and,
+	// for a rejection, the cause. The span is a no-op when tracing is disabled.
+	span := trace.SpanFromContext(r.Context())
+	start := time.Now()
 	rel, ok := limiter.Acquire(r.Context())
+	span.SetAttributes(
+		tracing.InitAdmittedKey.Bool(ok),
+		tracing.InitQueueWaitDurationKey.Float64(time.Since(start).Seconds()),
+	)
 	if !ok {
+		span.SetAttributes(tracing.InitShedReasonKey.String(shedReason(r, limiter)))
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds()))
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -103,6 +116,19 @@ func ProvideInitLimiter(limiter *concurrency.Limiter, maxHold time.Duration) fun
 func AcquireInitSlotFromContext(w http.ResponseWriter, r *http.Request) (release func(), ok bool) {
 	holder, _ := r.Context().Value(initLimiterCtxKey{}).(initLimiterHolder)
 	return AcquireInitSlot(holder.limiter, w, r)
+}
+
+// shedReason names the cause of a rejection, with the same decision order as the stream
+// shed path: a context that already ended means the client is gone, a closed limiter means
+// shutdown, and anything else is a full budget.
+func shedReason(r *http.Request, limiter *concurrency.Limiter) string {
+	if r.Context().Err() != nil {
+		return "client_gone"
+	}
+	if limiter.Closed() {
+		return "shutdown"
+	}
+	return "budget_full"
 }
 
 // retryAfterSeconds returns a small jittered Retry-After (in seconds) so a shed herd does

--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -49,6 +49,18 @@ const (
 	// another request's trace carries it.
 	SingleflightSharedKey = attribute.Key("launchdarkly.relay.singleflight.shared")
 
+	// InitAdmittedKey reports whether the request was admitted by the shared
+	// initialization-delivery budget. It appears only on requests that asked for a slot.
+	InitAdmittedKey = attribute.Key("launchdarkly.relay.init.admitted")
+
+	// InitQueueWaitDurationKey is the time in seconds the request waited for an
+	// initialization-delivery slot. It appears only on requests that asked for a slot.
+	InitQueueWaitDurationKey = attribute.Key("launchdarkly.relay.init.queue.wait.duration")
+
+	// InitShedReasonKey is the cause of an initialization-delivery rejection: budget_full,
+	// client_gone, or shutdown. It appears only on requests the budget rejected.
+	InitShedReasonKey = attribute.Key("launchdarkly.relay.init.shed.reason")
+
 	// SingleflightWaitDurationKey reports, on the request span of a request that received its
 	// payload from a flight another request was already executing, how long it spent waiting for
 	// that flight. The value is in seconds, OTel's base unit for a duration, so the unit stays out


### PR DESCRIPTION
Adds tracing for the initialization-delivery limiter, on top of the request spans the router already creates. Like the metrics PR, the signals come from the relay-owned layers only: without the eventsource logger bridge, a span cannot say whether a stream delivery ended because the client disconnected or because the relay's deadline cut it.

## Plan

| Signal | Form | Attributes |
|---|---|---|
| Poll admission | attributes on the request span | `launchdarkly.relay.init.admitted` (bool), `launchdarkly.relay.init.queue.wait.duration` (s), `launchdarkly.relay.init.shed.reason` (`budget_full` \| `client_gone` \| `shutdown`) |
| Stream delivery | child span `launchdarkly.relay.init.delivery` from the request context, producer-side | `protocol`, `outcome` (`completed` \| `connection_ended` \| `read_error`), `cap_engaged`, queue wait |
| Up-to-date replies and stream sheds | span events on the request span | reason on sheds |

The stream child span ends on the producer goroutine. A span is safe there: unlike a write deadline, it does not touch the connection. A test must still pin that the span ends exactly one time on every exit path.

## Status

- [x] Poll admission attributes and shed reason (this commit)
- [ ] Stream delivery child span with outcome and cap attributes
- [ ] Span events for up-to-date replies and stream sheds
- [ ] Span-lifecycle tests with a span recorder

Based on the metrics branch (#812): the outcome and cap surfaces come from its foundation commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **OpenTelemetry attributes on the existing request span** when a poll path acquires an initialization-delivery slot via `AcquireInitSlot` (including FDv1 `LimitConcurrency` and FDv2 lazy acquire). After `limiter.Acquire`, the span records whether the request was **admitted**, **queue wait time** (seconds), and on rejection **`launchdarkly.relay.init.shed.reason`** (`budget_full`, `client_gone`, or `shutdown`).
> 
> Introduces three attribute keys in `internal/tracing` and a **`shedReason`** helper that mirrors the stream shed decision order. Spans remain no-ops when tracing is off; admission behavior and 503 responses are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5153563797bcbd4381e7b5dd55f27b0446000a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->