### PR TITLE
fix(credential): keep the old SDK key valid until the new key takes over

### DIFF
--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -33,6 +33,10 @@ type AcceptedKeySet struct {
 type Rotator struct {
 	loggers ldlog.Loggers
 
+	// anchorPendingRemoval means a payload revoked the anchor, but it stays accepted because it is
+	// still serving. CommitAnchor drops it when the anchor moves. See reconcileSDKKeys.
+	anchorPendingRemoval bool
+
 	// There is only one mobile key active at a given time.
 	primaryMobileKey config.MobileKey
 
@@ -309,6 +313,13 @@ func (r *Rotator) Reconcile(set AcceptedSet, now time.Time) ReconcileResult {
 func (r *Rotator) CommitAnchor(key config.SDKKey) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// A revoked anchor stays accepted while it serves (see reconcileSDKKeys). It stops serving here, so
+	// drop it. Reconcile already queued its expiration, so the caller removes its mappings next.
+	if r.anchorPendingRemoval && key != r.anchorKey {
+		delete(r.acceptedSDKKeys, r.anchorKey)
+	}
+	r.anchorPendingRemoval = false
 	r.anchorKey = key
 }
 
@@ -323,6 +334,10 @@ func (r *Rotator) CommitAnchor(key config.SDKKey) {
 func (r *Rotator) RevertAnchorChange(change AnchorChange) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// The anchor never moved, so it keeps serving and stays accepted. Clear the flag so a later
+	// CommitAnchor does not act on this reconcile's decision.
+	r.anchorPendingRemoval = false
 
 	// Only re-admit a defined previous anchor. The rotator holds defined keys only, and an env that
 	// gains its first SDK key has an undefined previous anchor.
@@ -384,7 +399,23 @@ func (r *Rotator) reconcileSDKKeys(set AcceptedSet, now time.Time) {
 		}
 		desired[key] = info
 	}
+	// Snapshot the anchor before the diff deletes it, so its expiry and its name survive.
+	anchorBefore, anchorAcceptedBefore := r.acceptedSDKKeys[r.anchorKey]
+
 	reconcileAcceptedKeys(desired, r.acceptedSDKKeys, &r.additions, &r.expirations, r.loggers, "SDK key")
+
+	// The anchor keeps serving until a re-anchor commits. That commit happens after the new key's
+	// client is built. So a payload that revokes the anchor must not drop it yet. /status still lists
+	// that key, and GetStreamHandler still authenticates it. CommitAnchor drops the entry when the
+	// anchor moves. The expiration queued above stands, so the key's mappings come down after that.
+	// StepTime and DeprecatedCredentials guard the anchor the same way.
+	r.anchorPendingRemoval = false
+	if anchorAcceptedBefore {
+		if _, stillAccepted := r.acceptedSDKKeys[r.anchorKey]; !stillAccepted {
+			r.acceptedSDKKeys[r.anchorKey] = anchorBefore
+			r.anchorPendingRemoval = true
+		}
+	}
 }
 
 // reconcileMobileKeys does for mobile keys what reconcileSDKKeys does for SDK keys. An empty primary

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -682,3 +682,70 @@ func TestIsAcceptedFalseOnceExpiryElapses(t *testing.T) {
 	assert.True(t, r.IsAccepted(anchor), "the anchor never expires")
 	assert.True(t, r.IsAccepted(mob), "the primary mobile key is permanent")
 }
+
+func TestReconcileKeepsRevokedAnchorAcceptedUntilCommit(t *testing.T) {
+	// A payload that revokes the current anchor outright must not drop it from the accepted set while
+	// it is still serving. The re-anchor's client build runs between Reconcile and CommitAnchor, and
+	// throughout that window the environment answers requests on the old anchor.
+	r := newTestRotator()
+	keyA := config.SDKKey("keyA")
+	keyB := config.SDKKey("keyB")
+	keyAName := "anchor-sdk"
+	now := time.Now()
+
+	res := r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		WithAnchor(SDKKeyParams{Value: keyA, Key: &keyAName})), now)
+	require.NotNil(t, res.AnchorChange)
+	r.CommitAnchor(res.AnchorChange.NewAnchor)
+	r.StepTime(now)
+
+	// Rotate to keyB, omitting keyA entirely (immediate revocation).
+	res = r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: keyB})), now)
+	require.NotNil(t, res.AnchorChange)
+
+	// Mid-build: keyA is still the anchor, so it must still authenticate and still appear in /status.
+	assert.Equal(t, keyA, r.AnchorKey())
+	assert.True(t, r.IsAccepted(keyA), "the serving anchor must stay accepted until the anchor moves")
+	assert.Contains(t, r.AllCredentials(), SDKCredential(keyA))
+	assert.Equal(t, &keyAName, r.AcceptedKeys().Server[keyA].Key,
+		"the retained entry keeps its wire identifier, so /status still names the serving key")
+
+	// The revocation is still queued, so the caller tears the key's mappings down after the commit.
+	_, expirations := r.StepTime(now)
+	assert.Contains(t, expirations, SDKCredential(keyA), "the revocation is queued, only deferred")
+
+	// The anchor moves: the protection ends here.
+	r.CommitAnchor(keyB)
+	assert.Equal(t, keyB, r.AnchorKey())
+	assert.False(t, r.IsAccepted(keyA), "the outgoing anchor is dropped once the anchor has moved")
+	assert.NotContains(t, r.AllCredentials(), SDKCredential(keyA))
+}
+
+func TestRevertAnchorChangeKeepsRevokedAnchorAcceptedWithItsMetadata(t *testing.T) {
+	// The rollback counterpart: the build failed, so the anchor never moved. The revoked previous
+	// anchor keeps serving, so it stays accepted with its identifier intact.
+	r := newTestRotator()
+	keyA := config.SDKKey("keyA")
+	keyB := config.SDKKey("keyB")
+	keyAName := "anchor-sdk"
+	now := time.Now()
+
+	res := r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().
+		WithAnchor(SDKKeyParams{Value: keyA, Key: &keyAName})), now)
+	require.NotNil(t, res.AnchorChange)
+	r.CommitAnchor(res.AnchorChange.NewAnchor)
+	r.StepTime(now)
+
+	res = r.Reconcile(mustBuild(t, NewAcceptedSetBuilder().WithAnchor(SDKKeyParams{Value: keyB})), now)
+	require.NotNil(t, res.AnchorChange)
+	r.RevertAnchorChange(*res.AnchorChange) // no CommitAnchor: the build failed
+
+	assert.Equal(t, keyA, r.AnchorKey())
+	assert.True(t, r.IsAccepted(keyA), "a rolled-back re-anchor leaves the serving anchor accepted")
+	assert.Equal(t, &keyAName, r.AcceptedKeys().Server[keyA].Key)
+	assert.False(t, r.IsAccepted(keyB), "the failed new anchor is dropped")
+
+	// A later commit must not act on the reverted reconcile's decision.
+	r.CommitAnchor(keyA)
+	assert.True(t, r.IsAccepted(keyA), "committing the same anchor must not drop it")
+}

