### PR TITLE
test: Cover the relay-level limiter wiring and the unasserted observer paths

### DIFF
--- a/internal/streams/init_observer_test.go
+++ b/internal/streams/init_observer_test.go
@@ -2,6 +2,7 @@ package streams
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -62,6 +63,21 @@ func (f *fakeInitObserver) snapshot() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.calls...)
+}
+func (f *fakeInitObserver) deadlineErrors() int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.deadlineNs
+}
+
+// failingDeadlineRecorder rejects every write-deadline call, so a delivery through it
+// accumulates a deadline-set-error count for the observer to report.
+type failingDeadlineRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (f *failingDeadlineRecorder) SetWriteDeadline(time.Time) error {
+	return errors.New("deadline not supported")
 }
 
 func newObserverRecorder() *deadlineRecorder {
@@ -136,6 +152,95 @@ func TestStreamReplayReportsToInitObserver(t *testing.T) {
 		cancel()
 		calls = waitForCalls(t, obs, 2)
 		assert.Equal(t, "delivery:fdv2:connection_ended:false", calls[1])
+	})
+
+	t.Run("up-to-date after a wait", func(t *testing.T) {
+		// The store starts behind the client's basis and catches up during the queue
+		// wait, so the post-admission read takes the up-to-date path.
+		var stateNow atomic.Int64
+		stateNow.Store(1)
+		store := newMockStoreQueries()
+		store.setupSnapshotFn(func() (map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor, subsystems.Selector, error) {
+			st := int(stateNow.Load())
+			flag := ldbuilders.NewFlagBuilder("flagkey").Version(st).Build()
+			return map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor{
+				ldstoreimpl.Features(): {ldstoretypes.KeyedItemDescriptor{Key: "flagkey", Item: sharedtest.FlagDesc(flag)}},
+				ldstoreimpl.Segments(): {},
+			}, subsystems.NewSelector("s"+strconv.Itoa(st), st), nil
+		})
+
+		obs := &fakeInitObserver{}
+		limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 1})
+		hold, ok := limiter.Acquire(context.Background())
+		require.True(t, ok)
+
+		repo := &serverSideEnvStreamRepository{store: store, logger: slog.Default(), isV2: true, initLimiter: limiter, initObserver: obs}
+		eventCh := repo.ReplayWithContext(context.Background(), "", "s2")
+		deadline := time.Now().Add(2 * time.Second)
+		for limiter.Stats().Waiting != 1 {
+			if time.Now().After(deadline) {
+				require.Failf(t, "timeout", "client never queued (stats: %+v)", limiter.Stats())
+			}
+			time.Sleep(time.Millisecond)
+		}
+		stateNow.Store(2)
+		hold()
+		drainReplay(t, eventCh)
+		assert.Equal(t, []string{"up_to_date:true"}, waitForCalls(t, obs, 1))
+	})
+
+	t.Run("read error after admission", func(t *testing.T) {
+		// The first read decides that a full basis is needed; the refreshed read after
+		// admission fails.
+		var reads atomic.Int64
+		store := newMockStoreQueries()
+		store.setupSnapshotFn(func() (map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor, subsystems.Selector, error) {
+			if reads.Add(1) > 1 {
+				return nil, subsystems.NoSelector(), errors.New("store went away")
+			}
+			flag := ldbuilders.NewFlagBuilder("flagkey").Version(1).Build()
+			return map[ldstoretypes.DataKind][]ldstoretypes.KeyedItemDescriptor{
+				ldstoreimpl.Features(): {ldstoretypes.KeyedItemDescriptor{Key: "flagkey", Item: sharedtest.FlagDesc(flag)}},
+				ldstoreimpl.Segments(): {},
+			}, subsystems.NewSelector("s1", 1), nil
+		})
+
+		obs := &fakeInitObserver{}
+		limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 1})
+		hold, ok := limiter.Acquire(context.Background())
+		require.True(t, ok)
+
+		repo := &serverSideEnvStreamRepository{store: store, logger: slog.Default(), isV2: true, initLimiter: limiter, initObserver: obs}
+		eventCh := repo.ReplayWithContext(context.Background(), "", "s9")
+		deadline := time.Now().Add(2 * time.Second)
+		for limiter.Stats().Waiting != 1 {
+			if time.Now().After(deadline) {
+				require.Failf(t, "timeout", "client never queued (stats: %+v)", limiter.Stats())
+			}
+			time.Sleep(time.Millisecond)
+		}
+		hold()
+		drainReplay(t, eventCh)
+		assert.Equal(t, []string{"delivery:fdv2:read_error:false"}, waitForCalls(t, obs, 1))
+	})
+
+	t.Run("deadline set errors are reported", func(t *testing.T) {
+		obs := &fakeInitObserver{}
+		limiter := concurrency.New("t", concurrency.Params{MaxConcurrent: 1, MaxQueued: 0})
+		repo := &serverSideEnvStreamRepository{store: observerStore(t, 1), logger: slog.Default(), isV2: true, initLimiter: limiter, initObserver: obs}
+
+		// The test plays the handler role: after the producer begins the delivery, a
+		// write through the gated writer tries to arm the deadline and fails, and the
+		// end-of-batch flush completes the delivery.
+		iw := initwrite.WrapGated(&failingDeadlineRecorder{ResponseRecorder: httptest.NewRecorder()}, 30*time.Second)
+		ctx := context.WithValue(context.Background(), initWriterKey{}, iw)
+		drainReplay(t, repo.ReplayWithContext(ctx, "", "s9"))
+		_, _ = iw.Write([]byte("data: x\n\n"))
+		iw.Flush()
+
+		calls := waitForCalls(t, obs, 1)
+		assert.Equal(t, "delivery:fdv2:completed:false", calls[0])
+		assert.Equal(t, int64(1), obs.deadlineErrors(), "the failed deadline call must be reported")
 	})
 }
 

