### PR TITLE
fix: emit Vary: Origin on CORS responses (SEC-9501)

### DIFF
--- a/internal/browser/cors.go
+++ b/internal/browser/cors.go
@@ -60,7 +60,11 @@ func WithCORSContext(parent context.Context, cc CORSContext) context.Context {
 
 // SetCORSHeaders sets a standard set of CORS headers on an HTTP response. This is meant to be the same
 // behavior that the LaunchDarkly service endpoints uses for client-side JS requests.
+//
+// Because Access-Control-Allow-Origin is derived from the request's Origin header, "Origin" is added to
+// the response's Vary header so that shared caches do not serve one origin's response to another.
 func SetCORSHeaders(w http.ResponseWriter, origin string, extraAllowedHeaders []string) {
+	AddVaryHeader(w, "Origin")
 	w.Header().Set("Access-Control-Allow-Origin", origin)
 	w.Header().Set("Access-Control-Allow-Credentials", "false")
 	w.Header().Set("Access-Control-Max-Age", maxAge)
@@ -70,4 +74,17 @@ func SetCORSHeaders(w http.ResponseWriter, origin string, extraAllowedHeaders []
 	}
 	w.Header().Set("Access-Control-Allow-Headers", allAllowedHeaders)
 	w.Header().Set("Access-Control-Expose-Headers", "Date")
+}
+
+// AddVaryHeader adds a field name to the response's Vary header, preserving any values already present
+// and avoiding duplicates.
+func AddVaryHeader(w http.ResponseWriter, fieldName string) {
+	for _, existing := range w.Header().Values("Vary") {
+		for _, value := range strings.Split(existing, ",") {
+			if strings.EqualFold(strings.TrimSpace(value), fieldName) {
+				return
+			}
+		}
+	}
+	w.Header().Add("Vary", fieldName)
 }

--- a/internal/browser/cors_test.go
+++ b/internal/browser/cors_test.go
@@ -58,4 +58,33 @@ func TestCORSContext(t *testing.T) {
 		assert.Equal(t, expectedHeaders, rr.Header().Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "Date", rr.Header().Get("Access-Control-Expose-Headers"))
 	})
