### PR TITLE
fix(autoconfigcache): bump the cached model version to 2

### DIFF
--- a/internal/autoconfigcache/model.go
+++ b/internal/autoconfigcache/model.go
@@ -17,7 +17,7 @@ const (
 
 // CurrentModelVersion is the version of the serialization format.
 // Increment this when the shape of EnvironmentRep or FilterRep changes.
-const CurrentModelVersion = 1
+const CurrentModelVersion = 2
 
 // CachedItem is the versioned envelope stored in the cache. It wraps the actual data
 // with kind and version metadata so we can detect and handle format changes on read.


### PR DESCRIPTION
Bumps the auto-config cache model version from 1 to 2, so a relay built from this branch rejects cache entries written by a v8 relay instead of accepting them as its own.

Those entries are stamped `modelVersion: 1` but silently drop the new `sdkKeys` and `mobileKeys` arrays, so accepting one on a cold start leaves the relay serving only the singular `sdkKey` and `mobKey` and returning 401 for every other accepted key.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Bumps **`CurrentModelVersion`** from **1** to **2** so auto-config cache reads only accept envelopes stamped with the current serialization format.
> 
> Because **`unmarshalCachedItem`** rejects any **`modelVersion`** that does not match **`CurrentModelVersion`**, a relay built from this branch will **skip** cache entries written by an older relay that still used version 1. Those v1 blobs can look valid but omit the newer **`sdkKeys`** / **`mobileKeys`** arrays; loading them on a cold start would leave the relay with only the legacy singular **`sdkKey`** / **`mobKey`** and **401** for other accepted keys. After the bump, new writes use version 2 and stale v1 entries are ignored until the stream repopulates the cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f1a1322541467d6ad8799a1d0ab1c38ee0b3ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->