### PR TITLE
docs: Simplify comments per ASD-STE100

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,15 +38,13 @@ const (
 	// DefaultEventCapacity is the default value for EventsConfig.Capacity if not specified.
 	DefaultEventCapacity = 1000
 
-	// DefaultMetricsCapacity is the default value for EventsConfig.MetricsCapacity if not specified.
-	// This is the maximum queue capacity for the usage-metrics event publisher, which emits one event
-	// per concurrent unique connection on each flush. It is set well above DefaultEventCapacity because
-	// high-concurrency nodes routinely exceed 1000 unique connections.
+	// DefaultMetricsCapacity is the default for EventsConfig.MetricsCapacity: the maximum queue size
+	// for the usage-metrics publisher, which emits one event per unique connection on each flush.
+	// It exceeds DefaultEventCapacity because high-concurrency nodes exceed 1000 connections.
 	DefaultMetricsCapacity = 10000
 
 	// DefaultMetricsInitialCapacity is the number of events the usage-metrics publisher queue
-	// preallocates space for. The queue grows on demand from this size up to MetricsCapacity, so that
-	// the higher maximum does not reserve all of its memory up front on nodes that never reach it.
+	// preallocates space for. The queue grows on demand from this size up to MetricsCapacity.
 	DefaultMetricsInitialCapacity = 1000
 
 	// DefaultHeartbeatInterval is the default value for MainConfig.HeartBeatInterval if not specified.
@@ -107,9 +105,7 @@ const (
 	// It likely doesn't make sense to use an interval this frequent in production use-cases.
 	minimumCredentialCleanupInterval = 100 * time.Millisecond
 	// minimumMetricsCapacity is the smallest value accepted for EventsConfig.MetricsCapacity. Usage
-	// metrics are how LaunchDarkly reports on account usage, so we do not allow the maximum queue
-	// capacity to be shrunk below the historical default of 1000; smaller configured values are
-	// clamped up to this floor.
+	// metrics report account usage, so the floor is the historical default of 1000.
 	minimumMetricsCapacity = 1000
 )
 

--- a/config/config_validation.go
+++ b/config/config_validation.go
@@ -249,8 +249,7 @@ func validateMaxClientRequestBodySize(result *ct.ValidationResult, c *Config) {
 }
 
 // validateMetricsCapacity enforces the minimum queue capacity for the usage-metrics event publisher.
-// Rather than fail startup on a too-small value, it clamps the value up to the minimum and warns, so
-// that a misconfiguration never prevents Relay from running while still protecting usage telemetry.
+// Rather than fail startup on a too-small value, it clamps the value up to the minimum and warns.
 func validateMetricsCapacity(c *Config, loggers ldlog.Loggers) {
 	if !c.Events.MetricsCapacity.IsDefined() {
 		return

--- a/internal/api/status_reps.go
+++ b/internal/api/status_reps.go
@@ -16,13 +16,11 @@ type StatusRep struct {
 }
 
 // KeyStatus is the JSON representation of one accepted SDK or mobile key in the status endpoint's
-// sdkKeys[] / mobileKeys[] arrays.
+// sdkKeys[] and mobileKeys[] arrays.
 //
-// Key is the non-secret human-readable identifier from the wire format (the "key" field of a
-// sdkKeys/mobileKeys entry); it is omitted when the source carried no identifier (manual config, or
-// an old-format payload predating concurrent keys). Value is the obscured credential secret (via
-// sdks.ObscureKey). Expiry carries the Unix-millisecond expiry timestamp when the key is being phased
-// out; it is omitted for permanent keys.
+// Key is the non-secret wire identifier, omitted when the source carried none. Value is the credential
+// secret, obscured by sdks.ObscureKey. Expiry is the expiry timestamp in Unix milliseconds, omitted
+// for permanent keys.
 type KeyStatus struct {
 	Key    string `json:"key,omitempty"`
 	Value  string `json:"value"`
@@ -33,12 +31,10 @@ type KeyStatus struct {
 //
 // This is exported for use in integration test code.
 type EnvironmentStatusRep struct {
-	// SDKKey is the obscured anchor SDK key — the key relay uses for its upstream connection. It
-	// designates which SDKKeys entry is the anchor.
+	// SDKKey is the obscured anchor SDK key. It designates which SDKKeys entry is the anchor.
 	SDKKey string `json:"sdkKey"`
-	// SDKKeys carries the full accepted set of server-side SDK keys — including the anchor — with their
-	// identifiers, obscured values, and optional expiry. Always present; always contains at least the
-	// anchor.
+	// SDKKeys carries the full accepted set of server-side SDK keys, including the anchor. It is always
+	// present and always contains at least the anchor.
 	SDKKeys  []KeyStatus `json:"sdkKeys"`
 	EnvID    string      `json:"envId,omitempty"`
 	EnvKey   string      `json:"envKey,omitempty"`
@@ -47,8 +43,8 @@ type EnvironmentStatusRep struct {
 	ProjName string      `json:"projName,omitempty"`
 	// MobileKey is the obscured primary mobile key. It designates which MobileKeys entry is the primary.
 	MobileKey string `json:"mobileKey,omitempty"`
-	// MobileKeys carries the full accepted set of mobile keys — including the primary. Always present;
-	// empty for an environment with no mobile keys (e.g. server-side only).
+	// MobileKeys carries the full accepted set of mobile keys, including the primary. It is always
+	// present, and empty for an environment with no mobile keys.
 	MobileKeys       []KeyStatus          `json:"mobileKeys"`
 	ExpiringSDKKey   string               `json:"expiringSdkKey,omitempty"`
 	Status           string               `json:"status"`

--- a/internal/autoconfig/stream_manager.go
+++ b/internal/autoconfig/stream_manager.go
@@ -381,7 +381,7 @@ func (s *StreamManager) handleStreamEvent(event es.Event) bool {
 			s.loggers.Infof(logMsgWrongPath, PutEvent, putMessage.Path)
 			break
 		}
-		// The stream has authoritative data — cancel any in-flight cache read.
+		// The stream has authoritative data, so cancel any in-flight cache read.
 		if s.cacheCancel != nil {
 			s.cacheCancel()
 			s.cacheCancel = nil
@@ -481,7 +481,6 @@ func (s *StreamManager) handleStreamEvent(event es.Event) bool {
 	return shouldRestart
 }
 
-// dispatchEnvAction dispatches a single environment action to the handler.
 func (s *StreamManager) dispatchEnvAction(id config.EnvironmentID, rep envfactory.EnvironmentRep, action Action) {
 	switch action {
 	case ActionNoop:
@@ -498,9 +497,9 @@ func (s *StreamManager) dispatchEnvAction(id config.EnvironmentID, rep envfactor
 }
 
 // validateCredentialPayload checks that an environment rep carries a structurally valid credential
-// set. It runs at the stream parse boundary, before the rep's version is recorded via Upsert: a
-// malformed payload must not advance the version, or the backend's fresh put — which carries the same
-// version — would be deduplicated away by the MessageReceiver.
+// set. It runs at the stream parse boundary, before Upsert records the rep's version. A malformed
+// payload must not advance the version: the backend's fresh put carries the same version, and the
+// MessageReceiver would deduplicate it away.
 func (s *StreamManager) validateCredentialPayload(rep envfactory.EnvironmentRep) error {
 	_, _, err := envfactory.BuildAcceptedSet(rep.ToParams())
 	return err
@@ -529,8 +528,8 @@ func (s *StreamManager) applyCachedContent(content *PutContent) {
 // All of the private methods below can be assumed to be called from the same goroutine that consumeStream
 // is on. We will never be processing more than one stream message at the same time.
 //
-// handlePut returns true if the stream should be restarted — a malformed credential payload in any of
-// the environments triggers a reconnect, while still processing the well-formed ones.
+// handlePut returns true if the stream should be restarted. A malformed credential payload in any
+// environment triggers a reconnect, and the well-formed environments are still processed.
 func (s *StreamManager) handlePut(content PutContent) bool {
 	// A "put" message represents a full environment set. We will compare them one at a time to the
 	// current set of environments (if any), calling the handler's AddEnvironment for any new ones,
@@ -544,8 +543,7 @@ func (s *StreamManager) handlePut(content PutContent) bool {
 			s.loggers.Warnf(logMsgEnvHasWrongID, rep.EnvID, id)
 			continue
 		}
-		// Validate before Upsert so a malformed payload does not advance the version (see
-		// validateCredentialPayload). Skip this env, preserving its previous state, and reconnect.
+		// See handleStreamEvent: validate before Upsert. Skip this env and reconnect.
 		if err := s.validateCredentialPayload(rep); err != nil {
 			s.loggers.Errorf("Received malformed credential payload for environment %q (%s); preserving previous credentials and will restart stream", rep.EnvID, err)
 			shouldRestart = true
@@ -582,19 +580,14 @@ func (s *StreamManager) handlePut(content PutContent) bool {
 	return shouldRestart
 }
 
-// persistPut writes a put's content to the cache. A clean put is stored atomically with SetAll. When
-// the put carried malformed environments, a plain SetAll would corrupt the cache: filtering the
-// malformed envs out would drop them, and if every env was malformed it would wipe the cache entirely.
-// Instead we keep each malformed env's previously-cached entry and write the resulting snapshot — so
-// the valid envs and the filters in this put are persisted, the malformed envs keep their last-good
-// value (or are simply omitted when the cache has no prior entry for them), and envs the put removed
-// are still dropped. The reconnect a malformed put triggers fetches fresh data for the malformed envs.
-// If the prior cache genuinely can't be read, leave it untouched rather than risk dropping entries.
+// persistPut writes a put's content to the cache with SetAll. When the put carried malformed
+// environments, persistPut first substitutes each malformed env's previously-cached entry, because a
+// plain SetAll would drop those envs, or wipe the cache if every env was malformed. Envs the put
+// removed are still dropped. If the prior cache cannot be read, persistPut leaves it untouched.
 func (s *StreamManager) persistPut(content PutContent, malformedEnvIDs map[config.EnvironmentID]bool) {
 	if len(malformedEnvIDs) > 0 {
-		// A nil result with no error means an empty cache (per the Cache contract), not a failure —
-		// in that case there are simply no prior entries to restore. Only a real read error makes it
-		// unsafe to rewrite the snapshot, so bail out only then.
+		// A nil result with no error means an empty cache, not a failure, so there are no prior entries
+		// to restore. Only a read error makes it unsafe to rewrite the snapshot.
 		prev, err := s.cache.GetAll(context.Background())
 		if err != nil {
 			s.loggers.Warnf("Skipping AutoConfig cache write for a put with malformed credentials (cannot read prior cache): %v", err)

--- a/internal/credential/accepted_set.go
+++ b/internal/credential/accepted_set.go
@@ -6,28 +6,19 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/config"
 )
 
-// AcceptedSet is the full set of credentials that an environment should accept after a reconcile.
-// It carries every accepted server-side SDK key and mobile key — each with an optional per-key
-// expiry — plus the single environment ID and two primary designations:
+// AcceptedSet is the full set of credentials an environment accepts after a reconcile: every
+// server-side SDK key and mobile key with an optional expiry, the environment ID, and two
+// designations.
 //
-//   - The anchor: the one SDK key that owns the environment's upstream connection. Set with
-//     WithAnchor.
-//   - The primary mobile key: the singular default mobile key (the wire's mobKey), used where one
-//     mobile key is required, e.g. event forwarding. Set with WithPrimaryMobileKey.
+//   - The anchor is the one SDK key that owns the environment's upstream connection.
+//   - The primary mobile key is the default used where one mobile key is required, such as event
+//     forwarding.
 //
-// WithAnchor / WithPrimaryMobileKey both add the key to the set and designate it, so adding a
-// single key takes one call. Build requires that an anchor was designated. (Structural validation of
-// the wire payload — undefined credentials, a designated key absent from its array — happens upstream
-// when the payload is parsed into the set.)
-//
-// A key's expiry is taken from its entry in this set; the legacy sdkKey.expiring{} wire slot is not
-// consulted when building it.
-//
-// Construct an AcceptedSet with AcceptedSetBuilder (see accepted_set_builder.go).
+// Construct an AcceptedSet with AcceptedSetBuilder. Structural validation of the wire payload happens
+// upstream, in BuildAcceptedSet.
 type AcceptedSet struct {
-	// sdkKeys and mobileKeys store each accepted key once, keyed by value (the secret), so duplicates
-	// collapse without a containment scan. The map value carries the key's metadata (see
-	// AcceptedKey). A nil map is a valid empty set (reads return absent; only the builder writes).
+	// sdkKeys and mobileKeys store each accepted key once, keyed by value, so duplicates collapse. A
+	// nil map is a valid empty set, and only the builder writes.
 	sdkKeys          map[config.SDKKey]AcceptedKey
 	anchor           config.SDKKey
 	mobileKeys       map[config.MobileKey]AcceptedKey
@@ -48,27 +39,11 @@ func (s AcceptedSet) hasMobileKey(key config.MobileKey) bool {
 }
 
 // MalformedCredentialSetError is returned when a credential payload cannot produce a valid
-// AcceptedSet. This covers:
+// AcceptedSet. Each constructor below documents one cause.
 //
-//  1. The anchor SDK key (sdkKey.value) is absent or undefined, or defined but not present in
-//     sdkKeys[] — a violation of the invariant that the designated anchor is one of the accepted keys.
-//  2. The primary mobile key (mobKey) is defined but not present in mobileKeys[] — the mobile-key
-//     analogue of the anchor invariant.
-//  3. mobileKeys[] is non-empty but no primary mobile key (mobKey) is designated — accepting it would
-//     clear the environment's primary mobile key on reconcile with no repoint, so event forwarding
-//     would keep using the previous (possibly revoked) primary. (No mobile keys at all is valid.)
-//  4. An entry in sdkKeys[] or mobileKeys[] has an empty value — a credential that would be
-//     accepted by relay but can never authenticate any SDK.
-//  5. No SDK key survived at all, so the environment would have nothing to authenticate with. A
-//     payload reaches this by combining an undefined anchor with an sdkKeys[] array that is either
-//     empty or entirely made up of keys relay excludes, such as keys scoped to a view.
-//
-// Validation happens before Reconcile is called; Rotator.Reconcile trusts the set it is handed.
-// Because the error is raised before any state mutation, the environment's previous accepted set is
-// preserved automatically. The caller is responsible for the second half of the malformed-payload
-// policy: reconnecting the RAC stream with jitter to force a fresh put. RAC is one-way push with no
-// NAK channel, so without the reconnect the backend would believe the malformed patch was applied
-// and would not send fresh state.
+// Validation runs before Reconcile, so the environment keeps its previous accepted set. The caller
+// must also reconnect the RAC stream with jitter: RAC is one-way push with no NAK channel, so
+// without a reconnect the backend assumes the patch was applied and sends nothing new.
 type MalformedCredentialSetError struct {
 	// msg is the human-readable description set by the constructor.
 	msg string
@@ -83,40 +58,32 @@ func newMissingAnchorError() *MalformedCredentialSetError {
 	return &MalformedCredentialSetError{msg: "malformed credential set: anchor SDK key is missing"}
 }
 
-// newNoSDKKeysError returns a MalformedCredentialSetError for a set that ended up with no SDK key at
-// all. The message describes the payload rather than the builder, because that is what an operator
-// reading the log can act on.
+// newNoSDKKeysError returns a MalformedCredentialSetError for a set with no usable SDK key.
 func newNoSDKKeysError() *MalformedCredentialSetError {
 	return &MalformedCredentialSetError{msg: "malformed credential set: no usable SDK key in sdkKeys[]"}
 }
 
-// NewAnchorNotInSetError returns a MalformedCredentialSetError for a payload whose designated anchor
-// (sdkKey.value) is defined but not present in the sdkKeys[] array — a structural inconsistency. The
-// anchor value is a secret, so it is deliberately not included in the message.
+// NewAnchorNotInSetError reports a payload whose designated anchor (sdkKey.value) is defined but
+// absent from sdkKeys[]. Credential values are secrets, so no message here includes one.
 func NewAnchorNotInSetError() *MalformedCredentialSetError {
 	return &MalformedCredentialSetError{msg: "malformed credential set: anchor SDK key is not present in sdkKeys[]"}
 }
 
-// NewPrimaryMobileKeyNotInSetError returns a MalformedCredentialSetError for a payload whose
-// designated primary mobile key (mobKey) is defined but not present in the mobileKeys[] array — the
-// mobile-key analogue of NewAnchorNotInSetError. The key value is a secret, so it is deliberately not
-// included in the message.
+// NewPrimaryMobileKeyNotInSetError reports a payload whose designated primary mobile key (mobKey) is
+// defined but absent from mobileKeys[].
 func NewPrimaryMobileKeyNotInSetError() *MalformedCredentialSetError {
 	return &MalformedCredentialSetError{msg: "malformed credential set: primary mobile key is not present in mobileKeys[]"}
 }
 
-// NewPrimaryMobileKeyMissingError returns a MalformedCredentialSetError for a payload that carries a
-// non-empty mobileKeys[] array but leaves the primary mobile key (mobKey) undefined — no default is
-// designated. Accepting it would clear the environment's primary mobile key on reconcile with no
-// repoint, so event forwarding would keep using the previous (possibly revoked) primary. There are no
-// secrets to omit from the message.
+// NewPrimaryMobileKeyMissingError reports a payload with a non-empty mobileKeys[] and no designated
+// primary. Accepting it would clear the primary without a repoint, leaving event forwarding on the
+// previous key.
 func NewPrimaryMobileKeyMissingError() *MalformedCredentialSetError {
 	return &MalformedCredentialSetError{msg: "malformed credential set: mobileKeys[] is non-empty but no primary mobile key is designated"}
 }
 
-// NewEmptyCredentialError returns a MalformedCredentialSetError for a key-array entry whose
-// value field is empty. kind is "sdkKeys" or "mobileKeys"; key is the entry's wire "key" identifier
-// (may be empty for old-format payloads that synthesize from the singular fields).
+// NewEmptyCredentialError reports a key-array entry whose value field is empty. kind is "sdkKeys" or
+// "mobileKeys"; key is the entry's wire identifier, which old-format payloads leave empty.
 func NewEmptyCredentialError(kind, key string) *MalformedCredentialSetError {
 	if key == "" {
 		return &MalformedCredentialSetError{

--- a/internal/credential/accepted_set_builder.go
+++ b/internal/credential/accepted_set_builder.go
@@ -47,10 +47,9 @@ func (b *AcceptedSetBuilder) WithSDKKey(p SDKKeyParams) *AcceptedSetBuilder {
 	return b
 }
 
-// WithAnchor adds p.Value and designates it as the anchor — the SDK key that owns the environment's
-// upstream connection. The anchor is always permanent, so p.Expiry is ignored. It is a no-op if the
-// value is undefined. Unlike WithSDKKey it overwrites any existing entry for the value, since
-// designating the anchor takes precedence over an earlier non-anchor add.
+// WithAnchor adds p.Value and designates it as the anchor. The anchor is always permanent, so
+// p.Expiry is ignored. It is a no-op if the value is undefined. Unlike WithSDKKey, it overwrites an
+// existing entry for the value.
 func (b *AcceptedSetBuilder) WithAnchor(p SDKKeyParams) *AcceptedSetBuilder {
 	if !p.Value.Defined() {
 		return b
@@ -69,9 +68,8 @@ func (b *AcceptedSetBuilder) WithMobileKey(p MobileKeyParams) *AcceptedSetBuilde
 	return b
 }
 
-// WithPrimaryMobileKey adds p.Value and designates it as the primary mobile key — the singular
-// default (the wire's mobKey) used where one mobile key is required, e.g. event forwarding. The
-// primary is always permanent, so p.Expiry is ignored. It is a no-op if the value is undefined.
+// WithPrimaryMobileKey adds p.Value and designates it as the primary mobile key. The primary is
+// always permanent, so p.Expiry is ignored. It is a no-op if the value is undefined.
 func (b *AcceptedSetBuilder) WithPrimaryMobileKey(p MobileKeyParams) *AcceptedSetBuilder {
 	if !p.Value.Defined() {
 		return b
@@ -89,10 +87,8 @@ func (b *AcceptedSetBuilder) WithEnvironmentID(id config.EnvironmentID) *Accepte
 	return b
 }
 
-// Build validates and returns the accumulated AcceptedSet. It returns a
-// *MalformedCredentialSetError if no SDK key was added, or if no anchor was designated (via
-// WithAnchor). Because WithAnchor also adds the key, a designated anchor is always among the
-// accepted SDK keys.
+// Build validates and returns the accumulated AcceptedSet. It returns a *MalformedCredentialSetError
+// if no SDK key was added, or if no anchor was designated.
 func (b *AcceptedSetBuilder) Build() (AcceptedSet, error) {
 	if len(b.set.sdkKeys) == 0 {
 		return AcceptedSet{}, newNoSDKKeysError()

--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -10,24 +10,19 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/config"
 )
 
-// AcceptedKey is the metadata for one accepted credential: its optional expiry and optional wire
-// "key" identifier. The credential value itself is the map key wherever AcceptedKey is stored — the
-// rotator's accepted-key maps, the builder's AcceptedSet, and the AcceptedKeySet returned by
-// AcceptedKeys.
+// AcceptedKey is the metadata for one accepted credential: its optional expiry and its optional wire
+// identifier. The credential value itself is the map key wherever AcceptedKey is stored.
 type AcceptedKey struct {
 	// Expiry is the key's expiry. A nil expiry means the key is permanent.
 	Expiry *time.Time
-	// Key is the non-secret wire "key" identifier — a human-readable name. Nil when the source carried
-	// none (manual configuration, or an old-format payload predating concurrent keys).
+	// Key is the non-secret wire identifier, a human-readable name. Nil when the source carried none
+	// (manual configuration, or an old-format payload predating concurrent keys).
 	Key *string
 }
 
-// AcceptedKeySet is a point-in-time snapshot of an environment's full accepted credential set,
-// returned by Rotator.AcceptedKeys. Server and Mobile are keyed by credential value (the secret);
-// the value AcceptedKey carries that key's metadata. Anchor and PrimaryMobile name the designated
-// keys within Server and Mobile. The status endpoint maps Server/Mobile to the sdkKeys[]/mobileKeys[]
-// arrays and uses Anchor to mark the anchor entry. Reads of the maps and the designations are taken
-// under a single lock, so they are mutually consistent.
+// AcceptedKeySet is a point-in-time snapshot of an environment's full accepted set, returned by
+// Rotator.AcceptedKeys. Server and Mobile are keyed by credential value; Anchor and PrimaryMobile
+// name the designated keys within them. Reads are taken under one lock, so the fields agree.
 type AcceptedKeySet struct {
 	Server        map[config.SDKKey]AcceptedKey
 	Mobile        map[config.MobileKey]AcceptedKey
@@ -53,7 +48,6 @@ type Rotator struct {
 	acceptedSDKKeys map[config.SDKKey]AcceptedKey
 
 	// acceptedMobileKeys is the full set of accepted mobile keys with optional per-key expiry.
-	// A nil expiry means the key is permanent.
 	acceptedMobileKeys map[config.MobileKey]AcceptedKey
 
 	expirations []SDKCredential
@@ -103,7 +97,7 @@ func (r *Rotator) MobileKey() config.MobileKey {
 	return r.primaryMobileKey
 }
 
-// AnchorKey returns the anchor SDK key — the key that owns the upstream connection.
+// AnchorKey returns the anchor SDK key, which owns the upstream connection.
 func (r *Rotator) AnchorKey() config.SDKKey {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -133,12 +127,8 @@ func (r *Rotator) allCredentials() []SDKCredential {
 	return creds
 }
 
-// DeprecatedCredentials returns the SDK keys being phased out — every accepted SDK key, other than the
-// anchor, that carries a future expiry. (Per-key expiry is stored as data on the accepted entry; the
-// cleanup ticker drops the key once it elapses.)
-//
-// Mobile keys are deliberately not returned even though they expire the same way SDK keys do — carried
-// as per-key expiry and dropped by the same cleanup ticker.
+// DeprecatedCredentials returns every accepted SDK key, other than the anchor, that carries an
+// expiry. It does not return mobile keys, which expire the same way.
 func (r *Rotator) DeprecatedCredentials() []SDKCredential {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -152,9 +142,7 @@ func (r *Rotator) DeprecatedCredentials() []SDKCredential {
 	return out
 }
 
-// AllCredentials returns every accepted credential: every accepted SDK key, every accepted mobile
-// key (including those carrying a future expiry — they still authenticate until the cleanup ticker
-// drops them), and the environment ID.
+// AllCredentials returns every accepted credential: SDK keys, mobile keys, and the environment ID.
 func (r *Rotator) AllCredentials() []SDKCredential {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -167,22 +155,17 @@ func (r *Rotator) expireSDKKey(sdkKey config.SDKKey) {
 	r.expirations = append(r.expirations, sdkKey)
 }
 
-// expireMobileKey drops a mobile key from the accepted set and queues its expiration.
-// Deleting from acceptedMobileKeys is load-bearing: AllCredentials derives from that map,
-// so an expired key would otherwise linger as an accepted credential. Mirrors expireSDKKey.
+// expireMobileKey drops a mobile key from the accepted set and queues its expiration. Deleting from
+// acceptedMobileKeys is load-bearing: AllCredentials derives from that map.
 func (r *Rotator) expireMobileKey(mobileKey config.MobileKey) {
 	r.loggers.Infof("Deprecated mobile key %s has expired and is no longer valid for authentication", mobileKey.Masked())
 	delete(r.acceptedMobileKeys, mobileKey)
 	r.expirations = append(r.expirations, mobileKey)
 }
 
-// StepTime provides the current time to the Rotator, allowing it to compute the set of additions and
-// expirations for the tracked credentials since the last time this method was called.
-//
-// It enforces per-key expiry for both SDK and mobile keys: expiry is stored as data on the accepted
-// entry (AcceptedKey.Expiry); a nil expiry means the key is permanent and is never expired here.
-//
-// Expiry happens strictly after a key's expiry timestamp.
+// StepTime provides the current time to the Rotator, so it can compute the additions and expirations
+// for the tracked credentials since the last call. It enforces per-key expiry for SDK and mobile keys,
+// strictly after a key's expiry timestamp.
 func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expirations []SDKCredential) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -209,21 +192,15 @@ func (r *Rotator) StepTime(now time.Time) (additions []SDKCredential, expiration
 	return additions, expirations
 }
 
-// ReconcileResult signals state changes that the caller must apply synchronously rather than rely
-// on the normal addCredential / removeCredential flow driven by StepTime.
+// ReconcileResult signals state changes the caller must apply itself, rather than through the
+// StepTime-driven addCredential and removeCredential flow.
 //
-// AnchorChange is non-nil when the SDK anchor changed during Reconcile. The rotator does NOT flip
-// its anchor pointer in that case — the caller must drive the synchronous re-anchor sequence
-// (build the new anchor's SDK client if one does not exist, wait for Initialized, then invoke
-// CommitAnchor to atomically move the pointer, then call ReplaceCredential on the event dispatcher
-// and metrics publisher, then re-wire big-segment sync).
+// AnchorChange is non-nil when the SDK anchor changed. The caller drives the re-anchor sequence; see
+// envContextImpl.reanchor.
 //
-// MobilePrimaryRepoint is non-nil when the primary mobile key changed AND the new primary was
-// already in the accepted set. In that case it does not appear in StepTime's additions list and
-// addCredential's primary-mobile gate will not fire for it, so the caller must invoke
-// eventDispatcher.ReplaceCredential synchronously. When nil, either the primary mobile key did not
-// change, or it changed to a newly-accepted key — in which case the normal addCredential path
-// handles the ReplaceCredential call via the existing gate.
+// MobilePrimaryRepoint is non-nil when the primary mobile key changed to a key already accepted. Such
+// a key is not in additions, so addCredential does not repoint the event dispatcher for it and the
+// caller must do so.
 type ReconcileResult struct {
 	AnchorChange         *AnchorChange
 	MobilePrimaryRepoint *config.MobileKey
@@ -231,37 +208,25 @@ type ReconcileResult struct {
 
 // AnchorChange describes an SDK anchor transition produced by Reconcile.
 //
-// NewAnchorPreviouslyAccepted distinguishes the two re-anchor paths:
-//   - false (the anchor is a new key): the new anchor was not previously in the accepted set. The
-//     synchronous re-anchor must register the credential mappings (envStreams, handlers, connection
-//     mapping), construct and initialize a new SDK client, then invoke CommitAnchor + ReplaceCredential.
-//   - true (the anchor is a previously-accepted key): the new anchor was already accepted (typically
-//     a former anchor still in its grace period). Its credential mappings are already registered and a
-//     client may already exist; the synchronous re-anchor reuses it (or constructs one only if missing
-//     — see the re-anchor sequence in env_context_impl.go), then invokes CommitAnchor + ReplaceCredential.
+// NewAnchorPreviouslyAccepted is false when the new anchor is a brand-new key, so the re-anchor must
+// register that key's credential mappings. It is true when the key was already accepted, so the
+// mappings already exist and a client may too. See envContextImpl.reanchor.
 type AnchorChange struct {
 	PreviousAnchor              config.SDKKey
 	NewAnchor                   config.SDKKey
 	NewAnchorPreviouslyAccepted bool
 }
 
-// Reconcile updates the rotator to match set. The set names its own anchor (the primary SDK key) and
-// primary mobile key. It diffs the desired accepted set against the current one and queues additions
-// and expirations (drained by the next StepTime call); keys newly present are accepted, and keys no
-// longer present are revoked. Per-key expiry is stored as data on the accepted entry; the cleanup
-// ticker (StepTime) is what later acts on it, dropping a key once its expiry passes. An undefined
-// environment ID leaves the current one unchanged, since environments are removed via teardown
-// rather than reconcile.
+// Reconcile updates the rotator to match set. It queues additions and expirations, which the next
+// StepTime call drains. Keys newly present are accepted; keys no longer present are revoked. An
+// undefined environment ID leaves the current one unchanged. Per-key expiry is stored on the accepted
+// entry, and StepTime acts on it.
 //
-// The set is assumed well-formed: AcceptedSetBuilder.Build validates that an anchor was designated
-// (and, because WithAnchor adds the key as it designates it, that the anchor is among the SDK
-// keys), so Reconcile trusts what it is handed rather than re-validating.
+// set is assumed well-formed: AcceptedSetBuilder.Build already guaranteed a designated anchor.
 //
-// Reconcile does NOT flip the SDK anchor pointer when the anchor changes — the returned
-// ReconcileResult.AnchorChange signals the change so the caller can drive the synchronous re-anchor
-// sequence, then call CommitAnchor to atomically move the pointer. When the new anchor is a new key
-// (NewAnchorPreviouslyAccepted == false) it is also stripped from additions so that the async
-// startSDKClient invocation in addCredential does not race the synchronous client build.
+// Reconcile does NOT flip the anchor pointer. The returned AnchorChange signals the change; the
+// caller drives the re-anchor and then calls CommitAnchor. A brand-new anchor is also stripped from
+// additions, because reanchor registers that key's mappings itself.
 func (r *Rotator) Reconcile(set AcceptedSet, now time.Time) ReconcileResult {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -282,12 +247,8 @@ func (r *Rotator) Reconcile(set AcceptedSet, now time.Time) ReconcileResult {
 	r.reconcileSDKKeys(set, now)
 
 	if result.AnchorChange != nil && !result.AnchorChange.NewAnchorPreviouslyAccepted {
-		// The anchor is a new key: reconcileAcceptedKeys just appended it to r.additions. Strip it —
-		// the synchronous re-anchor sequence in env_context_impl owns the new anchor's setup
-		// (credential mappings + client build + flip + ReplaceCredential). If addCredential drained this
-		// addition normally, its async startSDKClient would race the synchronous build. When the anchor
-		// is a previously-accepted key it was already in acceptedSDKKeys, so reconcileAcceptedKeys did
-		// not add it — no strip needed.
+		// The anchor is a new key, so reconcileAcceptedKeys appended it to r.additions. Strip it:
+		// reanchor registers this key's mappings, so draining the addition would register them twice.
 		r.additions = slices.DeleteFunc(r.additions, func(c SDKCredential) bool { return c == newAnchor })
 	}
 
@@ -299,8 +260,7 @@ func (r *Rotator) Reconcile(set AcceptedSet, now time.Time) ReconcileResult {
 	}
 	r.reconcileMobileKeys(set, now)
 	if previousMobile != newMobile && newMobile.Defined() && newMobileAlreadyAccepted {
-		// Primary mobile key changed to a key already in the accepted set: addCredential's gate will
-		// not fire for it (it's not in additions), so the caller must call ReplaceCredential itself.
+		// The new primary is not in additions, so addCredential's gate will not fire for it.
 		m := newMobile
 		result.MobilePrimaryRepoint = &m
 	}
@@ -310,39 +270,28 @@ func (r *Rotator) Reconcile(set AcceptedSet, now time.Time) ReconcileResult {
 	return result
 }
 
-// CommitAnchor atomically moves the rotator's SDK anchor pointer to the given key. The caller
-// invokes this once the synchronous re-anchor sequence is ready to flip — i.e. after the new
-// anchor's client is built and reports Initialized (when the anchor is a new key) or after confirming
-// the existing client will be reused (when the anchor is a previously-accepted key). Until CommitAnchor
-// is called, the rotator's anchor stays on the previous key so GetClient() returns the still-serving
-// old client and the gate in addCredential does not fire for the pending new anchor.
-//
-// Aside from Initialize (which establishes the initial anchor), CommitAnchor is the only path that
-// moves the anchor pointer: Reconcile deliberately does not flip it (see reconcileSDKKeys).
+// CommitAnchor moves the rotator's SDK anchor pointer to key. The caller invokes it once the new
+// anchor's client is ready. Until then the anchor stays on the previous key, so GetClient() returns
+// the still-serving old client. Initialize and CommitAnchor are the only paths that move the pointer.
 func (r *Rotator) CommitAnchor(key config.SDKKey) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.anchorKey = key
 }
 
-// RevertAnchorChange undoes the accepted-set effects of an AnchorChange whose synchronous re-anchor
-// failed and rolled back. Because CommitAnchor was never called, the anchor pointer still names the
-// previous anchor; this realigns the accepted set with it so the two don't disagree.
+// RevertAnchorChange undoes the accepted-set effects of a failed re-anchor. CommitAnchor was never
+// called, so the anchor pointer still names the previous anchor. This method realigns the accepted set.
 //
-//   - If the previous anchor is a defined key that was revoked in the same reconcile (it is no longer
-//     accepted — an immediate revocation rather than a grace demotion), re-admit it as a permanent
-//     key, since it remains the anchor and keeps serving. If it is still accepted (grace demotion),
-//     leave it and its expiry untouched. An undefined previous anchor (the env's first SDK key) is
-//     never admitted.
-//   - Drop the failed new anchor, but only if it was brand new; a previously-accepted key that was
-//     promoted and failed stays accepted as the non-anchor key it already was.
+// If this reconcile revoked the previous anchor outright, RevertAnchorChange re-admits that key as a
+// permanent key with no expiry. The re-admission discards the key's previous expiry, because that key
+// is still the anchor and still serving. A previous anchor that is only grace-demoted stays accepted
+// and keeps its expiry. The new anchor is dropped only if that key was brand new.
 func (r *Rotator) RevertAnchorChange(change AnchorChange) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Only re-admit a defined previous anchor. When an env gains its first SDK key, the previous anchor
-	// is the empty (undefined) key — there is nothing to re-admit, and inserting "" would put an
-	// undefined credential into the accepted set (the rotator otherwise only holds defined keys).
+	// Only re-admit a defined previous anchor. The rotator holds defined keys only, and an env that
+	// gains its first SDK key has an undefined previous anchor.
 	if change.PreviousAnchor.Defined() {
 		if _, stillAccepted := r.acceptedSDKKeys[change.PreviousAnchor]; !stillAccepted {
 			r.acceptedSDKKeys[change.PreviousAnchor] = AcceptedKey{}
@@ -353,17 +302,16 @@ func (r *Rotator) RevertAnchorChange(change AnchorChange) {
 	}
 }
 
-// reconcilableKey constrains the generic reconcile helper to a comparable credential (so it can key a
-// map) that is also an SDKCredential (so it can be logged and appended to the credential lists).
+// reconcilableKey constrains the generic reconcile helper to a comparable SDKCredential, so the helper
+// can both key a map with it and log it.
 type reconcilableKey interface {
 	comparable
 	SDKCredential
 }
 
-// reconcileAcceptedKeys diffs the desired keys against the currently-accepted ones (SDK or mobile,
-// same algorithm): a desired key not yet accepted is recorded and queued as an addition; an accepted
-// key no longer desired is dropped and queued as an expiration. Per-key expiry is stored as data on
-// the accepted entry; the cleanup ticker is what later acts on it. The caller must hold the write lock.
+// reconcileAcceptedKeys diffs the desired keys against the currently-accepted ones, for SDK and
+// mobile keys alike: a desired key not yet accepted is queued as an addition; an accepted key no
+// longer desired is dropped and queued as an expiration. The caller must hold the write lock.
 func reconcileAcceptedKeys[K reconcilableKey](
 	desired map[K]AcceptedKey,
 	accepted map[K]AcceptedKey,
@@ -372,10 +320,8 @@ func reconcileAcceptedKeys[K reconcilableKey](
 	loggers ldlog.Loggers,
 	kind string,
 ) {
-	// First pass: walk every key the set wants us to accept. Writing the desired entry over the
-	// accepted one refreshes its metadata — both the expiry and the wire "key" identifier, clearing
-	// the identifier when the new payload carries none so a stale name never lingers in /status. A key
-	// we don't yet accept is also queued as an addition.
+	// Writing the desired entry over the accepted one refreshes the expiry and the wire identifier. It
+	// clears the identifier when the new payload carries none, so a stale name never lingers in /status.
 	for key, want := range desired {
 		if _, ok := accepted[key]; !ok {
 			*additions = append(*additions, key)
@@ -383,9 +329,7 @@ func reconcileAcceptedKeys[K reconcilableKey](
 		}
 		accepted[key] = want
 	}
-	// Second pass: walk every key we currently accept and drop the ones the set no longer wants.
-	// Keys still desired were handled above, so skip them; the rest are revoked outright (removed
-	// from the map) and queued as expirations.
+	// Drop every accepted key the set no longer wants. Those keys are revoked outright.
 	for key := range accepted {
 		if _, ok := desired[key]; ok {
 			continue
@@ -396,14 +340,8 @@ func reconcileAcceptedKeys[K reconcilableKey](
 	}
 }
 
-// reconcileSDKKeys diffs the desired SDK keys against the accepted set and applies the result via
-// reconcileAcceptedKeys. The set is trusted as well-formed: BuildAcceptedSet / the builder guarantee
-// the anchor is present and permanent (WithAnchor forces a nil expiry), so no special handling is
-// needed here. The caller must hold the write lock.
-//
-// NOTE: reconcileSDKKeys does NOT flip r.anchorKey when the anchor changes. The Reconcile caller
-// signals the anchor change via ReconcileResult.AnchorChange and invokes CommitAnchor to move the
-// pointer once the synchronous re-anchor sequence is ready (see Reconcile + CommitAnchor).
+// reconcileSDKKeys diffs the desired SDK keys against the accepted set via reconcileAcceptedKeys. The
+// anchor is present and permanent, per AcceptedSetBuilder. The caller must hold the write lock.
 func (r *Rotator) reconcileSDKKeys(set AcceptedSet, now time.Time) {
 	desired := make(map[config.SDKKey]AcceptedKey, len(set.sdkKeys))
 	for key, info := range set.sdkKeys {
@@ -415,10 +353,8 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, now time.Time) {
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
 }
 
-// reconcileMobileKeys mirrors reconcileSDKKeys for mobile keys. The set is trusted as well-formed:
-// when a primary mobile key is designated, the builder guarantees it is present and permanent
-// (WithPrimaryMobileKey forces a nil expiry). An empty primary means the set declared no mobile key.
-// The caller must hold the lock.
+// reconcileMobileKeys does for mobile keys what reconcileSDKKeys does for SDK keys. An empty primary
+// means the set declared no mobile key. The caller must hold the write lock.
 func (r *Rotator) reconcileMobileKeys(set AcceptedSet, now time.Time) {
 	desired := make(map[config.MobileKey]AcceptedKey, len(set.mobileKeys))
 	for key, info := range set.mobileKeys {
@@ -444,11 +380,7 @@ func (r *Rotator) reconcileEnvironmentID(set AcceptedSet) {
 	r.additions = append(r.additions, set.envID)
 }
 
-// AcceptedKeys returns a snapshot of the full accepted credential set — all server-side SDK keys and
-// all mobile keys (anchor and primary mobile key included) — grouped by kind, along with which keys
-// are the designated anchor and primary mobile. The maps and the designations are read under a single
-// lock so they are mutually consistent. The status endpoint maps each group to the sdkKeys[] /
-// mobileKeys[] arrays.
+// AcceptedKeys returns a snapshot of the full accepted set. See AcceptedKeySet.
 func (r *Rotator) AcceptedKeys() AcceptedKeySet {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/envfactory/env_params.go
+++ b/internal/envfactory/env_params.go
@@ -20,21 +20,19 @@ type EnvironmentParams struct {
 	// Identifiers contains the project and environment names and keys.
 	Identifiers relayenv.EnvIdentifiers
 
-	// SDKKey is the environment's SDK key; if there is more than one active key, it is the latest.
+	// SDKKey is the environment's anchor SDK key (the wire's sdkKey.value).
 	SDKKey config.SDKKey
 
 	// MobileKey is the environment's mobile key.
 	MobileKey config.MobileKey
 
-	// AcceptedSDKKeys is the full accepted set of SDK keys for this environment, including the
-	// anchor. Always non-nil after ToParams(): non-empty sdkKeys arrays populate directly; absent
-	// or empty sdkKeys are synthesized from the singular sdkKey field so there is always at least
-	// the anchor entry.
+	// AcceptedSDKKeys is the full accepted set of SDK keys, including the anchor. ToParams always
+	// leaves it non-nil, synthesizing from the singular sdkKey field when the payload has no
+	// sdkKeys array.
 	AcceptedSDKKeys []AcceptedSDKKey
 
-	// AcceptedMobileKeys is the full accepted set of mobile keys for this environment. Always
-	// non-nil after ToParams(): non-empty mobileKeys arrays populate directly; absent or empty
-	// mobileKeys are synthesized from the singular mobKey field.
+	// AcceptedMobileKeys is the full accepted set of mobile keys. ToParams always leaves it non-nil,
+	// synthesizing from the singular mobKey field when the payload has no mobileKeys array.
 	AcceptedMobileKeys []AcceptedMobileKey
 
 	// TTL is the cache TTL for PHP clients.

--- a/internal/envfactory/env_rep.go
+++ b/internal/envfactory/env_rep.go
@@ -14,42 +14,19 @@ import (
 // file data source archive are deliberately the same. Any properties that are only used in one
 // or the other of those contexts should be in the appropriate package instead of here.
 
-// EnvironmentRep is a representation of an environment that is being added or updated.
+// EnvironmentRep is the wire shape of an environment, shared by RAC and the offline archive.
 //
-// EnvironmentRep carries an environment's wire shape from RAC and the offline archive
-// (same struct serves both — keep them aligned).
+// Wire vocabulary: "key" is the non-secret human-readable identifier; "value" is the credential
+// secret. Relay's own SDKKey, MobileKey, and SDKCredential types hold what the wire calls "value".
+// Do not rename them.
 //
-// FIELD NAMING — read this before changing anything:
+// sdkKey and mobKey are the singular default credentials. sdkKey is an object because it also carries
+// the legacy sdkKey.expiring slot; mobKey is a plain string because mobile keys never had one.
+// sdkKeys and mobileKeys are the authoritative full accepted set, with entries of the form
+// { key, value, expiry?, hasViews? }.
 //
-//	sdkKey  is the singular *default* SDK key for the environment. It's an
-//	        object ({"value": "sdk-..."}) so it can also carry the legacy
-//	        sdkKey.expiring{value, timestamp} slot during default rotation
-//	        (back-compat for relays predating concurrent keys).
-//
-//	mobKey  is the singular default mobile key. It's a *plain string*
-//	        because mobile keys never had a legacy expiring slot. The shape
-//	        asymmetry is historical, not a design choice.
-//
-//	sdkKeys/mobileKeys  are the authoritative full accepted set. Entries:
-//	                    { key: <identifier>, value: <credential>, expiry?: <ms> }
-//
-// TERMINOLOGY:
-//
-//	The wire "key" field is the human-readable identifier (e.g. "default-sdk"),
-//	non-secret — stored as AcceptedSDKKey.Key / AcceptedMobileKey.Key internally.
-//	The wire "value" field is the actual credential string (e.g. "sdk-xxxx-..."),
-//	which is the secret — stored as AcceptedSDKKey.Value / AcceptedMobileKey.Value.
-//	Note that relay's own types (SDKKey, MobileKey, SDKCredential) refer to what
-//	the wire calls "value" — they are misnamed by today's standards but stable,
-//	so do not rename them.
-//
-// Anchor selection: anchor = the sdkKeys entry whose `value` matches sdkKey.value.
-// No isDefault flag — value match is the signal.
-//
-// Backwards compatibility: Go's default JSON decoder ignores unknown fields, so old
-// relays receiving payloads with sdkKeys/mobileKeys simply ignore them and continue
-// using sdkKey/mobKey. DisallowUnknownFields is intentionally not used anywhere in
-// this parse path.
+// This parse path never sets DisallowUnknownFields, so a relay predating concurrent keys ignores
+// sdkKeys and mobileKeys and keeps using sdkKey and mobKey.
 type EnvironmentRep struct {
 	EnvID      config.EnvironmentID `json:"envID"`
 	EnvKey     string               `json:"envKey"`
@@ -99,11 +76,9 @@ type ExpiringKeyRep struct {
 	Timestamp ldtime.UnixMillisecondTime `json:"timestamp"`
 }
 
-// ConcurrentKeyRep is an entry in the sdkKeys or mobileKeys array on EnvironmentRep.
-// It represents one accepted credential in an environment's concurrent key set.
-//
-// Key is the human-readable identifier (non-secret, e.g. "default-sdk"); Value is
-// the credential secret (e.g. "sdk-xxxx-..."). See the EnvironmentRep TERMINOLOGY comment.
+// ConcurrentKeyRep is an entry in the sdkKeys or mobileKeys array on EnvironmentRep. It represents one
+// accepted credential in an environment's concurrent key set. See EnvironmentRep for the wire
+// vocabulary.
 type ConcurrentKeyRep struct {
 	Key      string `json:"key"`
 	Value    string `json:"value"`
@@ -146,9 +121,8 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 			params.AcceptedSDKKeys = append(params.AcceptedSDKKeys, entry)
 		}
 	} else {
-		// Old-format payload: no sdkKeys array present. Synthesize AcceptedSDKKeys from the
-		// singular sdkKey fields so consumers always receive a consistent non-nil model
-		// regardless of wire format version. Key (identifier) is empty — the old format had none.
+		// Old-format payload: synthesize AcceptedSDKKeys from the singular sdkKey fields, so the model
+		// is always non-nil. The old format carried no identifier, so Key stays empty.
 		params.AcceptedSDKKeys = make([]AcceptedSDKKey, 0, 2)
 		params.AcceptedSDKKeys = append(params.AcceptedSDKKeys, AcceptedSDKKey{Value: r.SDKKey.Value})
 		if r.SDKKey.Expiring.Value.Defined() {
@@ -175,9 +149,8 @@ func (r EnvironmentRep) ToParams() EnvironmentParams {
 		}
 	} else {
 		// Old-format payload: synthesize from the singular mobKey field. An undefined mobKey means the
-		// environment has no mobile key (e.g. a server-side-only environment) — leave the set empty
-		// rather than synthesizing a phantom empty-value entry, which BuildAcceptedSet would otherwise
-		// reject as a malformed credential.
+		// environment has no mobile key, so leave the set empty. A phantom empty-value entry would make
+		// BuildAcceptedSet reject the payload.
 		params.AcceptedMobileKeys = []AcceptedMobileKey{}
 		if r.MobKey.Defined() {
 			params.AcceptedMobileKeys = append(params.AcceptedMobileKeys, AcceptedMobileKey{Value: r.MobKey})

--- a/internal/envfactory/reconcile_helper.go
+++ b/internal/envfactory/reconcile_helper.go
@@ -5,53 +5,39 @@ import (
 	"github.com/launchdarkly/ld-relay/v8/internal/util"
 )
 
-// BuildAcceptedSet converts an EnvironmentParams into the AcceptedSet needed by
-// EnvContext.ReconcileCredentials.
+// BuildAcceptedSet converts EnvironmentParams into the AcceptedSet that
+// EnvContext.ReconcileCredentials needs. It is the single home for the anchor invariant, for both RAC
+// and the offline archive.
 //
-// Credential identity is keyed by value (the secret string), not by key (the human-readable
-// identifier). A rename — same value, different identifier — therefore produces the same
-// AcceptedSet as if nothing changed.
+// Credential identity is the value (the secret), not the wire identifier, so a rename produces an
+// unchanged AcceptedSet.
 //
-// Expiry comes from AcceptedSDKKey.Expiry / AcceptedMobileKey.Expiry (the arrays). The legacy
-// sdkKey.expiring wire slot is never consulted here — relay trusts the array.
+// Expiry comes from the arrays. The legacy sdkKey.expiring wire slot is never consulted.
 //
-// The anchor (params.SDKKey) is added and designated as the primary SDK key, and the primary
-// mobile key (params.MobileKey) is added and designated, in addition to the full accepted arrays.
-// The builder de-duplicates by value, so an anchor or primary mobile key that also appears in its
-// array is added only once.
+// On a structurally malformed payload it returns a *credential.MalformedCredentialSetError and an
+// empty set. The caller must keep the previous accepted state, and RAC handlers must also reconnect
+// the stream with jitter.
 //
-// An error is returned (with an empty AcceptedSet) for a structurally malformed payload: an undefined
-// anchor (params.SDKKey not set), a defined anchor that is absent from params.AcceptedSDKKeys, a
-// defined primary mobile key (params.MobileKey) that is absent from params.AcceptedMobileKeys, a
-// non-empty params.AcceptedMobileKeys with no designated primary (params.MobileKey undefined), an
-// array entry with an empty value, or no usable SDK key at all. The caller must preserve the previous
-// accepted state and, for RAC handlers, reconnect the stream with jitter to force a fresh put. This is
-// the single home for the anchor invariant.
-//
-// Keys scoped to a view are filtered out here rather than at authentication time, making this the
-// single funnel for both RAC and the offline archive. The second return value names the keys that were
-// dropped, so callers can log what they lost. An SDK presenting one of them gets a 401: the key is
-// simply absent from the lookup map.
+// It filters out keys scoped to a view and names them in the second return value, so callers can log
+// what they dropped. An SDK presenting one gets a 401, because the key is absent from the lookup map.
 func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, []string, error) {
 	anchor := params.SDKKey
 	b := credential.NewAcceptedSetBuilder().WithEnvironmentID(params.EnvID)
 	var rejected []string
 
-	// Add every accepted SDK key, designating the anchor as we encounter it. WithAnchor both adds and
-	// designates, and forces the anchor permanent — so a payload that (wrongly) carries an expiry on
-	// the anchor's own entry cannot demote it. An undefined anchor never matches a (defined) array
-	// value, so it is never designated and Build rejects the payload.
+	// Add every accepted SDK key, designating the anchor on the way. WithAnchor forces the anchor
+	// permanent, so a payload cannot demote it with an expiry on the anchor's own entry. An undefined
+	// anchor never matches an array value, so Build rejects the payload.
 	//
-	// Entries with an empty value are structurally malformed: relay would silently accept them but
-	// they can never authenticate any SDK. Reject loudly rather than produce a credential-short env.
+	// An entry with an empty value can never authenticate any SDK, so reject it.
 	anchorInArray := false
 	for _, k := range params.AcceptedSDKKeys {
 		if !k.Value.Defined() {
 			return credential.AcceptedSet{}, nil, credential.NewEmptyCredentialError("sdkKeys", k.Key)
 		}
 		switch {
-		// A marker on the anchor's own entry is disregarded: dropping the designated key would take the
-		// whole environment down, and the backend forbids views on a default key in the first place.
+		// A view marker on the anchor's own entry is disregarded: dropping the designated key would
+		// take the whole environment down, and the backend forbids views on a default key.
 		case k.Value == anchor:
 			anchorInArray = true
 			b.WithAnchor(credential.SDKKeyParams{Value: k.Value, Key: util.PtrOrNil(k.Key)})
@@ -62,16 +48,14 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, []strin
 		}
 	}
 
-	// The anchor must be one of the accepted SDK keys: the backend lists it in sdkKeys[] (and ToParams
-	// synthesizes it into the array for old-format payloads). A defined anchor absent from the array is
-	// a structurally malformed payload — reject it.
+	// The anchor must be one of the accepted SDK keys: the backend lists it in sdkKeys[], and ToParams
+	// synthesizes it into the array for old-format payloads.
 	if anchor.Defined() && !anchorInArray {
 		return credential.AcceptedSet{}, nil, credential.NewAnchorNotInSetError()
 	}
 
-	// Add every accepted mobile key, designating the primary as we encounter it. Like the anchor,
-	// WithPrimaryMobileKey forces the primary permanent, so an expiry the payload may carry on the
-	// primary's own entry cannot demote it.
+	// Add every accepted mobile key, designating the primary on the way. WithPrimaryMobileKey forces
+	// the primary permanent, as WithAnchor does for the anchor.
 	primaryMobileInArray := false
 	for _, k := range params.AcceptedMobileKeys {
 		if !k.Value.Defined() {
@@ -89,20 +73,14 @@ func BuildAcceptedSet(params EnvironmentParams) (credential.AcceptedSet, []strin
 		}
 	}
 
-	// The primary mobile key, when the environment has one, must be in mobileKeys[] — the mobile
-	// analogue of the anchor invariant above. A defined mobKey absent from the array is malformed:
-	// without this guard the primary would be silently left undesignated, clearing it on reconcile and
-	// breaking event forwarding. (An undefined mobKey is valid — a server-side-only environment.)
+	// A defined primary mobile key must be in mobileKeys[], the mobile analogue of the anchor invariant
+	// above. Without this guard the primary stays undesignated, which breaks event forwarding.
 	if params.MobileKey.Defined() && !primaryMobileInArray {
 		return credential.AcceptedSet{}, nil, credential.NewPrimaryMobileKeyNotInSetError()
 	}
 
-	// A non-empty mobileKeys[] with no designated primary (undefined mobKey) is malformed: the reconcile
-	// would clear the rotator's primary mobile key without a repoint, so event forwarding would keep
-	// using the previous (possibly revoked) primary — silent misattribution rather than a loud
-	// rejection. (No mobile keys at all — empty array and undefined mobKey — stays valid: a
-	// server-side-only environment. Old-format payloads synthesize the array from mobKey only, so an
-	// undefined mobKey yields an empty array and is unaffected.)
+	// mobileKeys[] with no designated primary is malformed. See NewPrimaryMobileKeyMissingError.
+	// An empty array with an undefined mobKey stays valid: a server-side-only environment.
 	if len(params.AcceptedMobileKeys) > 0 && !params.MobileKey.Defined() {
 		return credential.AcceptedSet{}, nil, credential.NewPrimaryMobileKeyMissingError()
 	}

--- a/internal/events/event_publisher.go
+++ b/internal/events/event_publisher.go
@@ -160,11 +160,9 @@ func (o OptionCapacity) apply(p *HTTPEventPublisher) error {
 	return nil
 }
 
-// OptionInitialCapacity specifies how many events to preallocate space for in each event queue.
-// The queue still grows on demand (via append) up to OptionCapacity, and events are only dropped
-// once OptionCapacity is reached; this option only controls the initial allocation so that a
-// publisher with a large capacity does not reserve all of that memory up front. If unset, or not
-// smaller than the capacity, the full capacity is preallocated, preserving the original behavior.
+// OptionInitialCapacity is how many events each queue preallocates space for. The queue still grows
+// on demand up to OptionCapacity, which is where events start being dropped. If this option is unset,
+// or is not smaller than the capacity, the full capacity is preallocated.
 type OptionInitialCapacity int
 
 //nolint:unparam // the error result is required by the OptionType interface
@@ -257,10 +255,9 @@ func NewHTTPEventPublisher(authKey credential.SDKCredential, httpConfig httpconf
 	return p, nil
 }
 
-// initialQueueCapacity returns the number of events to preallocate space for in a new queue.
-// It is the smaller of the configured initial capacity and the maximum capacity; when no initial
-// capacity is configured (<= 0), the full maximum capacity is preallocated, which is the original
-// behavior. The queue can still grow (via append) up to the maximum capacity regardless.
+// initialQueueCapacity returns the number of events to preallocate space for in a new queue. It is
+// the smaller of the configured initial capacity and the maximum capacity. When no initial capacity
+// is configured, the full maximum capacity is preallocated.
 func initialQueueCapacity(capacity, initialCapacity int) int {
 	if initialCapacity > 0 && initialCapacity < capacity {
 		return initialCapacity
@@ -271,7 +268,6 @@ func initialQueueCapacity(capacity, initialCapacity int) int {
 func (p *HTTPEventPublisher) append(batch eventBatch) {
 	queue := p.queues[batch.metadata]
 	if queue == nil {
-		// The queue still grows up to p.capacity via append regardless of the initial allocation.
 		queue = &publisherQueue{events: make([]json.RawMessage, 0, initialQueueCapacity(p.capacity, p.initialCapacity))}
 		p.queues[batch.metadata] = queue
 	}

--- a/internal/relayenv/env_context.go
+++ b/internal/relayenv/env_context.go
@@ -40,32 +40,28 @@ type EnvContext interface {
 	// SetIdentifiers updates the environment and project names and keys.
 	SetIdentifiers(EnvIdentifiers)
 
-	// GetAnchorKey returns the anchor SDK key — the key that owns the upstream connection.
-	// Use this when you need exactly the anchor (e.g. the status endpoint's sdkKey field) rather
-	// than the full accepted set returned by GetCredentials.
+	// GetAnchorKey returns the anchor SDK key, which owns the upstream connection. Use it when you
+	// need exactly the anchor rather than the full accepted set that GetCredentials returns.
 	GetAnchorKey() config.SDKKey
 
-	// GetMobileKey returns the primary (default) mobile key. Like GetAnchorKey for the anchor, use this
-	// for the status endpoint's mobileKey field rather than iterating GetCredentials, which may return
-	// several accepted mobile keys (primary + expiring) in nondeterministic order.
+	// GetMobileKey returns the primary (default) mobile key. GetCredentials can return several accepted
+	// mobile keys in nondeterministic order, so use this method where one mobile key is required.
 	GetMobileKey() config.MobileKey
 
-	// GetAcceptedKeys returns a consistent snapshot of the full accepted credential set — all
-	// server-side SDK keys and all mobile keys (anchor and primary mobile key included), grouped by
-	// kind, plus which keys are the designated anchor and primary. The status endpoint maps each group
-	// to the full sdkKeys[] / mobileKeys[] arrays.
+	// GetAcceptedKeys returns a consistent snapshot of the full accepted set, grouped by kind. See
+	// credential.AcceptedKeySet.
 	GetAcceptedKeys() credential.AcceptedKeySet
 
-	// ReconcileCredentials atomically reconciles the environment's accepted credentials to match
-	// newSet. The set names its own anchor (the SDK key that owns the upstream connection) and
-	// primary mobile key. The method owns the order of operations internally (add → re-anchor →
-	// remove); callers do not sequence.
+	// ReconcileCredentials updates the environment's accepted credentials to match newSet. Calls are
+	// serialized. The method owns the order of operations (add, re-anchor, remove). If the re-anchor
+	// fails, only the anchor change is reverted; the other changes stand.
 	//
-	// newSet is assumed well-formed: it is built and validated via credential.AcceptedSetBuilder
-	// (which guarantees an anchor) before reaching here, so this method does not re-validate.
+	// newSet is assumed well-formed: credential.AcceptedSetBuilder validated it, so this method does
+	// not re-validate.
 	ReconcileCredentials(newSet credential.AcceptedSet)
 
-	// GetCredentials returns all currently enabled and non-deprecated credentials for the environment.
+	// GetCredentials returns every credential the environment currently accepts, including keys that
+	// carry a future expiry. Use GetAnchorKey or GetMobileKey for the designated keys.
 	GetCredentials() []credential.SDKCredential
 
 	// GetDeprecatedCredentials returns all deprecated and not-yet-removed credentials for the environment.

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -101,9 +101,8 @@ type envContextImpl struct {
 	evaluator       ldeval.Evaluator
 	eventDispatcher *events.EventDispatcher
 	bigSegmentSync  bigsegments.BigSegmentSynchronizer
-	// makeBigSegmentSync builds a BigSegmentSynchronizer for a given anchor SDK key, binding the
-	// construction-time inputs (http config, store, URIs, env ID, loggers). A re-anchor uses it to
-	// rebuild the synchronizer on the new anchor. nil when big segments are not configured.
+	// makeBigSegmentSync builds a BigSegmentSynchronizer for an anchor SDK key. A re-anchor uses it
+	// to rebuild the synchronizer on the new anchor. nil when big segments are not configured.
 	makeBigSegmentSync        func(anchor config.SDKKey) bigsegments.BigSegmentSynchronizer
 	bigSegmentStore           bigsegments.BigSegmentStore
 	bigSegmentsExist          bool
@@ -127,17 +126,13 @@ type envContextImpl struct {
 	offline                   bool
 	closed                    bool
 
-	// reconcileMu serializes reconcileCredentials calls — only one runs at a time, including the
-	// synchronous re-anchor sequence inside it. Held separately from mu so that GetClient / GetStore /
-	// GetEvaluator / addCredential continue to run during the (potentially seconds-long) SDK client
-	// construction when re-anchoring to a new key.
+	// reconcileMu serializes reconcileCredentials calls, including the re-anchor sequence they run. It
+	// is held separately from mu so that readers keep running during the SDK client construction.
 	reconcileMu sync.Mutex
 
-	// anchorClientGen counts how many times the upstream anchor client has been (re)established. A
-	// re-anchor commit bumps it. startSDKClient builds its client without c.mu, so a slow build can
-	// finish after a later re-anchor already installed a fresh anchor client; it captures this value at
-	// launch and, on completion, discards its (now stale) build if the generation has advanced rather
-	// than clobbering the current anchor client. Guarded by c.mu.
+	// anchorClientGen counts how many times the anchor client has been established. A re-anchor
+	// commit bumps it. startSDKClient captures it at launch and discards its build if the value
+	// advanced, because a slow build can finish after a later re-anchor. Guarded by c.mu.
 	anchorClientGen uint64
 }
 
@@ -233,10 +228,8 @@ func NewEnvContext(
 		if factory == nil {
 			factory = bigsegments.DefaultBigSegmentSynchronizerFactory
 		}
-		// Bind the construction-time inputs so a re-anchor can rebuild the synchronizer on the new anchor
-		// key (see reanchorBigSegmentSync). The synchronizer authenticates from the SDK key it is handed
-		// (bigsegments/sync sets the Authorization header from it directly), so re-anchoring only needs
-		// the new key; httpConfig is transport configuration and is reused as-is.
+		// Bind the construction-time inputs so a re-anchor can rebuild the synchronizer on the new
+		// anchor key (see reanchorBigSegmentSync). The synchronizer authenticates with the key it gets.
 		baseURI := allConfig.Main.BaseURI.String()
 		streamURI := allConfig.Main.StreamURI.String()
 		envContext.makeBigSegmentSync = func(anchor config.SDKKey) bigsegments.BigSegmentSynchronizer {
@@ -394,8 +387,7 @@ func NewEnvContext(
 	}
 
 	// Connecting may take time, so do this in parallel
-	// launchGen is 0 here: no re-anchor can have committed yet (the env isn't wired into reconcile until
-	// after construction returns), so this initial build is never superseded and its result is recorded.
+	// launchGen is 0 here: no re-anchor can have committed yet, so this build is never superseded.
 	go envContext.startSDKClient(envConfig.SDKKey, readyCh, allConfig.Main.IgnoreConnectionErrors, 0)
 
 	cleanupInterval := params.ExpiredCredentialCleanupInterval
@@ -429,14 +421,8 @@ func (c *envContextImpl) addCredential(newCredential credential.SDKCredential) {
 
 	c.registerCredentialMappings(newCredential)
 
-	// Registering the credential mappings above is all that most keys require. The one extra step is
-	// event forwarding for mobile keys: mobile-key event forwarding collapses to the primary mobile key,
-	// so a newly added mobile key repoints the event dispatcher only when it is the primary mobile key
-	// (a non-primary mobile key accepted in the same reconcile does not steal event forwarding).
-	// The upstream client lifecycle and SDK-key event repointing are deliberately not handled here: there
-	// is a single upstream connection per environment owned by the anchor key, and it is set up exclusively
-	// by construction (NewEnvContext) and moved by the re-anchor sequence (commitReanchor), which also
-	// repoints the SDK-key event forwarders since events collapse to the anchor per kind.
+	// Event forwarding collapses to the primary mobile key, so only the primary repoints the dispatcher.
+	// Client lifecycle and SDK-key event forwarding belong to NewEnvContext and commitReanchor.
 	if mobileKey, ok := newCredential.(config.MobileKey); ok && mobileKey == c.keyRotator.MobileKey() {
 		if c.eventDispatcher != nil {
 			c.eventDispatcher.ReplaceCredential(mobileKey)
@@ -466,14 +452,12 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 	client, err := c.sdkClientFactory(sdkKey, c.sdkConfig, c.sdkInitTimeout)
 	c.mu.Lock()
 	name := c.identifiers.GetDisplayName()
-	// The build happens before we take c.mu. By now the env may be closed, the key may have been
-	// revoked, or a re-anchor may have committed a fresh anchor client since this build was launched
-	// (anchorClientGen advanced). In any of those cases this build is stale: close it rather than install
-	// it, so it cannot clobber the current anchor client. This must not rely on client==nil: a failed SDK
-	// build returns a non-nil, uninitialized client together with the error, so a stale failed build
-	// would otherwise replace a healthy anchor client with a dead one. Only defined keys are
-	// revocation-checked: an undefined SDK key is never tracked, and dropping its client would break envs
-	// that legitimately run without an SDK key (offline / not-yet-configured / tests).
+	// The build ran without c.mu, so it may now be stale: the env closed, the key was revoked, or a
+	// re-anchor advanced anchorClientGen. Close a stale build instead of installing it.
+	//
+	// The guard cannot test client == nil, because a failed build returns a non-nil uninitialized
+	// client. Only defined keys are revocation-checked: an undefined key is never tracked, and envs
+	// legitimately run without one.
 	superseded := c.anchorClientGen != launchGen
 	droppedInactive := false
 	if client != nil && (c.closed || superseded || (sdkKey.Defined() && !c.sdkKeyIsActive(sdkKey))) {
@@ -482,19 +466,15 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 		droppedInactive = true
 	}
 	if client != nil {
-		// If a client already exists for this key (e.g. it was re-anchored back into the anchor slot
-		// while a prior client for it was still in its grace period), close the stale one before
-		// replacing it so its upstream connection and goroutines are not leaked.
+		// Close any stale client for this key, so its connection and goroutines are not leaked.
 		if existing := c.clients[sdkKey]; existing != nil && existing != client {
 			_ = existing.Close()
 		}
 		c.clients[sdkKey] = client
 		c.rebuildEvaluator() // the SDK created the data store during Build; wire the evaluator to it now
 	}
-	// Record this build's result as the env's init status only when it is the current anchor's build: not
-	// superseded by a newer anchor client, and its key is still the anchor. A genuine failure of the
-	// current anchor is thus recorded (the middleware 401s a broken env); a stale build's late failure is
-	// not, so it cannot 401 a healthy re-anchored env.
+	// Record this build's result as the env's init status only for the current anchor's build. A stale
+	// build's late failure must not 401 a healthy re-anchored env.
 	if !superseded && sdkKey == c.keyRotator.AnchorKey() {
 		c.initErr = err
 	}
@@ -502,10 +482,6 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 
 	switch {
 	case droppedInactive:
-		// The build finished but was superseded by a re-anchor, or its key was revoked, or the env
-		// closed, so it was discarded above rather than installed (even if it also errored -- a
-		// discarded build's error is moot). The environment is still consistent: no stale client left
-		// behind.
 		c.globalLoggers.Infof("SDK key %s build was superseded, revoked, or the environment was closed "+
 			"before it finished initializing; the client was discarded", sdkKey.Masked())
 	case err != nil:
@@ -528,9 +504,8 @@ func (c *envContextImpl) startSDKClient(sdkKey config.SDKKey, readyCh chan<- Env
 	}
 }
 
-// sdkKeyIsActive reports whether the given SDK key is still a tracked credential -- the anchor or a key
-// within its deprecation grace period -- according to the rotator. startSDKClient uses this to avoid
-// installing (and thereby leaking) a client for a key that was revoked while it was being built.
+// sdkKeyIsActive reports whether the rotator still accepts sdkKey. startSDKClient uses this to avoid
+// installing a client for a key revoked while the client was building.
 func (c *envContextImpl) sdkKeyIsActive(sdkKey config.SDKKey) bool {
 	return slices.Contains(c.keyRotator.AllCredentials(), credential.SDKCredential(sdkKey))
 }
@@ -557,19 +532,14 @@ func (c *envContextImpl) ReconcileCredentials(newSet credential.AcceptedSet) {
 	c.reconcileCredentials(newSet, time.Now())
 }
 
-// reconcileCredentials is the time-injectable implementation of ReconcileCredentials (now is the
-// reference time for expiry math).
+// reconcileCredentials is the time-injectable implementation of ReconcileCredentials. now is the
+// reference time for expiry math.
 //
-// Order: add -> re-anchor -> remove. Adding first registers the new keys' mappings; the re-anchor then
-// swaps the upstream client while the old anchor is still serving, closing the old anchor's client
-// once the new one is committed; removing last tears down revoked keys' mappings only once the new
-// anchor is up. addCredential opens an upstream client only for the anchor -- non-anchor server keys
-// are routed without a second connection.
+// The order is add, re-anchor, remove. Adding first registers the new keys' mappings. The re-anchor
+// then swaps the upstream client while the old anchor still serves. Removing last tears down revoked
+// mappings only after the new anchor is up. addCredential never opens a client; only reanchor does.
 //
-// reconcileMu serializes this whole method against concurrent reconciles and the cleanup ticker (see
-// triggerCredentialChanges). See reanchor for the SDK-anchor swap; MobilePrimaryRepoint is handled
-// inline below (a primary-mobile change to an already-accepted key isn't in additions, so addCredential
-// won't repoint event forwarding for it).
+// reconcileMu serializes this method against concurrent reconciles and the cleanup ticker.
 func (c *envContextImpl) reconcileCredentials(newSet credential.AcceptedSet, now time.Time) {
 	c.reconcileMu.Lock()
 	defer c.reconcileMu.Unlock()
@@ -583,17 +553,15 @@ func (c *envContextImpl) reconcileCredentials(newSet credential.AcceptedSet, now
 
 	if result.AnchorChange != nil {
 		if committed := c.reanchor(result.AnchorChange); !committed {
-			// Rolled back: the new anchor's client never came up. Undo just this anchor change (other
-			// changes in the payload stand), mirroring RevertAnchorChange. A brand-new anchor had its
-			// mappings registered this cycle, so tear them down here; a previously-accepted anchor keeps
-			// its mappings and reverts to the non-anchor key it already was.
+			// Rolled back: the new anchor's client never came up. Undo only the anchor change; the other
+			// changes in this payload stand. A brand-new anchor had its mappings registered this cycle,
+			// so tear them down here.
 			if !result.AnchorChange.NewAnchorPreviouslyAccepted {
 				c.removeCredential(result.AnchorChange.NewAnchor)
 			}
 			c.keyRotator.RevertAnchorChange(*result.AnchorChange)
-			// Keep the previous anchor's client serving by not expiring it here — even if this payload
-			// revoked it outright. (A grace-demoted previous anchor isn't in expirations anyway, so this
-			// only matters for an immediate revocation.)
+			// Keep the previous anchor's client serving by not expiring that key here, even if this
+			// payload revoked it outright.
 			previousAnchor := result.AnchorChange.PreviousAnchor
 			expirations = slices.DeleteFunc(expirations, func(cred credential.SDKCredential) bool {
 				return cred == previousAnchor
@@ -615,31 +583,20 @@ func (c *envContextImpl) reconcileCredentials(newSet credential.AcceptedSet, now
 	}
 }
 
-// reanchor drives the synchronous re-anchor sequence for an SDK anchor change signaled by Reconcile's
-// ReconcileResult.AnchorChange. Invoked by reconcileCredentials after additions have been processed
-// and before expirations, so the previous anchor's client is still alive while the new client is built
-// (or reused).
+// reanchor moves the environment's upstream connection to change.NewAnchor. It returns true if the
+// anchor was committed, and false if it rolled back (the build failed, or the env closed).
+// This function is the canonical re-anchor sequence: Reconcile signals the anchor change but does not
+// flip the rotator's pointer; reanchor builds or reuses the client, then commitReanchor moves it.
 //
-// reanchor holds c.mu for the whole sequence and releases it only around the SDK client build (which
-// must not hold the lock — see buildNewAnchorClient). Holding one continuous lock otherwise keeps
-// Close() (which also takes c.mu) from tearing down clients or the dispatcher mid-commit, and lets
-// commitReanchor assume the lock is held rather than re-acquiring it.
+// Concurrency: reanchor holds c.mu for the whole sequence and releases it only around the client
+// build. The continuous lock keeps Close() out of the middle of a commit, and lets commitReanchor
+// assume the lock is held.
 //
-//   - When there is no existing client for the new anchor and the env is online: register its credential
-//     mappings if the key is brand new (Reconcile stripped it from additions), build a new SDK client,
-//     and on Initialized commit the anchor. On init failure, roll back: do not commit, leave the previous
-//     anchor authoritative (its client keeps serving), and log a structured error.
-//   - When a client already exists for the new anchor, or the env is offline: no build, just commit.
-//     (A demoted former anchor no longer has a client -- it was closed when its demotion committed --
-//     so re-promoting an in-grace key builds a fresh client.)
+// The new anchor needs a client only when none exists and the env is online.
 //
-// Returns true if the anchor was committed, false if it rolled back (init failure or the env closed
-// mid-build), so reconcileCredentials can back out the anchor change. On commit, the previous
-// anchor's client is closed here: the anchor owns the environment's single upstream connection, and
-// leaving the demoted key's client running would hold a second upstream stream feeding the same
-// shared store wrapper, broadcasting every update twice to connected clients. Only the client goes;
-// the demoted key's credential mappings stay registered so it keeps authenticating downstream
-// connections until its grace period expires (removeCredential then finds no client to close).
+// On commit, reanchor closes the previous anchor's client. Two clients would feed the same store
+// wrapper and broadcast every update twice. The demoted key keeps its credential mappings, so it
+// still authenticates downstream connections until its grace period expires.
 func (c *envContextImpl) reanchor(change *credential.AnchorChange) bool {
 	newAnchor := change.NewAnchor
 	previousAnchor := change.PreviousAnchor
@@ -647,51 +604,40 @@ func (c *envContextImpl) reanchor(change *credential.AnchorChange) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Two independent questions:
-	//   - NewAnchorPreviouslyAccepted: are this key's credential mappings already registered? A brand-new
-	//     anchor was stripped from additions, so register them now; an already-accepted key already has them.
-	//   - the client check below: does a client already exist? If so reuse it, else build one.
-	// They differ for a previously-accepted non-anchor key promoted to anchor: mappings exist, client
-	// does not. (A live client always implies the key was already accepted, so registration never double-fires.)
+	// Mappings can exist without a client, but never the reverse. Reconcile stripped a brand-new anchor
+	// from additions, so register its mappings here; an already-accepted key has them already.
 	if !change.NewAnchorPreviouslyAccepted {
 		c.registerCredentialMappings(newAnchor)
 	}
 
-	// A live client for the new anchor is reused as-is; an offline env has no upstream client to build.
-	// Either way there is nothing to build, so fall through to commit.
+	// A live client is reused as-is, and an offline env builds none. Both cases fall through to commit.
 	why := "reused existing client"
 	if c.clients[newAnchor] == nil {
 		if c.offline {
 			why = "offline — no client build"
 		} else {
-			// Build the new client without the lock: sdkClientFactory can block for up to sdkInitTimeout,
-			// and holding c.mu that long would stall every GetClient/GetStore caller (see reconcileMu).
-			// reanchor's deferred Unlock releases the lock we re-acquire here on return.
+			// Build without the lock: sdkClientFactory can block for up to sdkInitTimeout, and holding
+			// c.mu that long would stall every GetClient and GetStore caller.
 			c.mu.Unlock()
 			client := c.buildNewAnchorClient(newAnchor, previousAnchor)
 			c.mu.Lock()
 
 			if client == nil {
-				// Init failed; buildNewAnchorClient already logged and closed the half-built client. Do not
-				// commit — leave the previous anchor authoritative.
+				// Init failed. buildNewAnchorClient logged the error and closed the half-built client.
 				return false
 			}
 			if c.closed {
-				// The env was torn down while the lock was released for the build (Close() does not hold
-				// reconcileMu, so it can run concurrently); its client-teardown loop has already finished and
-				// would never close this one, so discard the freshly-built client rather than install it into
-				// a closed env (mirrors the guard in startSDKClient).
+				// Close() ran while the lock was released, and its client-teardown loop already finished,
+				// so it would never close this client. Discard the client instead of installing it.
 				_ = client.Close()
 				return false
 			}
 			if existing := c.clients[newAnchor]; existing != nil && existing != client {
-				// Stale-client guard: the lock was released for the build, so re-check and close any client
-				// installed concurrently for newAnchor.
+				// The lock was released for the build, so close any client installed concurrently.
 				_ = existing.Close()
 			}
 			c.clients[newAnchor] = client
-			// With store handover, GetStore() returns the SAME wrapper the old client used, so the rebuilt
-			// evaluator serves the already-populated data immediately (no empty-store window).
+			// GetStore() returns the same wrapper the old client used, so there is no empty-store window.
 			c.rebuildEvaluator()
 			why = "built new client"
 		}
@@ -701,12 +647,9 @@ func (c *envContextImpl) reanchor(change *credential.AnchorChange) bool {
 		return false
 	}
 
-	// The new anchor's client is now authoritative, so tear down the previous anchor's client
-	// whether the key was grace-demoted or revoked outright (an undefined previous anchor has no
-	// entry, and a rolled-back commit never reaches here). The shared store wrapper survives: it is
-	// refcounted and the new anchor's client holds it. Offline mode is exempt, mirroring
-	// removeCredential: the offline branch above built no replacement, and the env's single
-	// file-data client (found by GetClient's map iteration) must keep serving across rotations.
+	// The new anchor's client is now authoritative, so close the previous anchor's client. The shared
+	// store wrapper survives: it is refcounted and the new anchor's client holds it. Offline mode is
+	// exempt because it built no replacement, and its single file-data client must keep serving.
 	if !c.offline {
 		if oldClient := c.clients[previousAnchor]; oldClient != nil {
 			delete(c.clients, previousAnchor)
@@ -716,25 +659,16 @@ func (c *envContextImpl) reanchor(change *credential.AnchorChange) bool {
 	return true
 }
 
-// buildNewAnchorClient constructs the SDK client for a re-anchor to newAnchor. It must run without c.mu
-// held: sdkClientFactory can block for up to sdkInitTimeout, and holding the lock that long would stall
-// every GetClient/GetStore caller. It touches only fields fixed at construction (sdkClientFactory,
-// sdkConfig, sdkInitTimeout, globalLoggers), so it needs no lock — mirroring startSDKClient, which also
-// builds before locking.
+// buildNewAnchorClient constructs the SDK client for a re-anchor to newAnchor. It returns nil if the
+// build failed, after closing any half-built client and logging the error.
 //
-// Returns the initialized client, or nil if the build failed, in which case it has already closed any
-// half-built client and logged a structured error. initErr is deliberately left untouched on failure:
-// it feeds the request middleware, and setting it to the new anchor's ErrInitializationFailed would 401
-// an env that is serving fine on the previous anchor.
+// The caller must not hold c.mu: sdkClientFactory can block for sdkInitTimeout, which would stall
+// every GetClient and GetStore caller. This method reads only construction-time fields.
 //
-// Factory contract (see sdks.ClientFactoryFunc): a factory whose construction builds the environment's
-// data store must return a non-nil client even on init failure, so that the client.Close() below releases
-// the store reference the build acquired (the store wrapper is refcounted — see streamUpdatesStoreWrapper).
-// When client == nil there is no handle to release, and this method cannot safely release one itself: it
-// has no signal for whether the store was built, so releasing unconditionally could double-release the
-// still-serving previous anchor's store on an early factory error. The real SDK honors the contract (a
-// failed init returns a non-nil client; an error before the store is built releases nothing); test
-// factories must uphold it too.
+// It leaves initErr alone on failure. initErr feeds the request middleware, so setting it would 401
+// an env that is still serving on the previous anchor.
+//
+// The Close() below relies on the store-release contract in sdks.ClientFactoryFunc.
 func (c *envContextImpl) buildNewAnchorClient(newAnchor, previousAnchor config.SDKKey) sdks.LDClientContext {
 	client, err := c.sdkClientFactory(newAnchor, c.sdkConfig, c.sdkInitTimeout)
 	if err != nil || client == nil || !client.Initialized() {
@@ -751,36 +685,23 @@ func (c *envContextImpl) buildNewAnchorClient(newAnchor, previousAnchor config.S
 	return client
 }
 
-// commitReanchor is the second half of the re-anchor sequence: atomically move the rotator's anchor
-// pointer, clear any stale init error now that a healthy client is current, and repoint downstream
-// event/metrics forwarding. The caller must hold c.mu — reanchor holds it across the whole sequence, so
-// the commit and Close() (which also takes c.mu) are mutually exclusive and Close can't tear the client
-// or dispatcher out mid-commit. This mirrors addCredential, which likewise repoints event forwarding
-// and reads rotator state under c.mu.
-//
-// Returns false without committing if the env was closed first, so callers report the rollback rather
-// than a phantom success.
+// commitReanchor is the second half of the re-anchor sequence: move the rotator's anchor pointer,
+// clear a stale init error, and repoint event and metrics forwarding. It returns false without
+// committing if the env was closed first. The caller must hold c.mu.
 func (c *envContextImpl) commitReanchor(newAnchor, previousAnchor config.SDKKey, why string) bool {
 	if c.closed {
-		// Close() ran before we could commit. Don't flip the anchor or touch the (now-closed) dispatcher
-		// and metrics publisher; the env is being torn down.
+		// Close() ran first. The env is being torn down, so do not flip the anchor.
 		return false
 	}
 
 	c.keyRotator.CommitAnchor(newAnchor)
-	// A new anchor client is now authoritative, so any startSDKClient build still in flight from before
-	// this commit is stale: bump the generation so it discards itself instead of clobbering this client.
-	// Only do this online: an offline commit (see reanchor above) installs no replacement client, so
-	// there is nothing for the bump to protect. Bumping anyway would strand the env's initial client
-	// build (launched with generation 0 at construction) if it is still in flight when this offline
-	// re-anchor commits: startSDKClient would see its generation superseded and discard the build,
-	// leaving GetClient() nil forever with no other build ever attempted.
+	// Any startSDKClient build still in flight is now stale, so bump the generation to make that build
+	// discard itself. Bump only when online: an offline commit installs no replacement client, and the
+	// bump would strand the env's initial build, leaving GetClient() nil forever.
 	if !c.offline {
 		c.anchorClientGen++
 	}
-	// The anchor now points at a healthy client (freshly built and Initialized, or a reused live
-	// client), so clear any init error a prior client left behind — otherwise GetInitError() and the
-	// request middleware would keep reporting a still-serving env as failed.
+	// The anchor now points at a healthy client, so clear any init error a prior client left behind.
 	c.initErr = nil
 
 	if c.metricsEventPub != nil {
@@ -790,21 +711,18 @@ func (c *envContextImpl) commitReanchor(newAnchor, previousAnchor config.SDKKey,
 		c.eventDispatcher.ReplaceCredential(newAnchor)
 	}
 
-	// Re-wire big-segment synchronization onto the new anchor: its poll/stream requests authenticate
-	// with the anchor SDK key, so it must follow the anchor like the event/metrics forwarding above.
+	// Big-segment requests authenticate with the anchor SDK key, so the synchronizer follows the anchor.
 	c.reanchorBigSegmentSync(newAnchor)
 
 	c.globalLoggers.Infof("Re-anchored SDK from %s to %s (%s)", previousAnchor.Masked(), newAnchor.Masked(), why)
 	return true
 }
 
-// rebuildEvaluator constructs the environment's Evaluator against the current data store. It is called
-// after (re)creating an SDK client, once the store is available, and is shared by the initial client
-// startup and the re-anchor path. It reads and writes envContextImpl fields directly, so the caller
-// must hold c.mu.
+// rebuildEvaluator constructs the environment's Evaluator against the current data store. Call it
+// after creating an SDK client. The caller must hold c.mu.
 //
-// EnableSecondaryKey is set because we may evaluate for client-side SDKs sending old-style user data
-// with the "secondary" attribute; it has no effect for newer SDKs that send contexts.
+// EnableSecondaryKey supports client-side SDKs that send old-style user data with the "secondary"
+// attribute. It has no effect for SDKs that send contexts.
 func (c *envContextImpl) rebuildEvaluator() {
 	store := c.storeAdapter.GetStore()
 	dataProvider := ldstoreimpl.NewDataStoreEvaluatorDataProvider(store, c.loggers)
@@ -817,27 +735,20 @@ func (c *envContextImpl) rebuildEvaluator() {
 	c.evaluator = ldeval.NewEvaluatorWithOptions(dataProvider, evalOptions...)
 }
 
-// registerCredentialMappings wires relay's downstream-facing routing for cred: it registers the
-// credential with the env's stream machinery and adds the connection→env mapping, so incoming
-// SDK/client connections that authenticate with cred are served by this env. Stream handlers are built
-// on demand per request in GetStreamHandler, so there is nothing per-credential to construct here. It
-// does NOT start the upstream SDK client or repoint event/metrics forwarding — those are anchor-only
-// concerns owned by the callers (addCredential, and the re-anchor sequence). The caller must hold c.mu.
+// registerCredentialMappings registers cred with the env's stream machinery and adds the
+// connection-to-env mapping, so connections that authenticate with cred reach this env. Stream
+// handlers are built per request in GetStreamHandler. The caller must hold c.mu.
 func (c *envContextImpl) registerCredentialMappings(cred credential.SDKCredential) {
 	c.envStreams.AddCredential(cred)
 	c.connectionMapper.AddConnectionMapping(sdkauth.NewScoped(c.filterKey, cred), c)
 }
 
-// triggerCredentialChanges drains the rotator's StepTime queue and applies the resulting additions
-// and expirations. It runs on the cleanup ticker (cleanupExpiredCredentials), so it can fire at any
-// moment — including while a synchronous re-anchor is in flight inside reconcileCredentials.
+// triggerCredentialChanges drains the rotator's StepTime queue and applies the additions and
+// expirations. It runs on the cleanup ticker, so it can fire during an in-flight re-anchor.
 //
-// It takes reconcileMu for the whole StepTime + add/remove pass so the ticker is serialized against
-// reconcileCredentials exactly the way concurrent reconciles already are. Without it, a credential
-// expiry firing during an in-flight re-anchor would drain the same StepTime queue the reconcile
-// relies on (the ticker could steal additions a reconcile just queued) and could removeCredential —
-// closing a client — partway through the re-anchor sequence. reconcileCredentials never calls this,
-// so taking reconcileMu here introduces no re-entrancy.
+// It holds reconcileMu for the whole pass. Without that lock the ticker could steal additions a
+// reconcile just queued, or close a client partway through a re-anchor. reconcileCredentials never
+// calls this function, so there is no re-entrancy.
 func (c *envContextImpl) triggerCredentialChanges(now time.Time) {
 	c.reconcileMu.Lock()
 	defer c.reconcileMu.Unlock()
@@ -874,13 +785,10 @@ func (c *envContextImpl) GetAcceptedKeys() credential.AcceptedKeySet {
 func (c *envContextImpl) GetClient() sdks.LDClientContext {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	// c.clients always has at most one entry — the anchor's client. Only the anchor key triggers
-	// startSDKClient (in addCredential and at construction), so non-anchor server keys never open
-	// their own upstream connection.
-	//
-	// Offline mode uses iteration rather than key-based lookup for historical reasons; both
-	// approaches are correct because keyRotator is initialized with envConfig.SDKKey before
-	// startSDKClient is ever called.
+	// c.clients holds at most one entry: the anchor's client. Only construction and the re-anchor
+	// sequence create clients, so non-anchor server keys never open an upstream connection. Offline mode
+	// iterates instead of looking up by key. Both work: the rotator is initialized with envConfig.SDKKey
+	// before any client is built.
 	if c.offline {
 		for _, client := range c.clients {
 			return client
@@ -917,10 +825,8 @@ func (c *envContextImpl) GetLoggers() ldlog.Loggers {
 }
 
 func (c *envContextImpl) GetStreamHandler(streamProvider streams.StreamProvider, cred credential.SDKCredential) http.Handler {
-	// Build the handler on demand rather than storing one per (credential, provider): every handler in a
-	// (filter, provider) slot is identical except for the credential-derived channel id, which we resolve
-	// here from the request's already-authenticated credential. c.filterKey is immutable after
-	// construction, so this needs no lock.
+	// Build the handler on demand: every handler in a (filter, provider) slot differs only by the
+	// credential-derived channel id. c.filterKey is immutable after construction, so this needs no lock.
 	if h := streamProvider.Handler(sdkauth.NewScoped(c.filterKey, cred)); h != nil {
 		return h
 	}
@@ -1049,10 +955,8 @@ func (c *envContextImpl) Close() error {
 	return nil
 }
 
-// consumeBigSegmentUpdates spawns a goroutine that drains sync's update channel, broadcasting a
-// cache-clear + client-side invalidation for each batch. The goroutine exits when the channel closes
-// (i.e. when sync is Closed). Called for the initial synchronizer and for each re-anchor replacement, so
-// each synchronizer instance gets its own consumer bound to its own channel.
+// consumeBigSegmentUpdates spawns a goroutine that drains sync's update channel and broadcasts a
+// cache-clear and a client-side invalidation for each batch. The goroutine exits when sync closes.
 func (c *envContextImpl) consumeBigSegmentUpdates(sync bigsegments.BigSegmentSynchronizer) {
 	ch := sync.SegmentUpdatesCh()
 	if ch == nil {
@@ -1060,8 +964,7 @@ func (c *envContextImpl) consumeBigSegmentUpdates(sync bigsegments.BigSegmentSyn
 	}
 	go func() {
 		for range ch {
-			// The batch's segment keys are not needed today: we just ping all connected client-side SDKs.
-			// (A future evaluation-stream design would use the keys to target re-evaluation.)
+			// The batch's segment keys are not needed: relay pings all connected client-side SDKs.
 			if c.sdkBigSegments != nil {
 				c.sdkBigSegments.ClearCache()
 			}
@@ -1072,15 +975,9 @@ func (c *envContextImpl) consumeBigSegmentUpdates(sync bigsegments.BigSegmentSyn
 	}()
 }
 
-// reanchorBigSegmentSync rebuilds the big-segment synchronizer on the new anchor when the SDK anchor
-// changes. The synchronizer bakes in its SDK key at construction and is not restartable, so re-anchoring
-// recreates it rather than mutating it. The caller (commitReanchor) holds c.mu.
-//
-// If a big segment had already appeared (bigSegmentsExist -> the old synchronizer was Started), the
-// replacement is Started immediately so synchronization continues without a gap. The old synchronizer is
-// Closed last, which also ends its update-consumer goroutine. When big segments are not configured for
-// this env there is no synchronizer and this is a no-op. sdkBigSegments (the SDK-facing store wrapper)
-// persists across the re-anchor, so its polling-active state does not need re-setting here.
+// reanchorBigSegmentSync rebuilds the big-segment synchronizer on the new anchor. The synchronizer
+// bakes in its SDK key and is not restartable, so a re-anchor recreates it. It starts the replacement
+// when the old synchronizer was started, then closes the old one. The caller holds c.mu.
 func (c *envContextImpl) reanchorBigSegmentSync(newAnchor config.SDKKey) {
 	if c.bigSegmentSync == nil {
 		return
@@ -1099,12 +996,9 @@ func (c *envContextImpl) setBigSegmentsExist() {
 	c.mu.Lock()
 	firstTime := !c.bigSegmentsExist
 	c.bigSegmentsExist = true
-	// Start the CURRENT synchronizer while holding the lock. Capturing the pointer and starting it after
-	// unlocking would let a concurrent re-anchor swap and Close that instance in between, so we'd Start()
-	// a synchronizer that was just retired. Starting c.bigSegmentSync under the lock guarantees we start
-	// whichever synchronizer is current -- the same one reanchorBigSegmentSync starts under this lock --
-	// and never a retired one. Start() only launches a goroutine (it is non-blocking), so holding c.mu is
-	// fine, exactly as in reanchorBigSegmentSync.
+	// Start c.bigSegmentSync while holding the lock. Starting it after unlocking could start a
+	// synchronizer that a concurrent re-anchor already retired. Start() only launches a goroutine, so
+	// holding c.mu is safe.
 	started := firstTime && c.bigSegmentSync != nil
 	if started {
 		c.bigSegmentSync.Start()
@@ -1116,11 +1010,9 @@ func (c *envContextImpl) setBigSegmentsExist() {
 	}
 }
 
-// bigSegmentSyncConfigured reports whether this env has a big-segment synchronizer. The field's
-// nil-ness is invariant over the env's life (nil iff big segments were never configured; a re-anchor
-// only swaps one non-nil synchronizer for another), but the read must still be synchronized against
-// that concurrent reassign in reanchorBigSegmentSync -- the store-update sink below runs on the SDK
-// data-source goroutine while a re-anchor runs on the reconcile goroutine.
+// bigSegmentSyncConfigured reports whether this env has a big-segment synchronizer. The read is
+// synchronized against the reassign in reanchorBigSegmentSync: the store-update sink below runs on
+// the SDK data-source goroutine while a re-anchor runs on the reconcile goroutine.
 func (c *envContextImpl) bigSegmentSyncConfigured() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/sdks/client_factory.go
+++ b/internal/sdks/client_factory.go
@@ -45,9 +45,8 @@ type DataStoreStatusInfo struct {
 //
 // Store-release contract: a factory whose client construction builds the environment's data store must
 // return a non-nil client even when initialization fails, so that the caller's Close() releases the
-// (refcounted) store reference the build acquired. Returning (nil, err) after the store has been built
-// leaks that reference — the caller has no handle to release it. Returning (nil, err) before the store
-// is built is fine, as nothing was acquired. The default SDK factory honors this; test factories must too.
+// refcounted store reference the build acquired. Returning (nil, err) after the store is built leaks
+// that reference. Returning (nil, err) before the store is built is fine, as nothing was acquired.
 type ClientFactoryFunc func(sdkKey config.SDKKey, config ld.Config, timeout time.Duration) (LDClientContext, error)
 
 // LDClientConstructor is the function type of the underlying SDK client constructor.

--- a/internal/sharedtest/configsource/rac_mock.go
+++ b/internal/sharedtest/configsource/rac_mock.go
@@ -41,7 +41,7 @@ func NewRACMock(t testing.TB, initialEvent *httphelpers.SSEEvent) *RACMock {
 }
 
 // NewRACMockWithReconnect creates a RACMock that serves firstEvent to the first client that connects
-// and reconnectEvent to the next client — modeling a stream that a client restarts and reconnects to.
+// and reconnectEvent to the next client, modeling a stream that a client restarts and reconnects to.
 // This supports malformed-payload recovery: a rejected patch forces Relay to restart
 // its config stream, and the backend serves a fresh, corrected put on the reconnection.
 //

--- a/internal/store/relay_feature_store.go
+++ b/internal/store/relay_feature_store.go
@@ -21,9 +21,10 @@ import (
 // Also, since streamUpdatesStoreWrapper is a wrapper for an underlying data store that could be a database,
 // we need to be able to specify which data store implementation is being used - also as a factory.
 //
-// So, this factory implementation - which should only be used for a single client at a time - calls the
-// wrapped factory to produce the underlying data store, then creates our own store instance, and then
-// puts a reference to that instance inside itself where we can see it.
+// So, this factory implementation - which is used by one environment, and hands the same wrapper to
+// the incoming client on a re-anchor (see Build) - calls the wrapped factory to produce the underlying
+// data store, then creates our own store instance, and then puts a reference to that instance inside
+// itself where we can see it.
 type SSERelayDataStoreAdapter struct {
 	store          subsystems.DataStore
 	wrappedFactory subsystems.ComponentConfigurer[subsystems.DataStore]
@@ -68,13 +69,10 @@ func NewSSERelayDataStoreAdapter(
 
 // Build is called by the SDK when the LDClient is being created.
 //
-// Store handover (re-anchor): if the adapter already holds a wrapper from
-// a prior client construction, that wrapper is returned again instead of building a fresh one. This
-// hands the populated, initialized data store over to the new anchor's client during a re-anchor —
-// no empty-store window, no re-sync. The wrapper refcounts its holders so the underlying store is
-// only torn down by the final Close (see streamUpdatesStoreWrapper.Close). If the parked wrapper has
-// already been fully closed (acquire returns false), a fresh one is built rather than resurrecting a
-// wrapper whose underlying store is torn down.
+// Store handover: if the adapter already holds a live wrapper, Build returns that wrapper again
+// instead of building a fresh one. A re-anchor therefore hands the populated store to the new anchor's
+// client with no empty-store window. The wrapper refcounts its holders, so only the final Close tears
+// the store down. A fully-closed wrapper (acquire returns false) is not reused.
 func (a *SSERelayDataStoreAdapter) Build(
 	context subsystems.ClientContext,
 ) (subsystems.DataStore, error) {
@@ -109,11 +107,10 @@ type streamUpdatesStoreWrapper struct {
 	updates streams.EnvStreamUpdates
 	loggers ldlog.Loggers
 
-	// refCount tracks how many SDK clients hold this wrapper. The first holder is implicit
-	// (count starts at 1 in newStreamUpdatesStoreWrapper). Each handover (Build reuse) calls
-	// acquire to bump the count; each client's Close decrements. The underlying store is torn
-	// down only when the count reaches zero, at which point closed is set so a later acquire
-	// refuses to hand back a wrapper whose underlying store is gone. Guarded by refMu.
+	// refCount tracks how many SDK clients hold this wrapper. Each handover calls acquire to bump the
+	// count, and each client's Close decrements it. The underlying store is torn down only when the
+	// count reaches zero, which also sets closed so a later acquire refuses the wrapper. Guarded by
+	// refMu.
 	refMu    sync.Mutex
 	refCount int
 	closed   bool
@@ -133,10 +130,8 @@ func newStreamUpdatesStoreWrapper(
 	return relayStore
 }
 
-// acquire records an additional holder of the wrapper, used by SSERelayDataStoreAdapter.Build when it
-// hands this wrapper to a new client during a re-anchor. It returns false if the
-// wrapper has already been fully closed (refCount reached zero and the underlying store was torn
-// down); the caller must then build a fresh wrapper rather than resurrect a dead one.
+// acquire records an additional holder of the wrapper. It returns false if the wrapper is already
+// fully closed, in which case the caller must build a fresh wrapper.
 func (sw *streamUpdatesStoreWrapper) acquire() bool {
 	sw.refMu.Lock()
 	defer sw.refMu.Unlock()
@@ -150,10 +145,9 @@ func (sw *streamUpdatesStoreWrapper) acquire() bool {
 func (sw *streamUpdatesStoreWrapper) Close() error {
 	sw.refMu.Lock()
 	if sw.closed {
-		// Already fully torn down. A stray extra Close (the SDK's LDClient.Close is not idempotent, so
-		// this depends on caller discipline) must not decrement below zero and re-satisfy the final
-		// guard — that would close the underlying store a second time, double-releasing a persistent
-		// store's connection pool. Close is idempotent past the final release.
+		// Already torn down. A stray extra Close must not decrement below zero and re-satisfy the
+		// final guard, which would close the underlying store twice and double-release a persistent
+		// store's connection pool.
 		sw.refMu.Unlock()
 		return nil
 	}
@@ -164,9 +158,8 @@ func (sw *streamUpdatesStoreWrapper) Close() error {
 	}
 	sw.refMu.Unlock()
 	if !final {
-		// Re-anchor handover in progress: another client is still using this underlying store.
-		// The retiring client's Close must not tear it down — see SSERelayDataStoreAdapter.Build
-		// for the other half of this contract.
+		// Re-anchor handover in progress: another client still uses this underlying store, so the
+		// retiring client's Close must not tear it down.
 		return nil
 	}
 	return sw.store.Close()

--- a/relay/autoconfig_actions.go
+++ b/relay/autoconfig_actions.go
@@ -22,7 +22,7 @@ const (
 )
 
 // logViewScopedKeys reports the view-scoped credentials that BuildAcceptedSet filtered out of a
-// payload. This logs once per payload that actually reaches a handler.
+// payload.
 func logViewScopedKeys(loggers ldlog.Loggers, envName string, rejected []string) {
 	if len(rejected) > 0 {
 		loggers.Warnf(logMsgViewScopedKeysRejected, envName, strings.Join(rejected, ", "))
@@ -70,9 +70,7 @@ func (a *relayAutoConfigActions) UpdateEnvironment(params envfactory.Environment
 
 	set, rejected, buildErr := envfactory.BuildAcceptedSet(params)
 	if buildErr != nil {
-		// Credential payloads are validated at the stream parse boundary (see StreamManager) before
-		// being dispatched here, so a malformed set should not reach this point. Log defensively and
-		// preserve the previous credentials rather than applying a partial set.
+		// Already validated in StreamManager; keep the previous credentials if it somehow fails.
 		a.r.loggers.Errorf(logMsgAutoConfEnvInitError, params.Identifiers.GetDisplayName(), buildErr)
 		return
 	}

--- a/relay/endpoints_status.go
+++ b/relay/endpoints_status.go
@@ -49,14 +49,11 @@ func statusHandler(relay *Relay) http.Handler {
 				ProjName: identifiers.ProjName,
 			}
 
-			// One consistent snapshot of the accepted credential set drives every credential field
-			// below — the scalar anchor/primary designations, the full sdkKeys[]/mobileKeys[] arrays,
-			// and expiringSdkKey — so they cannot drift relative to each other under a concurrent
-			// reconcile.
+			// One snapshot drives every credential field below, so they cannot drift against each
+			// other under a concurrent reconcile.
 			accepted := clientCtx.GetAcceptedKeys()
 
-			// Scalar fields: the anchor SDK key and primary mobile key designate which array entry is
-			// the anchor / primary.
+			// The scalar fields designate which array entry is the anchor and which is the primary.
 			if accepted.Anchor.Defined() {
 				status.SDKKey = sdks.ObscureKey(string(accepted.Anchor))
 			}
@@ -75,7 +72,6 @@ func statusHandler(relay *Relay) http.Handler {
 			var expiringCandidates []expiringSDKKey
 			for value, info := range accepted.Server {
 				status.SDKKeys = append(status.SDKKeys, keyStatus(string(value), info))
-				// expiringSdkKey considers non-anchor server keys that carry an expiry.
 				if value != accepted.Anchor && info.Expiry != nil {
 					expiringCandidates = append(expiringCandidates, expiringSDKKey{value: string(value), expiry: *info.Expiry})
 				}
@@ -85,9 +81,8 @@ func statusHandler(relay *Relay) http.Handler {
 				status.MobileKeys = append(status.MobileKeys, keyStatus(string(value), info))
 			}
 
-			// expiringSdkKey: the soonest-expiring non-anchor SDK key. Comparing by expiry then by value
-			// gives a total order, so the chosen key is deterministic even when several keys share the
-			// same expiry (map iteration order, and hence MinFunc's pick on a tie, is otherwise unstable).
+			// expiringSdkKey is the soonest-expiring non-anchor SDK key. The value comparison breaks
+			// ties, because map iteration order is unstable.
 			if len(expiringCandidates) > 0 {
 				earliest := slices.MinFunc(expiringCandidates, func(a, b expiringSDKKey) int {
 					if c := a.expiry.Compare(b.expiry); c != 0 {
@@ -189,14 +184,13 @@ func statusHandler(relay *Relay) http.Handler {
 }
 
 // expiringSDKKey is a candidate for the status endpoint's expiringSdkKey field: a non-anchor SDK key
-// that carries an expiry. value is the plain credential; expiry is its (non-nil) expiry.
+// that carries an expiry.
 type expiringSDKKey struct {
 	value  string
 	expiry time.Time
 }
 
-// keyStatus converts an accepted key — its credential value plus metadata — into its status-endpoint
-// JSON representation, obscuring the secret value and surfacing the optional identifier and expiry.
+// keyStatus converts an accepted key and its metadata into the status-endpoint JSON representation.
 func keyStatus(value string, k credential.AcceptedKey) api.KeyStatus {
 	ks := api.KeyStatus{Value: sdks.ObscureKey(value)}
 	if k.Key != nil {

--- a/relay/filedata_actions.go
+++ b/relay/filedata_actions.go
@@ -60,8 +60,8 @@ func (a *relayFileDataActions) AddEnvironment(ae filedata.ArchiveEnvironment) {
 	set, rejected, buildErr := envfactory.BuildAcceptedSet(ae.Params)
 	if buildErr != nil {
 		a.r.loggers.Errorf(logMsgOfflineMalformedPayload, ae.Params.Identifiers.GetDisplayName(), buildErr)
-		// No reconnect for offline mode: preserve previous state (env was just created with
-		// the singular sdkKey from envConfig) and wait for the next archive reload.
+		// No reconnect for offline mode, which has no live stream: keep the previous credentials and
+		// wait for the next archive reload.
 	} else {
 		logViewScopedKeys(a.r.loggers, ae.Params.Identifiers.GetDisplayName(), rejected)
 		env.ReconcileCredentials(set)
@@ -99,7 +99,7 @@ func (a *relayFileDataActions) UpdateEnvironment(ae filedata.ArchiveEnvironment)
 	set, rejected, buildErr := envfactory.BuildAcceptedSet(ae.Params)
 	if buildErr != nil {
 		a.r.loggers.Errorf(logMsgOfflineMalformedPayload, ae.Params.Identifiers.GetDisplayName(), buildErr)
-		// Preserve previous credentials; no reconnect (offline path has no live stream).
+		// Keep the previous credentials. See addEnvironment: offline mode has no reconnect.
 	} else {
 		logViewScopedKeys(a.r.loggers, ae.Params.Identifiers.GetDisplayName(), rejected)
 		env.ReconcileCredentials(set)


### PR DESCRIPTION
## Summary

Comment-only cleanup of the non-test Go files that #817 touches. Every changed line is inside a comment; no production logic changed.

The comments added by #817 are rewritten to follow Simplified Technical English: sentences of 25 words or fewer, active voice, one idea per sentence, named nouns instead of an ambiguous "it" or "this", and one term per meaning ("anchor", "accepted set").

Added comment lines drop from 715 to 418 across the 19 files reviewed, a cut of 297 lines (42%). The two largest files carry most of it: `env_context_impl.go` 226 -> 118 and `rotator.go` 148 -> 80. Most of the saving comes from collapsing narrative doc comments and removing duplicated invariants -- the re-anchor protocol was written out six times, and `envContextImpl.reanchor` is now its single home.

Facts that exist only in comments are kept: lock ordering, why the lock is dropped around the client build, the `anchorClientGen` rationale, the double-broadcast hazard, the store-release contract, the refcount handover, and the RAC one-way push behavior.

All 79 comment lines carrying non-ASCII characters are now ASCII. Em-dashes became `--` or a sentence break; two Unicode arrows became `->`.

### Stale comments corrected

Six comments asserted behavior the code does not have. Each was checked against the code, and in every case the comment was wrong rather than the code:

- Four claimed `addCredential` still calls `startSDKClient`. It no longer does -- `NewEnvContext` is the only caller. The strip of a new anchor from `additions` stays, now documented with its real reason: `reanchor` registers that key's credential mappings itself.
- `EnvContext.GetCredentials` claimed to exclude deprecated keys. It returns `AllCredentials()`, which deliberately includes keys carrying a future expiry so a key inside its grace period still authenticates through `EnvironmentLookup.InsertEnvironment`.
- `sdkKeyIsActive` enumerated a narrower set than `AllCredentials` returns; a non-anchor key with no expiry is neither the anchor nor in a grace period.
- `CommitAnchor` cited a gate in `addCredential` that does not exist for SDK keys. The `GetClient()` half of that comment is correct and is kept.
- `ReconcileCredentials` was documented as atomic. It is serialized by `reconcileMu`, and a failed re-anchor reverts only the anchor change.
- Two pre-existing lines that #817 made false are updated: the store adapter's "single client at a time" claim, now that `Build` hands a refcounted wrapper to a second client, and `EnvironmentParams.SDKKey` described as "the latest" key, which has no meaning with concurrent keys.

`EnvironmentRep`'s documented wire shape now includes `hasViews`, which drives a rejection path in `BuildAcceptedSet`.

### Rollback behavior left as-is

Two rollback details are stated more explicitly rather than compressed, because both describe current behavior that is under separate review: `RevertAnchorChange` re-admits an outright-revoked previous anchor as a permanent key with no expiry, discarding that key's previous expiry, while a grace-demoted previous anchor keeps its expiry; and `reconcileCredentials` reverts only the anchor change on a failed re-anchor, leaving the other changes in the payload applied. No behavior is changed here and no TODO markers were added, so a follow-up change can own both.

### Note for reviewers

`internal/relayenv/store_handover_realclient_test.go` fails `gofmt` on the base branch and is untouched by this PR. A formatting lint failure on this branch originates there, not here.
