### PR TITLE
fix: Report OTel attribute values as received instead of replacing slashes

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -102,6 +102,11 @@ Attribute values that are absent are reported as `not_provided` rather than bein
 endpoints and requests that matched no route are not associated with an SDK or an LD environment, so
 they report `not_provided` for `launchdarkly.environment.name` and the other SDK attributes.
 
+Values that are present are reported as received, apart from bytes that are not valid UTF-8, which are
+stripped because they would otherwise fail the OTLP export. In particular a value containing a slash --
+an application version such as `2026/08/01`, or an environment name such as `My Project / Staging` --
+keeps it.
+
 `platform.category`, `sdk.wrapper`, and `instance.id` are no longer reported on metrics. `instance.id`
 in particular is per SDK *instance*, which made these metrics grow a series per client process. All
 three are still included in the usage data the Relay Proxy sends to LaunchDarkly.

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -132,26 +132,17 @@ func requestKVs(ri RequestInfo) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		userAgentAttrKey.String(sanitizeVerbatimValue(ri.UserAgent)),
 		httpRouteAttrKey.String(sanitizeRouteValue(ri.Route)),
-		httpRequestMethodAttrKey.String(sanitizeTagValue(ri.Method)),
+		httpRequestMethodAttrKey.String(sanitizeVerbatimValue(ri.Method)),
 		urlSchemeAttrKey.String(ri.URLScheme),
-		applicationIDAttrKey.String(sanitizeTagValue(ri.ApplicationID)),
-		applicationVersionAttrKey.String(sanitizeTagValue(ri.ApplicationVersion)),
-		endpointTypeAttrKey.String(sanitizeTagValue(string(ri.EndpointType))),
+		applicationIDAttrKey.String(sanitizeVerbatimValue(ri.ApplicationID)),
+		applicationVersionAttrKey.String(sanitizeVerbatimValue(ri.ApplicationVersion)),
+		endpointTypeAttrKey.String(sanitizeVerbatimValue(string(ri.EndpointType))),
 	}
 }
 
-// sanitizeTagValue ensures OTel attribute values are valid.
-// Empty values are replaced with the absent-value sentinel, and slashes are replaced with underscores.
-// This is not appropriate for routes, where slashes are meaningful, nor for values that a semantic
-// convention defines as verbatim.
-func sanitizeTagValue(v string) string {
-	return sanitizeReplacingSlashes(v, notProvidedValue)
-}
-
-// sanitizeUsageTagValue is sanitizeTagValue for the usage data Relay reports to LaunchDarkly. It
-// exists only to keep that payload's absent-value sentinel independent of the OTel one: the two
-// sinks have different consumers, so renaming an attribute value must not change what the usage
-// events carry.
+// sanitizeUsageTagValue sanitizes a value for the usage data Relay reports to LaunchDarkly. That payload
+// has its own consumer and wire format, so it carries its own absent-value sentinel and replaces slashes
+// with underscores.
 func sanitizeUsageTagValue(v string) string {
 	return sanitizeReplacingSlashes(v, usageNotProvidedValue)
 }
@@ -189,9 +180,9 @@ func sanitizeVerbatimValue(v string) string {
 	return v
 }
 