--- a/internal/relayenv/env_context_reanchor_serving_key_test.go
+++ b/internal/relayenv/env_context_reanchor_serving_key_test.go
@@ -1,0 +1,177 @@
+package relayenv
+
+// The key an environment is serving on stays usable for the whole re-anchor.
+//
+// A re-anchor moves the anchor pointer only after the new key's client is built, which takes up to
+// Main.InitTimeout. Throughout that build the environment still answers requests on the previous
+// anchor. A payload that revokes that key outright must therefore not drop it from the accepted set
+// until the anchor actually moves, or GetStreamHandler answers 404 for SDKs authenticating with the
+// very key relay is serving from.
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/credential"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdkauth"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+	"github.com/launchdarkly/ld-relay/v8/internal/streams"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const servingKeyTestNewAnchor = config.SDKKey("serving-key-new-anchor")
+
+// alwaysOKStreamProvider yields a 200 handler for any credential, so a 404 from GetStreamHandler can
+// only come from its accepted-set check.
+type alwaysOKStreamProvider struct{}
+
+func (alwaysOKStreamProvider) Handler(_ sdkauth.ScopedCredential) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }
+}
+
+func (alwaysOKStreamProvider) Register(
+	_ sdkauth.ScopedCredential, _ streams.EnvStoreQueries, _ ldlog.Loggers,
+) streams.EnvStreamProvider {
+	return nil
+}
+
+func (alwaysOKStreamProvider) Close() {}
+
+// streamStatusFor drives a real request through GetStreamHandler and returns the status code.
+func streamStatusFor(env *envContextImpl, cred credential.SDKCredential) int {
+	handler := env.GetStreamHandler(alwaysOKStreamProvider{}, cred)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest("GET", "/all", nil))
+	return rec.Code
+}
+
+// revokeAnchorSet designates newAnchor as the only SDK key, revoking every other key outright.
+func revokeAnchorSet(t *testing.T, newAnchor config.SDKKey) credential.AcceptedSet {
+	t.Helper()
+	set, err := credential.NewAcceptedSetBuilder().
+		WithAnchor(credential.SDKKeyParams{Value: newAnchor}).
+		WithPrimaryMobileKey(credential.MobileKeyParams{Value: st.EnvMain.Config.MobileKey}).
+		WithEnvironmentID(st.EnvMain.Config.EnvID).
+		Build()
+	require.NoError(t, err)
+	return set
+}
+
+// servingKeyProbe observes the serving key's stream status from inside the new anchor's client build,
+// which is the window where c.mu is released and the accepted set has already been re-diffed.
+type servingKeyProbe struct {
+	mu       sync.Mutex
+	statuses []int
+	impl     *envContextImpl
+}
+
+func (p *servingKeyProbe) record(servingKey config.SDKKey) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.statuses = append(p.statuses, streamStatusFor(p.impl, servingKey))
+}
+
+func (p *servingKeyProbe) snapshot() []int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]int(nil), p.statuses...)
+}
+
+// newServingKeyEnv builds an environment whose new-anchor build calls probe.record before returning
+// buildResult, so the test can observe state mid-build.
+func newServingKeyEnv(
+	t *testing.T,
+	probe *servingKeyProbe,
+	buildFails bool,
+) *envContextImpl {
+	t.Helper()
+	mockLog := ldlogtest.NewMockLog()
+	t.Cleanup(func() { mockLog.DumpIfTestFailed(t) })
+
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	healthy := testclient.FakeLDClientFactoryWithChannel(true, clientCh)
+	factory := func(key config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		if key != servingKeyTestNewAnchor {
+			return healthy(key, cfg, timeout)
+		}
+		probe.record(st.EnvMain.Config.SDKKey)
+		if buildFails {
+			return nil, errors.New("serving-key test: build refused")
+		}
+		return healthy(key, cfg, timeout)
+	}
+
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, st.EnvMain.Config, factory, mockLog.Loggers, readyCh)
+	t.Cleanup(func() { _ = env.Close() })
+	require.Equal(t, env, requireEnvReady(t, readyCh))
+	requireClientReady(t, clientCh)
+
+	envImpl := env.(*envContextImpl)
+	probe.impl = envImpl
+	return envImpl
+}
+
+// TestServingKeyStaysAuthenticatedDuringSuccessfulReanchor is the regression test for the defect: a
+// rotation that revokes the outgoing anchor must not 404 that key while its replacement is being built.
+// This holds for an ordinary, entirely successful rotation -- no rollback and no retry involved.
+func TestServingKeyStaysAuthenticatedDuringSuccessfulReanchor(t *testing.T) {
+	servingKey := st.EnvMain.Config.SDKKey
+	probe := &servingKeyProbe{}
+	envImpl := newServingKeyEnv(t, probe, false)
+
+	require.Equal(t, http.StatusOK, streamStatusFor(envImpl, servingKey), "sanity: usable before the rotation")
+
+	now := time.Unix(2000, 0)
+	envImpl.reconcileCredentials(revokeAnchorSet(t, servingKeyTestNewAnchor), now)
+
+	for i, code := range probe.snapshot() {
+		assert.Equal(t, http.StatusOK, code,
+			"build attempt %d: the key the environment is serving on must not be rejected", i+1)
+	}
+	require.Len(t, probe.snapshot(), 1, "the rotation built the new anchor's client exactly once")
+
+	// After the commit the rotation is complete, so the revoked key is correctly rejected.
+	assert.Equal(t, servingKeyTestNewAnchor, envImpl.keyRotator.AnchorKey())
+	assert.Equal(t, http.StatusNotFound, streamStatusFor(envImpl, servingKey),
+		"once the anchor has moved, the revoked key is no longer accepted")
+	assert.NotContains(t, envImpl.GetCredentials(), credential.SDKCredential(servingKey))
+}
+
+// TestServingKeyStaysAuthenticatedAcrossReanchorRetries covers the same window on the retry path, where
+// it recurs once per credential cleanup interval for as long as the build keeps failing.
+func TestServingKeyStaysAuthenticatedAcrossReanchorRetries(t *testing.T) {
+	servingKey := st.EnvMain.Config.SDKKey
+	probe := &servingKeyProbe{}
+	envImpl := newServingKeyEnv(t, probe, true)
+
+	now := time.Unix(2000, 0)
+	envImpl.reconcileCredentials(revokeAnchorSet(t, servingKeyTestNewAnchor), now)
+	envImpl.triggerCredentialChanges(now.Add(time.Minute))
+	envImpl.triggerCredentialChanges(now.Add(2 * time.Minute))
+
+	statuses := probe.snapshot()
+	require.GreaterOrEqual(t, len(statuses), 3, "the retry rebuilt the client on each cleanup interval")
+	for i, code := range statuses {
+		assert.Equal(t, http.StatusOK, code,
+			"build attempt %d: the serving key must stay usable on every retry", i+1)
+	}
+
+	// The rollback keeps the environment on the serving key, so it stays usable between retries too.
+	assert.Equal(t, servingKey, envImpl.keyRotator.AnchorKey())
+	assert.Equal(t, http.StatusOK, streamStatusFor(envImpl, servingKey))
+	assert.Contains(t, envImpl.GetCredentials(), credential.SDKCredential(servingKey))
+}


