### PR TITLE
fix(streams): treat a nil replay result as no event instead of panicking

### DIFF
--- a/internal/streams/stream_provider_server_side.go
+++ b/internal/streams/stream_provider_server_side.go
@@ -98,7 +98,7 @@ func (r *serverSideEnvStreamRepository) Replay(channel, id string) chan eventsou
 	go func() {
 		defer close(out)
 		event, err := r.getReplayEvent()
-		if err != nil {
+		if err != nil || event == nil {
 			return
 		}
 		out <- event
@@ -109,6 +109,9 @@ func (r *serverSideEnvStreamRepository) Replay(channel, id string) chan eventsou
 // getReplayEvent will return a ServerSidePutEvent with all the data needed for a Replay.
 func (r *serverSideEnvStreamRepository) getReplayEvent() (eventsource.Event, error) {
 	data, err, _ := r.flightGroup.Do("getReplayEvent", func() (interface{}, error) {
+		if !r.store.IsInitialized() {
+			return nil, nil
+		}
 		flags, err := r.store.GetAll(ldstoreimpl.Features())
 
 		if err != nil {
@@ -134,7 +137,9 @@ func (r *serverSideEnvStreamRepository) getReplayEvent() (eventsource.Event, err
 		return nil, err
 	}
 
-	// panic if it's not an eventsource.Event - as this should be impossible
-	event := data.(eventsource.Event)
+	event, ok := data.(eventsource.Event)
+	if !ok {
+		return nil, nil
+	}
 	return event, nil
 }

--- a/internal/streams/stream_provider_server_side.go
+++ b/internal/streams/stream_provider_server_side.go
@@ -86,7 +86,10 @@ func (e *serverSideEnvStreamProvider) Close() {
 }
 
 func (r *serverSideEnvStreamRepository) Replay(channel, id string) chan eventsource.Event {
-	out := make(chan eventsource.Event)
+	// Buffered so the goroutine below can always finish its send. The eventsource handler abandons
+	// this channel without draining it when the client disconnects or MaxConnTime fires, which would
+	// otherwise park the goroutine forever and pin the whole environment's replay payload.
+	out := make(chan eventsource.Event, 1)
 	if !r.store.IsInitialized() {
 		// If the data store has never been populated, we won't send an initial event. This is desirable
 		// behavior because, if Relay is still waiting on flag data from LD, we want SDK clients to stay
@@ -137,8 +140,15 @@ func (r *serverSideEnvStreamRepository) getReplayEvent() (eventsource.Event, err
 		return nil, err
 	}
 
+	if data == nil {
+		// The store was not initialized when the query ran; see Replay. The caller sends no event.
+		return nil, nil
+	}
 	event, ok := data.(eventsource.Event)
 	if !ok {
+		// Should be impossible: the closure above returns either nil or a put event.
+		r.loggers.Errorf("Internal error: replay computation returned %T, not an eventsource.Event;"+
+			" sending no initial event", data)
 		return nil, nil
 	}
 	return event, nil

--- a/internal/streams/stream_provider_server_side_flags.go
+++ b/internal/streams/stream_provider_server_side_flags.go
@@ -125,7 +125,9 @@ func (r *serverSideFlagsOnlyEnvStreamRepository) getReplayEvent() (eventsource.E
 		return nil, err
 	}
 
-	// panic if it's not an eventsource.Event - as this should be impossible
-	event := data.(eventsource.Event)
+	event, ok := data.(eventsource.Event)
+	if !ok {
+		return nil, nil
+	}
 	return event, nil
 }

--- a/internal/streams/stream_provider_server_side_flags.go
+++ b/internal/streams/stream_provider_server_side_flags.go
@@ -89,7 +89,10 @@ func (e *serverSideFlagsOnlyEnvStreamProvider) Close() {
 }
 
 func (r *serverSideFlagsOnlyEnvStreamRepository) Replay(channel, id string) chan eventsource.Event {
-	out := make(chan eventsource.Event)
+	// Buffered so the goroutine below can always finish its send. The eventsource handler abandons
+	// this channel without draining it when the client disconnects or MaxConnTime fires, which would
+	// otherwise park the goroutine forever and pin the whole environment's replay payload.
+	out := make(chan eventsource.Event, 1)
 	if !r.store.IsInitialized() { // See serverSideEnvStreamRepository.Replay
 		close(out)
 		return out
@@ -125,8 +128,15 @@ func (r *serverSideFlagsOnlyEnvStreamRepository) getReplayEvent() (eventsource.E
 		return nil, err
 	}
 
+	if data == nil {
+		// The store was not initialized when the query ran; see Replay. The caller sends no event.
+		return nil, nil
+	}
 	event, ok := data.(eventsource.Event)
 	if !ok {
+		// Should be impossible: the closure above returns either nil or a put event.
+		r.loggers.Errorf("Internal error: replay computation returned %T, not an eventsource.Event;"+
+			" sending no initial event", data)
 		return nil, nil
 	}
 	return event, nil

--- a/internal/streams/stream_provider_server_side_flags_test.go
+++ b/internal/streams/stream_provider_server_side_flags_test.go
@@ -1,6 +1,7 @@
 package streams
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -191,5 +192,14 @@ func TestStreamProviderServerSideFlagsOnly(t *testing.T) {
 
 			verifyHandlerHeartbeat(t, sp, esp, validCredential)
 		})
+	})
+
+	t.Run("Replay - store becomes uninitialized after the initial check", func(t *testing.T) {
+		var initializedChecks atomic.Int32
+		store := newMockStoreQueries()
+		store.setupIsInitializedFn(func() bool { return initializedChecks.Add(1) == 1 })
+		repo := &serverSideFlagsOnlyEnvStreamRepository{store: store, loggers: ldlog.NewDisabledLoggers()}
+
+		assert.Empty(t, readAllEvents(repo.Replay("", "")))
 	})
 }

--- a/internal/streams/stream_provider_server_side_flags_test.go
+++ b/internal/streams/stream_provider_server_side_flags_test.go
@@ -203,3 +203,18 @@ func TestStreamProviderServerSideFlagsOnly(t *testing.T) {
 		assert.Empty(t, readAllEvents(repo.Replay("", "")))
 	})
 }
+
+// See TestStreamProviderServerSideReplayDoesNotParkWhenNobodyReads.
+func TestStreamProviderServerSideFlagsOnlyReplayDoesNotParkWhenNobodyReads(t *testing.T) {
+	store := newMockStoreQueries()
+	store.setupIsInitialized(true)
+	store.setupGetAllFn(func(_ ldstoretypes.DataKind) ([]ldstoretypes.KeyedItemDescriptor, error) {
+		return nil, nil
+	})
+	repo := &serverSideFlagsOnlyEnvStreamRepository{store: store, loggers: ldlog.NewDisabledLoggers()}
+
+	out := repo.Replay("", "") // deliberately never read
+
+	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond,
+		"Replay goroutine never completed its send; it is parked on an unbuffered channel")
+}

--- a/internal/streams/stream_provider_server_side_test.go
+++ b/internal/streams/stream_provider_server_side_test.go
@@ -336,3 +336,20 @@ func TestStreamProviderServerSide(t *testing.T) {
 		})
 	})
 }
