### PR TITLE
refactor(credential): make Rotator.Initialize take each credential explicitly

### DIFF
--- a/internal/credential/rotator.go
+++ b/internal/credential/rotator.go
@@ -71,26 +71,26 @@ func NewRotator(loggers ldlog.Loggers) *Rotator {
 	return r
 }
 
-// Initialize sets the initial credentials. Only credentials that are defined
-// will be stored.
-func (r *Rotator) Initialize(credentials []SDKCredential) {
+// Initialize sets an environment's initial credentials: the anchor SDK key, the primary mobile key and
+// the environment ID. Each is stored only if it is defined, because an environment legitimately runs
+// without a mobile key or without an environment ID.
+//
+// It takes one credential of each kind rather than a set: an environment starts from a single
+// configured SDK key, and any further accepted keys arrive later, through Reconcile.
+func (r *Rotator) Initialize(sdkKey config.SDKKey, mobileKey config.MobileKey, envID config.EnvironmentID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for _, cred := range credentials {
-		if !cred.Defined() {
-			continue
-		}
-		switch cred := cred.(type) {
-		case config.SDKKey:
-			r.anchorKey = cred
-			r.acceptedSDKKeys[cred] = AcceptedKey{}
-		case config.MobileKey:
-			r.primaryMobileKey = cred
-			r.acceptedMobileKeys[cred] = AcceptedKey{}
-		case config.EnvironmentID:
-			r.primaryEnvironmentID = cred
-		}
+	if sdkKey.Defined() {
+		r.anchorKey = sdkKey
+		r.acceptedSDKKeys[sdkKey] = AcceptedKey{}
+	}
+	if mobileKey.Defined() {
+		r.primaryMobileKey = mobileKey
+		r.acceptedMobileKeys[mobileKey] = AcceptedKey{}
+	}
+	if envID.Defined() {
+		r.primaryEnvironmentID = envID
 	}
 }
 

--- a/internal/credential/rotator_test.go
+++ b/internal/credential/rotator_test.go
@@ -23,7 +23,7 @@ func TestInitializePopulatesAcceptedSets(t *testing.T) {
 	mobileKey := config.MobileKey("mob-test-key")
 	envID := config.EnvironmentID("env-test-id")
 
-	rotator.Initialize([]SDKCredential{sdkKey, mobileKey, envID})
+	rotator.Initialize(sdkKey, mobileKey, envID)
 
 	// Verify accepted SDK key set: one entry, no expiry.
 	assert.Len(t, rotator.acceptedSDKKeys, 1)
@@ -41,6 +41,25 @@ func TestInitializePopulatesAcceptedSets(t *testing.T) {
 	assert.Equal(t, sdkKey, rotator.AnchorKey())
 	assert.Equal(t, mobileKey, rotator.MobileKey())
 	assert.Equal(t, envID, rotator.EnvironmentID())
+}
+
+func TestInitializeSkipsUndefinedCredentials(t *testing.T) {
+	rotator := newTestRotator()
+
+	sdkKey := config.SDKKey("sdk-test-key")
+	rotator.Initialize(sdkKey, "", "")
+
+	assert.Equal(t, sdkKey, rotator.AnchorKey())
+	assert.Len(t, rotator.acceptedSDKKeys, 1)
+
+	// An environment legitimately runs without a mobile key or without an environment ID. Neither may
+	// become a primary, and an undefined key must never land in an accepted set -- an entry there would
+	// make IsAccepted admit the empty credential.
+	assert.Empty(t, rotator.MobileKey())
+	assert.Empty(t, rotator.acceptedMobileKeys)
+	assert.Empty(t, rotator.EnvironmentID())
+	assert.False(t, rotator.IsAccepted(config.MobileKey("")))
+	assert.False(t, rotator.IsAccepted(config.EnvironmentID("")))
 }
 
 // TestReconcileDiff covers the additions/expirations diff Reconcile produces for the basic accepted-set

--- a/internal/relayenv/env_context_handler_fanout_test.go
+++ b/internal/relayenv/env_context_handler_fanout_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/credential"
@@ -25,12 +26,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// rotatorAccepting returns a rotator whose accepted set is exactly creds. GetStreamHandler consults the
-// accepted set before asking the provider for a handler, so a test envContextImpl needs a real rotator
-// rather than the zero value.
-func rotatorAccepting(creds ...credential.SDKCredential) *credential.Rotator {
+// rotatorAccepting returns a rotator initialized with these credentials, any of which may be undefined.
+// GetStreamHandler consults the accepted set before asking the provider for a handler, so a test
+// envContextImpl needs a real rotator rather than the zero value.
+func rotatorAccepting(
+	sdkKey config.SDKKey,
+	mobileKey config.MobileKey,
+	envID config.EnvironmentID,
+) *credential.Rotator {
 	r := credential.NewRotator(ldlog.NewDisabledLoggers())
-	r.Initialize(creds)
+	r.Initialize(sdkKey, mobileKey, envID)
+	return r
+}
+
+// rotatorAcceptingSDKKeys returns a rotator anchored on anchor with others accepted alongside it.
+// Initialize takes a single SDK key, so a multi-key accepted set is reached the way a relay reaches one:
+// by reconciling.
+func rotatorAcceptingSDKKeys(t *testing.T, anchor config.SDKKey, others ...config.SDKKey) *credential.Rotator {
+	t.Helper()
+
+	builder := credential.NewAcceptedSetBuilder().WithAnchor(credential.SDKKeyParams{Value: anchor})
+	for _, key := range others {
+		builder.WithSDKKey(credential.SDKKeyParams{Value: key})
+	}
+
+	r := credential.NewRotator(ldlog.NewDisabledLoggers())
+	now := time.Unix(1000, 0)
+	result := r.Reconcile(mustBuildAcceptedSet(t, builder), now)
+	require.NotNil(t, result.AnchorChange, "the first anchor is signaled as a change")
+	r.CommitAnchor(result.AnchorChange.NewAnchor)
+	r.StepTime(now)
+
 	return r
 }
 
@@ -69,7 +95,7 @@ func TestGetStreamHandler_BuildsOnDemandScopedWithEnvFilterKey(t *testing.T) {
 
 	c := &envContextImpl{
 		filterKey:  filter,
-		keyRotator: rotatorAccepting(config.SDKKey("sdk-A"), config.SDKKey("sdk-B")),
+		keyRotator: rotatorAcceptingSDKKeys(t, config.SDKKey("sdk-A"), config.SDKKey("sdk-B")),
 	}
 
 	// A valid (right-kind) credential: the provider is asked for that credential scoped with the env's
@@ -104,7 +130,7 @@ func TestGetStreamHandler_WrongKindCredentialServes404(t *testing.T) {
 	// wrong credential kind, so the accepted-set check must pass in order for the request to reach it.
 	c := &envContextImpl{
 		filterKey:  config.DefaultFilter,
-		keyRotator: rotatorAccepting(config.MobileKey("mob-key")),
+		keyRotator: rotatorAccepting("", config.MobileKey("mob-key"), ""),
 	}
 
 	// A credential the provider rejects (returns nil for) must fall back to the invalid-stream 404

--- a/internal/relayenv/env_context_impl.go
+++ b/internal/relayenv/env_context_impl.go
@@ -215,11 +215,7 @@ func NewEnvContext(
 		offline:                   envConfig.Offline,
 	}
 
-	envContext.keyRotator.Initialize([]credential.SDKCredential{
-		envConfig.SDKKey,
-		envConfig.MobileKey,
-		envConfig.EnvID,
-	})
+	envContext.keyRotator.Initialize(envConfig.SDKKey, envConfig.MobileKey, envConfig.EnvID)
 
 	bigSegmentStoreFactory := params.BigSegmentStoreFactory
 	if bigSegmentStoreFactory == nil {

--- a/internal/relayenv/env_context_stream_handler_revocation_test.go
+++ b/internal/relayenv/env_context_stream_handler_revocation_test.go
@@ -101,7 +101,7 @@ func TestGetStreamHandlerDoesNotConsultProviderForRevokedCredential(t *testing.T
 	// never reach the point of creating a channel subscription.
 	c := &envContextImpl{
 		filterKey:  config.DefaultFilter,
-		keyRotator: rotatorAccepting(config.SDKKey("accepted-sdk-key")),
+		keyRotator: rotatorAccepting(config.SDKKey("accepted-sdk-key"), "", ""),
 	}
 	sp := alwaysServingProvider()
 
@@ -119,7 +119,7 @@ func TestGetStreamHandlerRejectsForeignEnvironmentID(t *testing.T) {
 	// environment's own ID is accepted.
 	c := &envContextImpl{
 		filterKey:  config.DefaultFilter,
-		keyRotator: rotatorAccepting(config.EnvironmentID("this-env")),
+		keyRotator: rotatorAccepting("", "", config.EnvironmentID("this-env")),
 	}
 	sp := alwaysServingProvider()
 


### PR DESCRIPTION
## Summary

`Rotator.Initialize` took a `[]SDKCredential` and sorted it with a type switch. It expects one SDK key,
one mobile key, and one environment ID, but the signature never said so — pass two SDK keys and the last
one silently became the anchor. It now takes the three credentials as separate typed parameters, so the
compiler enforces what the code only assumed.

Follow-up to a review comment on #817, inline on `internal/credential/rotator.go:86`. No Jira ticket.

## Background

The signature predates concurrent SDK keys. Once an environment could hold several keys, the slice's
ambiguity started to matter. The only production caller already passed exactly one of each, so relay
behavior does not change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> `Rotator.Initialize` now takes one SDK key, one mobile key, and one environment ID as separate parameters instead of a `[]SDKCredential` slice. The compiler enforces the one-of-each contract that the type switch previously only assumed (a second SDK key used to silently become the anchor).
> 
> Undefined credentials are still skipped. Extra accepted SDK keys continue to arrive only through `Reconcile`. Tests that needed a multi-key accepted set now build it that way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc38a6d8eefa38b277e5fe6889b113dc746072e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->