### PR TITLE
fix: Remove the Retry-After header from shed polling responses

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,7 +167,7 @@ At startup, the Relay Proxy clamps a value outside the supported range and write
 
 The throughput floor and the cap measure the bytes that the Relay Proxy writes, before compression. A compressed connection puts fewer bytes on the wire for the same written bytes, so compression gives a slow reader more applicable margin against the floor.
 
-When the budget is full, the Relay Proxy sheds a polling request with an HTTP `503` response and a `Retry-After` header. For a streaming request, the response has already started, so the Relay Proxy closes the connection instead, and the SDK reconnects with backoff.
+When the budget is full, the Relay Proxy sheds a polling request with an HTTP `503` response, and the SDK retries on its own backoff schedule with jitter. For a streaming request, the response has already started, so the Relay Proxy closes the connection instead, and the SDK reconnects with backoff.
 
 
 ### File section: `[Environment "NAME"]`

--- a/internal/middleware/concurrency.go
+++ b/internal/middleware/concurrency.go
@@ -2,9 +2,7 @@ package middleware
 
 import (
 	"context"
-	"math/rand/v2"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/launchdarkly/ld-relay/v9/internal/concurrency"
@@ -31,7 +29,7 @@ type InitShedRecorder interface {
 
 // AcquireInitSlot draws one slot from the shared initialization-delivery limiter for the
 // current request, holding it until the returned release is called. If the budget is full it
-// writes a 503 (with a jittered Retry-After and a JSON body) and returns ok=false; the caller
+// writes a 503 (with a JSON body) and returns ok=false; the caller
 // must then write nothing further. A disabled or nil limiter always admits with a no-op
 // release, so callers can invoke this unconditionally.
 //
@@ -64,7 +62,6 @@ func AcquireInitSlot(limiter *concurrency.Limiter, recorder InitShedRecorder, w 
 			recorder.RecordPollShed(envNameFromContext(r))
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds()))
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write(util.ErrorJSONMsg("relay initialization concurrency limit reached; retry shortly"))
 		return func() {}, false
@@ -152,10 +149,4 @@ func shedReason(r *http.Request, limiter *concurrency.Limiter) string {
 		return "shutdown"
 	}
 	return "budget_full"
-}
-
-// retryAfterSeconds returns a small jittered Retry-After (in seconds) so a shed herd does
-// not retry in lockstep and re-synchronize the next burst.
-func retryAfterSeconds() int {
-	return 2 + rand.IntN(4) //nolint:gosec // Retry-After jitter is not security-sensitive; a fast PRNG is fine. 2..5 seconds
 }

--- a/internal/middleware/concurrency_test.go
+++ b/internal/middleware/concurrency_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -47,12 +46,9 @@ func TestLimitConcurrencyShedsWhenBudgetFull(t *testing.T) {
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 	assert.Contains(t, rr.Body.String(), "concurrency limit reached")
 
-	// Retry-After is a small positive integer, jittered into a range so a shed herd does not
-	// retry in lockstep.
-	ra, err := strconv.Atoi(rr.Header().Get("Retry-After"))
-	require.NoError(t, err)
-	assert.GreaterOrEqual(t, ra, 2)
-	assert.LessOrEqual(t, ra, 5)
+	// The shed reply names no retry time. The SDKs pace their own retries with
+	// exponential backoff and jitter.
+	assert.Empty(t, rr.Header().Get("Retry-After"))
 }
 
 func TestLimitConcurrencyReleasesSlotWhenHandlerReturns(t *testing.T) {


### PR DESCRIPTION
## Summary

Removes the jittered `Retry-After` header from the 503 that sheds a polling request when the initialization budget and queue are full.

The SDKs pace their own retries with exponential backoff and jitter, and no SDK reads `Retry-After` on a 503, so the header named a retry time that nothing honored. The shed response is unchanged otherwise: a 503 with the JSON body, and the SDK retries on its own schedule.

Also removes the jitter helper and its test assertions, and updates the shed paragraph in `docs/configuration.md`. A test now pins that the shed reply carries no `Retry-After` header.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> When the initialization concurrency budget is full, **503** shed responses for polling no longer include a **`Retry-After`** header. The JSON body and status code are unchanged; clients are expected to retry using SDK backoff with jitter, which was not honoring the header anyway.
> 
> The jitter helper **`retryAfterSeconds`** and related imports are removed from **`AcquireInitSlot`**, and **`docs/configuration.md`** is updated to describe SDK-driven retries instead of **`Retry-After`**. Tests now assert the shed response has an empty **`Retry-After`** header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b1f47ac5e0287ff153d36dfc3004f1439308ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->