+
+// The eventsource handler abandons the replay channel without draining it when the client
+// disconnects or MaxConnTime fires. The Replay goroutine must still finish rather than park on the
+// send forever, holding the environment's entire replay payload alive.
+func TestStreamProviderServerSideReplayDoesNotParkWhenNobodyReads(t *testing.T) {
+	store := newMockStoreQueries()
+	store.setupIsInitialized(true)
+	store.setupGetAllFn(func(_ ldstoretypes.DataKind) ([]ldstoretypes.KeyedItemDescriptor, error) {
+		return nil, nil
+	})
+	repo := &serverSideEnvStreamRepository{store: store, loggers: ldlog.NewDisabledLoggers()}
+
+	out := repo.Replay("", "") // deliberately never read
+
+	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond,
+		"Replay goroutine never completed its send; it is parked on an unbuffered channel")
+}

--- a/internal/streams/stream_provider_server_side_test.go
+++ b/internal/streams/stream_provider_server_side_test.go
@@ -3,6 +3,7 @@ package streams
 import (
 	"encoding/json"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -322,6 +323,16 @@ func TestStreamProviderServerSide(t *testing.T) {
 
 			assert.Equal(t, 1, getFlagFromEventData(t, events1[0]).Version)
 			assert.Equal(t, 1, getFlagFromEventData(t, events2[0]).Version) // only one computation was done
+		})
+
+		t.Run("store becomes uninitialized after the initial check", func(t *testing.T) {
+			var initializedChecks atomic.Int32
+			store := newMockStoreQueries()
+			store.setupIsInitializedFn(func() bool { return initializedChecks.Add(1) == 1 })
+			store.setupGetAllFn(queryThatIncrementsFlagVersionOnEachCall())
+			repo := &serverSideEnvStreamRepository{store: store, loggers: ldlog.NewDisabledLoggers()}
+
+			assert.Empty(t, expectReplayedEvents(t, repo.Replay("", "")))
 		})
 	})
 }


