### PR TITLE
feat: Back off big segment synchronization on a rejected SDK key

### DIFF
--- a/internal/bigsegments/sync.go
+++ b/internal/bigsegments/sync.go
@@ -2,6 +2,7 @@ package bigsegments
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/launchdarkly/ld-relay/v8/config"
 	"github.com/launchdarkly/ld-relay/v8/internal/httpconfig"
+	"github.com/launchdarkly/ld-relay/v8/internal/retry"
 
 	es "github.com/launchdarkly/eventsource"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
@@ -18,12 +20,30 @@ import (
 )
 
 const (
-	unboundedPollPath          = "/sdk/big-segments/revisions"
-	unboundedStreamPath        = "/big-segments"
-	streamReadTimeout          = 5 * time.Minute
-	revisionsPollTimeout       = 90 * time.Second
-	defaultStreamRetryInterval = 10 * time.Second
-	synchronizedOnInterval     = 30 * time.Second
+	unboundedPollPath      = "/sdk/big-segments/revisions"
+	unboundedStreamPath    = "/big-segments"
+	streamReadTimeout      = 5 * time.Minute
+	revisionsPollTimeout   = 90 * time.Second
+	synchronizedOnInterval = 30 * time.Second
+
+	// The retry binding for this component. A failure that is unlikely to correct itself
+	// soon, such as a rejected SDK key, moves the synchronizer from the normal delays to
+	// the extended ones. It keeps retrying either way, because an operator can make the key
+	// valid again without Relay knowing.
+	//
+	// The extended ceiling bounds how much load a whole fleet of Relay Proxy instances puts
+	// on a service that is rejecting every request. The Relay Proxy reports big segment
+	// data as potentially stale well before then, so a long wait stays visible: read
+	// bigSegmentsStaleThreshold in the status resource.
+	retryInitialDelay         = 10 * time.Second
+	retryNormalCeiling        = 30 * time.Second
+	retryExtendedInitialDelay = 5 * time.Minute
+	retryExtendedCeiling      = time.Hour
+
+	// How long the synchronizer must keep the store marked as synchronized before its retry
+	// state returns to the normal delays. The synchronizer marks the store on every stream
+	// message and at least every synchronizedOnInterval, so this is two of those marks.
+	retryResetThreshold = 60 * time.Second
 
 	segmentUpdatesChannelBufferSize = 20
 )
