### PR TITLE
feat: register and record the init-concurrency limiter's observability

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -18,6 +18,24 @@ The Relay Proxy can export metrics via [OpenTelemetry Protocol (OTLP)](https://o
 | `launchdarkly.relay.events.dropped` | Counter | `{event}` | The cumulative number of events dropped due to capacity overflow. |
 | `launchdarkly.relay.events.pending` | Gauge | `{event}` | The current number of events buffered in the queue. |
 
+### Initialization-delivery limiter metrics
+
+These instruments are active only when the `[Concurrency]` limit is configured; read
+[Configuration](./configuration.md). They come from the relay's own layers, so one limitation
+applies: a `connection_ended` delivery outcome does not say why the connection ended -- a client
+disconnect and a relay deadline cut look the same.
+
+| Metric | Type | Unit | Description |
+|--------|------|------|-------------|
+| `launchdarkly.relay.init.slots.held` | Gauge | `{slot}` | The number of initialization-delivery slots currently held. |
+| `launchdarkly.relay.init.queue.waiting` | Gauge | `{request}` | The number of requests currently waiting for a slot. |
+| `launchdarkly.relay.init.admitted` | Counter | `{request}` | The cumulative number of requests the budget admitted. |
+| `launchdarkly.relay.init.rejected` | Counter | `{request}` | The cumulative number of requests the budget rejected, with the cause in `launchdarkly.relay.init.reason`: `budget_full`, `client_gone`, or `shutdown`. Only `budget_full` shows saturation; alert on that cause, not on the total. |
+| `launchdarkly.relay.init.deliveries` | Counter | `{delivery}` | Gated stream deliveries, with `launchdarkly.relay.init.protocol` (`fdv1` or `fdv2`), `launchdarkly.relay.init.outcome` (`completed`, `connection_ended`, or `read_error`), and `launchdarkly.relay.init.cap_engaged` (the absolute cap, not the throughput floor, governed the delivery). |
+| `launchdarkly.relay.init.sheds` | Counter | `{request}` | Requests shed because the budget and queue were full, with `launchdarkly.relay.init.transport` (`poll` or `stream`). Poll sheds carry `launchdarkly.environment.name`; stream sheds do not, because the stream layer does not know its environment. |
+| `launchdarkly.relay.init.replays.up_to_date` | Counter | `{reply}` | Stream replays answered with the small up-to-date reply, which is never charged to the budget. `launchdarkly.relay.init.after_wait` is true when the client's basis became current while it waited in the queue. |
+| `launchdarkly.relay.init.deadline.set_errors` | Counter | `{error}` | Failed attempts to set the connection write deadline. Above zero, the deadline protection is not in force. |
+
 ### Counting stream connections
 
 Version 8 exported two stream-specific metrics, `connections` and `newconnections`. Neither has a

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -51,6 +51,7 @@ activity.
 | `relay.response.write` | Writing the response body to the client |
 | `relay.events.dispatch` | Handing a received analytics or diagnostic event batch to the publisher |
 | `relay.singleflight.wait` | A request waiting for a payload another request was already building |
+| `relay.init.delivery` | One gated stream initialization delivery, from budget admission to the flushed basis or the end of the connection. Active only when the `[Concurrency]` limit is configured. |
 
 Span names are short and unprefixed on purpose: they are display strings in a trace waterfall, not
 queryable dimensions, and the semantic conventions do not namespace them either.
@@ -59,6 +60,10 @@ A failure sets the span's status to `Error`. Where there is an underlying error 
 that failed, a response that could not be written -- it is also recorded as a span event carrying the
 message. A rejected `relay.auth` has no such value: the reason is the
 `launchdarkly.relay.auth.result` attribute.
+
+Two initialization events can appear on the request span of a stream connect: `relay.init.shed`
+(the budget shed the replay; the reason is in `launchdarkly.relay.init.shed.reason`) and
+`relay.init.up_to_date` (the replay was answered with the small up-to-date reply).
 
 ## Span attributes
 
@@ -76,6 +81,12 @@ the Relay Proxy's own work are `launchdarkly.relay.<thing>`.
 | `launchdarkly.relay.payload.size` | `relay.payload.serialize` | Size of the serialized payload, in bytes |
 | `launchdarkly.relay.events.kind` | `relay.events.dispatch` | The kind of event batch received |
 | `http.response.status_code` | `relay.response.write` | The status written to the client |
+| `launchdarkly.relay.init.admitted` | request span | Whether the initialization budget admitted the request; only on requests that asked for a slot |
+| `launchdarkly.relay.init.queue.wait.duration` | request span, `relay.init.delivery` | Time spent waiting for an initialization slot, in seconds |
+| `launchdarkly.relay.init.shed.reason` | request span | Cause of an initialization rejection: `budget_full`, `client_gone`, or `shutdown` |
+| `launchdarkly.relay.init.protocol` | `relay.init.delivery` | `fdv1` or `fdv2` |
+| `launchdarkly.relay.init.outcome` | `relay.init.delivery` | `completed`, `connection_ended`, `read_error`, or `up_to_date`. A `connection_ended` outcome does not say why the connection ended: a client disconnect and a relay deadline cut look the same. |
+| `launchdarkly.relay.init.cap_engaged` | `relay.init.delivery` | The absolute delivery cap, not the throughput floor, governed the write deadline |
 
 `launchdarkly.relay.payload.size` is what the Relay Proxy *built*. What actually went out on the wire
 is `http.response.body.size` on the request span, counted outside the compression middleware, and the

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -22,6 +22,17 @@ const (
 	eventsDroppedMeasureName   = "launchdarkly.relay.events.dropped"
 	eventsPendingMeasureName   = "launchdarkly.relay.events.pending"
 
+	// The initialization-delivery limiter instruments. They are active only when the
+	// [Concurrency] limit is configured.
+	initSlotsHeldMeasureName         = "launchdarkly.relay.init.slots.held"
+	initQueueWaitingMeasureName      = "launchdarkly.relay.init.queue.waiting"
+	initAdmittedMeasureName          = "launchdarkly.relay.init.admitted"
+	initRejectedMeasureName          = "launchdarkly.relay.init.rejected"
+	initDeliveriesMeasureName        = "launchdarkly.relay.init.deliveries"
+	initShedsMeasureName             = "launchdarkly.relay.init.sheds"
+	initUpToDateMeasureName          = "launchdarkly.relay.init.replays.up_to_date"
+	initDeadlineSetErrorsMeasureName = "launchdarkly.relay.init.deadline.set_errors"
+
 	defaultFlushInterval = time.Minute
 
 	// notProvidedValue is the sentinel reported for an OTel attribute whose value is absent. It is
@@ -83,6 +94,14 @@ var (
 	applicationIDAttrKey      = attribute.Key("launchdarkly.application.id")      //nolint:gochecknoglobals
 	applicationVersionAttrKey = attribute.Key("launchdarkly.application.version") //nolint:gochecknoglobals
 	endpointTypeAttrKey       = attribute.Key("launchdarkly.relay.endpoint.type") //nolint:gochecknoglobals
+
+	// Attribute keys for the initialization-delivery limiter instruments.
+	initReasonAttrKey     = attribute.Key("launchdarkly.relay.init.reason")      //nolint:gochecknoglobals
+	initTransportAttrKey  = attribute.Key("launchdarkly.relay.init.transport")   //nolint:gochecknoglobals
+	initProtocolAttrKey   = attribute.Key("launchdarkly.relay.init.protocol")    //nolint:gochecknoglobals
+	initOutcomeAttrKey    = attribute.Key("launchdarkly.relay.init.outcome")     //nolint:gochecknoglobals
+	initCapEngagedAttrKey = attribute.Key("launchdarkly.relay.init.cap_engaged") //nolint:gochecknoglobals
+	initAfterWaitAttrKey  = attribute.Key("launchdarkly.relay.init.after_wait")  //nolint:gochecknoglobals
 
 	// OTEL HTTP semantic convention attribute keys (from semconv package)
 	userAgentAttrKey           = semconv.UserAgentOriginalKey      //nolint:gochecknoglobals

--- a/internal/metrics/init_measures.go
+++ b/internal/metrics/init_measures.go
@@ -1,0 +1,153 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/concurrency"
+
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+// InitInstruments records the initialization-delivery limiter's synchronous measurements:
+// deliveries with their outcomes, sheds, up-to-date replies, and failed write-deadline
+// calls. The observable side of the limiter -- held slots, queue depth, and the admission
+// and rejection totals -- comes from RegisterInitConcurrencyObservers instead, which reads
+// the limiter's own counters.
+type InitInstruments struct {
+	deliveries        otelmetric.Int64Counter
+	sheds             otelmetric.Int64Counter
+	upToDate          otelmetric.Int64Counter
+	deadlineSetErrors otelmetric.Int64Counter
+}
+
+func newInitInstruments(meter otelmetric.Meter) *InitInstruments {
+	deliveries, _ := meter.Int64Counter(initDeliveriesMeasureName,
+		otelmetric.WithDescription("Initialization deliveries, by protocol and outcome"),
+		otelmetric.WithUnit("{delivery}"))
+	sheds, _ := meter.Int64Counter(initShedsMeasureName,
+		otelmetric.WithDescription("Requests shed because the initialization budget and queue were full"),
+		otelmetric.WithUnit("{request}"))
+	upToDate, _ := meter.Int64Counter(initUpToDateMeasureName,
+		otelmetric.WithDescription("Stream replays answered with the small up-to-date reply, which is never charged to the budget"),
+		otelmetric.WithUnit("{reply}"))
+	deadlineSetErrors, _ := meter.Int64Counter(initDeadlineSetErrorsMeasureName,
+		otelmetric.WithDescription("Failed attempts to set the connection write deadline; above zero, the deadline protection is not in force"),
+		otelmetric.WithUnit("{error}"))
+	return &InitInstruments{
+		deliveries:        deliveries,
+		sheds:             sheds,
+		upToDate:          upToDate,
+		deadlineSetErrors: deadlineSetErrors,
+	}
+}
+
+// RecordDelivery records one gated delivery. The outcome is completed, connection_ended, or
+// read_error. A connection_ended outcome does not say why the connection ended: a client
+// disconnect and a relay deadline cut look the same to the producer.
+func (i *InitInstruments) RecordDelivery(protocol, outcome string, capEngaged bool) {
+	if i == nil {
+		return
+	}
+	i.deliveries.Add(context.Background(), 1, otelmetric.WithAttributes(
+		initProtocolAttrKey.String(protocol),
+		initOutcomeAttrKey.String(outcome),
+		initCapEngagedAttrKey.Bool(capEngaged),
+	))
+}
+
+// RecordUpToDate records one up-to-date reply. afterWait is true when the client's basis
+// became current while the client waited in the queue.
+func (i *InitInstruments) RecordUpToDate(afterWait bool) {
+	if i == nil {
+		return
+	}
+	i.upToDate.Add(context.Background(), 1, otelmetric.WithAttributes(
+		initAfterWaitAttrKey.Bool(afterWait),
+	))
+}
+
+// RecordShed records one shed stream replay. Stream sheds carry no environment name: the
+// stream repository does not know its environment.
+func (i *InitInstruments) RecordShed() {
+	if i == nil {
+		return
+	}
+	i.sheds.Add(context.Background(), 1, otelmetric.WithAttributes(
+		initTransportAttrKey.String("stream"),
+	))
+}
+
+// RecordPollShed records one shed polling request, with the environment name.
+func (i *InitInstruments) RecordPollShed(envName string) {
+	if i == nil {
+		return
+	}
+	attrs := []otelmetric.AddOption{otelmetric.WithAttributes(
+		initTransportAttrKey.String("poll"),
+		envNameAttrKey.String(sanitizeTagValue(envName)),
+	)}
+	i.sheds.Add(context.Background(), 1, attrs...)
+}
+
+// AddDeadlineSetErrors adds the count of failed write-deadline calls a delivery observed.
+func (i *InitInstruments) AddDeadlineSetErrors(n int64) {
+	if i == nil || n <= 0 {
+		return
+	}
+	i.deadlineSetErrors.Add(context.Background(), n)
+}
+
+// InitInstruments returns the recorder for the initialization-delivery measurements. It is
+// nil when OpenTelemetry is disabled; every method of the recorder accepts a nil receiver
+// and does nothing, so callers can record without a check.
+func (m *Manager) InitInstruments() *InitInstruments {
+	return m.initInstruments
+}
+
+// RegisterInitConcurrencyObservers registers the observable limiter instruments: the held
+// slots, the queue depth, and the admission and rejection totals, with the rejections split
+// by cause. Call it one time, after the limiter is built and only when the limiter is
+// enabled; the callback reads the limiter's counters at each collection.
+func (m *Manager) RegisterInitConcurrencyObservers(limiter *concurrency.Limiter) error {
+	if m.meter == nil {
+		return nil // OpenTelemetry is disabled
+	}
+	held, err := m.meter.Int64ObservableGauge(initSlotsHeldMeasureName,
+		otelmetric.WithDescription("Initialization-delivery slots currently held"),
+		otelmetric.WithUnit("{slot}"))
+	if err != nil {
+		return err
+	}
+	waiting, err := m.meter.Int64ObservableGauge(initQueueWaitingMeasureName,
+		otelmetric.WithDescription("Requests currently waiting for an initialization-delivery slot"),
+		otelmetric.WithUnit("{request}"))
+	if err != nil {
+		return err
+	}
+	admitted, err := m.meter.Int64ObservableCounter(initAdmittedMeasureName,
+		otelmetric.WithDescription("Requests admitted by the initialization-delivery budget"),
+		otelmetric.WithUnit("{request}"))
+	if err != nil {
+		return err
+	}
+	rejected, err := m.meter.Int64ObservableCounter(initRejectedMeasureName,
+		otelmetric.WithDescription("Requests rejected by the initialization-delivery budget, by cause; only budget_full shows saturation"),
+		otelmetric.WithUnit("{request}"))
+	if err != nil {
+		return err
+	}
+	_, err = m.meter.RegisterCallback(func(_ context.Context, o otelmetric.Observer) error {
+		s := limiter.Stats()
+		o.ObserveInt64(held, int64(s.Held))
+		o.ObserveInt64(waiting, int64(s.Waiting))
+		o.ObserveInt64(admitted, s.Admitted)
+		o.ObserveInt64(rejected, s.RejectedFull,
+			otelmetric.WithAttributes(initReasonAttrKey.String("budget_full")))
+		o.ObserveInt64(rejected, s.RejectedClientGone,
+			otelmetric.WithAttributes(initReasonAttrKey.String("client_gone")))
+		o.ObserveInt64(rejected, s.RejectedShutdown,
+			otelmetric.WithAttributes(initReasonAttrKey.String("shutdown")))
+		return nil
+	}, held, waiting, admitted, rejected)
+	return err
+}

--- a/internal/metrics/init_measures_test.go
+++ b/internal/metrics/init_measures_test.go
@@ -1,0 +1,149 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/concurrency"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// collect gathers everything the reader has and returns the metrics by name.
+func collect(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Metrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	out := map[string]metricdata.Metrics{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out[m.Name] = m
+		}
+	}
+	return out
+}
+
+func sumPoints(t *testing.T, m metricdata.Metrics) []metricdata.DataPoint[int64] {
+	t.Helper()
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "%s must be an int64 sum", m.Name)
+	return sum.DataPoints
+}
+
+func pointWith(t *testing.T, points []metricdata.DataPoint[int64], kv attribute.KeyValue) metricdata.DataPoint[int64] {
+	t.Helper()
+	for _, p := range points {
+		if v, ok := p.Attributes.Value(kv.Key); ok && v == kv.Value {
+			return p
+		}
+	}
+	require.Failf(t, "missing data point", "no point with %v=%v", kv.Key, kv.Value)
+	return metricdata.DataPoint[int64]{}
+}
+
+func TestInitInstrumentsRecordTheSynchronousMeasurements(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	meter := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test")
+	ii := newInitInstruments(meter)
+
+	ii.RecordDelivery("fdv2", "completed", false)
+	ii.RecordDelivery("fdv2", "connection_ended", true)
+	ii.RecordDelivery("fdv1", "read_error", false)
+	ii.RecordUpToDate(false)
+	ii.RecordUpToDate(true)
+	ii.RecordShed()
+	ii.RecordPollShed("Production Env")
+	ii.AddDeadlineSetErrors(3)
+	ii.AddDeadlineSetErrors(0) // must not create a data point
+
+	ms := collect(t, reader)
+
+	deliveries := sumPoints(t, ms[initDeliveriesMeasureName])
+	assert.Len(t, deliveries, 3)
+	assert.Equal(t, int64(1), pointWith(t, deliveries, initOutcomeAttrKey.String("connection_ended")).Value)
+	p := pointWith(t, deliveries, initOutcomeAttrKey.String("connection_ended"))
+	capVal, _ := p.Attributes.Value(initCapEngagedAttrKey)
+	assert.True(t, capVal.AsBool(), "the cap_engaged attribute must survive")
+
+	upToDate := sumPoints(t, ms[initUpToDateMeasureName])
+	assert.Equal(t, int64(1), pointWith(t, upToDate, initAfterWaitAttrKey.Bool(true)).Value)
+	assert.Equal(t, int64(1), pointWith(t, upToDate, initAfterWaitAttrKey.Bool(false)).Value)
+
+	sheds := sumPoints(t, ms[initShedsMeasureName])
+	assert.Equal(t, int64(1), pointWith(t, sheds, initTransportAttrKey.String("stream")).Value)
+	pollShed := pointWith(t, sheds, initTransportAttrKey.String("poll"))
+	envVal, ok := pollShed.Attributes.Value(envNameAttrKey)
+	require.True(t, ok, "a poll shed must carry the environment name")
+	assert.NotEmpty(t, envVal.AsString())
+
+	errs := sumPoints(t, ms[initDeadlineSetErrorsMeasureName])
+	require.Len(t, errs, 1)
+	assert.Equal(t, int64(3), errs[0].Value)
+}
+
+func TestRegisterInitConcurrencyObserversReadTheLimiter(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	meter := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test")
+	m := &Manager{meter: meter}
+
+	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 2, MaxQueued: 1})
+	require.NoError(t, m.RegisterInitConcurrencyObservers(limiter))
+
+	// Drive the limiter to a known state: two held slots, one rejection of each cause.
+	r1, ok := limiter.Acquire(context.Background())
+	require.True(t, ok)
+	_, ok = limiter.Acquire(context.Background())
+	require.True(t, ok)
+	gone, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, ok = limiter.Acquire(gone) // client_gone
+	require.False(t, ok)
+	// Fill the queue, then overflow it for a budget_full rejection.
+	go func() {
+		if r, ok := limiter.Acquire(context.Background()); ok {
+			r()
+		}
+	}()
+	for limiter.Stats().Waiting != 1 {
+	}
+	_, ok = limiter.Acquire(context.Background()) // budget_full
+	require.False(t, ok)
+
+	ms := collect(t, reader)
+	heldGauge, ok2 := ms[initSlotsHeldMeasureName].Data.(metricdata.Gauge[int64])
+	require.True(t, ok2)
+	assert.Equal(t, int64(2), heldGauge.DataPoints[0].Value)
+
+	waitingGauge, _ := ms[initQueueWaitingMeasureName].Data.(metricdata.Gauge[int64])
+	assert.Equal(t, int64(1), waitingGauge.DataPoints[0].Value)
+
+	admitted := sumPoints(t, ms[initAdmittedMeasureName])
+	require.Len(t, admitted, 1)
+	assert.Equal(t, int64(2), admitted[0].Value)
+
+	rejected := sumPoints(t, ms[initRejectedMeasureName])
+	assert.Equal(t, int64(1), pointWith(t, rejected, initReasonAttrKey.String("budget_full")).Value)
+	assert.Equal(t, int64(1), pointWith(t, rejected, initReasonAttrKey.String("client_gone")).Value)
+	assert.Equal(t, int64(0), pointWith(t, rejected, initReasonAttrKey.String("shutdown")).Value)
+
+	r1()
+	limiter.Close()
+}
+
+func TestInitInstrumentsAreSafeWhenDisabled(t *testing.T) {
+	// When OpenTelemetry is disabled the recorder is nil; every method must do nothing.
+	var ii *InitInstruments
+	assert.NotPanics(t, func() {
+		ii.RecordDelivery("fdv2", "completed", false)
+		ii.RecordUpToDate(true)
+		ii.RecordShed()
+		ii.RecordPollShed("env")
+		ii.AddDeadlineSetErrors(1)
+	})
+	m := &Manager{} // no meter: registration must be a quiet no-op
+	assert.NoError(t, m.RegisterInitConcurrencyObservers(concurrency.New("t", concurrency.Params{MaxConcurrent: 1})))
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
@@ -21,16 +22,18 @@ var errAddEnvironmentAfterClosed = errors.New("tried to add new environment afte
 // Manager is the top-level object that controls all of our metrics exporter activity. It should be
 // created and retained by the Relay instance, and closed when the Relay instance is closed.
 type Manager struct {
-	metricsRelayID string
-	instruments    *Instruments
-	meterProvider  *sdkmetric.MeterProvider
-	flushInterval  time.Duration
-	logger         *slog.Logger
-	closeOnce      sync.Once
-	closed         bool
-	lock           sync.Mutex
-	environments   []*EnvironmentManager
-	unscopedEnv    *EnvironmentManager
+	metricsRelayID  string
+	instruments     *Instruments
+	initInstruments *InitInstruments
+	meter           otelmetric.Meter
+	meterProvider   *sdkmetric.MeterProvider
+	flushInterval   time.Duration
+	logger          *slog.Logger
+	closeOnce       sync.Once
+	closed          bool
+	lock            sync.Mutex
+	environments    []*EnvironmentManager
+	unscopedEnv     *EnvironmentManager
 
 	usageChan            chan any
 	environmentsForUsage map[string]*environmentMetricUsage
@@ -74,6 +77,8 @@ func NewManager(
 	// 3.5 KB each, only to be handed to an instrument that discards them.
 	var meterProvider *sdkmetric.MeterProvider
 	var instruments *Instruments
+	var initInstruments *InitInstruments
+	var meter otelmetric.Meter
 	if otlpConfig.Enabled {
 		opts, err := newOTLPExporters(otlpConfig, logger)
 		if err != nil {
@@ -89,16 +94,20 @@ func NewManager(
 		if err := runtime.Start(runtime.WithMeterProvider(meterProvider)); err != nil {
 			logger.Warn("failed to start Go runtime metrics", "error", err)
 		}
-		instruments, err = newInstruments(meterProvider.Meter("ld-relay"))
+		meter = meterProvider.Meter("ld-relay")
+		instruments, err = newInstruments(meter)
 		if err != nil {
 			return nil, err
 		}
+		initInstruments = newInitInstruments(meter)
 	}
 
 	usageChan := make(chan any, 256)
 	m := &Manager{
 		metricsRelayID:       metricsRelayID,
 		instruments:          instruments,
+		initInstruments:      initInstruments,
+		meter:                meter,
 		meterProvider:        meterProvider,
 		flushInterval:        flushInterval,
 		logger:               logger,

--- a/internal/middleware/concurrency.go
+++ b/internal/middleware/concurrency.go
@@ -56,8 +56,11 @@ func AcquireInitSlot(limiter *concurrency.Limiter, recorder InitShedRecorder, w 
 		tracing.InitQueueWaitDurationKey.Float64(time.Since(start).Seconds()),
 	)
 	if !ok {
-		span.SetAttributes(tracing.InitShedReasonKey.String(shedReason(r, limiter)))
-		if recorder != nil {
+		reason := shedReason(r, limiter)
+		span.SetAttributes(tracing.InitShedReasonKey.String(reason))
+		// Only budget pressure counts as a shed. A client that left the queue, and a
+		// shutdown drain, show on the rejected counter under their own causes.
+		if reason == "budget_full" && recorder != nil {
 			recorder.RecordPollShed(envNameFromContext(r))
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/middleware/concurrency.go
+++ b/internal/middleware/concurrency.go
@@ -18,8 +18,15 @@ import (
 type initLimiterCtxKey struct{}
 
 type initLimiterHolder struct {
-	limiter *concurrency.Limiter
-	maxHold time.Duration
+	limiter  *concurrency.Limiter
+	maxHold  time.Duration
+	recorder InitShedRecorder
+}
+
+// InitShedRecorder counts polling requests the initialization-delivery budget shed. The
+// metrics package implements it. A nil recorder is permitted and records nothing.
+type InitShedRecorder interface {
+	RecordPollShed(envName string)
 }
 
 // AcquireInitSlot draws one slot from the shared initialization-delivery limiter for the
@@ -34,7 +41,7 @@ type initLimiterHolder struct {
 // It is called both by LimitConcurrency (which gates a whole handler, e.g. the FDv1 all-flags
 // poll) and directly by the FDv2 poll handlers, which acquire only on the full-basis branch so
 // a cheap up-to-date reply is never charged.
-func AcquireInitSlot(limiter *concurrency.Limiter, w http.ResponseWriter, r *http.Request) (release func(), ok bool) {
+func AcquireInitSlot(limiter *concurrency.Limiter, recorder InitShedRecorder, w http.ResponseWriter, r *http.Request) (release func(), ok bool) {
 	if !limiter.Enabled() {
 		return func() {}, true
 	}
@@ -50,6 +57,9 @@ func AcquireInitSlot(limiter *concurrency.Limiter, w http.ResponseWriter, r *htt
 	)
 	if !ok {
 		span.SetAttributes(tracing.InitShedReasonKey.String(shedReason(r, limiter)))
+		if recorder != nil {
+			recorder.RecordPollShed(envNameFromContext(r))
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds()))
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -67,13 +77,13 @@ func AcquireInitSlot(limiter *concurrency.Limiter, w http.ResponseWriter, r *htt
 // pass-through with zero overhead. Handlers that have a cheap no-payload branch (the FDv2
 // polls) should instead call AcquireInitSlot directly, after that branch, so the cheap reply
 // is not charged.
-func LimitConcurrency(limiter *concurrency.Limiter, maxHold time.Duration) func(http.Handler) http.Handler {
+func LimitConcurrency(limiter *concurrency.Limiter, maxHold time.Duration, recorder InitShedRecorder) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		if !limiter.Enabled() {
 			return next
 		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			release, ok := AcquireInitSlot(limiter, w, r)
+			release, ok := AcquireInitSlot(limiter, recorder, w, r)
 			if !ok {
 				return
 			}
@@ -96,14 +106,14 @@ func clearWriteDeadline(w http.ResponseWriter) {
 // in the progress-aware writer. It is used for the FDv2 poll endpoints, whose handlers acquire
 // lazily (via AcquireInitSlotFromContext) only on the full-basis branch, so a cheap up-to-date
 // reply is never charged. A disabled or nil limiter is a pass-through with zero overhead.
-func ProvideInitLimiter(limiter *concurrency.Limiter, maxHold time.Duration) func(http.Handler) http.Handler {
+func ProvideInitLimiter(limiter *concurrency.Limiter, maxHold time.Duration, recorder InitShedRecorder) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		if !limiter.Enabled() {
 			return next
 		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer clearWriteDeadline(w)
-			ctx := context.WithValue(r.Context(), initLimiterCtxKey{}, initLimiterHolder{limiter: limiter, maxHold: maxHold})
+			ctx := context.WithValue(r.Context(), initLimiterCtxKey{}, initLimiterHolder{limiter: limiter, maxHold: maxHold, recorder: recorder})
 			next.ServeHTTP(initwrite.Wrap(w, maxHold), r.WithContext(ctx))
 		})
 	}
@@ -115,7 +125,17 @@ func ProvideInitLimiter(limiter *concurrency.Limiter, maxHold time.Duration) fun
 // path.
 func AcquireInitSlotFromContext(w http.ResponseWriter, r *http.Request) (release func(), ok bool) {
 	holder, _ := r.Context().Value(initLimiterCtxKey{}).(initLimiterHolder)
-	return AcquireInitSlot(holder.limiter, w, r)
+	return AcquireInitSlot(holder.limiter, holder.recorder, w, r)
+}
+
+// envNameFromContext returns the display name of the request's environment, or an empty
+// string when the context has none. It must not panic: the shed path runs on routes whose
+// stacks differ in when they attach the environment.
+func envNameFromContext(r *http.Request) string {
+	if info, ok := r.Context().Value(contextKey).(EnvContextInfo); ok && info.Env != nil {
+		return info.Env.GetIdentifiers().GetDisplayName()
+	}
+	return ""
 }
 
 // shedReason names the cause of a rejection, with the same decision order as the stream

--- a/internal/middleware/concurrency_test.go
+++ b/internal/middleware/concurrency_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 func TestLimitConcurrencyDisabledIsPassThrough(t *testing.T) {
 	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 0}) // disabled
 	called := false
-	h := LimitConcurrency(limiter, time.Second)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	h := LimitConcurrency(limiter, time.Second, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -35,7 +36,7 @@ func TestLimitConcurrencyShedsWhenBudgetFull(t *testing.T) {
 	defer release()
 
 	called := false
-	h := LimitConcurrency(limiter, time.Second)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+	h := LimitConcurrency(limiter, time.Second, nil)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		called = true
 	}))
 	rr := httptest.NewRecorder()
@@ -56,7 +57,7 @@ func TestLimitConcurrencyShedsWhenBudgetFull(t *testing.T) {
 
 func TestLimitConcurrencyReleasesSlotWhenHandlerReturns(t *testing.T) {
 	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 0})
-	h := LimitConcurrency(limiter, time.Second)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	h := LimitConcurrency(limiter, time.Second, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	// Two sequential requests both succeed, which is only possible if the single slot is
@@ -81,7 +82,7 @@ func TestAcquireInitSlotFromContextChargesOnlyWhenProvided(t *testing.T) {
 	assert.Equal(t, int64(0), limiter.Stats().Admitted, "absent limiter must not charge a slot")
 
 	// When ProvideInitLimiter installed the limiter, a full-basis handler charges a slot.
-	provided := ProvideInitLimiter(limiter, time.Second)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	provided := ProvideInitLimiter(limiter, time.Second, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rel, ok := AcquireInitSlotFromContext(w, r)
 		require.True(t, ok)
 		defer rel()
@@ -100,7 +101,7 @@ func TestAcquireInitSlotFromContextShedsWhenBudgetFull(t *testing.T) {
 	defer release()
 
 	handlerRan := false
-	provided := ProvideInitLimiter(limiter, time.Second)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	provided := ProvideInitLimiter(limiter, time.Second, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rel, ok := AcquireInitSlotFromContext(w, r)
 		if !ok {
 			return
@@ -114,4 +115,43 @@ func TestAcquireInitSlotFromContextShedsWhenBudgetFull(t *testing.T) {
 
 	assert.False(t, handlerRan, "full-basis handler must not proceed once shed")
 	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+type fakePollShedRecorder struct {
+	mu    sync.Mutex
+	sheds []string
+}
+
+func (f *fakePollShedRecorder) RecordPollShed(envName string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sheds = append(f.sheds, envName)
+}
+
+func TestAcquireInitSlotRecordsAPollShed(t *testing.T) {
+	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 0})
+	hold, ok := limiter.Acquire(context.Background())
+	require.True(t, ok)
+	defer hold()
+
+	rec := &fakePollShedRecorder{}
+	h := LimitConcurrency(limiter, time.Second, rec)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("the shed request must not reach the handler")
+	}))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.Len(t, rec.sheds, 1, "a poll shed must be recorded")
+	// With no environment in the context, the name is empty rather than a panic; the routes
+	// that carry an environment attach its display name.
+	require.Equal(t, "", rec.sheds[0])
+
+	// An admitted request records nothing.
+	hold()
+	served := false
+	h2 := LimitConcurrency(limiter, time.Second, rec)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { served = true }))
+	h2.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+	require.True(t, served)
+	require.Len(t, rec.sheds, 1)
 }

--- a/internal/middleware/concurrency_test.go
+++ b/internal/middleware/concurrency_test.go
@@ -154,4 +154,20 @@ func TestAcquireInitSlotRecordsAPollShed(t *testing.T) {
 	h2.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
 	require.True(t, served)
 	require.Len(t, rec.sheds, 1)
+
+	// A client that left the queue is not budget pressure, so it is not a shed. The
+	// rejected counter reports it under the client_gone cause.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	wGone := httptest.NewRecorder()
+	h.ServeHTTP(wGone, httptest.NewRequest("GET", "/", nil).WithContext(cancelled))
+	require.Equal(t, http.StatusServiceUnavailable, wGone.Code)
+	require.Len(t, rec.sheds, 1, "a client that left must not count as a shed")
+
+	// A shutdown drain is not budget pressure either.
+	limiter.Close()
+	wShutdown := httptest.NewRecorder()
+	h.ServeHTTP(wShutdown, httptest.NewRequest("GET", "/", nil))
+	require.Equal(t, http.StatusServiceUnavailable, wShutdown.Code)
+	require.Len(t, rec.sheds, 1, "a shutdown rejection must not count as a shed")
 }

--- a/internal/streams/init_observer_test.go
+++ b/internal/streams/init_observer_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -180,6 +181,67 @@ func TestStreamReplayDeliverySpanEndsOnceWithOutcome(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "the shed event must land on the request span")
+}
+
+func TestStreamReplayUpToDateAfterWaitEventLandsOnTheRequestSpan(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+	defer otel.SetTracerProvider(prev)
+
+	// The store starts behind the client's basis and catches up while the client waits in
+	// the queue, so the post-admission read takes the up-to-date path.
+	var stateNow atomic.Int64
+	stateNow.Store(1)
+	store := newMockStoreQueries()
+	store.setupSnapshotFn(func() (map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor, subsystems.Selector, error) {
+		st := int(stateNow.Load())
+		flag := ldbuilders.NewFlagBuilder("flagkey").Version(st).Build()
+		return map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor{
+			ldstoreimpl.Features(): {ldstoretypes.KeyedItemDescriptor{Key: "flagkey", Item: sharedtest.FlagDesc(flag)}},
+			ldstoreimpl.Segments(): {},
+		}, subsystems.NewSelector("s"+strconv.Itoa(st), st), nil
+	})
+
+	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 1})
+	hold, ok := limiter.Acquire(context.Background())
+	require.True(t, ok)
+
+	repo := &serverSideEnvStreamRepository{store: store, logger: slog.Default(), isV2: true, initLimiter: limiter}
+	pctx, parent := tracing.Tracer().Start(context.Background(), "request-parent")
+	eventCh := repo.ReplayWithContext(pctx, "", "s2")
+	deadline := time.Now().Add(2 * time.Second)
+	for limiter.Stats().Waiting != 1 {
+		if time.Now().After(deadline) {
+			require.Failf(t, "timeout", "client never queued (stats: %+v)", limiter.Stats())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	stateNow.Store(2)
+	hold()
+	drainReplay(t, eventCh)
+	parent.End()
+
+	// The delivery span ends with the up_to_date outcome, but the event itself belongs on
+	// the request span, the same as the no-wait path and the documentation.
+	waitForSpan(t, sr, tracing.SpanInitDelivery)
+	dspans := endedSpans(sr, tracing.SpanInitDelivery)
+	require.Len(t, dspans, 1)
+	assert.Contains(t, attrString(dspans[0]), "up_to_date")
+	for _, e := range dspans[0].Events() {
+		assert.NotEqual(t, tracing.EventInitUpToDate, e.Name, "the event must not land on the delivery span")
+	}
+	found := false
+	for _, s := range sr.Ended() {
+		if s.Name() == "request-parent" {
+			for _, e := range s.Events() {
+				if e.Name == tracing.EventInitUpToDate {
+					found = true
+				}
+			}
+		}
+	}
+	assert.True(t, found, "the up-to-date event must land on the request span")
 }
 
 func drainReplay(t *testing.T, ch <-chan eventsource.Event) {

--- a/internal/streams/init_observer_test.go
+++ b/internal/streams/init_observer_test.go
@@ -1,0 +1,227 @@
+package streams
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+
+	"net/http/httptest"
+
+	"github.com/launchdarkly/eventsource"
+
+	"github.com/launchdarkly/ld-relay/v9/internal/concurrency"
+	"github.com/launchdarkly/ld-relay/v9/internal/initwrite"
+	"github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// fakeInitObserver records every call, safely across goroutines.
+type fakeInitObserver struct {
+	mu         sync.Mutex
+	calls      []string
+	deadlineNs int64
+}
+
+func (f *fakeInitObserver) RecordDelivery(protocol, outcome string, capEngaged bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, fmt.Sprintf("delivery:%s:%s:%v", protocol, outcome, capEngaged))
+}
+func (f *fakeInitObserver) RecordUpToDate(afterWait bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, fmt.Sprintf("up_to_date:%v", afterWait))
+}
+func (f *fakeInitObserver) RecordShed() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "shed")
+}
+func (f *fakeInitObserver) AddDeadlineSetErrors(n int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deadlineNs += n
+}
+func (f *fakeInitObserver) snapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func newObserverRecorder() *deadlineRecorder {
+	return &deadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func observerStore(t *testing.T, state int) *mockStoreQueries {
+	t.Helper()
+	store := newMockStoreQueries()
+	store.setupSnapshotFn(func() (map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor, subsystems.Selector, error) {
+		flag := ldbuilders.NewFlagBuilder("flagkey").Version(state).Build()
+		return map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor{
+			ldstoreimpl.Features(): {ldstoretypes.KeyedItemDescriptor{Key: "flagkey", Item: sharedtest.FlagDesc(flag)}},
+			ldstoreimpl.Segments(): {},
+		}, subsystems.NewSelector("s"+strconv.Itoa(state), state), nil
+	})
+	return store
+}
+
+func waitForCalls(t *testing.T, f *fakeInitObserver, n int) []string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		calls := f.snapshot()
+		if len(calls) >= n {
+			return calls
+		}
+		if time.Now().After(deadline) {
+			require.Failf(t, "timeout", "observer saw only %v", calls)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestStreamReplayReportsToInitObserver(t *testing.T) {
+	t.Run("shed", func(t *testing.T) {
+		obs := &fakeInitObserver{}
+		limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 0})
+		hold, _ := limiter.Acquire(context.Background())
+		defer hold()
+		repo := &serverSideEnvStreamRepository{store: observerStore(t, 1), logger: slog.Default(), isV2: true, initLimiter: limiter, initObserver: obs}
+		drainReplay(t, repo.ReplayWithContext(context.Background(), "", "s9"))
+		assert.Equal(t, []string{"shed"}, waitForCalls(t, obs, 1))
+	})
+
+	t.Run("up-to-date without a wait", func(t *testing.T) {
+		obs := &fakeInitObserver{}
+		limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 1})
+		repo := &serverSideEnvStreamRepository{store: observerStore(t, 2), logger: slog.Default(), isV2: true, initLimiter: limiter, initObserver: obs}
+		drainReplay(t, repo.ReplayWithContext(context.Background(), "", "s2"))
+		assert.Equal(t, []string{"up_to_date:false"}, waitForCalls(t, obs, 1))
+	})
+
+	t.Run("completed and connection_ended", func(t *testing.T) {
+		obs := &fakeInitObserver{}
+		limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 2, MaxQueued: 1})
+		repo := &serverSideEnvStreamRepository{store: observerStore(t, 1), logger: slog.Default(), isV2: true, initLimiter: limiter, initObserver: obs}
+
+		// Completed: the test plays the handler role and flushes at end of batch.
+		iw := initwrite.WrapGated(newObserverRecorder(), 30*time.Second)
+		ctx := context.WithValue(context.Background(), initWriterKey{}, iw)
+		drainReplay(t, repo.ReplayWithContext(ctx, "", "s9"))
+		iw.Flush()
+		calls := waitForCalls(t, obs, 1)
+		assert.Equal(t, "delivery:fdv2:completed:false", calls[0])
+
+		// Connection ended: the client goes away instead of the flush arriving.
+		iw2 := initwrite.WrapGated(newObserverRecorder(), 30*time.Second)
+		cctx, cancel := context.WithCancel(context.Background())
+		cctx = context.WithValue(cctx, initWriterKey{}, iw2)
+		drainReplay(t, repo.ReplayWithContext(cctx, "", "s9"))
+		cancel()
+		calls = waitForCalls(t, obs, 2)
+		assert.Equal(t, "delivery:fdv2:connection_ended:false", calls[1])
+	})
+}
+
+func TestStreamReplayDeliverySpanEndsOnceWithOutcome(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+	defer otel.SetTracerProvider(prev)
+
+	limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 2, MaxQueued: 1})
+	repo := &serverSideEnvStreamRepository{store: observerStore(t, 1), logger: slog.Default(), isV2: true, initLimiter: limiter}
+
+	// A completed delivery: exactly one delivery span, with the completed outcome.
+	pctx, parent := tracing.Tracer().Start(context.Background(), "parent")
+	iw := initwrite.WrapGated(newObserverRecorder(), 30*time.Second)
+	pctx = context.WithValue(pctx, initWriterKey{}, iw)
+	drainReplay(t, repo.ReplayWithContext(pctx, "", "s9"))
+	iw.Flush()
+	waitForSpan(t, sr, tracing.SpanInitDelivery)
+	spans := endedSpans(sr, tracing.SpanInitDelivery)
+	require.Len(t, spans, 1, "the delivery span must end exactly one time")
+	assert.Contains(t, attrString(spans[0]), "completed")
+	parent.End()
+
+	// A shed: no delivery span, and the shed event lands on the request span. A separate
+	// limiter with no queue, its only slot held, makes the shed deterministic.
+	shedLimiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 0})
+	hold, _ := shedLimiter.Acquire(context.Background())
+	defer hold()
+	sctx, sparent := tracing.Tracer().Start(context.Background(), "shed-parent")
+	repo2 := &serverSideEnvStreamRepository{store: observerStore(t, 1), logger: slog.Default(), isV2: true, initLimiter: shedLimiter}
+	drainReplay(t, repo2.ReplayWithContext(sctx, "", "s9"))
+	sparent.End()
+	assert.Len(t, endedSpans(sr, tracing.SpanInitDelivery), 1, "a shed must not create a delivery span")
+	found := false
+	for _, s := range sr.Ended() {
+		if s.Name() == "shed-parent" {
+			for _, e := range s.Events() {
+				if e.Name == tracing.EventInitShed {
+					found = true
+				}
+			}
+		}
+	}
+	assert.True(t, found, "the shed event must land on the request span")
+}
+
+func drainReplay(t *testing.T, ch <-chan eventsource.Event) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, open := <-ch:
+			if !open {
+				return
+			}
+		case <-deadline:
+			require.Fail(t, "timed out draining the replay")
+		}
+	}
+}
+
+func endedSpans(sr *tracetest.SpanRecorder, name string) []sdktrace.ReadOnlySpan {
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range sr.Ended() {
+		if s.Name() == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func waitForSpan(t *testing.T, sr *tracetest.SpanRecorder, name string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for len(endedSpans(sr, name)) == 0 {
+		if time.Now().After(deadline) {
+			require.Failf(t, "timeout", "span %s never ended", name)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func attrString(s sdktrace.ReadOnlySpan) string {
+	out := ""
+	for _, kv := range s.Attributes() {
+		out += string(kv.Key) + "=" + kv.Value.Emit() + " "
+	}
+	return out
+}

--- a/internal/streams/stream_provider.go
+++ b/internal/streams/stream_provider.go
@@ -72,9 +72,35 @@ type EnvStreamProvider interface {
 type Option func(*providerOptions)
 
 type providerOptions struct {
-	initLimiter *concurrency.Limiter
-	sendTimeout time.Duration
-	logger      *slog.Logger
+	initLimiter  *concurrency.Limiter
+	sendTimeout  time.Duration
+	logger       *slog.Logger
+	initObserver InitObserver
+}
+
+// InitObserver receives the initialization-delivery measurements the stream provider makes:
+// deliveries with their outcomes, sheds, up-to-date replies, and failed write-deadline
+// calls. The metrics package implements it. A nil observer is permitted; the provider then
+// records nothing.
+type InitObserver interface {
+	// RecordDelivery records one gated delivery. The outcome is completed,
+	// connection_ended, or read_error.
+	RecordDelivery(protocol, outcome string, capEngaged bool)
+	// RecordUpToDate records one up-to-date reply. afterWait is true when the client's
+	// basis became current while it waited in the queue.
+	RecordUpToDate(afterWait bool)
+	// RecordShed records one shed stream replay.
+	RecordShed()
+	// AddDeadlineSetErrors adds the count of failed write-deadline calls a delivery saw.
+	AddDeadlineSetErrors(n int64)
+}
+
+// WithInitObserver sends the initialization-delivery measurements to the given observer.
+// Only the server-side stream provider records them.
+func WithInitObserver(o InitObserver) Option {
+	return func(opts *providerOptions) {
+		opts.initObserver = o
+	}
 }
 
 // WithLogger sends the connection-write errors of the SSE server to a logger. This makes a
@@ -134,10 +160,11 @@ func NewStreamProvider(kind basictypes.StreamKind, maxConnTime, pingStreamJitter
 			fdv2.Logger = l
 		}
 		return &serverSideStreamProvider{
-			fdv1Server:  fdv1,
-			fdv2Server:  fdv2,
-			initLimiter: o.initLimiter,
-			sendTimeout: o.sendTimeout,
+			fdv1Server:   fdv1,
+			fdv2Server:   fdv2,
+			initLimiter:  o.initLimiter,
+			sendTimeout:  o.sendTimeout,
+			initObserver: o.initObserver,
 		}
 	}
 }

--- a/internal/streams/stream_provider_server_side.go
+++ b/internal/streams/stream_provider_server_side.go
@@ -14,6 +14,8 @@ import (
 	"github.com/launchdarkly/ld-relay/v9/internal/sdkauth"
 	"github.com/launchdarkly/ld-relay/v9/internal/tracing"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/launchdarkly/ld-relay/v9/config"
 	"golang.org/x/sync/singleflight"
 
@@ -40,6 +42,8 @@ type serverSideStreamProvider struct {
 	// closes the connection to get the budget slot back (see withInitDeadline).
 	initLimiter *concurrency.Limiter
 	sendTimeout time.Duration
+	// initObserver receives the delivery measurements; nil records nothing.
+	initObserver InitObserver
 
 	closeOnce sync.Once
 }
@@ -60,6 +64,8 @@ type serverSideEnvStreamRepository struct {
 	// client is old or absent. A cheap up-to-date reply never draws from it. A limiter that
 	// is nil or disabled applies no limit.
 	initLimiter *concurrency.Limiter
+	// initObserver receives the delivery measurements; nil records nothing.
+	initObserver InitObserver
 
 	flightGroup singleflight.Group
 }
@@ -166,7 +172,8 @@ func (s *serverSideStreamProvider) RegisterV1(
 	}
 	repo := &serverSideEnvStreamRepository{
 		store: store, logger: logger, isV2: false,
-		initLimiter: s.initLimiter,
+		initLimiter:  s.initLimiter,
+		initObserver: s.initObserver,
 	}
 	s.fdv1Server.Register(credential.String(), repo)
 	envStream := &serverSideEnvStreamProvider{server: s.fdv1Server, channels: []string{credential.String()}, isV2: false}
@@ -183,7 +190,8 @@ func (s *serverSideStreamProvider) RegisterV2(
 	}
 	repo := &serverSideEnvStreamRepository{
 		store: store, logger: logger, isV2: true,
-		initLimiter: s.initLimiter,
+		initLimiter:  s.initLimiter,
+		initObserver: s.initObserver,
 	}
 	s.fdv2Server.Register(credential.String(), repo)
 	envStream := &serverSideEnvStreamProvider{server: s.fdv2Server, channels: []string{credential.String()}, isV2: true}
@@ -257,6 +265,14 @@ func (e *serverSideEnvStreamProvider) Close() {
 	}
 }
 
+// protocol names the repository's wire protocol for measurements and span attributes.
+func (r *serverSideEnvStreamRepository) protocol() string {
+	if r.isV2 {
+		return "fdv2"
+	}
+	return "fdv1"
+}
+
 // Ensure the repository advertises context support so the eventsource server calls
 // ReplayWithContext (and thus propagates the connection's lifetime) rather than Replay.
 var _ eventsource.RepositoryWithContext = (*serverSideEnvStreamRepository)(nil)
@@ -318,6 +334,10 @@ func (r *serverSideEnvStreamRepository) replay(ctx context.Context, id string) c
 		// reply. That reply builds no payload, so it does not draw from the budget. The
 		// basis travels as the Last-Event-ID; see the note in HandlerV2.
 		if r.isV2 && id != "" && selector.IsDefined() && selector.State() == id {
+			if r.initObserver != nil {
+				r.initObserver.RecordUpToDate(false)
+			}
+			trace.SpanFromContext(ctx).AddEvent(tracing.EventInitUpToDate)
 			r.sendEvents(ctx, out, MakeEventsForUpToDate(selector))
 			return
 		}
@@ -326,7 +346,9 @@ func (r *serverSideEnvStreamRepository) replay(ctx context.Context, id string) c
 		// serialization, so the budget limits how many full bases the relay builds and sends
 		// at the same time, and reconnects at the same basis can share one serialization.
 		if r.initLimiter.Enabled() {
+			acquireStart := time.Now()
 			release, ok := r.initLimiter.Acquire(ctx)
+			queueWait := time.Since(acquireStart)
 			if !ok {
 				if ctx.Err() != nil {
 					// The client disconnected while it waited for a slot. This is the
@@ -347,11 +369,30 @@ func (r *serverSideEnvStreamRepository) replay(ctx context.Context, id string) c
 				// instead, so the SDK reconnects with backoff and does not stay connected
 				// without data.
 				r.logger.Warn("initialization concurrency limit reached; closing stream so the SDK reconnects")
+				if r.initObserver != nil {
+					r.initObserver.RecordShed()
+				}
+				trace.SpanFromContext(ctx).AddEvent(tracing.EventInitShed,
+					trace.WithAttributes(tracing.InitShedReasonKey.String("budget_full")))
 				if closeConn, ok := ctx.Value(closeConnectionKey{}).(func()); ok {
 					closeConn()
 				}
 				return
 			}
+
+			// The delivery span covers everything from admission to the flushed basis or
+			// the end of the connection. The producer goroutine ends it -- a span is safe
+			// there, unlike a deadline call, because it does not touch the connection --
+			// and the single deferred End runs on every exit below exactly one time. The
+			// span's context feeds the reads and the serialization, so their spans nest
+			// under the delivery.
+			dctx, dspan := tracing.Tracer().Start(ctx, tracing.SpanInitDelivery,
+				trace.WithAttributes(
+					tracing.InitProtocolKey.String(r.protocol()),
+					tracing.InitQueueWaitDurationKey.Float64(queueWait.Seconds()),
+				))
+			defer dspan.End()
+			ctx = dctx
 
 			// The wait for a slot can be long. Read the store again, so the payload is
 			// serialized from the store as it is now, and do the up-to-date check again: a
@@ -365,11 +406,20 @@ func (r *serverSideEnvStreamRepository) replay(ctx context.Context, id string) c
 			snapshot, selector, err = r.peek(ctx, id)
 			if err != nil {
 				r.logger.Error("error getting all flags after admission", "error", err)
+				dspan.SetAttributes(tracing.InitOutcomeKey.String("read_error"))
+				if r.initObserver != nil {
+					r.initObserver.RecordDelivery(r.protocol(), "read_error", false)
+				}
 				release()
 				return
 			}
 			if r.isV2 && id != "" && selector.IsDefined() && selector.State() == id {
 				release()
+				dspan.SetAttributes(tracing.InitOutcomeKey.String("up_to_date"))
+				if r.initObserver != nil {
+					r.initObserver.RecordUpToDate(true)
+				}
+				trace.SpanFromContext(ctx).AddEvent(tracing.EventInitUpToDate)
 				r.sendEvents(ctx, out, MakeEventsForUpToDate(selector))
 				return
 			}
@@ -397,8 +447,20 @@ func (r *serverSideEnvStreamRepository) replay(ctx context.Context, id string) c
 						// regression brought it back, would leak the slot.
 						time.Sleep(5 * time.Millisecond)
 					}
-					iw.WaitAndFinish(ctx)
+					flushed := iw.WaitAndFinish(ctx)
 					release()
+					outcome := "connection_ended"
+					if flushed {
+						outcome = "completed"
+					}
+					dspan.SetAttributes(
+						tracing.InitOutcomeKey.String(outcome),
+						tracing.InitCapEngagedKey.Bool(iw.CapEngaged()),
+					)
+					if r.initObserver != nil {
+						r.initObserver.RecordDelivery(r.protocol(), outcome, iw.CapEngaged())
+						r.initObserver.AddDeadlineSetErrors(iw.DeadlineSetErrors())
+					}
 				}()
 			} else {
 				// This path has no progress-aware writer (for example, the Replay path that

--- a/internal/streams/stream_provider_server_side.go
+++ b/internal/streams/stream_provider_server_side.go
@@ -385,7 +385,9 @@ func (r *serverSideEnvStreamRepository) replay(ctx context.Context, id string) c
 			// there, unlike a deadline call, because it does not touch the connection --
 			// and the single deferred End runs on every exit below exactly one time. The
 			// span's context feeds the reads and the serialization, so their spans nest
-			// under the delivery.
+			// under the delivery. The request span keeps the up-to-date event, so keep a
+			// reference before the delivery span replaces it in ctx.
+			reqSpan := trace.SpanFromContext(ctx)
 			dctx, dspan := tracing.Tracer().Start(ctx, tracing.SpanInitDelivery,
 				trace.WithAttributes(
 					tracing.InitProtocolKey.String(r.protocol()),
@@ -419,7 +421,7 @@ func (r *serverSideEnvStreamRepository) replay(ctx context.Context, id string) c
 				if r.initObserver != nil {
 					r.initObserver.RecordUpToDate(true)
 				}
-				trace.SpanFromContext(ctx).AddEvent(tracing.EventInitUpToDate)
+				reqSpan.AddEvent(tracing.EventInitUpToDate)
 				r.sendEvents(ctx, out, MakeEventsForUpToDate(selector))
 				return
 			}

--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -15,11 +15,20 @@ func Tracer() trace.Tracer { return otel.Tracer(TracerName) }
 
 // Span name constants.
 const (
-	SpanAuth             = "relay.auth"
-	SpanStoreSnapshot    = "relay.store.snapshot"
-	SpanStoreGetAll      = "relay.store.get_all"
-	SpanStoreGet         = "relay.store.get"
-	SpanEvaluateFlags    = "relay.flags.evaluate"
+	SpanAuth          = "relay.auth"
+	SpanStoreSnapshot = "relay.store.snapshot"
+	SpanStoreGetAll   = "relay.store.get_all"
+	SpanStoreGet      = "relay.store.get"
+	SpanEvaluateFlags = "relay.flags.evaluate"
+
+	// SpanInitDelivery covers one gated stream initialization delivery, from budget
+	// admission to the flushed basis or the end of the connection.
+	SpanInitDelivery = "relay.init.delivery"
+
+	// EventInitShed marks a stream replay the budget shed, on the request span.
+	EventInitShed = "relay.init.shed"
+	// EventInitUpToDate marks a stream replay answered with the small up-to-date reply.
+	EventInitUpToDate    = "relay.init.up_to_date"
 	SpanEventsDispatch   = "relay.events.dispatch"
 	SpanSerializePayload = "relay.payload.serialize"
 	SpanWriteResponse    = "relay.response.write"
@@ -56,6 +65,19 @@ const (
 	// InitQueueWaitDurationKey is the time in seconds the request waited for an
 	// initialization-delivery slot. It appears only on requests that asked for a slot.
 	InitQueueWaitDurationKey = attribute.Key("launchdarkly.relay.init.queue.wait.duration")
+
+	// InitProtocolKey is the protocol of a gated stream delivery: fdv1 or fdv2.
+	InitProtocolKey = attribute.Key("launchdarkly.relay.init.protocol")
+
+	// InitOutcomeKey is how a gated stream delivery ended: completed, connection_ended,
+	// read_error, or up_to_date. A connection_ended outcome does not say why the
+	// connection ended; a client disconnect and a relay deadline cut look the same.
+	InitOutcomeKey = attribute.Key("launchdarkly.relay.init.outcome")
+
+	// InitCapEngagedKey reports that the absolute delivery cap clamped a write deadline:
+	// the delivery was large enough that the cap, not the throughput floor, decided when a
+	// slow client would be cut.
+	InitCapEngagedKey = attribute.Key("launchdarkly.relay.init.cap_engaged")
 
 	// InitShedReasonKey is the cause of an initialization-delivery rejection: budget_full,
 	// client_gone, or shutdown. It appears only on requests the budget rejected.

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -151,11 +151,17 @@ func newRelayInternal(c config.Config, options relayInternalOptions) (*Relay, er
 	// memory or egress without limit. It is disabled by default.
 	initConc := newInitConcurrency(c.Concurrency, logger)
 	initConc.logEnabled(logger)
+	if initConc.limiter.Enabled() {
+		if err := metricsManager.RegisterInitConcurrencyObservers(initConc.limiter); err != nil {
+			logger.Warn("failed to register the init-concurrency limiter instruments", "error", err)
+		}
+	}
 
 	r := &Relay{
 		envsByCredential: NewEnvironmentLookup(),
 		serverSideStreamProvider: streams.NewStreamProvider(basictypes.ServerSideStream, maxConnTime, 0,
 			streams.WithInitLimiter(initConc.limiter, initConc.sendTimeout),
+			streams.WithInitObserver(metricsManager.InitInstruments()),
 			streams.WithLogger(logger)),
 		serverSideFlagsStreamProvider: streams.NewStreamProvider(basictypes.ServerSideFlagsOnlyStream, maxConnTime, 0),
 		mobileStreamProvider:          streams.NewStreamProvider(basictypes.MobilePingStream, maxConnTime, pingStreamJitterTime),

--- a/relay/relay_routes.go
+++ b/relay/relay_routes.go
@@ -129,8 +129,8 @@ func (r *Relay) makeRouter() *mux.Router {
 	// handler instead. The handler takes a slot only on its full-basis branch, and a cheap
 	// up-to-date reply never uses one. Both wrappers are disabled by default and then do
 	// nothing.
-	pollLimit := middleware.LimitConcurrency(r.initConcurrency.limiter, r.initConcurrency.sendTimeout)
-	provideInitLimiter := middleware.ProvideInitLimiter(r.initConcurrency.limiter, r.initConcurrency.sendTimeout)
+	pollLimit := middleware.LimitConcurrency(r.initConcurrency.limiter, r.initConcurrency.sendTimeout, r.metricsManager.InitInstruments())
+	provideInitLimiter := middleware.ProvideInitLimiter(r.initConcurrency.limiter, r.initConcurrency.sendTimeout, r.metricsManager.InitInstruments())
 
 	sdkRouter := router.PathPrefix("/sdk/").Subrouter()
 	// (?)TODO: there is a bug in gorilla mux (see see https://github.com/gorilla/mux/pull/378) that means the middleware below


### PR DESCRIPTION
The metrics PR (#812) and the tracing PR (#816) merged with their signal sources -- the rejection-cause split, the delivery-outcome report, the cap and deadline-error surfaces, and the poll-admission span attributes -- but the instrument registration and most of the recording never landed. The testing harness flagged the gap: no `launchdarkly.relay.init.*` instruments existed. This PR completes both plans.

## Metrics (completes #812)

| Instrument | Type | Attributes |
|---|---|---|
| `launchdarkly.relay.init.slots.held` | observable gauge | -- |
| `launchdarkly.relay.init.queue.waiting` | observable gauge | -- |
| `launchdarkly.relay.init.admitted` | observable counter | -- |
| `launchdarkly.relay.init.rejected` | observable counter | `launchdarkly.relay.init.reason`: `budget_full` \| `client_gone` \| `shutdown` -- alert on `budget_full`, not the total |
| `launchdarkly.relay.init.deliveries` | counter | `protocol`, `outcome`, `cap_engaged` |
| `launchdarkly.relay.init.sheds` | counter | `transport`; `launchdarkly.environment.name` on poll sheds |
| `launchdarkly.relay.init.replays.up_to_date` | counter | `after_wait` |
| `launchdarkly.relay.init.deadline.set_errors` | counter | -- |

The observables read the limiter's counters at each collection. The synchronous recorder follows the manager's nil-when-disabled pattern: every method accepts a nil receiver, so the wiring records without a check and pays nothing when OpenTelemetry is off.

## Tracing (completes #816)

A gated stream delivery gets a `relay.init.delivery` child span from admission to the flushed basis or the end of the connection, with the protocol, queue wait, outcome, and cap attributes; the store reads and serialization nest under it. The producer goroutine ends the span -- safe, unlike a deadline call, because a span does not touch the connection; a test pins that it ends exactly one time per delivery. Sheds and up-to-date replies are events on the request span.

## Fidelity

A `connection_ended` outcome does not say why the connection ended: a client disconnect and a relay deadline cut look the same without the eventsource logger bridge, which this work deliberately does not use. The metrics and tracing documentation state the limitation. Stream sheds carry no environment name; the stream layer does not know its environment.

## Validation

Manual-reader tests pin every instrument, value, and attribute, including the rejection causes read from a live limiter; a span-recorder test pins the delivery span's single end and outcome and the shed event's placement; a middleware test pins the poll-shed count and the no-panic environment read. Recording-removed and observation-removed mutations each turn their test red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Completes the init-concurrency observability work from earlier metrics/tracing plans by **registering** `launchdarkly.relay.init.*` instruments and **recording** from the limiter, poll middleware, and server-side stream replays when `[Concurrency]` is enabled.
> 
> **Metrics:** Adds `InitInstruments` (deliveries, sheds, up-to-date replays, deadline set errors) plus observable gauges/counters for held slots, queue depth, admissions, and rejections split by `budget_full` / `client_gone` / `shutdown`. Poll sheds go through `InitShedRecorder` on `LimitConcurrency` / `ProvideInitLimiter` (only `budget_full`). Relay startup registers limiter observers and passes the recorder into routes and `WithInitObserver` on the stream provider.
> 
> **Tracing:** Gated stream full-basis paths emit a `relay.init.delivery` child span (protocol, queue wait, outcome, `cap_engaged`) from admission through flush or disconnect; sheds and up-to-date replies stay as request-span events (`relay.init.shed`, `relay.init.up_to_date`).
> 
> **Docs:** `docs/metrics.md` and `docs/tracing.md` document the new instruments, spans, attributes, and the limitation that `connection_ended` does not distinguish client disconnect from relay deadline cuts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc358f9bf440767f1e5fc481580863836c9ab0c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->