### PR DESCRIPTION
A nil result from the replay singleflight is now handled as "no replay event" instead of panicking on an unchecked type assertion.

Closes [SEC-9494](https://launchdarkly.atlassian.net/browse/SEC-9494).

- `/flags` replay no longer crashes the relay process when the store becomes uninitialized between `Replay`'s check and the singleflight body
- `/all` replay re-checks store initialization inside the singleflight and skips the event instead of publishing an empty `put`
- Regression tests cover the uninitialized-after-check race on both stream providers

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

<details>
<summary>Implementation details</summary>

**Root cause.** `serverSideFlagsOnlyEnvStreamRepository.getReplayEvent` runs inside a `singleflight.Group`. The inner function returns `(nil, nil)` when `store.IsInitialized()` is false, but the caller only checked `err != nil` and then did `data.(eventsource.Event)`. Asserting a nil interface to a non-empty interface type panics, and the panic happens in the goroutine spawned by `Replay` with no recover, so the whole relay process dies. The window opens when the store wrapper is swapped for a fresh, empty one (re-anchor / credential rotation racing an in-flight client build): the outer `Replay` check sees initialized, the singleflight body sees uninitialized.

**Fix.** Both server-side repositories now use a comma-ok assertion and return `(nil, nil)` for a non-event result; `serverSideEnvStreamRepository.Replay` skips sending when the event is nil. The `/all` repository also re-checks `IsInitialized()` inside the singleflight, matching the `/flags` behavior, so a store swap in that window results in no replay event rather than a `put` with no flags.

**Testing.** `make lint` (0 issues), `make test` (full suite, race-enabled) both pass. The new subtests fail with the original panic when the source fix is reverted.

**Scope.** No recovery middleware or refactoring of the store-swap lifecycle; this is the minimal defensive fix for the panic plus the empty-`put` integrity effect of the same race.

</details>


Link to Devin session: https://app.devin.ai/sessions/5aee0829cd694229ad382e5efc386bd9
Open in Devin Desktop: https://app.devin.ai/desktop/session/5aee0829cd694229ad382e5efc386bd9?variant=devin
Requested by: @kparkinson-ld

[SEC-9494]: https://launchdarkly.atlassian.net/browse/SEC-9494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Hardens server-side **`/all`** and **`/flags`** SSE replay so relay no longer crashes or leaks when the env store or the client connection races replay.
> 
> **Nil replay / store race:** When `singleflight` returns `(nil, nil)` because the store flips to uninitialized between `Replay`'s first check and the in-flight computation, both repositories now treat that as “no initial event” (comma-ok type assert + log on impossible types) instead of panicking on `data.(eventsource.Event)`. **`/all`** also re-checks `IsInitialized()` inside the singleflight (like **`/flags`** already did), avoiding an empty `put` in the same window. **`Replay`** on **`/all`** skips the send when `event` is nil.
> 
> **Goroutine leak:** Replay output channels are **buffered (1)** so the replay goroutine can finish its send when the eventsource handler drops the channel on disconnect or `MaxConnTime` without draining—preventing a blocked goroutine from pinning the full replay payload.
> 
> Tests cover the uninitialized-after-check race and the abandoned-channel case for both stream types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b46f3e58690055f268b6180fca9b9e39990d4617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->