@@ -82,20 +102,23 @@ type BigSegmentSynchronizerFactory func(
 
 // defaultBigSegmentSynchronizer is the standard implementation of BigSegmentSynchronizer.
 type defaultBigSegmentSynchronizer struct {
-	httpConfig          httpconfig.HTTPConfig
-	store               BigSegmentStore
-	pollURI             string
-	streamURI           string
-	envID               config.EnvironmentID
-	sdkKey              config.SDKKey
-	streamRetryInterval time.Duration
-	segmentUpdatesChan  chan UpdatesSummary
-	hasSynced           bool
-	syncedLock          sync.RWMutex
-	startOnce           sync.Once
-	closeChan           chan struct{}
-	closeOnce           sync.Once
-	loggers             ldlog.Loggers
+	httpConfig httpconfig.HTTPConfig
+	store      BigSegmentStore
+	pollURI    string
+	streamURI  string
+	envID      config.EnvironmentID
+	sdkKey     config.SDKKey
+	// retryStrategy decides how long to wait after each failed synchronization. Only the
+	// syncSupervisor goroutine touches it, so it needs no lock: sync, consumeStream and
+	// setSynced all run on that goroutine.
+	retryStrategy      *retry.Strategy
+	segmentUpdatesChan chan UpdatesSummary
+	hasSynced          bool
+	syncedLock         sync.RWMutex
+	startOnce          sync.Once
+	closeChan          chan struct{}
+	closeOnce          sync.Once
+	loggers            ldlog.Loggers
 }
 
 type segmentChangesSummary map[string]struct{}
@@ -131,16 +154,16 @@ func newDefaultBigSegmentSynchronizer(
 	logPrefix string,
 ) *defaultBigSegmentSynchronizer {
 	s := defaultBigSegmentSynchronizer{
-		httpConfig:          httpConfig,
-		store:               store,
-		pollURI:             strings.TrimSuffix(pollURI, "/") + unboundedPollPath,
-		streamURI:           strings.TrimSuffix(streamURI, "/") + unboundedStreamPath,
-		envID:               envID,
-		sdkKey:              sdkKey,
-		streamRetryInterval: defaultStreamRetryInterval,
-		segmentUpdatesChan:  make(chan UpdatesSummary, segmentUpdatesChannelBufferSize),
-		closeChan:           make(chan struct{}),
-		loggers:             loggers,
+		httpConfig:         httpConfig,
+		store:              store,
+		pollURI:            strings.TrimSuffix(pollURI, "/") + unboundedPollPath,
+		streamURI:          strings.TrimSuffix(streamURI, "/") + unboundedStreamPath,
+		envID:              envID,
+		sdkKey:             sdkKey,
+		retryStrategy:      retry.NewStrategy(defaultRetryConfig()),
+		segmentUpdatesChan: make(chan UpdatesSummary, segmentUpdatesChannelBufferSize),
+		closeChan:          make(chan struct{}),
+		loggers:            loggers,
 	}
 
 	if logPrefix != "" {
@@ -195,23 +218,51 @@ func (s *defaultBigSegmentSynchronizer) syncSupervisor() {
 	for {
 		err := s.sync(isRetry)
 		if err != nil {
-			s.loggers.Error("Synchronization failed:", err)
-			if statusError, ok := err.(httpStatusError); ok {
-				if !isHTTPErrorRecoverable(statusError.statusCode) {
-					return
-				}
-			}
+			s.recordFailure(err)
+		} else {
+			// sync returns a nil error when the stream ends, or when an out-of-order patch
+			// makes it restart. The connection is gone either way, so this is an ordinary
+			// transient failure and gets the normal delays.
+			s.retryStrategy.OnFailure(retry.Normal)
 		}
-		s.loggers.Warn("Will retry")
-		timer := time.NewTimer(s.streamRetryInterval)
-		defer timer.Stop()
+
+		wait := s.retryStrategy.NextWait()
+		s.loggers.Warnf("Will retry in %s", wait)
+		timer := time.NewTimer(wait)
 		select {
 		case <-s.closeChan:
+			timer.Stop()
 			close(s.segmentUpdatesChan)
 			return
 		case <-timer.C:
 		}
 		isRetry = true
+	}
+}
+
+// recordFailure sorts a synchronization failure into a retry class, logs it, and updates
+// the retry state. It never stops the synchronizer: an operator can make a rejected SDK key
+// valid again without Relay knowing, so the synchronizer keeps trying on the extended
+// delays instead.
+func (s *defaultBigSegmentSynchronizer) recordFailure(err error) {
+	var class retry.FailureClass
+	var statusError *httpStatusError
+	if errors.As(err, &statusError) {
+		class = retry.ClassifyHTTPStatus(statusError.statusCode)
+	} else {
+		class = retry.ClassifyTransportError(err)
+	}
+
+	// An unexpected failure nearly always means a real configuration problem, so it is worth
+	// an error even though the synchronizer recovers on its own if the problem is fixed.
+	if class == retry.Unexpected {
+		s.loggers.Error("Synchronization failed:", err)
+	} else {
+		s.loggers.Warn("Synchronization failed:", err)
+	}
+
+	if s.retryStrategy.OnFailure(class) {
+		s.loggers.Info("Classified failure as UNEXPECTED; engaging extended backoff.")
 	}
 }
 
@@ -276,26 +327,25 @@ func (s *defaultBigSegmentSynchronizer) setSynced() error {
 	s.syncedLock.Lock()
 	s.hasSynced = true
 	s.syncedLock.Unlock()
+
+	// Marking the store as synchronized is what this component exists to do, so it is the
+	// signal that the synchronizer is healthy. Enough of these in a row returns the retry
+	// state to the normal delays. A successful HTTP response alone is not enough, because
+	// the store is what readers depend on.
+	s.retryStrategy.OnHealthy()
+
 	return nil
 }
 
-// Tests whether an HTTP error status represents a condition that might resolve
-// on its own if we retry, or at least should not make us permanently stop
-// sending requests.
-func isHTTPErrorRecoverable(statusCode int) bool {
-	if statusCode >= 400 && statusCode < 500 {
-		switch statusCode {
-		case 400: // bad request
-			return true
-		case 408: // request timeout
-			return true
-		case 429: // too many requests
-			return true
-		default:
-			return false // all other 4xx errors are unrecoverable
-		}
+// defaultRetryConfig returns this component's binding of the retry timings.
+func defaultRetryConfig() retry.Config {
+	return retry.Config{
+		InitialDelay:         retryInitialDelay,
+		NormalCeiling:        retryNormalCeiling,
+		ExtendedInitialDelay: retryExtendedInitialDelay,
+		ExtendedCeiling:      retryExtendedCeiling,
+		ResetThreshold:       retryResetThreshold,
 	}
-	return true
 }
 
 func (s *defaultBigSegmentSynchronizer) poll() (bool, segmentChangesSummary, error) {

--- a/internal/bigsegments/sync_test.go
+++ b/internal/bigsegments/sync_test.go
@@ -3,11 +3,13 @@ package bigsegments
 import (
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/launchdarkly/ld-relay/v8/config"
+	"github.com/launchdarkly/ld-relay/v8/internal/retry"
 	"github.com/launchdarkly/ld-relay/v8/internal/sharedtest"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
@@ -373,7 +375,7 @@ func TestSyncSkipsOutOfOrderUpdateFromStreamAndRestartsStream(t *testing.T) {
 
 			segmentSync := newDefaultBigSegmentSynchronizer(sharedtest.MakeBasicHTTPConfig(), storeMock,
 				pollServer.URL, streamServer.URL, config.EnvironmentID("env-xyz"), testSDKKey, mockLog.Loggers, "")
-			segmentSync.streamRetryInterval = time.Millisecond
+			segmentSync.retryStrategy = fastRetryStrategy()
 			defer segmentSync.Close()
 			segmentSync.Start()
 
@@ -461,7 +463,7 @@ func TestSyncRetryIfStreamFails(t *testing.T) {
 
 			segmentSync := newDefaultBigSegmentSynchronizer(sharedtest.MakeBasicHTTPConfig(), storeMock,
 				pollServer.URL, streamServer.URL, config.EnvironmentID("env-xyz"), testSDKKey, mockLog.Loggers, "")
-			segmentSync.streamRetryInterval = time.Millisecond
+			segmentSync.retryStrategy = fastRetryStrategy()
 			defer segmentSync.Close()
 			segmentSync.Start()
 
@@ -521,12 +523,109 @@ func TestSyncRetryIfStreamFails(t *testing.T) {
 				"BigSegmentSynchronizer: Applied 1 update",
 				"BigSegmentSynchronizer: Applied 1 update",
 			}, mockLog.GetOutput(ldlog.Info))
-			assert.Equal(t, []string{
-				"BigSegmentSynchronizer: Stream connection failed: EOF",
-				"BigSegmentSynchronizer: Will retry",
-				"BigSegmentSynchronizer: Re-established connection",
-			}, mockLog.GetOutput(ldlog.Warn))
+			warnOutput := mockLog.GetOutput(ldlog.Warn)
+			require.Len(t, warnOutput, 3)
+			assert.Equal(t, "BigSegmentSynchronizer: Stream connection failed: EOF", warnOutput[0])
+			// The retry delay carries jitter, so match the message and not the duration.
+			assert.Regexp(t, `^BigSegmentSynchronizer: Will retry in \S+$`, warnOutput[1])
+			assert.Equal(t, "BigSegmentSynchronizer: Re-established connection", warnOutput[2])
 			assert.Len(t, mockLog.GetOutput(ldlog.Error), 0)
+		})
+	})
+}
+
+// fastRetryStrategy scales this component's retry binding down so a test does not wait out
+// real delays. The proportions are kept so the curve still doubles and clamps.
+func fastRetryStrategy() *retry.Strategy {
+	return retry.NewStrategy(retry.Config{
+		InitialDelay:         time.Millisecond,
+		NormalCeiling:        3 * time.Millisecond,
+		ExtendedInitialDelay: 30 * time.Millisecond,
+		ExtendedCeiling:      360 * time.Millisecond,
+		ResetThreshold:       6 * time.Millisecond,
+	})
+}
+
+// hasLogMessage reports whether any line at the given level contains substr.
+func hasLogMessage(mockLog *ldlogtest.MockLog, level ldlog.LogLevel, substr string) bool {
+	for _, line := range mockLog.GetOutput(level) {
+		if strings.Contains(line, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSyncKeepsRetryingAfterUnauthorized(t *testing.T) {
+	// A rejected SDK key must not stop the synchronizer. An operator can make the key valid
+	// again without Relay knowing, so it keeps trying, but on the extended delays so that a
+	// fleet of Relay Proxy instances does not hammer a service rejecting every request.
+	//
+	// Before the retry work, the synchronizer intended to stop here and failed to: it
+	// returned a *httpStatusError while testing for a value-typed httpStatusError, so the
+	// branch never ran. This test pins the behavior either way.
+	mockLog := ldlogtest.NewMockLog()
+	mockLog.Loggers.SetMinLevel(ldlog.Debug)
+	defer mockLog.DumpIfTestFailed(t)
+
+	pollHandler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(401))
+
+	httphelpers.WithServer(pollHandler, func(pollServer *httptest.Server) {
+		httphelpers.WithServer(httphelpers.HandlerWithStatus(401), func(streamServer *httptest.Server) {
+			storeMock := newBigSegmentStoreMock()
+			defer storeMock.Close()
+
+			segmentSync := newDefaultBigSegmentSynchronizer(sharedtest.MakeBasicHTTPConfig(), storeMock,
+				pollServer.URL, streamServer.URL, config.EnvironmentID("env-xyz"), testSDKKey, mockLog.Loggers, "")
+			segmentSync.retryStrategy = fastRetryStrategy()
+			defer segmentSync.Close()
+			segmentSync.Start()
+
+			// Three attempts show it did not give up after the first rejection.
+			for i := 1; i <= 3; i++ {
+				helpers.RequireValue(t, requestsCh, time.Second, "expected poll attempt %d", i)
+			}
+
+			require.Eventually(t, func() bool {
+				return hasLogMessage(mockLog, ldlog.Info, "engaging extended backoff")
+			}, time.Second, 10*time.Millisecond, "expected the extended delays to be engaged")
+
+			// An unexpected failure is worth an error even though it recovers on its own.
+			assert.True(t, hasLogMessage(mockLog, ldlog.Error, "Synchronization failed"))
+		})
+	})
+}
+
+func TestSyncStaysOnNormalDelaysAfterServerError(t *testing.T) {
+	// A 5xx is transient, so it must not engage the extended delays. This is the other half
+	// of the classification: without it, a test that only covers 401 would pass even if
+	// every failure were treated as unexpected.
+	mockLog := ldlogtest.NewMockLog()
+	mockLog.Loggers.SetMinLevel(ldlog.Debug)
+	defer mockLog.DumpIfTestFailed(t)
+
+	pollHandler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(503))
+
+	httphelpers.WithServer(pollHandler, func(pollServer *httptest.Server) {
+		httphelpers.WithServer(httphelpers.HandlerWithStatus(503), func(streamServer *httptest.Server) {
+			storeMock := newBigSegmentStoreMock()
+			defer storeMock.Close()
+
+			segmentSync := newDefaultBigSegmentSynchronizer(sharedtest.MakeBasicHTTPConfig(), storeMock,
+				pollServer.URL, streamServer.URL, config.EnvironmentID("env-xyz"), testSDKKey, mockLog.Loggers, "")
+			segmentSync.retryStrategy = fastRetryStrategy()
+			defer segmentSync.Close()
+			segmentSync.Start()
+
+			for i := 1; i <= 3; i++ {
+				helpers.RequireValue(t, requestsCh, time.Second, "expected poll attempt %d", i)
+			}
+
+			assert.False(t, hasLogMessage(mockLog, ldlog.Info, "engaging extended backoff"),
+				"a 503 is transient and must stay on the normal delays")
+			assert.False(t, hasLogMessage(mockLog, ldlog.Error, "Synchronization failed"),
+				"a transient failure logs at warn, not error")
+			assert.True(t, hasLogMessage(mockLog, ldlog.Warn, "Synchronization failed"))
 		})
 	})
 }

--- a/internal/bigsegments/sync_test.go
+++ b/internal/bigsegments/sync_test.go
@@ -535,15 +535,71 @@ func TestSyncRetryIfStreamFails(t *testing.T) {
 }
 
 // fastRetryStrategy scales this component's retry binding down so a test does not wait out
-// real delays. The proportions are kept so the curve still doubles and clamps.
-func fastRetryStrategy() *retry.Strategy {
-	return retry.NewStrategy(retry.Config{
+// real delays. The proportions are kept so the curve still doubles and clamps. Options let a
+// test remove jitter or supply a clock when it needs to assert an exact wait.
+func fastRetryStrategy(options ...retry.Option) *retry.Strategy {
+	return retry.NewStrategy(fastRetryConfig(), options...)
+}
+
+// fastRetryConfig is the scaled-down binding behind fastRetryStrategy.
+func fastRetryConfig() retry.Config {
+	return retry.Config{
 		InitialDelay:         time.Millisecond,
 		NormalCeiling:        3 * time.Millisecond,
 		ExtendedInitialDelay: 30 * time.Millisecond,
 		ExtendedCeiling:      360 * time.Millisecond,
 		ResetThreshold:       6 * time.Millisecond,
-	})
+	}
+}
+
+// zeroJitter removes jitter so a test can assert an exact retry delay.
+func zeroJitter() retry.Option {
+	return retry.WithJitter(func(time.Duration) time.Duration { return 0 })
+}
+
+// testClock is advanced explicitly by the test, never as a side effect of being read, so a
+// test asserts on time it controls rather than on how many times the code reads the clock.
+type testClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *testClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *testClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// retryDelays returns the delay from each "Will retry in ..." warning, in order. Parsing the
+// duration back out keeps the assertions about time rather than about log formatting.
+func retryDelays(t *testing.T, mockLog *ldlogtest.MockLog) []time.Duration {
+	t.Helper()
+	var out []time.Duration
+	for _, line := range mockLog.GetOutput(ldlog.Warn) {
+		_, after, found := strings.Cut(line, "Will retry in ")
+		if !found {
+			continue
+		}
+		d, err := time.ParseDuration(strings.TrimSpace(after))
+		require.NoError(t, err, "could not parse a delay out of %q", line)
+		out = append(out, d)
+	}
+	return out
+}
+
+// drainUpdates consumes the updates channel so notifySegmentsUpdated never blocks the
+// supervisor while a test is only interested in retry timing.
+func drainUpdates(ch <-chan UpdatesSummary) {
+	go func() {
+		for range ch {
+		}
+	}()
 }
 
 // hasLogMessage reports whether any line at the given level contains substr.
@@ -586,9 +642,18 @@ func TestSyncKeepsRetryingAfterUnauthorized(t *testing.T) {
 				helpers.RequireValue(t, requestsCh, time.Second, "expected poll attempt %d", i)
 			}
 
-			require.Eventually(t, func() bool {
-				return hasLogMessage(mockLog, ldlog.Info, "engaging extended backoff")
-			}, time.Second, 10*time.Millisecond, "expected the extended delays to be engaged")
+			// Keep reading the recorder while waiting for the log line. If a regression left
+			// the synchronizer on the normal delays it would poll every few milliseconds; the
+			// recorder channel then fills, its handler blocks, and the server's Close hangs the
+			// package for the full test timeout instead of failing here.
+			deadline := time.After(time.Second)
+			for !hasLogMessage(mockLog, ldlog.Info, "engaging extended backoff") {
+				select {
+				case <-requestsCh:
+				case <-deadline:
+					require.FailNow(t, "expected the extended delays to be engaged")
+				}
+			}
 
 			// An unexpected failure is worth an error even though it recovers on its own.
 			assert.True(t, hasLogMessage(mockLog, ldlog.Error, "Synchronization failed"))
@@ -626,6 +691,117 @@ func TestSyncStaysOnNormalDelaysAfterServerError(t *testing.T) {
 			assert.False(t, hasLogMessage(mockLog, ldlog.Error, "Synchronization failed"),
 				"a transient failure logs at warn, not error")
 			assert.True(t, hasLogMessage(mockLog, ldlog.Warn, "Synchronization failed"))
+		})
+	})
+}
+
+func TestSyncReturnsToNormalDelaysAfterHealthyPeriod(t *testing.T) {
+	// Once a rejected key is valid again, ResetThreshold of continuous healthy operation must
+	// return the synchronizer to the normal delays. Healthy operation here is setSynced
+	// succeeding, so this pins the OnHealthy call in setSynced; without it the extended
+	// ceiling would persist for the life of the process.
+	mockLog := ldlogtest.NewMockLog()
+	mockLog.Loggers.SetMinLevel(ldlog.Debug)
+	defer mockLog.DumpIfTestFailed(t)
+
+	patch1 := newPatchBuilder("segment.g1", "1", "").build()
+
+	pollHandler, requestsCh := httphelpers.RecordingHandler(
+		httphelpers.SequentialHandler(
+			httphelpers.HandlerWithStatus(401),                            // rejected key: extended delays engage
+			httphelpers.HandlerWithJSONResponse([]bigSegmentPatch{}, nil), // key valid again
+			httphelpers.HandlerWithJSONResponse([]bigSegmentPatch{}, nil), // completes alongside the stream
+		),
+	)
+	sseHandler, sseControl := httphelpers.SSEHandler(nil)
+	streamHandler, streamRequestsCh := httphelpers.RecordingHandler(sseHandler)
+
+	clock := &testClock{t: time.Now()}
+
+	httphelpers.WithServer(pollHandler, func(pollServer *httptest.Server) {
+		httphelpers.WithServer(streamHandler, func(streamServer *httptest.Server) {
+			storeMock := newBigSegmentStoreMock()
+			defer storeMock.Close()
+
+			segmentSync := newDefaultBigSegmentSynchronizer(sharedtest.MakeBasicHTTPConfig(), storeMock,
+				pollServer.URL, streamServer.URL, config.EnvironmentID("env-xyz"), testSDKKey, mockLog.Loggers, "")
+			segmentSync.retryStrategy = fastRetryStrategy(zeroJitter(), retry.WithClock(clock.now))
+			defer segmentSync.Close()
+			segmentSync.Start()
+			drainUpdates(segmentSync.SegmentUpdatesCh())
+
+			helpers.RequireValue(t, requestsCh, time.Second, "expected the rejected poll")
+			helpers.RequireValue(t, requestsCh, time.Second, "expected the poll after recovery")
+			helpers.RequireValue(t, requestsCh, time.Second, "expected the poll alongside the stream")
+			helpers.RequireValue(t, streamRequestsCh, time.Second, "expected the stream request")
+
+			// The first health mark starts the healthy period.
+			helpers.RequireValue(t, storeMock.syncTimeCh, time.Second, "expected the first health mark")
+
+			// Advance past the reset threshold, then cause a second mark. Advancing here rather
+			// than on every clock read keeps the assertion independent of how often the
+			// implementation reads the clock.
+			clock.advance(fastRetryConfig().ResetThreshold)
+			sseControl.Enqueue(*makePatchEvent(patch1))
+			requirePatch(t, storeMock, patch1)
+			helpers.RequireValue(t, storeMock.syncTimeCh, time.Second, "expected the second health mark")
+
+			// Drop the healthy stream. That is an ordinary failure, so the wait must come from
+			// the normal curve, not the extended one it was on before the reset.
+			sseControl.EndAll()
+
+			require.Eventually(t, func() bool { return len(retryDelays(t, mockLog)) >= 2 },
+				time.Second, time.Millisecond, "expected a second retry delay to be logged")
+			delays := retryDelays(t, mockLog)
+			cfg := fastRetryConfig()
+			assert.Equal(t, cfg.ExtendedInitialDelay, delays[0], "the rejected key waits the extended base delay")
+			assert.Equal(t, cfg.InitialDelay, delays[1],
+				"after the reset threshold of healthy operation the wait returns to the normal base delay")
+		})
+	})
+}
+
+func TestSyncBacksOffExponentiallyAcrossStreamEnds(t *testing.T) {
+	// A stream that ends reaches the supervisor as a nil error. It must still count as an
+	// ordinary failure, so consecutive stream ends double the wait and clamp at the normal
+	// ceiling rather than retrying on a flat interval.
+	mockLog := ldlogtest.NewMockLog()
+	mockLog.Loggers.SetMinLevel(ldlog.Debug)
+	defer mockLog.DumpIfTestFailed(t)
+
+	pollHandler := httphelpers.HandlerWithJSONResponse([]bigSegmentPatch{}, nil)
+	sseHandler, sseControl := httphelpers.SSEHandler(nil)
+	streamHandler, streamRequestsCh := httphelpers.RecordingHandler(sseHandler)
+
+	httphelpers.WithServer(pollHandler, func(pollServer *httptest.Server) {
+		httphelpers.WithServer(streamHandler, func(streamServer *httptest.Server) {
+			storeMock := newBigSegmentStoreMock()
+			defer storeMock.Close()
+
+			segmentSync := newDefaultBigSegmentSynchronizer(sharedtest.MakeBasicHTTPConfig(), storeMock,
+				pollServer.URL, streamServer.URL, config.EnvironmentID("env-xyz"), testSDKKey, mockLog.Loggers, "")
+			// Each cycle marks the store once and then fails, and a failure ends the healthy
+			// period, so no reset can interfere with the doubling. The real clock is therefore
+			// safe here.
+			segmentSync.retryStrategy = fastRetryStrategy(zeroJitter())
+			defer segmentSync.Close()
+			segmentSync.Start()
+			drainUpdates(segmentSync.SegmentUpdatesCh())
+
+			for i := 1; i <= 3; i++ {
+				helpers.RequireValue(t, streamRequestsCh, time.Second, "expected stream connection %d", i)
+				helpers.RequireValue(t, storeMock.syncTimeCh, time.Second, "expected the store to be marked synchronized")
+				sseControl.EndAll()
+			}
+
+			require.Eventually(t, func() bool { return len(retryDelays(t, mockLog)) >= 3 },
+				time.Second, time.Millisecond, "expected three retry delays to be logged")
+			cfg := fastRetryConfig()
+			assert.Equal(t, []time.Duration{
+				cfg.InitialDelay,     // 1ms
+				2 * cfg.InitialDelay, // 2ms
+				cfg.NormalCeiling,    // 4ms clamped to 3ms
+			}, retryDelays(t, mockLog)[:3], "consecutive stream ends must double and clamp")
 		})
 	})
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,220 @@
+// Package retry implements the backoff behavior that LaunchDarkly's RETRY specification
+// defines for long-running components.
+//
+// A long-running component repeatedly initiates operations against one service, and its
+// lifetime matches the lifetime of the process. The Relay Proxy's big segment synchronizer
+// and auto-configuration stream are both long-running components. No response and no
+// transport failure makes such a component stop permanently. Instead the component sorts
+// each failure into one of two classes and backs off proportionally.
+//
+// A "normal" failure is transient, so the component retries on a short curve. An
+// "unexpected" failure is unlikely to correct itself soon, so the component raises its
+// ceiling and retries far more slowly. An invalid credential is the motivating example: the
+// component keeps trying, because an operator can make the credential valid again without
+// the component knowing, but it must not hammer the service in the meantime.
+package retry
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"math"
+	"math/rand"
+	"time"
+)
+
+// FailureClass sorts a failure by how likely it is to correct itself soon.
+type FailureClass int
+
+const (
+	// Normal is a transient failure. The component retries on the normal curve.
+	Normal FailureClass = iota
+	// Unexpected is a failure that is unlikely to correct itself soon. The component raises
+	// its ceiling to the extended value and keeps retrying.
+	Unexpected
+)
+
+// ClassifyHTTPStatus returns the class for a failed HTTP response.
+//
+// Call this only for a status that the caller treats as a failure. Most 4xx statuses mean a
+// bad credential or a bad request shape, and neither corrects itself quickly. The three
+// exceptions are transient: a 400 can come from an intermediary, a 408 is a timeout, and a
+// 429 asks the caller to slow down.
+func ClassifyHTTPStatus(statusCode int) FailureClass {
+	if statusCode >= 400 && statusCode < 500 {
+		switch statusCode {
+		case 400, 408, 429:
+			return Normal
+		default:
+			return Unexpected
+		}
+	}
+	return Normal
+}
+
+// ClassifyTransportError returns the class for a transport-level failure.
+//
+// A TLS or certificate failure comes from a misconfiguration, such as an expired
+// certificate or an untrusted issuer, so it does not correct itself without operator
+// action. Every other network failure is transient.
+func ClassifyTransportError(err error) FailureClass {
+	if err == nil {
+		return Normal
+	}
+	var certErr *tls.CertificateVerificationError
+	if errors.As(err, &certErr) {
+		return Unexpected
+	}
+	var unknownAuthorityErr x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthorityErr) {
+		return Unexpected
+	}
+	var hostnameErr x509.HostnameError
+	if errors.As(err, &hostnameErr) {
+		return Unexpected
+	}
+	var invalidErr x509.CertificateInvalidError
+	if errors.As(err, &invalidErr) {
+		return Unexpected
+	}
+	return Normal
+}
+
+// Config holds the timing values for one component. Each component binds its own values.
+type Config struct {
+	// InitialDelay is the base delay for the normal curve.
+	InitialDelay time.Duration
+	// NormalCeiling is the largest delay the normal curve produces.
+	NormalCeiling time.Duration
+	// ExtendedInitialDelay is the base delay after the first unexpected failure.
+	ExtendedInitialDelay time.Duration
+	// ExtendedCeiling is the largest delay the extended curve produces.
+	ExtendedCeiling time.Duration
+	// ResetThreshold is how long the component must operate healthily before its retry
+	// state returns to the normal curve.
+	ResetThreshold time.Duration
+}
+
+// Strategy holds the retry state for one component and computes each wait.
+//
+// A Strategy is not safe for concurrent use. Each component owns one Strategy and calls it
+// from a single goroutine.
+type Strategy struct {
+	cfg    Config
+	now    func() time.Time
+	jitter func(limit time.Duration) time.Duration
+
+	// attempts is the exponent input. NextWait raises 2 to attempts-1.
+	attempts int
+	// maxDelay is the current ceiling. It rises to the extended value on an unexpected
+	// failure and only a reset lowers it again.
+	maxDelay time.Duration
+	// initialDelay is the base delay for the current curve.
+	initialDelay time.Duration
+	// inExtended records whether the extended curve is active, so that the first unexpected
+	// failure is told apart from later ones.
+	inExtended bool
+	// healthySince is when the current unbroken healthy period started. A zero value means
+	// the component is not currently healthy.
+	healthySince time.Time
+}
+
+// Option changes how a Strategy measures time or computes jitter. Tests use these to make
+// the output deterministic.
+type Option func(*Strategy)
+
+// WithClock replaces the clock the reset condition reads.
+func WithClock(now func() time.Time) Option {
+	return func(s *Strategy) { s.now = now }
+}
+
+// WithJitter replaces the jitter source. The function receives the exclusive upper bound
+// and returns the amount to subtract from the computed delay.
+func WithJitter(jitter func(limit time.Duration) time.Duration) Option {
+	return func(s *Strategy) { s.jitter = jitter }
+}
+
+// NewStrategy creates a Strategy for one component.
+func NewStrategy(cfg Config, options ...Option) *Strategy {
+	//nolint:gosec // jitter is not a cryptographic use, so a weak source is fine
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	s := &Strategy{
+		cfg:          cfg,
+		now:          time.Now,
+		jitter:       func(limit time.Duration) time.Duration { return time.Duration(rng.Int63n(int64(limit))) },
+		maxDelay:     cfg.NormalCeiling,
+		initialDelay: cfg.InitialDelay,
+	}
+	for _, o := range options {
+		o(s)
+	}
+	return s
+}
+
+// OnFailure records a failure and returns true if this call activated the extended curve.
+// The caller can use the return value to log the change exactly once.
+//
+// A failure always ends the current healthy period, so the reset condition starts over.
+func (s *Strategy) OnFailure(class FailureClass) (engagedExtended bool) {
+	s.healthySince = time.Time{}
+
+	if class == Unexpected {
+		// The ceiling never comes back down except through a reset, so raise it before
+		// checking whether this is the first unexpected failure.
+		s.maxDelay = s.cfg.ExtendedCeiling
+		if !s.inExtended {
+			// Start the extended curve at its own base delay rather than continuing the
+			// normal curve's exponent, so the first extended wait is exactly
+			// ExtendedInitialDelay.
+			s.attempts = 1
+			s.initialDelay = s.cfg.ExtendedInitialDelay
+			s.inExtended = true
+			return true
+		}
+	}
+
+	s.attempts++
+	return false
+}
+
+// OnHealthy records that the component is doing what it exists to do. The caller reports
+// this repeatedly while healthy. Once the component has been healthy without interruption
+// for the reset threshold, the retry state returns to the normal curve.
+func (s *Strategy) OnHealthy() {
+	now := s.now()
+	if s.healthySince.IsZero() {
+		s.healthySince = now
+		return
+	}
+	if now.Sub(s.healthySince) >= s.cfg.ResetThreshold {
+		s.attempts = 0
+		s.maxDelay = s.cfg.NormalCeiling
+		s.initialDelay = s.cfg.InitialDelay
+		s.inExtended = false
+	}
+}
+
+// NextWait returns how long to wait before the next attempt.
+//
+// The delay doubles with each accumulated failure and stops growing at the current ceiling.
+// Jitter then removes up to half of it. Jitter matters because a server that closes many
+// connections at once would otherwise make every Relay Proxy retry in the same instant.
+func (s *Strategy) NextWait() time.Duration {
+	if s.attempts <= 0 {
+		return s.cfg.InitialDelay
+	}
+	delay := time.Duration(math.Min(
+		float64(s.initialDelay)*math.Pow(2, float64(s.attempts-1)),
+		float64(s.maxDelay),
+	))
+	if halfDelay := delay / 2; halfDelay > 0 {
+		delay -= s.jitter(halfDelay)
+	}
+	return delay
+}
+
+// InExtendedRegime reports whether the extended curve is active. Status reporting and tests
+// use this; the wait computation does not.
+func (s *Strategy) InExtendedRegime() bool {
+	return s.inExtended
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -196,3 +196,24 @@ func TestNextWaitBeforeAnyFailure(t *testing.T) {
 	s := NewStrategy(testConfig(), noJitter())
 	assert.Equal(t, time.Second, s.NextWait())
 }
+
+func TestResetRestoresTheNormalCeiling(t *testing.T) {
+	// A reset must lower maxDelay back to the normal ceiling, not only restore the base delay.
+	// Otherwise the normal curve after a recovery would keep doubling up to the extended
+	// ceiling instead of clamping at NormalCeiling.
+	clock := &fakeClock{t: time.Now()}
+	s := NewStrategy(testConfig(), noJitter(), WithClock(clock.now))
+
+	require.True(t, s.OnFailure(Unexpected))
+	s.OnHealthy()
+	clock.advance(30 * time.Second)
+	s.OnHealthy()
+	require.False(t, s.InExtendedRegime())
+
+	// Six normal failures would reach 32s against the extended ceiling; the normal ceiling
+	// must clamp them at 4s.
+	for range 6 {
+		s.OnFailure(Normal)
+	}
+	assert.Equal(t, 4*time.Second, s.NextWait(), "after a reset the normal ceiling clamps the curve again")
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,198 @@
+package retry
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testConfig mirrors the shape of a real binding with values that make the arithmetic easy
+// to read: the normal curve runs 1s -> 2s -> 4s with a 4s ceiling, and the extended curve
+// starts at 60s with a 240s ceiling.
+func testConfig() Config {
+	return Config{
+		InitialDelay:         time.Second,
+		NormalCeiling:        4 * time.Second,
+		ExtendedInitialDelay: 60 * time.Second,
+		ExtendedCeiling:      240 * time.Second,
+		ResetThreshold:       30 * time.Second,
+	}
+}
+
+// noJitter removes jitter so a test can assert an exact delay. Jitter itself is covered by
+// TestJitterStaysWithinHalfTheDelay.
+func noJitter() Option {
+	return WithJitter(func(time.Duration) time.Duration { return 0 })
+}
+
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func TestClassifyHTTPStatus(t *testing.T) {
+	for _, p := range []struct {
+		status int
+		want   FailureClass
+	}{
+		{400, Normal},     // an intermediary can produce this
+		{401, Unexpected}, // invalid credential
+		{403, Unexpected}, // invalid credential
+		{404, Unexpected},
+		{408, Normal}, // timeout
+		{418, Unexpected},
+		{429, Normal}, // asked to slow down
+		{500, Normal},
+		{502, Normal},
+		{503, Normal},
+	} {
+		t.Run(fmt.Sprint(p.status), func(t *testing.T) {
+			assert.Equal(t, p.want, ClassifyHTTPStatus(p.status))
+		})
+	}
+}
+
+func TestClassifyTransportError(t *testing.T) {
+	assert.Equal(t, Normal, ClassifyTransportError(nil))
+	assert.Equal(t, Normal, ClassifyTransportError(errors.New("connection refused")))
+
+	// A certificate problem needs operator action, so it is not transient.
+	assert.Equal(t, Unexpected, ClassifyTransportError(&tls.CertificateVerificationError{}))
+	assert.Equal(t, Unexpected, ClassifyTransportError(x509.UnknownAuthorityError{}))
+	assert.Equal(t, Unexpected, ClassifyTransportError(x509.HostnameError{Host: "example.com"}))
+	assert.Equal(t, Unexpected, ClassifyTransportError(x509.CertificateInvalidError{}))
+
+	// Classification looks through a wrapped error.
+	assert.Equal(t, Unexpected,
+		ClassifyTransportError(fmt.Errorf("dial failed: %w", x509.UnknownAuthorityError{})))
+}
+
+func TestNormalCurveDoublesAndStopsAtTheCeiling(t *testing.T) {
+	s := NewStrategy(testConfig(), noJitter())
+
+	for _, want := range []time.Duration{
+		time.Second,     // 1s * 2^0
+		2 * time.Second, // 1s * 2^1
+		4 * time.Second, // 1s * 2^2
+		4 * time.Second, // clamped
+		4 * time.Second, // clamped
+	} {
+		require.False(t, s.OnFailure(Normal))
+		assert.Equal(t, want, s.NextWait())
+	}
+	assert.False(t, s.InExtendedRegime())
+}
+
+func TestFirstUnexpectedFailureWaitsTheExtendedBaseDelay(t *testing.T) {
+	s := NewStrategy(testConfig(), noJitter())
+
+	// Accumulate normal failures first, so the test also shows that the extended curve
+	// starts from its own base rather than continuing the normal curve's exponent.
+	s.OnFailure(Normal)
+	s.OnFailure(Normal)
+	require.Equal(t, 2*time.Second, s.NextWait())
+
+	assert.True(t, s.OnFailure(Unexpected), "the first unexpected failure reports the change")
+	assert.True(t, s.InExtendedRegime())
+	assert.Equal(t, 60*time.Second, s.NextWait(), "the first extended wait is the extended base delay")
+}
+
+func TestExtendedCurveDoublesAndStopsAtTheExtendedCeiling(t *testing.T) {
+	s := NewStrategy(testConfig(), noJitter())
+
+	require.True(t, s.OnFailure(Unexpected))
+	for _, want := range []time.Duration{
+		60 * time.Second,  // 60s * 2^0
+		120 * time.Second, // 60s * 2^1
+		240 * time.Second, // 60s * 2^2
+		240 * time.Second, // clamped
+	} {
+		assert.Equal(t, want, s.NextWait())
+		assert.False(t, s.OnFailure(Unexpected), "only the first unexpected failure reports the change")
+	}
+}
+
+func TestNormalFailureDoesNotLowerTheExtendedCeiling(t *testing.T) {
+	s := NewStrategy(testConfig(), noJitter())
+
+	require.True(t, s.OnFailure(Unexpected))
+	require.Equal(t, 60*time.Second, s.NextWait())
+
+	// A normal failure after an unexpected one keeps the raised ceiling, so a service that
+	// alternates between a 401 and a 503 does not fall back to the fast curve.
+	s.OnFailure(Normal)
+	assert.Equal(t, 120*time.Second, s.NextWait())
+	assert.True(t, s.InExtendedRegime())
+}
+
+func TestHealthyOperationResetsOnlyAfterTheThreshold(t *testing.T) {
+	clock := &fakeClock{t: time.Now()}
+	s := NewStrategy(testConfig(), noJitter(), WithClock(clock.now))
+
+	require.True(t, s.OnFailure(Unexpected))
+	require.Equal(t, 60*time.Second, s.NextWait())
+
+	// Start a healthy period, then report health again just short of the threshold.
+	s.OnHealthy()
+	clock.advance(29 * time.Second)
+	s.OnHealthy()
+	assert.True(t, s.InExtendedRegime(), "29s of health is below the 30s threshold")
+
+	clock.advance(time.Second)
+	s.OnHealthy()
+	assert.False(t, s.InExtendedRegime(), "30s of continuous health returns to the normal curve")
+
+	s.OnFailure(Normal)
+	assert.Equal(t, time.Second, s.NextWait(), "the reset restored the normal base delay")
+}
+
+func TestFailureBreaksTheHealthyPeriod(t *testing.T) {
+	clock := &fakeClock{t: time.Now()}
+	s := NewStrategy(testConfig(), noJitter(), WithClock(clock.now))
+
+	require.True(t, s.OnFailure(Unexpected))
+
+	s.OnHealthy()
+	clock.advance(29 * time.Second)
+
+	// A failure one second before the threshold means the clock starts over, so the
+	// following stretch of health does not reset even though the two spans together exceed
+	// the threshold.
+	s.OnFailure(Normal)
+	s.OnHealthy()
+	clock.advance(29 * time.Second)
+	s.OnHealthy()
+
+	assert.True(t, s.InExtendedRegime(), "health must be continuous to count")
+}
+
+func TestJitterStaysWithinHalfTheDelay(t *testing.T) {
+	s := NewStrategy(testConfig())
+	s.OnFailure(Normal)
+	s.OnFailure(Normal)
+	s.OnFailure(Normal) // exponent puts the undithered delay at the 4s ceiling
+
+	sawBelowCeiling := false
+	for range 200 {
+		wait := s.NextWait()
+		assert.GreaterOrEqual(t, wait, 2*time.Second, "jitter removes at most half the delay")
+		assert.LessOrEqual(t, wait, 4*time.Second, "jitter never adds to the delay")
+		if wait < 4*time.Second {
+			sawBelowCeiling = true
+		}
+	}
+	assert.True(t, sawBelowCeiling, "jitter should actually vary the delay")
+}
+
+func TestNextWaitBeforeAnyFailure(t *testing.T) {
+	// Nothing calls NextWait before a failure, but it must not raise 2 to a negative power
+	// if something ever does.
+	s := NewStrategy(testConfig(), noJitter())
+	assert.Equal(t, time.Second, s.NextWait())
+}


### PR DESCRIPTION
## Summary

The big segment synchronizer retried every failure on a flat ten-second interval, with no backoff, no jitter, and no attempt counter. A service rejecting every request therefore saw each Relay Proxy instance return roughly six times a minute, indefinitely, and a fleet scaled that load in step. That is the retry storm LaunchDarkly's RETRY specification exists to prevent, and RETRY lists `relay-proxy` in its applies-to.

Adds `internal/retry`, which implements the RETRY backoff algorithm for long-running components, and uses it in the synchronizer:

- A **transient** failure (`400`, `408`, `429`, any `5xx`, ordinary network errors) keeps short delays, growing 10s -> 20s -> 30s and clamping at 30s.
- A failure **unlikely to correct itself soon** (`401`, `403`, other `4xx`, TLS or certificate validation) moves to delays growing 5m -> 10m -> ... -> 1h and clamping at 1h.
- Both curves subtract jitter of up to half the computed delay, because a server that closes many connections at once would otherwise make every instance retry in the same instant.
- Once the extended ceiling is engaged it stays engaged until a reset, so a service alternating between a `401` and a `503` does not fall back to the fast curve.

The synchronizer still never stops. An operator can make a rejected key valid again without Relay knowing, so it keeps trying and returns to the short delays after 60 seconds of continuously marking the store as synchronized. That signal is deliberately stronger than "the last request returned 200" -- marking the store is what this component exists to do, and it is what readers depend on.

`internal/retry` is shared on purpose: the auto-config stream (SDK-3061) and event forwarding (SDK-3067) need the same classification, and each will bind its own timings.

### Please look closely at the deleted branch

This removes `isHTTPErrorRecoverable` and the branch that called it. **That branch has never executed.** `poll` and `connectStream` return `&httpStatusError{...}`, while the supervisor tested for a value-typed `httpStatusError`:

```go
if statusError, ok := err.(httpStatusError); ok {   // never true for *httpStatusError
    if !isHTTPErrorRecoverable(statusError.statusCode) {
        return
    }
}
```

I verified the assertion misses at runtime rather than only by reading, and confirmed the mismatch is present in the revision that introduced the code in 7.0.0, so there is no release in which it worked. No test covered it. Deleting it therefore changes no observed behavior -- big segment sync already retried a `401` forever, just at a punishing cadence.

Its **intent** was sound: the comment said such a status "should not make us permanently stop sending requests," and stopping was one way to avoid hammering an invalid key. The extended curve is a better expression of the same intent, since it bounds the load without needing a process restart to recover. So this is not discarding a feature; it is implementing one for the first time.

The `v9` line carries the identical defect and will need the same fix.

### Other fixes carried along

`syncSupervisor` called `defer timer.Stop()` inside its `for` loop, so deferred stops accumulated for the life of the goroutine. The permanent-stop path also returned without closing `segmentUpdatesChan`, which only the shutdown path does; removing the path makes that moot.

### Operator-visible change

Big segment data will report as `potentiallyStale` during an extended backoff, and a deployment running `bigSegmentsStaleAsDegraded` will see Relay report degraded during an auth outage. That reporting already exists, is driven by `LastSynchronizedOn` against `bigSegmentsStaleThreshold` (default 5 minutes) rather than by the cause, and so keeps a long wait visible. I believe reporting degraded is correct here, but it is a behavior change and belongs in the release notes.

### Not addressed

Relay's auth gate keying on the SDK client's construction error, the `/status` payload omitting the HTTP status code, and the two remaining components with pre-RETRY handling are tracked separately under the same epic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`internal/retry`**, a shared RETRY-spec backoff helper (exponential delays, jitter, normal vs extended curves, health-based reset), and wires it into the **big segment synchronizer** instead of a fixed ~10s retry.
> 
> **Transient** failures (5xx, most network issues, 400/408/429) back off on a short curve (10s → 30s cap). **Unexpected** failures (e.g. **401**/403, TLS cert errors) switch to a long curve (5m → 1h cap) while **still retrying forever** so a fixed SDK key can recover without restart. Successful **`setSynced`** marks drive return to normal delays after 60s of health. Logs now include **“Will retry in …”** with classified failure levels.
> 
> Removes **`isHTTPErrorRecoverable`** and the supervisor branch that was meant to stop on unrecoverable 4xx but never ran (`*httpStatusError` vs value-type assert). Fixes **`defer timer.Stop()`** accumulating in the retry loop.
> 
> New unit and integration tests cover classification, backoff curves, 401 vs 503, reset after recovery, and stream-end doubling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7fce0b66dccd40f77980ded5eee0490b400ce5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->