### PR TITLE
fix: Stop reporting a connection timeout the SDK client has outgrown

### DIFF
--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -862,10 +862,17 @@ func (c *envContextImpl) GetAcceptedKeys() credential.AcceptedKeySet {
 func (c *envContextImpl) GetClient() sdks.LDClientContext {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	// c.clients holds at most one entry: the anchor's client. Only construction and the re-anchor
-	// sequence create clients, so non-anchor server keys never open an upstream connection. Offline mode
-	// iterates instead of looking up by key. Both work: the rotator is initialized with envConfig.SDKKey
-	// before any client is built.
+	return c.anchorClient()
+}
+
+// anchorClient returns the client that owns the upstream connection, or nil when there is none. The
+// caller must hold at least a read lock.
+//
+// c.clients holds at most one entry: the anchor's client. Only construction and the re-anchor sequence
+// create clients, so non-anchor server keys never open an upstream connection. Offline mode iterates
+// instead of looking up by key. Both work: the rotator is initialized with envConfig.SDKKey before any
+// client is built.
+func (c *envContextImpl) anchorClient() sdks.LDClientContext {
 	if c.offline {
 		for _, client := range c.clients {
 			return client
@@ -967,10 +974,38 @@ func (c *envContextImpl) GetFilter() config.FilterKey {
 	return c.filterKey
 }
 
+// GetInitError reports the outcome of the anchor client's build, unless that outcome is a timeout the
+// client has since outgrown.
+//
+// initErr is written once per build, by startSDKClient and by commitReanchor. Neither one runs again
+// when the client connects later. A recorded timeout would therefore describe the environment for the
+// rest of the process, even after the SDK connects on its own.
+//
+// Only a timeout gets this treatment, and only when the data source reports Valid. A timeout means
+// exactly "not connected yet, still trying", so a connected data source contradicts it. Every other
+// error keeps reporting:
+//
+//   - ErrInitializationFailed is terminal, and the request middleware rejects requests on that value
+//     alone. A client whose data source stopped must keep that error.
+//   - A host application supplies its own ClientFactoryFunc, and relay cannot know what an arbitrary
+//     error means. The client's own status must not override it.
+//
+// The extra work happens only while an error is recorded. A healthy environment returns on the first
+// branch, which keeps the request middleware's per-request call cheap.
 func (c *envContextImpl) GetInitError() error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	if c.initErr == nil {
+		return nil
+	}
+	if !errors.Is(c.initErr, ld.ErrInitializationTimeout) {
+		return c.initErr
+	}
+	if client := c.anchorClient(); client != nil &&
+		client.GetDataSourceStatus().State == interfaces.DataSourceStateValid {
+		return nil
+	}
 	return c.initErr
 }
 

--- a/internal/relayenv/env_context_init_error_staleness_test.go
+++ b/internal/relayenv/env_context_init_error_staleness_test.go
@@ -1,0 +1,181 @@
+package relayenv
+
+// initErr records the outcome of one client build. Nothing rewrites it when the client connects later,
+// so GetInitError consults the anchor client's data source before it reports a recorded error.
+//
+// These tests cover both writers of initErr, startSDKClient and commitReanchor, through the one read
+// path they share.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/sdks"
+	st "github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
+	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest/testclient"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const initErrStaleKeyB = config.SDKKey("init-err-stale-anchor-b")
+
+// staleErrFactory returns an initialized client for every key except targetKey. For targetKey it
+// returns a client that has not connected, paired with targetErr, and reports it on targetCh.
+func staleErrFactory(
+	targetKey config.SDKKey,
+	targetErr error,
+	healthyCh chan *testclient.FakeLDClient,
+	targetCh chan *testclient.FakeLDClient,
+) sdks.ClientFactoryFunc {
+	healthy := testclient.FakeLDClientFactoryWithChannel(true, healthyCh)
+	return func(sdkKey config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		if sdkKey != targetKey {
+			return healthy(sdkKey, cfg, timeout)
+		}
+		client := &testclient.FakeLDClient{Key: sdkKey, CloseCh: make(chan struct{})}
+		targetCh <- client
+		return client, targetErr
+	}
+}
+
+// TestInitErrStaleness_ReanchorTimeoutClearsOnceDataSourceIsValid covers the commitReanchor writer. A
+// re-anchor commits a client that has not connected, so the timeout is recorded. Once that client's
+// data source reports Valid, the environment is healthy and GetInitError must stop reporting the
+// timeout.
+func TestInitErrStaleness_ReanchorTimeoutClearsOnceDataSourceIsValid(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	healthyCh := make(chan *testclient.FakeLDClient, 10)
+	targetCh := make(chan *testclient.FakeLDClient, 10)
+	factory := staleErrFactory(initErrStaleKeyB, ld.ErrInitializationTimeout, healthyCh, targetCh)
+
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, envConfig, factory, mockLog.Loggers, readyCh)
+	defer env.Close()
+	require.Equal(t, env, requireEnvReady(t, readyCh))
+	oldClient := requireClientReady(t, healthyCh)
+	require.Eventually(t, func() bool { return env.GetClient() == oldClient }, time.Second, 10*time.Millisecond)
+
+	now := time.Unix(2000, 0)
+	reanchorViaReconcile(t, env, initErrStaleKeyB, envConfig.SDKKey, "", envConfig.MobileKey, envConfig.EnvID, now)
+	newClient := requireClientReady(t, targetCh)
+
+	// The client has not connected, so the recorded timeout still describes the environment.
+	require.Equal(t, ld.ErrInitializationTimeout, env.GetInitError(),
+		"a client that has not connected keeps reporting its timeout")
+
+	// An Interrupted data source is not a connected one, so the timeout still stands.
+	newClient.SetDataSourceStatus(interfaces.DataSourceStatus{State: interfaces.DataSourceStateInterrupted})
+	assert.Equal(t, ld.ErrInitializationTimeout, env.GetInitError(),
+		"an interrupted data source must not clear the recorded timeout")
+
+	// The SDK connects on its own. The recorded timeout is now stale.
+	newClient.SetDataSourceStatus(interfaces.DataSourceStatus{State: interfaces.DataSourceStateValid})
+	assert.NoError(t, env.GetInitError(),
+		"a connected data source means the recorded timeout no longer describes the environment")
+}
+
+// TestInitErrStaleness_StartupTimeoutClearsOnceDataSourceIsValid covers the startSDKClient writer. The
+// initial build times out, and the same read path must clear the error once that client connects.
+func TestInitErrStaleness_StartupTimeoutClearsOnceDataSourceIsValid(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	healthyCh := make(chan *testclient.FakeLDClient, 10)
+	targetCh := make(chan *testclient.FakeLDClient, 10)
+	// The environment's own key is the target, so the initial build reports a timeout.
+	factory := staleErrFactory(envConfig.SDKKey, ld.ErrInitializationTimeout, healthyCh, targetCh)
+
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, envConfig, factory, mockLog.Loggers, readyCh)
+	defer env.Close()
+	require.Equal(t, env, requireEnvReady(t, readyCh))
+	client := requireClientReady(t, targetCh)
+
+	require.Equal(t, ld.ErrInitializationTimeout, env.GetInitError(),
+		"the initial build's timeout is recorded")
+
+	client.SetDataSourceStatus(interfaces.DataSourceStatus{State: interfaces.DataSourceStateValid})
+	assert.NoError(t, env.GetInitError(),
+		"the same read path clears a startup timeout, so both writers behave alike")
+}
+
+// TestInitErrStaleness_FailedIsNotClearedByAnOffDataSource pins the middleware contract. A permanent
+// failure must keep reporting, because the middleware rejects requests on that value alone.
+func TestInitErrStaleness_FailedIsNotClearedByAnOffDataSource(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	healthyCh := make(chan *testclient.FakeLDClient, 10)
+	targetCh := make(chan *testclient.FakeLDClient, 10)
+	factory := staleErrFactory(envConfig.SDKKey, ld.ErrInitializationFailed, healthyCh, targetCh)
+
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, envConfig, factory, mockLog.Loggers, readyCh)
+	defer env.Close()
+	require.Equal(t, env, requireEnvReady(t, readyCh))
+	client := requireClientReady(t, targetCh)
+
+	client.SetDataSourceStatus(interfaces.DataSourceStatus{State: interfaces.DataSourceStateOff})
+	assert.Equal(t, ld.ErrInitializationFailed, env.GetInitError(),
+		"an Off data source keeps the permanent failure, so the middleware still rejects requests")
+}
+
+// TestInitErrStaleness_NoClientKeepsTheRecordedError guards the nil-client branch. A recorded error
+// with no anchor client must still report, rather than reading a nil client's status.
+func TestInitErrStaleness_NoClientKeepsTheRecordedError(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	env := makeBasicEnv(t, envConfig, testclient.ClientFactoryThatFails(ld.ErrInitializationFailed),
+		mockLog.Loggers, make(chan EnvContext, 1))
+	defer env.Close()
+
+	envImpl := env.(*envContextImpl)
+	require.Eventually(t, func() bool { return envImpl.GetInitError() != nil }, time.Second, 10*time.Millisecond)
+	require.Nil(t, env.GetClient(), "sanity: the failing factory installed no client")
+	assert.Equal(t, ld.ErrInitializationFailed, env.GetInitError(),
+		"with no client there is nothing to prove the error stale")
+}
+
+// TestInitErrStaleness_ArbitraryErrorIsNeverCleared pins the boundary a host application depends on.
+// A ClientFactoryFunc supplied by a host can return any error, and relay cannot know what it means, so
+// the client's own status must not override it. Here the client reports a Valid data source and the
+// error still stands.
+func TestInitErrStaleness_ArbitraryErrorIsNeverCleared(t *testing.T) {
+	envConfig := st.EnvMain.Config
+	mockLog := ldlogtest.NewMockLog()
+	defer mockLog.DumpIfTestFailed(t)
+
+	hostErr := errors.New("host factory rejected this environment")
+	clientCh := make(chan *testclient.FakeLDClient, 10)
+	// An initialized fake reports a Valid data source, which is the shape that would wrongly clear the
+	// error if the check were not limited to timeouts.
+	factory := func(sdkKey config.SDKKey, cfg ld.Config, timeout time.Duration) (sdks.LDClientContext, error) {
+		client, _ := testclient.FakeLDClientFactoryWithChannel(true, clientCh)(sdkKey, cfg, timeout)
+		return client, hostErr
+	}
+
+	readyCh := make(chan EnvContext, 1)
+	env := makeBasicEnv(t, envConfig, factory, mockLog.Loggers, readyCh)
+	defer env.Close()
+	require.Equal(t, env, requireEnvReady(t, readyCh))
+	client := requireClientReady(t, clientCh)
+
+	require.Equal(t, interfaces.DataSourceStateValid, client.GetDataSourceStatus().State,
+		"sanity: this fixture reports a connected data source")
+	assert.Equal(t, hostErr, env.GetInitError(),
+		"an error relay does not understand must survive, whatever the client reports")
+}