--- a/relay/concurrency_endpoints_test.go
+++ b/relay/concurrency_endpoints_test.go
@@ -1,0 +1,128 @@
+package relay
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	c "github.com/launchdarkly/ld-relay/v9/config"
+	st "github.com/launchdarkly/ld-relay/v9/internal/sharedtest"
+
+	"github.com/launchdarkly/eventsource"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This test proves the wiring between the [Concurrency] configuration and the endpoints.
+// The limiter, the middleware, and the stream producer have their own tests, but only a
+// request through a started relay shows that the budget is connected to each gated route.
+// A relay with the wiring removed passes every package test; this test is what fails.
+func TestInitConcurrencyGatesEndpointsEndToEnd(t *testing.T) {
+	sdkKey := st.EnvMain.Config.SDKKey
+
+	var config c.Config
+	config.Environment = st.MakeEnvConfigs(st.EnvMain)
+	config.Concurrency = c.ConcurrencyConfig{
+		MaxConcurrent: optInt(1),
+		MaxQueued:     optInt(0),
+	}
+
+	flagsReq := func() *http.Request {
+		return (endpointTestParams{"flags", "GET", "/sdk/flags", nil, sdkKey, 0, st.ExpectNoBody()}).request()
+	}
+	pollReq := func() *http.Request {
+		return (endpointTestParams{"poll", "GET", "/sdk/poll?basis=not-current", nil, sdkKey, 0, st.ExpectNoBody()}).request()
+	}
+	streamReq := func() *http.Request {
+		return (endpointTestParams{"stream", "GET", "/sdk/stream", nil, sdkKey, 0, st.ExpectNoBody()}).request()
+	}
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		limiter := p.relay.initConcurrency.limiter
+		require.True(t, limiter.Enabled(), "the configuration must construct an enabled limiter")
+
+		// Hold the only slot, so every gated route must shed.
+		hold, ok := limiter.Acquire(context.Background())
+		require.True(t, ok)
+
+		t.Run("PHP all-flags poll sheds while the budget is full", func(t *testing.T) {
+			resp, body := st.DoRequest(flagsReq(), p.relay)
+			assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+			assert.Contains(t, string(body), "concurrency limit reached")
+		})
+
+		t.Run("FDv2 server poll sheds a full transfer while the budget is full", func(t *testing.T) {
+			resp, body := st.DoRequest(pollReq(), p.relay)
+			assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+			assert.Contains(t, string(body), "concurrency limit reached")
+		})
+
+		t.Run("FDv2 server stream sheds the replay while the budget is full", func(t *testing.T) {
+			// A shed replay closes the connection, so the handler returns on its own.
+			// An admitted replay keeps the stream open until the client leaves, so a
+			// prompt return is the signature of the shed. The recorder writes into a
+			// pipe, so a reader must drain it or the handler blocks on the write.
+			w, bodyReader := st.NewStreamRecorder()
+			go func() { _, _ = io.Copy(io.Discard, bodyReader) }()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			handlerDone := make(chan struct{})
+			go func() {
+				p.relay.ServeHTTP(w, streamReq().WithContext(ctx))
+				close(handlerDone)
+			}()
+			select {
+			case <-handlerDone:
+			case <-time.After(3 * time.Second):
+				require.Fail(t, "the stream was not shed: the handler did not return while the budget was full")
+			}
+		})
+
+		// The budget frees, and every route serves again.
+		hold()
+
+		t.Run("PHP all-flags poll is served once a slot is free", func(t *testing.T) {
+			resp, _ := st.DoRequest(flagsReq(), p.relay)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("FDv2 server poll is served once a slot is free", func(t *testing.T) {
+			resp, _ := st.DoRequest(pollReq(), p.relay)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("FDv2 server stream delivers data once a slot is free", func(t *testing.T) {
+			st.WithStreamRequest(t, streamReq(), p.relay, func(eventCh <-chan eventsource.Event) {
+				// Drain the whole basis: the event channel has a small buffer, and an
+				// undrained stream blocks the handler behind it.
+				deadline := time.After(3 * time.Second)
+				var got []string
+				for {
+					select {
+					case ev := <-eventCh:
+						require.NotNil(t, ev, "the stream closed before the basis was transferred (events: %v)", got)
+						got = append(got, ev.Event())
+						if ev.Event() == "payload-transferred" {
+							assert.Equal(t, "server-intent", got[0])
+							return
+						}
+					case <-deadline:
+						require.Failf(t, "timeout", "did not receive the full basis (events: %v)", got)
+					}
+				}
+			})
+		})
+
+		// The served requests returned their slots: nothing leaked.
+		deadline := time.Now().Add(2 * time.Second)
+		for limiter.Stats().Held != 0 {
+			if time.Now().After(deadline) {
+				require.Failf(t, "slot leak", "slots still held after all requests finished (stats: %+v)", limiter.Stats())
+			}
+			time.Sleep(time.Millisecond)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes the wiring coverage hole from the #833 review (finding 2): the limiter, the middleware, and the stream producer each had thorough package tests, but nothing tested the composition. A relay built with every wiring point severed -- the stream-provider options, the observer registration, and both poll middlewares -- passed the entire suite.

**Relay-level gating test.** `TestInitConcurrencyGatesEndpointsEndToEnd` builds a relay through `withStartedRelay` with `maxConcurrent=1, maxQueued=0`, holds the only slot, and observes the gate at each route: the PHP all-flags poll sheds with a 503, the FDv2 server poll sheds its full transfer with a 503, and the FDv2 server stream closes its replay (the handler returns on its own, which only happens when the budget wiring installed the close function). Once the slot frees, all three routes serve again, and the budget returns to zero slots held.

**Observer record paths.** Three producer paths recorded to the init observer with no assertion: the up-to-date reply after a queue wait, the read-error outcome after admission, and the failed write-deadline count. Each now has a subtest in the streams observer test, including a write-deadline recorder that rejects every call so the count is nonzero.

## Validation

Every new test was verified against its exact target mutation: unwiring `pollLimit`, unwiring `provideInitLimiter`, and dropping `WithInitLimiter` each fail their gating subtest; dropping the after-wait `RecordUpToDate`, the read-error `RecordDelivery`, and `AddDeadlineSetErrors` each fail their observer subtest. All six mutants were previously survivable by the full suite.

The three relay-level observability wirings (`WithInitObserver`, `RegisterInitConcurrencyObservers`, the poll-shed recorder argument) remain untested here: killing those requires OpenTelemetry enabled inside a constructed relay, and `metrics.NewManager` has no meter-provider seam. The external testing harness's instrument check covers that gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **end-to-end relay tests** so init concurrency config actually gates **PHP all-flags**, **FDv2 poll**, and **FDv2 stream** routes (503 when the budget is full, success after a slot frees, no held-slot leak).
> 
> Extends **stream init observer** tests for paths that were recorded but not asserted: **up-to-date after a queue wait**, **read error after admission**, and **deadline-set errors** via a `failingDeadlineRecorder` stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c373e18bbbed9420326647931be3569573122d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->