### PR TITLE
fix: Close remaining v8 parity gaps

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -77,5 +77,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
+        TAG: ${{ inputs.tag }}
       run: |
-        gh release upload ${{ inputs.tag }} ./dist/*.deb ./dist/*.rpm ./dist/*.tar.gz ./dist/*.txt --clobber
+        set -euo pipefail
+        gh release upload "$TAG" ./dist/*.deb ./dist/*.rpm ./dist/*.tar.gz ./dist/*.txt --clobber

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,8 @@
 # Reporting and Fixing Security Issues
 
-Please report all security issues to the LaunchDarkly security team by submitting a bug bounty report to our [HackerOne program](https://hackerone.com/launchdarkly?type=team). LaunchDarkly will triage and address all valid security issues following the response targets defined in our program policy. Valid security issues may be eligible for a bounty.
+**Do not open Issues or Pull Requests for security issues.**  
+This will make potential issues publicly visible before LaunchDarkly's Security Team can address them, which could lead to a compromise of the platform and negatively impact our customers. 
 
-Please do not open issues or pull requests for security issues. This makes the problem immediately visible to everyone, including potentially malicious actors.
+Security issues must be reported through our [Bug Bounty program](https://bugcrowd.com/engagements/launchdarkly-mbb-og), following the program policy, for triage and remediation by the LaunchDarkly Security Team. Valid security issues may be eligible for a bounty.
+
+Please do not attempt to directly contact members of LaunchDarkly staff.

--- a/internal/browser/cors.go
+++ b/internal/browser/cors.go
@@ -29,6 +29,7 @@ var DefaultAllowedHeaders = strings.Join([]string{ //nolint:gochecknoglobals
 	"X-LaunchDarkly-User-Agent",
 	"X-LaunchDarkly-Payload-ID",
 	"X-LaunchDarkly-Wrapper",
+	"X-LaunchDarkly-Instance-Id",
 	events.EventSchemaHeader,
 	events.TagsHeader,
 }, ",")

--- a/internal/browser/cors_test.go
+++ b/internal/browser/cors_test.go
@@ -73,6 +73,24 @@ func TestCORSContext(t *testing.T) {
 	})
 }
 
+func TestDefaultAllowedHeaders(t *testing.T) {
+	// The existing CORS assertions compare a response against DefaultAllowedHeaders itself, so they
+	// hold whatever the list happens to contain. This pins the headers a browser SDK actually sends,
+	// so dropping one shows up here rather than as a preflight rejection at runtime.
+	for _, header := range []string{
+		"Cache-Control",
+		"Content-Type",
+		"Content-Length",
+		"Accept-Encoding",
+		"X-LaunchDarkly-User-Agent",
+		"X-LaunchDarkly-Payload-ID",
+		"X-LaunchDarkly-Wrapper",
+		"X-LaunchDarkly-Instance-Id",
+	} {
+		assert.Contains(t, strings.Split(DefaultAllowedHeaders, ","), header)
+	}
+}
+
 func TestAddVaryHeader(t *testing.T) {
 	t.Run("appends to an existing comma-separated value", func(t *testing.T) {
 		rr := httptest.ResponseRecorder{}

--- a/internal/streams/stream_events_benchmark_test.go
+++ b/internal/streams/stream_events_benchmark_test.go
@@ -88,7 +88,7 @@ func makeLargePutDataSet() []ldstoretypes.Collection {
 			fb.AddTarget(t, userKeys...)
 		}
 		flag := fb.Build()
-		allData[0].Items = append(allData[0].Items, ldstoretypes.KeyedItemDescriptor{flag.Key, sharedtest.FlagDesc(flag)})
+		allData[0].Items = append(allData[0].Items, ldstoretypes.KeyedItemDescriptor{Key: flag.Key, Item: sharedtest.FlagDesc(flag)})
 	}
 
 	return allData

--- a/relay/relay_endpoints_benchmark_test.go
+++ b/relay/relay_endpoints_benchmark_test.go
@@ -37,7 +37,7 @@ func BenchmarkEvaluateAllFlags(b *testing.B) {
 			SingleVariation(ldvalue.String(fmt.Sprintf("value%d", i))).
 			ClientSideUsingEnvironmentID(true).
 			Build()
-		allData[0].Items = append(allData[0].Items, ldstoretypes.KeyedItemDescriptor{flag.Key, sharedtest.FlagDesc(flag)})
+		allData[0].Items = append(allData[0].Items, ldstoretypes.KeyedItemDescriptor{Key: flag.Key, Item: sharedtest.FlagDesc(flag)})
 	}
 
 	user := lduser.NewUserBuilder("user-key").Name("name").Email("email").Custom("a", ldvalue.String("b")).Build()


### PR DESCRIPTION
## Summary

Follow-up to #860, #861, #862 and #863. With the dependency and toolchain work merged, I swept all 60 `v8` commits that postdate the branch point (`2c43bda0`) to find anything else `v9` was missing. Four items came out of it.

**The publish action passed the release tag straight into a shell command.** This is the half of SEC-9481 / SEC-9482 the earlier port missed -- `v9` already had the `ARTIFACTS` hardening, but the upload step still interpolated `${{ inputs.tag }}` into the `run` block. The tag now travels through a quoted `TAG` env var under `set -euo pipefail`, matching `v8`.

**SECURITY.md still pointed reporters at HackerOne.** `v8` moved to Bugcrowd in #682 (2026-06-03) and added the note against contacting staff directly. `v9`'s copy was the original 2023 file, so anyone following it was heading to the wrong program.

**`X-LaunchDarkly-Instance-Id` was missing from the CORS allowed-headers list** (#734), so a browser SDK sending that header failed preflight. Every existing assertion compares a response against `DefaultAllowedHeaders` itself, which holds no matter what the list contains -- `v8` shipped this without a test for the same reason. This adds one that pins the headers a browser SDK actually sends, so a future drop shows up here instead of at runtime.

**Two benchmark files used unkeyed `KeyedItemDescriptor` literals** (#690). With these keyed, `go vet ./...` is clean on `v9`.

### Confirmed absent on purpose, not gaps

Worth recording so the next sweep doesn't re-litigate them:

- **#708** (send-on-closed-channel in `StartHTTPServer`) -- `v9` solves it differently. The sending goroutine closes `errCh` itself, so there is exactly one closer and the send precedes the close in the same goroutine. `v8` uses a `WaitGroup` and closes from the shutdown goroutine.
- **#652** (double-close of the autoconfig cache) -- does not apply. `v9` never registers `autoConfigCache` with `thingsToCleanUp`.
- **#749** (SEC-8503 body-size bound), **#634** (`request_duration`), **#750** (`MetricsCapacity`), **#663**, **#642**, the Alpine pins and the third-party action SHA pinning from #610 are all already present.
- **#817 / #839** (concurrent SDK and mobile keys) -- deliberately not a backport. That is planned as three-phase work on `v9`; `v8`'s version is RAC-only, with `EnvConfig` still single-key.
- Four modules where `v8`'s dependency versions lead (`fsnotify`, `hashicorp/go-version`, `miekg/dns`, `gomega`) are test-only transitive deps of `go-redis` and `consul/api` and never reach the shipped binary.
- The six remaining `test:` commits are test-only against tests that have diverged substantially on `v9`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Backports remaining **v8 parity** fixes: release workflow hardening, security reporting docs, browser CORS for instance ID, and small vet/benchmark fixes.
> 
> The **publish** composite action no longer interpolates the release tag directly in the shell. The tag is passed as a quoted **`TAG`** env var with **`set -euo pipefail`**, aligning with earlier **`ARTIFACTS`** hardening (SEC-9481/9482).
> 
> **`SECURITY.md`** now directs reporters to **Bugcrowd** instead of HackerOne, warns against opening public issues/PRs for vulnerabilities, and discourages direct staff contact.
> 
> **`DefaultAllowedHeaders`** gains **`X-LaunchDarkly-Instance-Id`** so browser SDK preflights that send that header (already handled in middleware) are not rejected. A new **`TestDefaultAllowedHeaders`** pins the expected SDK header set so removals fail in CI.
> 
> Two benchmark tests use **keyed** **`KeyedItemDescriptor`** literals so **`go vet ./...`** stays clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a86317cb690290adc170a827df4a0e64e34da240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->