+
+	t.Run("SetCORSHeaders sets Vary: Origin", func(t *testing.T) {
+		rr := httptest.ResponseRecorder{}
+		SetCORSHeaders(&rr, "http://good.cat", nil)
+		assert.Equal(t, []string{"Origin"}, rr.Header().Values("Vary"))
+	})
+
+	t.Run("SetCORSHeaders preserves an existing Vary value", func(t *testing.T) {
+		rr := httptest.ResponseRecorder{}
+		rr.Header().Set("Vary", "Authorization")
+		SetCORSHeaders(&rr, "http://good.cat", nil)
+		assert.Equal(t, []string{"Authorization", "Origin"}, rr.Header().Values("Vary"))
+	})
+}
+
+func TestAddVaryHeader(t *testing.T) {
+	t.Run("appends to an existing comma-separated value", func(t *testing.T) {
+		rr := httptest.ResponseRecorder{}
+		rr.Header().Set("Vary", "Authorization, Accept-Encoding")
+		AddVaryHeader(&rr, "Origin")
+		assert.Equal(t, []string{"Authorization, Accept-Encoding", "Origin"}, rr.Header().Values("Vary"))
+	})
+
+	t.Run("does not duplicate a value that is already present", func(t *testing.T) {
+		rr := httptest.ResponseRecorder{}
+		rr.Header().Set("Vary", "Authorization, origin")
+		AddVaryHeader(&rr, "Origin")
+		assert.Equal(t, []string{"Authorization, origin"}, rr.Header().Values("Vary"))
+	})
 }

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -411,6 +411,7 @@ func TestCORSMiddlewareSetsCorrectDefaultHeaders(t *testing.T) {
 	assert.Equal(t, "300", resp.Result().Header.Get("Access-Control-Max-Age"))
 	assert.Equal(t, browser.DefaultAllowedHeaders, resp.Result().Header.Get("Access-Control-Allow-Headers"))
 	assert.Equal(t, "Date", resp.Result().Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, []string{"Origin"}, resp.Result().Header.Values("Vary"))
 }
 
 func TestCORSMiddlewareSetsCorrectDefaultHeadersWhenRequestHasOrigin(t *testing.T) {
@@ -435,6 +436,7 @@ func TestCORSMiddlewareSetsAllowedOriginFromContextWhenOriginMatches(t *testing.
 	CORS(nullHandler()).ServeHTTP(resp, req)
 
 	assert.Equal(t, "def", resp.Result().Header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, []string{"Origin"}, resp.Result().Header.Values("Vary"))
 }
 
 func TestCORSMiddlewareSetsAllowedOriginFromContextWhenOriginDoesNotMatch(t *testing.T) {
@@ -448,6 +450,22 @@ func TestCORSMiddlewareSetsAllowedOriginFromContextWhenOriginDoesNotMatch(t *tes
 	CORS(nullHandler()).ServeHTTP(resp, req)
 
 	assert.Equal(t, "abc", resp.Result().Header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, []string{"Origin"}, resp.Result().Header.Values("Vary"))
+}
+
+func TestCORSMiddlewarePreservesExistingVaryValues(t *testing.T) {
+	wrappedHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		browser.AddVaryHeader(w, "Authorization")
+		w.WriteHeader(200)
+	})
+	headers := make(http.Header)
+	headers.Set("Origin", "blah")
+	req := buildPreRoutedRequest("GET", nil, headers, nil, nil)
+	resp := httptest.NewRecorder()
+
+	CORS(wrappedHandler).ServeHTTP(resp, req)
+
+	assert.Equal(t, []string{"Origin", "Authorization"}, resp.Result().Header.Values("Vary"))
 }
 
 func TestCORSMiddlewareSetsAllowedHeaderFromContext(t *testing.T) {

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -423,6 +423,7 @@ func TestCORSMiddlewareSetsCorrectDefaultHeadersWhenRequestHasOrigin(t *testing.
 	CORS(nullHandler()).ServeHTTP(resp, req)
 
 	assert.Equal(t, "blah", resp.Result().Header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, []string{"Origin"}, resp.Result().Header.Values("Vary"))
 }
 
 func TestCORSMiddlewareSetsAllowedOriginFromContextWhenOriginMatches(t *testing.T) {

--- a/internal/sharedtest/testdata_responses.go
+++ b/internal/sharedtest/testdata_responses.go
@@ -68,6 +68,9 @@ func AssertExpectedCORSHeaders(t *testing.T, resp *http.Response, endpointMethod
 	assert.ElementsMatch(t, []string{endpointMethod, "OPTIONS"},
 		strings.Split(resp.Header.Get("Access-Control-Allow-Methods"), ","))
 	assert.Equal(t, host, resp.Header.Get("Access-Control-Allow-Origin"))
+	// Access-Control-Allow-Origin is derived from the request's Origin header, so every response
+	// that carries it must also vary on Origin.
+	assert.Contains(t, resp.Header.Values("Vary"), "Origin")
 }
 
 func MakeEvalBody(flags []TestFlag, reasons bool) string {

--- a/relay/relay_endpoints.go
+++ b/relay/relay_endpoints.go
@@ -15,6 +15,7 @@ import (
 	ldeval "github.com/launchdarkly/go-server-sdk-evaluation/v3"
 
 	"github.com/launchdarkly/ld-relay/v8/internal/basictypes"
+	"github.com/launchdarkly/ld-relay/v8/internal/browser"
 	"github.com/launchdarkly/ld-relay/v8/internal/logging"
 	"github.com/launchdarkly/ld-relay/v8/internal/middleware"
 	"github.com/launchdarkly/ld-relay/v8/internal/relayenv"
@@ -336,7 +337,7 @@ func writeCacheableJSONResponse(w http.ResponseWriter, req *http.Request, client
 	bytes []byte, etagValue string) {
 	ttl := clientContext.GetTTL()
 	if ttl > 0 {
-		w.Header().Set("Vary", "Authorization")
+		browser.AddVaryHeader(w, "Authorization")
 		expiresAt := time.Now().UTC().Add(ttl)
 		w.Header().Set("Expires", expiresAt.Format(http.TimeFormat))
 		// We're setting "Expires:" instead of "Cache-Control:max-age=" so that if someone puts an

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -221,6 +221,43 @@ func TestCompressionIsAppliedWhenEnabled(t *testing.T) {
 	})
 }
 
+func TestCacheableResponseKeepsVaryAcceptEncodingWhenCompressed(t *testing.T) {
+	// gzhttp adds "Vary: Accept-Encoding" in the outermost middleware, so writeCacheableJSONResponse
+	// must append "Authorization" rather than overwrite the header. Otherwise a shared cache honoring
+	// the Expires header could store the gzipped representation and serve it to a client that never
+	// sent Accept-Encoding -- made worse by the fact that both encodings share one Etag.
+	config := c.Config{
+		HTTP: c.HTTPConfig{
+			EnableCompression: true,
+		},
+		Environment: map[string]*c.EnvConfig{
+			"test": {
+				SDKKey: "test-key",
+				TTL:    configtypes.NewOptDuration(time.Minute),
+			},
+		},
+	}
+
+	withStartedRelay(t, config, func(p relayTestParams) {
+		req, _ := http.NewRequest("GET", "/sdk/flags", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		req.Header.Set("Authorization", "test-key")
+
+		w := httptest.NewRecorder()
+		p.relay.ServeHTTP(w, req)
+
+		result := w.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+		// Guards the test itself: without Expires we are not on the ttl > 0 path at all.
+		require.NotEmpty(t, result.Header.Get("Expires"), "test requires the ttl > 0 code path")
+		assert.Equal(t, "gzip", result.Header.Get("Content-Encoding"))
+
+		vary := result.Header.Values("Vary")
+		assert.Contains(t, vary, "Accept-Encoding")
+		assert.Contains(t, vary, "Authorization")
+	})
+}
+
 func TestCompressionIsNotAppliedWhenDisabled(t *testing.T) {
 	// Test with compression disabled
 	configWithoutCompression := c.Config{


### PR DESCRIPTION
Browser (JS client SDK) endpoint responses set `Access-Control-Allow-Origin` from the request's `Origin` header but never declared `Vary: Origin`, so a shared cache in front of the relay could serve one origin's ACAO to another.

Closes [SEC-9501](https://launchdarkly.atlassian.net/browse/SEC-9501).

- `browser.SetCORSHeaders` now adds `Origin` to `Vary` on every browser response.
- New `browser.AddVaryHeader` appends additively and skips duplicates (case-insensitive), so existing `Vary` values are preserved.
- `writeCacheableJSONResponse` uses it for `Authorization` instead of `Set`, which would have clobbered `Vary: Origin`.
- No change to cache-control/ETag policy; that redesign is tracked separately in [SEC-9495](https://launchdarkly.atlassian.net/browse/SEC-9495).

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

[SEC-9501](https://launchdarkly.atlassian.net/browse/SEC-9501)

<details>
<summary>Implementation details</summary>

**Describe the solution you've provided**

`middleware.CORS` derives ACAO from the request `Origin` (reflected when no origins are configured, otherwise the matching configured origin, falling back to the first one). RFC 9110 requires such a response to name `Origin` in `Vary` so caches key on it. `SetCORSHeaders` now does that for all browser endpoints (evalx, goals, events, events pixel).

Because `Vary` can already carry other values, the fix is additive: `AddVaryHeader` scans existing `Vary` field values (including comma-separated ones) and only appends when the field name is not already present. The pre-existing `w.Header().Set("Vary", "Authorization")` in `writeCacheableJSONResponse` would otherwise have removed `Origin` for TTL-cached responses, so it was switched to the same helper.

**Describe alternatives you've considered**

Adding `Cache-Control: no-store/private` instead would also satisfy the fix criteria but would change caching behavior for the goals/eval endpoints, which is deliberately out of scope here.

**Additional context**

Testing: `make lint` (0 issues), `go test ./internal/browser/... ./internal/middleware/... ./relay/...`, and `make test`. New tests cover allowed origin, disallowed origin (fallback), default/reflected origin, preservation of an existing `Vary: Authorization`, and duplicate suppression.

</details>

Link to Devin session: https://app.devin.ai/sessions/cee6e0d219e34ae4964a0aba1f638fd3
Open in Devin Desktop: https://app.devin.ai/desktop/session/cee6e0d219e34ae4964a0aba1f638fd3?variant=devin
Requested by: @kparkinson-ld

[SEC-9501]: https://launchdarkly.atlassian.net/browse/SEC-9501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEC-9495]: https://launchdarkly.atlassian.net/browse/SEC-9495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEC-9501]: https://launchdarkly.atlassian.net/browse/SEC-9501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes a **cache poisoning / cross-origin CORS leak** where responses reflected `Access-Control-Allow-Origin` from the request `Origin` without `Vary: Origin`, so a shared cache could serve one site's ACAO to another.
> 
> **`SetCORSHeaders`** now adds **`Vary: Origin`** on every browser/CORS response. A new **`AddVaryHeader`** helper appends field names without clobbering existing `Vary` values and skips case-insensitive duplicates.
> 
> **`writeCacheableJSONResponse`** switches from `Header.Set("Vary", "Authorization")` to **`AddVaryHeader`**, so TTL-cached responses keep `Origin` (and, with compression enabled, **`Accept-Encoding`** from gzhttp) instead of overwriting the header.
> 
> Tests cover CORS middleware paths, shared test assertions for OPTIONS, and an integration test that compressed cacheable `/sdk/flags` responses include both `Accept-Encoding` and `Authorization` in `Vary`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 850dda3a7dd27f9585977fbc1e0a52a5fc3b25f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->