### PR TITLE
fix: Commit a re-anchor when the new client is still connecting

### DIFF
--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -2,6 +2,7 @@ package relayenv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -584,7 +585,8 @@ func (c *envContextImpl) reconcileCredentials(newSet credential.AcceptedSet, now
 }
 
 // reanchor moves the environment's upstream connection to change.NewAnchor. It returns true if the
-// anchor was committed, and false if it rolled back (the build failed, or the env closed).
+// anchor was committed, and false if it rolled back. A rollback happens when the build produces no
+// usable client, or when the env closed.
 // This function is the canonical re-anchor sequence: Reconcile signals the anchor change but does not
 // flip the rotator's pointer; reanchor builds or reuses the client, then commitReanchor moves it.
 //
@@ -612,18 +614,20 @@ func (c *envContextImpl) reanchor(change *credential.AnchorChange) bool {
 
 	// A live client is reused as-is, and an offline env builds none. Both cases fall through to commit.
 	why := "reused existing client"
+	var buildErr error
 	if c.clients[newAnchor] == nil {
 		if c.offline {
-			why = "offline — no client build"
+			why = "offline -- no client build"
 		} else {
 			// Build without the lock: sdkClientFactory can block for up to sdkInitTimeout, and holding
 			// c.mu that long would stall every GetClient and GetStore caller.
 			c.mu.Unlock()
-			client := c.buildNewAnchorClient(newAnchor, previousAnchor)
+			client, err := c.buildNewAnchorClient(newAnchor, previousAnchor)
 			c.mu.Lock()
 
 			if client == nil {
-				// Init failed. buildNewAnchorClient logged the error and closed the half-built client.
+				// The re-anchor must roll back. buildNewAnchorClient logged the reason, and it closed
+				// any half-built client.
 				return false
 			}
 			if c.closed {
@@ -639,11 +643,12 @@ func (c *envContextImpl) reanchor(change *credential.AnchorChange) bool {
 			c.clients[newAnchor] = client
 			// GetStore() returns the same wrapper the old client used, so there is no empty-store window.
 			c.rebuildEvaluator()
+			buildErr = err
 			why = "built new client"
 		}
 	}
 
-	if !c.commitReanchor(newAnchor, previousAnchor, why) {
+	if !c.commitReanchor(newAnchor, previousAnchor, why, buildErr) {
 		return false
 	}
 
@@ -659,36 +664,42 @@ func (c *envContextImpl) reanchor(change *credential.AnchorChange) bool {
 	return true
 }
 
-// buildNewAnchorClient constructs the SDK client for a re-anchor to newAnchor. It returns nil if the
-// build failed, after closing any half-built client and logging the error.
+// buildNewAnchorClient constructs the SDK client for a re-anchor to newAnchor. It returns the client
+// and the build error. The error is non-nil when the client exists but is not initialized yet.
+//
+// It returns a nil client when the re-anchor must roll back. Two conditions cause a rollback: the
+// factory produced no client, or the SDK reports ErrInitializationFailed. ErrInitializationFailed is
+// permanent, because the SDK stops the data source and makes no more attempts. A timeout is
+// different. The SDK keeps retrying, so the caller commits that client and lets it connect later.
 //
 // The caller must not hold c.mu: sdkClientFactory can block for sdkInitTimeout, which would stall
 // every GetClient and GetStore caller. This method reads only construction-time fields.
 //
-// It leaves initErr alone on failure. initErr feeds the request middleware, so setting it would 401
-// an env that is still serving on the previous anchor.
+// It leaves initErr alone. commitReanchor records the build error, so a rollback keeps the previous
+// anchor's init status.
 //
 // The Close() below relies on the store-release contract in sdks.ClientFactoryFunc.
-func (c *envContextImpl) buildNewAnchorClient(newAnchor, previousAnchor config.SDKKey) sdks.LDClientContext {
+func (c *envContextImpl) buildNewAnchorClient(newAnchor, previousAnchor config.SDKKey) (sdks.LDClientContext, error) {
 	client, err := c.sdkClientFactory(newAnchor, c.sdkConfig, c.sdkInitTimeout)
-	if err != nil || client == nil || !client.Initialized() {
-		var initialized bool
+	if client == nil || errors.Is(err, ld.ErrInitializationFailed) {
 		if client != nil {
-			initialized = client.Initialized()
 			_ = client.Close()
 		}
-		c.globalLoggers.Errorf("Re-anchor to SDK key %s failed (err=%v initialized=%v); "+
+		c.globalLoggers.Errorf("Re-anchor to SDK key %s failed permanently (err=%v); "+
 			"preserving previous anchor %s",
-			newAnchor.Masked(), err, initialized, previousAnchor.Masked())
-		return nil
+			newAnchor.Masked(), err, previousAnchor.Masked())
+		return nil, err
 	}
-	return client
+	return client, err
 }
 
 // commitReanchor is the second half of the re-anchor sequence: move the rotator's anchor pointer,
-// clear a stale init error, and repoint event and metrics forwarding. It returns false without
-// committing if the env was closed first. The caller must hold c.mu.
-func (c *envContextImpl) commitReanchor(newAnchor, previousAnchor config.SDKKey, why string) bool {
+// record the new client's init status, and repoint event and metrics forwarding. It returns false
+// without committing if the env was closed first. The caller must hold c.mu.
+//
+// buildErr is the error from this re-anchor's client build. It is nil when the client initialized. It
+// is also nil for a reused client and for an offline env, because neither builds a client.
+func (c *envContextImpl) commitReanchor(newAnchor, previousAnchor config.SDKKey, why string, buildErr error) bool {
 	if c.closed {
 		// Close() ran first. The env is being torn down, so do not flip the anchor.
 		return false
@@ -701,8 +712,11 @@ func (c *envContextImpl) commitReanchor(newAnchor, previousAnchor config.SDKKey,
 	if !c.offline {
 		c.anchorClientGen++
 	}
-	// The anchor now points at a healthy client, so clear any init error a prior client left behind.
-	c.initErr = nil
+	// Record this build's outcome as the env's init status. This also clears an error that a prior
+	// client left behind. A client that is still connecting keeps its timeout error here, which is
+	// safe: the request middleware rejects only ErrInitializationFailed, and that value never reaches
+	// a commit.
+	c.initErr = buildErr
 
 	if c.metricsEventPub != nil {
 		c.metricsEventPub.ReplaceCredential(newAnchor)
@@ -714,7 +728,14 @@ func (c *envContextImpl) commitReanchor(newAnchor, previousAnchor config.SDKKey,
 	// Big-segment requests authenticate with the anchor SDK key, so the synchronizer follows the anchor.
 	c.reanchorBigSegmentSync(newAnchor)
 
-	c.globalLoggers.Infof("Re-anchored SDK from %s to %s (%s)", previousAnchor.Masked(), newAnchor.Masked(), why)
+	if buildErr == nil {
+		c.globalLoggers.Infof("Re-anchored SDK from %s to %s (%s)",
+			previousAnchor.Masked(), newAnchor.Masked(), why)
+	} else {
+		c.globalLoggers.Warnf("Re-anchored SDK from %s to %s (%s), but the client is not initialized "+
+			"yet: %v. The SDK continues to retry, and the data store keeps serving requests.",
+			previousAnchor.Masked(), newAnchor.Masked(), why, buildErr)
+	}
 	return true
 }
 

--- a/internal/relayenv/env_context_reanchor_init_tolerance_test.go
+++ b/internal/relayenv/env_context_reanchor_init_tolerance_test.go
@@ -1,0 +1,244 @@
+package relayenv
+
+// Re-anchor init tolerance.
+//
+// The SDK reports two different not-initialized outcomes, and the re-anchor treats them differently:
+//
+//   - ErrInitializationTimeout, or a nil error with the client not yet connected, means the SDK keeps
+//     trying. The re-anchor commits that client. The shared data store keeps serving until the client
+//     connects, and the timeout goes into initErr. Only the request middleware and the startup wait
+//     loop read initErr, and the middleware rejects ErrInitializationFailed alone.
+//   - ErrInitializationFailed means the SDK stopped the data source and makes no more attempts. The
+//     re-anchor rolls back, because committing would close a working client and install a dead one.
+//
+// A rollback is expensive: the autoconfiguration layer records the payload's version before the
+// re-anchor runs, so a discarded rotation is never re-sent. That is why only a permanent failure
+// rolls back.
+//
+// These tests use fake clients, so Initialized() reports the flag the fake was built with. The real
+// client behaves differently on a re-anchor: it inherits the populated store, which gives it Cached
+// data availability, so Initialized() returns true before its own data source connects. Relay's
+// commit decision does not read Initialized(), so that difference does not affect what these tests
+// pin down.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+	"github.com/launchdarkly/ld-relay/v8/internal/store"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const initTolerKeyB = config.SDKKey("init-toler-anchor-b")
+const initTolerKeyC = config.SDKKey("init-toler-anchor-c")
+
+// initTolerFactory serves an initialized client for every key except targetKey, and reports those
+// clients on healthyCh. For targetKey it returns a non-nil client that is not initialized, paired
+// with targetErr, and reports it on targetCh.
+//
+// It builds the data store for targetKey too. The real SDK builds the store before it waits for the
+// initial payload, so a client that times out still holds a store reference.
+func initTolerFactory(
+	targetKey config.SDKKey,
+	targetErr error,
+	healthyCh chan *testclient.FakeLDClient,
+	targetCh chan *testclient.FakeLDClient,
+) sdks.ClientFactoryFunc {
+	healthy := testclient.FakeLDClientFactoryWithChannel(true, healthyCh)
+	return func(sdkKey config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		if sdkKey != targetKey {
+			return healthy(sdkKey, cfg, timeout)
+		}
+		if adapter, ok := cfg.DataStore.(*store.SSERelayDataStoreAdapter); ok {
+			if _, err := adapter.Build(subsystems.BasicClientContext{SDKKey: string(sdkKey)}); err != nil {
+				return nil, err
+			}
+		}
+		client := &testclient.FakeLDClient{Key: sdkKey, CloseCh: make(chan struct{})}
+		targetCh <- client
+		return client, targetErr
+	}
+}
+
+// initTolerEnv starts an environment whose new-anchor build produces an unconverged client, and
+// returns the env plus the initial anchor's client.
+func initTolerEnv(
+	t *testing.T,
+	targetErr error,
+	mockLog *ldlogtest.MockLog,
+	targetCh chan *testclient.FakeLDClient,
+) (EnvContext, *testclient.FakeLDClient) {
+	t.Helper()
+	healthyCh := make(chan *testclient.FakeLDClient, 10)
+	factory := initTolerFactory(initTolerKeyB, targetErr, healthyCh, targetCh)
+
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, st.EnvMain.Config, factory, mockLog.Loggers, readyCh)
+	require.Equal(t, env, requireEnvReady(t, readyCh))
+	oldClient := requireClientReady(t, healthyCh)
+	require.Eventually(t, func() bool { return env.GetClient() == oldClient }, time.Second, 10*time.Millisecond)
+	return env, oldClient
+}
+
+// TestReanchorInitTolerance_TimeoutCommits proves that a timed-out build still moves the anchor. The
+// SDK retries in the background, so relay keeps the new key and records the timeout. It must not
+// record ErrInitializationFailed, because the request middleware rejects only that value.
+func TestReanchorInitTolerance_TimeoutCommits(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	targetCh := make(chan *testclient.FakeLDClient, 10)
+	env, oldClient := initTolerEnv(t, ld.ErrInitializationTimeout, mockLog, targetCh)
+	defer env.Close()
+
+	now := time.Unix(2000, 0)
+	reanchorViaReconcile(t, env, initTolerKeyB, envConfig.SDKKey, "", envConfig.MobileKey, envConfig.EnvID, now)
+	newClient := requireClientReady(t, targetCh)
+
+	assert.Equal(t, initTolerKeyB, env.(*envContextImpl).keyRotator.AnchorKey(),
+		"the anchor moves even though the client is still connecting")
+	assert.Same(t, newClient, env.GetClient(), "the unconverged client backs the anchor")
+	assert.False(t, env.GetClient().Initialized(), "sanity: this fake reports itself as not initialized")
+	assert.Equal(t, ld.ErrInitializationTimeout, env.GetInitError(),
+		"the timeout is recorded rather than discarded")
+	assert.NotEqual(t, ld.ErrInitializationFailed, env.GetInitError(),
+		"the middleware rejects only ErrInitializationFailed, so it must not appear here")
+	mockLog.AssertMessageMatch(t, true, ldlog.Warn, "Re-anchored SDK from .* the client is not initialized yet")
+
+	oldClient.AwaitClose(t, time.Second)
+}
+
+// TestReanchorInitTolerance_PermanentFailureRollsBack covers the shape the SDK uses for an
+// unrecoverable status such as 401: a non-nil client that is not initialized, with
+// ErrInitializationFailed. The SDK stops the data source, so there is nothing to wait for. The
+// re-anchor must keep the previous anchor and its working client.
+func TestReanchorInitTolerance_PermanentFailureRollsBack(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	targetCh := make(chan *testclient.FakeLDClient, 10)
+	env, oldClient := initTolerEnv(t, ld.ErrInitializationFailed, mockLog, targetCh)
+	defer env.Close()
+
+	now := time.Unix(2000, 0)
+	reanchorViaReconcile(t, env, initTolerKeyB, envConfig.SDKKey, "", envConfig.MobileKey, envConfig.EnvID, now)
+	rejected := requireClientReady(t, targetCh)
+
+	assert.Equal(t, envConfig.SDKKey, env.(*envContextImpl).keyRotator.AnchorKey(),
+		"the anchor stays on the previous key")
+	assert.Same(t, oldClient, env.GetClient(), "the previous anchor's client still serves")
+	assert.NoError(t, env.GetInitError(), "a rollback leaves the serving env's init status alone")
+	mockLog.AssertMessageMatch(t, true, ldlog.Error, "Re-anchor to SDK key .* failed permanently")
+
+	rejected.AwaitClose(t, time.Second)
+	select {
+	case <-oldClient.CloseCh:
+		t.Fatal("the previous anchor's client must stay open after a rollback")
+	default:
+	}
+
+	envImpl := env.(*envContextImpl)
+	envImpl.mu.RLock()
+	_, installed := envImpl.clients[initTolerKeyB]
+	envImpl.mu.RUnlock()
+	assert.False(t, installed, "the permanently failed client must not be installed")
+}
+
+// TestReanchorInitTolerance_UninitializedWithNilErrorCommits covers a zero InitTimeout. The SDK
+// constructor returns at once with a client that has not connected and a nil error, and the client
+// connects in the background. The re-anchor must commit it.
+//
+// The previous guard rejected this shape. In production it only bit when the data store was not yet
+// initialized, because a handed-over populated store makes the real client report itself initialized.
+func TestReanchorInitTolerance_UninitializedWithNilErrorCommits(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	targetCh := make(chan *testclient.FakeLDClient, 10)
+	env, oldClient := initTolerEnv(t, nil, mockLog, targetCh)
+	defer env.Close()
+
+	now := time.Unix(2000, 0)
+	reanchorViaReconcile(t, env, initTolerKeyB, envConfig.SDKKey, "", envConfig.MobileKey, envConfig.EnvID, now)
+	newClient := requireClientReady(t, targetCh)
+
+	assert.Equal(t, initTolerKeyB, env.(*envContextImpl).keyRotator.AnchorKey(), "the anchor moves")
+	assert.Same(t, newClient, env.GetClient(), "the unconverged client backs the anchor")
+	assert.NoError(t, env.GetInitError(), "a nil build error records no init error, as at startup")
+
+	oldClient.AwaitClose(t, time.Second)
+}
+
+// TestReanchorInitTolerance_HealthyReanchorClearsRecordedTimeout proves the recorded timeout is not
+// sticky. commitReanchor records each build's outcome, so a later healthy re-anchor replaces the
+// timeout with nil.
+func TestReanchorInitTolerance_HealthyReanchorClearsRecordedTimeout(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	targetCh := make(chan *testclient.FakeLDClient, 10)
+	env, _ := initTolerEnv(t, ld.ErrInitializationTimeout, mockLog, targetCh)
+	defer env.Close()
+
+	now := time.Unix(2000, 0)
+	reanchorViaReconcile(t, env, initTolerKeyB, envConfig.SDKKey, "", envConfig.MobileKey, envConfig.EnvID, now)
+	require.Equal(t, ld.ErrInitializationTimeout, env.GetInitError(), "sanity: the timeout was recorded")
+
+	// Key C is not the factory's target key, so its build produces an initialized client.
+	reanchorViaReconcile(t, env, initTolerKeyC, initTolerKeyB, "", envConfig.MobileKey, envConfig.EnvID, now)
+
+	assert.Equal(t, initTolerKeyC, env.(*envContextImpl).keyRotator.AnchorKey(), "the anchor moved again")
+	assert.NoError(t, env.GetInitError(), "a healthy re-anchor clears the recorded timeout")
+	assert.True(t, env.GetClient().Initialized(), "the anchor's client is initialized")
+}
+
+// TestReanchorInitTolerance_UnconvergedCommitKeepsStoreServing proves the point of committing an
+// unconverged client: the store is handed over, not rebuilt, so relay answers requests from the
+// existing data while the new client connects.
+func TestReanchorInitTolerance_UnconvergedCommitKeepsStoreServing(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	targetCh := make(chan *testclient.FakeLDClient, 10)
+	env, _ := initTolerEnv(t, ld.ErrInitializationTimeout, mockLog, targetCh)
+	defer env.Close()
+
+	storeBefore := env.GetStore()
+	require.NotNil(t, storeBefore)
+	require.NoError(t, storeBefore.Init(st.AllData))
+	flagsBefore, err := storeBefore.GetAll(ldstoreimpl.Features())
+	require.NoError(t, err)
+	require.NotEmpty(t, flagsBefore, "sanity: the store holds data before the re-anchor")
+
+	now := time.Unix(2000, 0)
+	reanchorViaReconcile(t, env, initTolerKeyB, envConfig.SDKKey, "", envConfig.MobileKey, envConfig.EnvID, now)
+	newClient := requireClientReady(t, targetCh)
+
+	require.Equal(t, initTolerKeyB, env.(*envContextImpl).keyRotator.AnchorKey(),
+		"sanity: the unconverged client was committed")
+	require.Same(t, newClient, env.GetClient(), "sanity: the unconverged client backs the anchor")
+
+	assert.Same(t, storeBefore, env.GetStore(),
+		"the unconverged client shares the previous client's store wrapper")
+	flagsAfter, err := env.GetStore().GetAll(ldstoreimpl.Features())
+	require.NoError(t, err)
+	assert.Len(t, flagsAfter, len(flagsBefore), "the store keeps serving while the new client connects")
+	assert.NotNil(t, env.GetEvaluator(), "the evaluator is wired to the handed-over store")
+}


### PR DESCRIPTION
## Summary

A re-anchor rolled back whenever the new anchor's client build returned any error, including `ErrInitializationTimeout`. That is too strict. On a timeout the SDK keeps retrying on its own, and the new client inherits the populated data store, so Relay keeps serving from it until the client connects.

Rolling back is also expensive. The autoconfiguration layer records the payload's version before the re-anchor runs (`stream_manager.go` evaluates `envReceiver.Upsert(...)` as the argument to `dispatchEnvAction`), and `MessageReceiver.Upsert` returns `ActionNoop` for a replayed version. A discarded rotation is therefore never re-sent, and the environment stays anchored on a key the payload demoted.

Rollback now happens only when there is nothing usable to install:

- the factory produced no client, or
- the SDK reports `ErrInitializationFailed`. That is permanent, because the SDK stops the data source and makes no further attempts. Committing it would close a working client and install a dead one.

`commitReanchor` records the build error in `initErr` instead of always clearing it, mirroring `startSDKClient`. Only the request middleware and the startup wait loop read `initErr`, and the middleware rejects `ErrInitializationFailed` alone, so a recorded timeout does not reject downstream requests.

### Relationship to #823

#823 has since landed and is merged into this branch. It attacks the same root cause from the other side: it keeps the rollback and has the credential cleanup ticker replay the rolled-back set until the build succeeds.

The two compose, and the combination is better than either alone:

- This PR narrows what rolls back. #823 retries whatever still does.
- After the merge, `recordFailedReanchor` fires only for a nil client or `ErrInitializationFailed`. A timeout commits on the first attempt and never arms `pendingReanchor`.
- That also terminates a retry loop #823 would otherwise run indefinitely. Before this change, a build that only needed more time would roll back, and the ticker would rebuild a whole client once per cleanup interval, discarding progress each time. Now the SDK's own stream reconnect handles it, and the reconnect keeps the populated store.

Every retry test from #823 passes unchanged: its `countingFactory` returns a nil client for failing keys, which still rolls back under the narrowed guard. The `PreviousAnchorName` restoration in `RevertAnchorChange` is likewise still exercised, because the rollback path is preserved.

Two points for @aaronz to weigh, neither blocking:

- The retry's remaining scope is dominated by `ErrInitializationFailed`, the case least likely to self-resolve, since the SDK has already stopped its data source. The uncapped retry is deliberate, but it now mostly polls a key LaunchDarkly is rejecting, one client build per cleanup interval.
- A committed-but-unconverged client gets no relay-level watchdog by design, since the SDK retries internally. If such a client's data source later goes `Off`, nothing re-evaluates `initErr` and nothing arms a retry. That gap predates both PRs, but the machinery to close it now exists.

### Effect on the status endpoint

No health blip. The new client inherits the populated store, so `FDv1.DataAvailability()` returns `Cached` and `Initialized()` is true right away. `/status` keeps reporting `connected` and `healthy`, and degrades only if the client still has not connected after `DisconnectedStatusTime` (default 1 minute). `connectionStatus.state` does change immediately, which is the intended detail signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Re-anchor rollback is narrowed** so SDK key rotation no longer aborts when the new anchor’s client build returns `ErrInitializationTimeout` or a non-nil client with a nil error while still connecting. Rollback now happens only when the factory returns no client or `ErrInitializationFailed` (permanent failure where the SDK stops retrying).
> 
> `buildNewAnchorClient` returns `(client, error)` and `commitReanchor` records the build error in `initErr` instead of always clearing it—matching startup behavior. Request middleware still rejects only `ErrInitializationFailed`, so a recorded timeout does not block downstream traffic while the SDK reconnects on the inherited data store.
> 
> Adds **`env_context_reanchor_init_tolerance_test.go`** covering timeout commit, permanent failure rollback, nil-error commit, clearing timeout on a later healthy re-anchor, and store continuity during unconverged commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada55af9b2be918ab769f16a35c102c89dc5f3f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->