### PR DESCRIPTION
## Summary

`initErr` records the outcome of one client build. `startSDKClient` and `commitReanchor` each write it once, and neither runs again when the SDK connects later. A build that timed out therefore described the environment for the rest of the process, even after the client came up on its own.

`GetInitError` now consults the anchor client's data source before it reports a recorded error. A `Valid` data source means the client connected, so a recorded timeout no longer describes anything. Fixing the single reader covers both writers, which keeps the two paths consistent and avoids duplicating clearing logic at each write site.

Follow-up to #835, which made a re-anchor commit a client that has not finished connecting. That change made this reachable on the re-anchor path, but the latching itself predates it: a startup timeout already stuck for the life of the process.

### Why only a timeout

`ErrInitializationTimeout` means exactly "not connected yet, still trying", so a `Valid` data source contradicts it. Every other error keeps reporting:

- `ErrInitializationFailed` is terminal, and the request middleware rejects requests on that value alone. A client whose data source stopped must keep that error.
- A host application supplies its own `ClientFactoryFunc`, and relay cannot know what an arbitrary error means. The client's own status must not override it.

An earlier draft cleared *any* error on a `Valid` data source. That broke `TestRelayUninitializedEnvironment`, whose fixture returns an initialized client paired with a generic error and asserts `waitForAllClients` reports it. The fixture is unrealistic for the real SDK, which never pairs a `Valid` data source with an error, but the lesson holds: relay should not second-guess a contract it does not own, with `ExitOnError` downstream. Narrowing to timeouts makes that test pass unchanged.