-// sanitizeRouteValue ensures route attribute values are valid.
-// Empty values are replaced with descriptive defaults. Unlike sanitizeTagValue,
-// slashes are preserved since they are meaningful in route paths.
+// sanitizeRouteValue ensures route attribute values are valid. Empty values are replaced with the
+// absent-value sentinel. Route templates come from the router rather than from request data, so they
+// need no UTF-8 sanitizing.
 func sanitizeRouteValue(v string) string {
 	if strings.TrimSpace(v) == "" {
 		return notProvidedValue

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -105,7 +105,7 @@ func NewManager(
 		usageChan:            usageChan,
 		environmentsForUsage: make(map[string]*environmentMetricUsage),
 		unscopedEnv: &EnvironmentManager{
-			envKVs: []attribute.KeyValue{envNameAttrKey.String(sanitizeTagValue(""))},
+			envKVs: []attribute.KeyValue{envNameAttrKey.String(sanitizeVerbatimValue(""))},
 		},
 	}
 	if m.flushInterval <= 0 {
@@ -234,7 +234,7 @@ func (m *Manager) AddEnvironment(envName string, publisher events.EventPublisher
 		return nil, errAddEnvironmentAfterClosed
 	}
 
-	envKVs := []attribute.KeyValue{envNameAttrKey.String(sanitizeTagValue(envName))}
+	envKVs := []attribute.KeyValue{envNameAttrKey.String(sanitizeVerbatimValue(envName))}
 
 	var collector *RelayMetricsCollector
 	if publisher != nil {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -579,13 +579,6 @@ func TestWithCountCallsFunctionForNonPollingMeasure(t *testing.T) {
 	})
 }
 
-func TestSanitizeTagValue(t *testing.T) {
-	assert.Equal(t, "abc", sanitizeTagValue("abc"))
-	assert.Equal(t, "not_provided", sanitizeTagValue(""))
-	assert.Equal(t, "not_provided", sanitizeTagValue("   "))
-	assert.Equal(t, "react_2.0.0", sanitizeTagValue("react/2.0.0"))
-}
-
 // The usage payload Relay reports to LaunchDarkly is a separate sink with its own consumer, so its
 // absent-value sentinel does not follow the OTel attribute one.
 func TestSanitizeUsageTagValue(t *testing.T) {
@@ -692,11 +685,43 @@ func TestUserAgentUsesSemconvKeyAndVerbatimValue(t *testing.T) {
 	assert.False(t, ok, "the bare user_agent key shadows the semconv user_agent namespace")
 }
 
+// OTLP places no restriction on attribute values, and altering one that a customer supplied corrupts it:
+// an application version can be a date, and an environment name can contain a slash.
+func TestClientSuppliedAttributesKeepSlashes(t *testing.T) {
+	attrs := buildRequestAttributes(nil, RequestInfo{
+		ApplicationID:      "checkout/web",
+		ApplicationVersion: "2026/08/01",
+	})
+
+	for key, want := range map[string]string{
+		"launchdarkly.application.id":      "checkout/web",
+		"launchdarkly.application.version": "2026/08/01",
+	} {
+		value, ok := attrs.Value(attribute.Key(key))
+		require.True(t, ok, "%s attribute not present", key)
+		assert.Equal(t, want, value.AsString(), key)
+	}
+}
+
+func TestEnvironmentNameKeepsSlashes(t *testing.T) {
+	m, err := NewManager(config.OpenTelemetryConfig{}, 0, slog.Default())
+	require.NoError(t, err)
+	defer m.Close()
+
+	em, err := m.AddEnvironment("My Project / Staging", nil)
+	require.NoError(t, err)
+
+	envAttrs := em.GetAttributes()
+	value, ok := envAttrs.Value(attribute.Key("launchdarkly.environment.name"))
+	require.True(t, ok, "launchdarkly.environment.name attribute not present")
+	assert.Equal(t, "My Project / Staging", value.AsString())
+}
+
 // Attribute values are serialized into OTLP protobuf string fields, which proto3 requires to be valid
 // UTF-8. One bad byte fails the marshal for the whole export batch, and the poisoned series is
 // cumulative, so exports keep failing until restart. Header values are not restricted to ASCII, so this
 // has to be handled here rather than assumed away.
-func TestSanitizeTagValueStripsInvalidUTF8(t *testing.T) {
+func TestSanitizeVerbatimValueStripsInvalidUTF8(t *testing.T) {
 	specs := []struct {
 		name  string
 		input string
@@ -705,14 +730,14 @@ func TestSanitizeTagValueStripsInvalidUTF8(t *testing.T) {
 		{name: "invalid bytes in the middle", input: "bad-\xff\xfe-agent", want: "bad--agent"},
 		{name: "leading invalid byte", input: "\xffGoClient", want: "GoClient"},
 		{name: "entirely invalid collapses to sentinel", input: "\xff\xfe", want: notProvidedValue},
-		{name: "invalid plus a slash", input: "Node\xff/3.4.0", want: "Node_3.4.0"},
+		{name: "invalid plus a slash", input: "Node\xff/3.4.0", want: "Node/3.4.0"},
 		{name: "valid multi-byte UTF-8 is preserved", input: "Ruby-\u00e9", want: "Ruby-\u00e9"},
 		{name: "valid ASCII is untouched", input: "GoClient", want: "GoClient"},
 	}
 
 	for _, tt := range specs {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeTagValue(tt.input)
+			got := sanitizeVerbatimValue(tt.input)
 			assert.Equal(t, tt.want, got)
 			assert.True(t, utf8.ValidString(got), "sanitized value must be valid UTF-8, got %q", got)
 		})


### PR DESCRIPTION
## Summary

Every OTel attribute value except `user_agent.original` had slashes replaced with underscores, a constraint inherited from the OpenCensus exporters. OTLP places no restriction on attribute values, and the substitution corrupted values that customers supply:

- `launchdarkly.application.version` of `2026/08/01` was reported as `2026_08_01`
- `launchdarkly.environment.name` of `My Project / Staging` was reported as `My Project _ Staging`

`user_agent.original` was already exempt, so two values arriving through the same request headers were mangled by different rules.

All OTel attribute values now go through `sanitizeVerbatimValue`, which strips only invalid UTF-8 -- necessary because a single bad byte fails the OTLP marshal for the whole export batch. That leaves `sanitizeTagValue` unused, so it is removed; `sanitizeReplacingSlashes` survives for the usage data Relay reports to LaunchDarkly, which keeps the substitution because that payload has its own consumer and wire format.

`http.request.method` and `launchdarkly.relay.endpoint.type` were also switched over. Neither can contain a slash, so their values do not change; this keeps one rule for OTel attribute values rather than two.

Breaking for anyone grouping by an affected attribute whose value contains a slash, since the series identity changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **OTel metric attributes now preserve customer-supplied values**, including slashes in `launchdarkly.application.version` (e.g. `2026/08/01`) and `launchdarkly.environment.name` (e.g. `My Project / Staging`). Request-scoped attributes and environment names route through `sanitizeVerbatimValue`, which only strips invalid UTF-8 and maps empty/whitespace to `not_provided`—matching OTLP and aligning with how `user_agent.original` was already handled.
> 
> The legacy **`sanitizeTagValue` path (slash → underscore) is removed** for OTLP; **`sanitizeUsageTagValue` / `sanitizeReplacingSlashes` remain** for LaunchDarkly usage payloads, which still use their own absent sentinel and slash substitution.
> 
> `docs/metrics.md` documents that present values are exported as received aside from UTF-8 sanitization. Tests cover slash preservation and updated UTF-8 cases (slashes no longer rewritten when invalid bytes are stripped).
> 
> **Breaking change:** dashboards or alerts that grouped on underscore-mangled series will see new label values where slashes were in the source data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5de7a9db03fecacdcb4698b6b6b1206d785f5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->