### PR DESCRIPTION
## Summary

Relay serves each environment through one SDK key. That key is the anchor.

A rotation replaces the anchor. Relay builds a client for the new key first. The anchor moves only after that build finishes. The build takes up to `Main.InitTimeout`, which is 10 seconds by default.

When a payload revoked the old key, `Reconcile` dropped it from the accepted set at once. Relay kept serving on that key for the whole build. So Relay served on a key it no longer accepted.

`GetStreamHandler` checks the accepted set. During the build it answered 404 for the key Relay was serving on. Any SDK that connected or reconnected in that window got that 404.

This PR keeps the old key accepted until the anchor moves.

## Background

A 404 from a stream endpoint is terminal for an SDK data source. Only 400, 408 and 429 are recoverable. An SDK that reconnects inside the window can stop its data source for good.

The window also broke a documented rule for `/status`: the `sdkKeys[]` array always contains the anchor. During the build it did not.

This defect is older than the re-anchor retry. An ordinary successful rotation opens the same window. The retry reopens the window once per credential cleanup interval while a build keeps failing. That is how it surfaced.

The rotator already applies this rule in two places. `StepTime` never expires the anchor, and `DeprecatedCredentials` excludes it. This PR extends the same rule to `Reconcile`.

## Changes

`reconcileSDKKeys` restores the anchor's entry when the diff drops it, so the key keeps its expiry and its name. `CommitAnchor` deletes that entry once the anchor moves, and the revocation queued during reconcile still removes the key's mappings straight after.