### What this deliberately does not do

It does not work in the other direction. A data source that goes `Off` after a commit leaves the recorded error alone, so this never *starts* rejecting requests for an environment that still serves from its data store. Promoting a post-commit failure into a request-rejecting error is a separate policy decision.

### Incidental

`GetClient`'s body moves to a new `anchorClient` helper, because `GetInitError` already holds the read lock and must not re-enter it.

### Coverage

`env_context_init_error_staleness_test.go` covers both writers through the shared read path, plus three boundaries: a terminal failure with an `Off` data source keeps reporting, a recorded error with no anchor client keeps reporting, and an arbitrary host-factory error keeps reporting even when the client reports `Valid`. The two clearing tests fail against the previous implementation; the three boundary tests pass either way, which is the point of having them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> `GetInitError` no longer latches `ErrInitializationTimeout` for the life of the process. After a startup or re-anchor build times out, a later `Valid` data source on the anchor client is treated as connected and the timeout is not reported.
> 
> Only timeouts are cleared this way. Terminal `ErrInitializationFailed` and arbitrary host-factory errors still report, including when the data source is `Off` or `Valid`. `GetClient` lookup is extracted to `anchorClient` so the already-locked reader can inspect status without re-locking.
> 
> Tests cover both writers of `initErr` through that shared read path, plus the nil-client and non-timeout boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec75b698ec1bb8d74c64bd35b42de1441c969d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->