### PR TITLE
fix(relayenv): retry an SDK key rotation whose new client failed to build

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,8 @@ _(4)_ For details about `disconnectedStatusTime`, read [Service endpoints - Stat
 _(5)_ Relevant only when using AutoConfig or Offline Mode. In these modes, when an environment's SDK key is rotated in 
 LaunchDarkly, it's possible to specify a deprecation/grace period for the previous key where existing SDKs are still able
 to authorize using that credential. Relay will periodically check for expired credentials and remove them on this interval.
+This interval is also how often Relay retries a key rotation whose new SDK key failed to connect: until it succeeds, the
+environment keeps serving on the previous key, which LaunchDarkly may already be invalidating.
 
 ### File section: `[AutoConfig]`
 

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -211,8 +211,13 @@ type ReconcileResult struct {
 // NewAnchorPreviouslyAccepted is false when the new anchor is a brand-new key, so the re-anchor must
 // register that key's credential mappings. It is true when the key was already accepted, so the
 // mappings already exist and a client may too. See envContextImpl.reanchor.
+//
+// PreviousAnchorName is the previous anchor's wire "key" identifier, captured before this reconcile. A
+// rollback that re-admits the previous anchor restores the name from here. See RevertAnchorChange. It
+// is nil when the key had no name.
 type AnchorChange struct {
 	PreviousAnchor              config.SDKKey
+	PreviousAnchorName          *string
 	NewAnchor                   config.SDKKey
 	NewAnchorPreviouslyAccepted bool
 }
@@ -237,8 +242,11 @@ func (r *Rotator) Reconcile(set AcceptedSet, now time.Time) ReconcileResult {
 	newAnchor := set.anchor
 	if previousAnchor != newAnchor && newAnchor.Defined() {
 		_, alreadyAccepted := r.acceptedSDKKeys[newAnchor]
+		// Capture the previous anchor's name now, before reconcileSDKKeys can drop its entry: an
+		// immediate revocation removes it outright, and a rollback then has to re-admit it.
 		result.AnchorChange = &AnchorChange{
 			PreviousAnchor:              previousAnchor,
+			PreviousAnchorName:          r.acceptedSDKKeys[previousAnchor].Key,
 			NewAnchor:                   newAnchor,
 			NewAnchorPreviouslyAccepted: alreadyAccepted,
 		}
@@ -284,8 +292,9 @@ func (r *Rotator) CommitAnchor(key config.SDKKey) {
 //
 // If this reconcile revoked the previous anchor outright, RevertAnchorChange re-admits that key as a
 // permanent key with no expiry. The re-admission discards the key's previous expiry, because that key
-// is still the anchor and still serving. A previous anchor that is only grace-demoted stays accepted
-// and keeps its expiry. The new anchor is dropped only if that key was brand new.
+// is still the anchor and still serving. It keeps the key's name, so /status still names the key that
+// is serving. A previous anchor that is only grace-demoted stays accepted and keeps its expiry. The new
+// anchor is dropped only if that key was brand new.
 func (r *Rotator) RevertAnchorChange(change AnchorChange) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -294,7 +303,7 @@ func (r *Rotator) RevertAnchorChange(change AnchorChange) {
 	// gains its first SDK key has an undefined previous anchor.
 	if change.PreviousAnchor.Defined() {
 		if _, stillAccepted := r.acceptedSDKKeys[change.PreviousAnchor]; !stillAccepted {
-			r.acceptedSDKKeys[change.PreviousAnchor] = AcceptedKey{}
+			r.acceptedSDKKeys[change.PreviousAnchor] = AcceptedKey{Key: change.PreviousAnchorName}
 		}
 	}
 	if !change.NewAnchorPreviouslyAccepted {

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -427,12 +427,15 @@ func TestReconcileMobilePrimaryToNewKeyDoesNotSignalRepoint(t *testing.T) {
 func TestRevertAnchorChangeReadmitsRevokedPreviousAnchor(t *testing.T) {
 	// When the previous anchor was immediately revoked in the same reconcile (dropped from the accepted
 	// set) and the re-anchor rolled back, RevertAnchorChange re-admits it and drops the failed new key.
+	// The re-admitted key keeps its wire "key" identifier, so /status still names the key it is serving on.
 	r := newTestRotator()
 	keyA := config.SDKKey("keyA")
 	keyB := config.SDKKey("keyB")
+	keyAName := "anchor-sdk"
 	now := time.Now()
 
-	res := r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: keyA})), now)
+	res := r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		WithAnchor(SDKKeyParams{Value: keyA, Key: &keyAName})), now)
 	require.NotNil(t, res.AnchorChange)
 	r.CommitAnchor(res.AnchorChange.NewAnchor)
 	r.StepTime(now)
@@ -449,6 +452,8 @@ func TestRevertAnchorChangeReadmitsRevokedPreviousAnchor(t *testing.T) {
 	creds := r.AllCredentials()
 	assert.Contains(t, creds, SDKCredential(keyA), "previous anchor re-admitted")
 	assert.NotContains(t, creds, SDKCredential(keyB), "failed new anchor dropped")
+	assert.Equal(t, &keyAName, r.AcceptedKeys().Server[keyA].Key,
+		"the re-admitted anchor keeps its key identifier")
 }
 
 func TestRevertAnchorChangeLeavesGraceDemotedPreviousAnchorUntouched(t *testing.T) {

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -130,6 +130,14 @@ type envContextImpl struct {
 	// is held separately from mu so that readers keep running during the SDK client construction.
 	reconcileMu sync.Mutex
 
+	// pendingReanchor holds the credential set from the most recent reconcile whose re-anchor rolled
+	// back, so the cleanup ticker can retry it. It is nil once a reconcile fully applies. Guarded by
+	// reconcileMu, which the reconcile path and the ticker's replay both already hold.
+	//
+	// The set is immutable and safe to replay. Its expiries are absolute instants, so a later attempt
+	// does not extend a grace period, and it does not resurrect a key whose expiry has passed.
+	pendingReanchor *credential.AcceptedSet
+
 	// anchorClientGen counts how many times the anchor client has been established. A re-anchor
 	// commit bumps it. startSDKClient captures it at launch and discards its build if the value
 	// advanced, because a slow build can finish after a later re-anchor. Guarded by c.mu.
@@ -544,12 +552,22 @@ func (c *envContextImpl) reconcileCredentials(newSet credential.AcceptedSet, now
 	c.reconcileMu.Lock()
 	defer c.reconcileMu.Unlock()
 
+	c.applyCredentialSet(newSet, now)
+}
+
+// applyCredentialSet is the body of reconcileCredentials, split out so the cleanup ticker can replay a
+// rolled-back set without releasing and retaking reconcileMu. The caller must hold reconcileMu.
+func (c *envContextImpl) applyCredentialSet(newSet credential.AcceptedSet, now time.Time) {
 	result := c.keyRotator.Reconcile(newSet, now)
 	additions, expirations := c.keyRotator.StepTime(now)
 
 	for _, cred := range additions {
 		c.addCredential(cred)
 	}
+
+	// Any pending retry belongs to an earlier payload. This reconcile either re-arms it below or
+	// supersedes it, so drop it up front.
+	c.pendingReanchor = nil
 
 	if result.AnchorChange != nil {
 		if committed := c.reanchor(result.AnchorChange); !committed {
@@ -566,6 +584,11 @@ func (c *envContextImpl) reconcileCredentials(newSet credential.AcceptedSet, now
 			expirations = slices.DeleteFunc(expirations, func(cred credential.SDKCredential) bool {
 				return cred == previousAnchor
 			})
+			// Arm the cleanup ticker to retry. Without a retry the environment stays on the previous
+			// anchor. LaunchDarkly re-puts the same payload, the MessageReceiver deduplicates it by
+			// version, and nothing drives the re-anchor again. The previous anchor then serves only until
+			// LaunchDarkly invalidates it.
+			c.recordFailedReanchor(newSet)
 		}
 	}
 
@@ -581,6 +604,26 @@ func (c *envContextImpl) reconcileCredentials(newSet credential.AcceptedSet, now
 	for _, cred := range expirations {
 		c.removeCredential(cred)
 	}
+}
+
+// recordFailedReanchor arms the cleanup ticker to replay set, after a re-anchor rolled back. The caller
+// must hold reconcileMu.
+//
+// The retry has no attempt limit. Giving up would leave the environment on a key LaunchDarkly is
+// invalidating, which is the state this retry prevents. Each attempt costs one SDK client build per
+// cleanup interval, so the cost is already rate-limited. buildNewAnchorClient logs an error on every
+// failed attempt, and commitReanchor logs the re-anchor that finally succeeds.
+//
+// A rollback caused by the environment closing mid-build arms nothing, because the ticker has already
+// stopped and would never run the replay.
+func (c *envContextImpl) recordFailedReanchor(set credential.AcceptedSet) {
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return
+	}
+	c.pendingReanchor = &set
 }
 
 // reanchor moves the environment's upstream connection to change.NewAnchor. It returns true if the
@@ -678,7 +721,7 @@ func (c *envContextImpl) buildNewAnchorClient(newAnchor, previousAnchor config.S
 			_ = client.Close()
 		}
 		c.globalLoggers.Errorf("Re-anchor to SDK key %s failed (err=%v initialized=%v); "+
-			"preserving previous anchor %s",
+			"preserving previous anchor %s and retrying on the credential cleanup interval",
 			newAnchor.Masked(), err, initialized, previousAnchor.Masked())
 		return nil
 	}
@@ -752,6 +795,16 @@ func (c *envContextImpl) registerCredentialMappings(cred credential.SDKCredentia
 func (c *envContextImpl) triggerCredentialChanges(now time.Time) {
 	c.reconcileMu.Lock()
 	defer c.reconcileMu.Unlock()
+
+	// A rolled-back re-anchor is retried here. The retry replays the whole set instead of only rebuilding
+	// the client. That keeps the retry on the one path that sequences add -> re-anchor -> remove, and it
+	// makes the retry idempotent. A newer payload replaces the pending set, and a set whose anchor is
+	// already current produces no anchor change and clears the retry. The replay also does this method's
+	// StepTime pass, so nothing else runs afterwards.
+	if pending := c.pendingReanchor; pending != nil {
+		c.applyCredentialSet(*pending, now)
+		return
+	}
 
 	additions, expirations := c.keyRotator.StepTime(now)
 	for _, cred := range additions {

--- a/internal/relayenv/env_context_reanchor_retry_test.go
+++ b/internal/relayenv/env_context_reanchor_retry_test.go
@@ -1,0 +1,236 @@
+package relayenv
+
+// Regression tests for retrying a rolled-back re-anchor.
+//
+// A re-anchor whose new client fails to build rolls back and leaves the environment serving on the
+// previous anchor -- the key LaunchDarkly is in the process of invalidating. Nothing else re-drives it:
+// the payload's version was already recorded by the autoconfig MessageReceiver, so LaunchDarkly's
+// re-put of the same payload is deduplicated to a noop and a stream reconnect does not help. The
+// credential cleanup ticker replays the rolled-back set until it commits.
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const reanchorRetryTestKey2 = config.SDKKey("reanchor-retry-new-anchor")
+
+// hasPendingReanchor reports whether a rolled-back re-anchor is armed for the cleanup ticker to retry.
+// It reads the field under reconcileMu, the lock that guards it. Production code has no such accessor:
+// the retry is observable through the environment's behavior and its logs, not through its API.
+func (c *envContextImpl) hasPendingReanchor() bool {
+	c.reconcileMu.Lock()
+	defer c.reconcileMu.Unlock()
+	return c.pendingReanchor != nil
+}
+
+// countingFactory wraps a client factory, counting build attempts per SDK key and failing the ones
+// named in failFor until stopFailing is called.
+type countingFactory struct {
+	mu       sync.Mutex
+	attempts map[config.SDKKey]int
+	failing  map[config.SDKKey]bool
+	delegate sdks.ClientFactoryFunc
+}
+
+func newCountingFactory(delegate sdks.ClientFactoryFunc, failFor ...config.SDKKey) *countingFactory {
+	f := &countingFactory{
+		attempts: make(map[config.SDKKey]int),
+		failing:  make(map[config.SDKKey]bool),
+		delegate: delegate,
+	}
+	for _, key := range failFor {
+		f.failing[key] = true
+	}
+	return f
+}
+
+func (f *countingFactory) build(key config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+	f.mu.Lock()
+	f.attempts[key]++
+	failing := f.failing[key]
+	f.mu.Unlock()
+	if failing {
+		return nil, errors.New("re-anchor: new client init refused")
+	}
+	return f.delegate(key, cfg, timeout)
+}
+
+func (f *countingFactory) attemptsFor(key config.SDKKey) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.attempts[key]
+}
+
+func (f *countingFactory) stopFailing(key config.SDKKey) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.failing, key)
+}
+
+// newRetryTestEnv builds an environment whose client factory fails for failFor, and returns it along
+// with the factory and the environment's first client.
+func newRetryTestEnv(t *testing.T, failFor ...config.SDKKey) (*envContextImpl, *countingFactory, *testclient.FakeLDClient) {
+	t.Helper()
+	mockLog := ldlogtest.NewMockLog()
+	t.Cleanup(func() { mockLog.DumpIfTestFailed(t) })
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	factory := newCountingFactory(testclient.FakeLDClientFactoryWithChannel(true, clientCh), failFor...)
+
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, st.EnvMain.Config, factory.build, mockLog.Loggers, readyCh)
+	require.Equal(t, env, requireEnvReady(t, readyCh))
+
+	client := requireClientReady(t, clientCh)
+	require.Eventually(t, func() bool { return env.GetClient() == client }, time.Second, 10*time.Millisecond)
+
+	return env.(*envContextImpl), factory, client
+}
+
+// rotationSet builds the payload the backend sends for a default rotation: newAnchor becomes the
+// permanent anchor and oldAnchor is demoted with a one-hour grace expiry.
+func rotationSet(t *testing.T, newAnchor, oldAnchor config.SDKKey, now time.Time) credential.AcceptedSet {
+	t.Helper()
+	graceExpiry := now.Add(time.Hour)
+	set, err := credential.NewAcceptedSetBuilder().
+		WithAnchor(credential.SDKKeyParams{Value: newAnchor}).
+		WithSDKKey(credential.SDKKeyParams{Value: oldAnchor, Expiry: &graceExpiry}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: st.EnvMain.Config.MobileKey}).
+		WithEnvironmentID(st.EnvMain.Config.EnvID).
+		Build()
+	require.NoError(t, err)
+	return set
+}
+
+// anchorOnlySet designates anchor as the environment's only SDK key, revoking every other key outright.
+func anchorOnlySet(t *testing.T, anchor config.SDKKey) credential.AcceptedSet {
+	t.Helper()
+	set, err := credential.NewAcceptedSetBuilder().
+		WithAnchor(credential.SDKKeyParams{Value: anchor}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: st.EnvMain.Config.MobileKey}).
+		WithEnvironmentID(st.EnvMain.Config.EnvID).
+		Build()
+	require.NoError(t, err)
+	return set
+}
+
+// TestReanchorRetry_RolledBackReanchorIsRetriedByCleanupTicker is the regression basis for the defect:
+// a transient SDK client build failure during a rotation must not permanently strand the environment
+// on the outgoing anchor. The build is attempted once by the reconcile, fails, and rolls back; the
+// cleanup ticker retries until it commits.
+func TestReanchorRetry_RolledBackReanchorIsRetriedByCleanupTicker(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	envImpl, factory, originalClient := newRetryTestEnv(t, reanchorRetryTestKey2)
+	defer envImpl.Close()
+	require.NoError(t, envImpl.GetStore().Init(st.AllData))
+
+	now := time.Unix(2000, 0)
+	set := rotationSet(t, reanchorRetryTestKey2, envConfig.SDKKey, now)
+
+	// First attempt: the build fails and the re-anchor rolls back.
+	envImpl.reconcileCredentials(set, now)
+	require.Equal(t, 1, factory.attemptsFor(reanchorRetryTestKey2), "the reconcile attempts the build once")
+	require.Equal(t, envConfig.SDKKey, envImpl.keyRotator.AnchorKey(), "anchor stayed on the previous key")
+	require.Same(t, originalClient, envImpl.GetClient(), "the previous anchor's client keeps serving")
+	require.True(t, envImpl.hasPendingReanchor(), "the rolled-back set must be armed for retry")
+
+	// The ticker retries while the failure persists. This is the assertion the defect fails: without a
+	// retry path the build is attempted exactly once, ever.
+	envImpl.triggerCredentialChanges(now.Add(time.Minute))
+	require.GreaterOrEqual(t, factory.attemptsFor(reanchorRetryTestKey2), 2,
+		"the cleanup ticker must retry the rolled-back re-anchor")
+	require.Equal(t, envConfig.SDKKey, envImpl.keyRotator.AnchorKey(), "still rolled back while the build fails")
+	require.True(t, envImpl.hasPendingReanchor())
+
+	// The transient failure clears; the next ticker commits the re-anchor.
+	factory.stopFailing(reanchorRetryTestKey2)
+	envImpl.triggerCredentialChanges(now.Add(2 * time.Minute))
+
+	assert.Equal(t, reanchorRetryTestKey2, envImpl.keyRotator.AnchorKey(), "the retry committed the new anchor")
+	assert.NoError(t, envImpl.GetInitError(), "a committed re-anchor clears any init error")
+	assert.False(t, envImpl.hasPendingReanchor(), "a committed re-anchor disarms the retry")
+	originalClient.AwaitClose(t, time.Second) // the demoted anchor's client closes once the commit lands
+
+	// The demoted key keeps authenticating downstream connections until its grace expiry passes. The
+	// expiry comes from the original payload, so the retries must not have extended it.
+	assert.Contains(t, envImpl.GetCredentials(), credential.SDKCredential(envConfig.SDKKey))
+	envImpl.triggerCredentialChanges(now.Add(2 * time.Hour))
+	assert.NotContains(t, envImpl.GetCredentials(), credential.SDKCredential(envConfig.SDKKey),
+		"the grace expiry from the original payload is honored, not extended by the retries")
+}
+
+// TestReanchorRetry_NewerPayloadEndsPendingRetry covers the two ways a newer payload ends a pending
+// retry: it rotates to a different key that builds, or it cancels the rotation by naming the anchor the
+// environment is already on. Either way the superseded set must not keep being replayed.
+func TestReanchorRetry_NewerPayloadEndsPendingRetry(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	thirdKey := config.SDKKey("reanchor-retry-third-anchor")
+
+	for _, tc := range []struct {
+		name           string
+		newer          func(t *testing.T) credential.AcceptedSet
+		expectedAnchor config.SDKKey
+	}{
+		{
+			name:           "rotates to a different key",
+			newer:          func(t *testing.T) credential.AcceptedSet { return anchorOnlySet(t, thirdKey) },
+			expectedAnchor: thirdKey,
+		},
+		{
+			name:           "cancels the rotation",
+			newer:          func(t *testing.T) credential.AcceptedSet { return anchorOnlySet(t, envConfig.SDKKey) },
+			expectedAnchor: envConfig.SDKKey,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			envImpl, factory, _ := newRetryTestEnv(t, reanchorRetryTestKey2)
+			defer envImpl.Close()
+
+			now := time.Unix(2000, 0)
+			envImpl.reconcileCredentials(rotationSet(t, reanchorRetryTestKey2, envConfig.SDKKey, now), now)
+			require.True(t, envImpl.hasPendingReanchor())
+
+			envImpl.reconcileCredentials(tc.newer(t), now)
+			require.Equal(t, tc.expectedAnchor, envImpl.keyRotator.AnchorKey())
+			assert.False(t, envImpl.hasPendingReanchor(), "the newer payload disarms the retry")
+
+			attemptsBefore := factory.attemptsFor(reanchorRetryTestKey2)
+			envImpl.triggerCredentialChanges(now.Add(time.Minute))
+			assert.Equal(t, attemptsBefore, factory.attemptsFor(reanchorRetryTestKey2),
+				"the ticker must not keep rebuilding the abandoned anchor")
+			assert.Equal(t, tc.expectedAnchor, envImpl.keyRotator.AnchorKey())
+		})
+	}
+}
+
+// TestReanchorRetry_ClosedEnvDoesNotArmRetry covers a re-anchor that rolls back because the environment
+// was torn down mid-build. The cleanup ticker has already stopped, so arming a retry would only log a
+// promise that can never be kept.
+func TestReanchorRetry_ClosedEnvDoesNotArmRetry(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	envImpl, _, _ := newRetryTestEnv(t, reanchorRetryTestKey2)
+
+	now := time.Unix(2000, 0)
+	require.NoError(t, envImpl.Close())
+
+	envImpl.reconcileCredentials(rotationSet(t, reanchorRetryTestKey2, envConfig.SDKKey, now), now)
+
+	assert.False(t, envImpl.hasPendingReanchor(),
+		"a closed environment must not arm a retry the stopped ticker can never run")
+}


### PR DESCRIPTION
## Summary

When LaunchDarkly rotates an environment's SDK key, Relay builds a new SDK client for the new key. If that build fails, Relay rolls back and keeps serving on the old key — but nothing ever retried, so the environment stayed on a key LaunchDarkly was about to turn off. Once that happened, the SDK stream took a terminal 401 and the environment served stale flags until the process restarted.

This makes the existing credential cleanup ticker retry the rotation until it succeeds.

---

The first commit is a small related fix: a rollback dropped the old key's display name, so `/status` showed the still-serving key without a name.

Two choices worth a reviewer's attention:
- The retry is uncapped on purpose. Giving up would put the environment back in the state this fixes, so each failed attempt is logged as an error instead.
- `Close()` can now block for up to `Main.InitTimeout`, because a retry can be mid-build when it runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes a case where a **failed re-anchor during SDK key rotation** left the environment permanently on the outgoing anchor. LaunchDarkly deduplicates the same AutoConfig payload, so nothing re-triggered the rotation after rollback.
> 
> The **credential cleanup ticker** (`expiredCredentialCleanupInterval`) now **replays the rolled-back credential set** until the new anchor client builds and commits. A `pendingReanchor` pointer arms that retry; each reconcile clears or supersedes it, and a closed environment does not arm retries.
> 
> Credential reconcile logic is split so the ticker can call **`applyCredentialSet`** on the same path as a normal reconcile (add → re-anchor → remove), keeping retries idempotent and honoring original grace expiries.
> 
> A small related change: on rollback, **`RevertAnchorChange`** restores the previous anchor’s wire **key identifier** (via `PreviousAnchorName`) so **`/status`** still names the key that is serving.
> 
> Configuration docs note that the cleanup interval also drives rotation retries when the new SDK key fails to connect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b88e91560ce4cdd6d957f6d271aee6687b18e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->